### PR TITLE
Revert "feat(github-action): update image ghcr.io/allenporter/flux-local to v6.1.0"

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -35,7 +35,7 @@ jobs:
           path: default
 
       - name: Diff Resources
-        uses: docker://ghcr.io/allenporter/flux-local:v6.1.0
+        uses: docker://ghcr.io/allenporter/flux-local:v6.0.2
         with:
           args: >-
             diff ${{ matrix.resources }}


### PR DESCRIPTION
Reverts LukeEvansTech/talos-cluster#342

https://github.com/onedr0p/home-ops/blob/main/.github/workflows/flux-image-test.yaml
https://github.com/onedr0p/home-ops/actions/runs/12473136322/job/34813129881

allenporter — Yesterday at 21:30
There is a single change to improve how help values are merged: https://github.com/allenporter/flux-local/pull/812 -- perhaps that is causing a problem