### PR TITLE
feat(flux): centralize cluster-secrets injection in cluster-apps

### DIFF
--- a/kubernetes/apps/ai/ollama/ks.yaml
+++ b/kubernetes/apps/ai/ollama/ks.yaml
@@ -25,9 +25,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/ai/open-webui/ks.yaml
+++ b/kubernetes/apps/ai/open-webui/ks.yaml
@@ -22,9 +22,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -34,4 +31,3 @@ spec:
   targetNamespace: *namespace
   timeout: 5m
   wait: false
-

--- a/kubernetes/apps/cert-manager/cert-manager/ks.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/ks.yaml
@@ -16,10 +16,6 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -50,10 +46,6 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/cert-manager/cert-manager/tls
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/actual/ks.yaml
+++ b/kubernetes/apps/default/actual/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/changedetection/ks.yaml
+++ b/kubernetes/apps/default/changedetection/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/convertx/ks.yaml
+++ b/kubernetes/apps/default/convertx/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/cyberchef/ks.yaml
+++ b/kubernetes/apps/default/cyberchef/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/echo-server/ks.yaml
+++ b/kubernetes/apps/default/echo-server/ks.yaml
@@ -15,9 +15,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/fusion/ks.yaml
+++ b/kubernetes/apps/default/fusion/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/it-tools/ks.yaml
+++ b/kubernetes/apps/default/it-tools/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/karakeep/ks.yaml
+++ b/kubernetes/apps/default/karakeep/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/smokeping/ks.yaml
+++ b/kubernetes/apps/default/smokeping/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/stirling-pdf/ks.yaml
+++ b/kubernetes/apps/default/stirling-pdf/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/universal/ks.yaml
+++ b/kubernetes/apps/default/universal/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/uptimekuma/ks.yaml
+++ b/kubernetes/apps/default/uptimekuma/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/downloads/prowlarr/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/downloads/qbittorrent/ks.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/downloads/sabnzbd/ks.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/external-secrets/external-secrets/ks.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/external-secrets/external-secrets/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/external-secrets/onepassword/ks.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/ks.yaml
@@ -24,10 +24,7 @@ spec:
       current: status.conditions.filter(e, e.type == 'Ready').all(e, e.status == 'True')
   interval: 1h
   path: ./kubernetes/apps/external-secrets/onepassword/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/flux-system/flux-instance/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/ks.yaml
@@ -14,10 +14,7 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-instance/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: false # let's not make happy accidents
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/flux-system/flux-operator/ks.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/flux-system/flux-operator/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: false # let's not make happy accidents
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/games/satisfactory/ks.yaml
+++ b/kubernetes/apps/games/satisfactory/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/infrastructure/certwarden/ks.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/infrastructure/smtp-relay/ks.yaml
+++ b/kubernetes/apps/infrastructure/smtp-relay/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/infrastructure/vlmcsd/ks.yaml
+++ b/kubernetes/apps/infrastructure/vlmcsd/ks.yaml
@@ -16,9 +16,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/cilium/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/cilium/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: false # let's not make happy accidents
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/coredns/ks.yaml
+++ b/kubernetes/apps/kube-system/coredns/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/coredns/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: false # let's not make happy accidents
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/fstrim/ks.yaml
+++ b/kubernetes/apps/kube-system/fstrim/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/fstrim/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
+++ b/kubernetes/apps/kube-system/generic-device-plugin/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/generic-device-plugin/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: false # let's not make happy accidents
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/metrics-server/ks.yaml
+++ b/kubernetes/apps/kube-system/metrics-server/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/metrics-server/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/reloader/ks.yaml
+++ b/kubernetes/apps/kube-system/reloader/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/reloader/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/ks.yaml
@@ -16,10 +16,7 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/kube-system/snapshot-controller/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/kube-system/spegel/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/bazarr/ks.yaml
+++ b/kubernetes/apps/media/bazarr/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/jellyseerr/ks.yaml
+++ b/kubernetes/apps/media/jellyseerr/ks.yaml
@@ -23,9 +23,6 @@ spec:
       GATUS_PATH: /api/v1/status
       GATUS_SUBDOMAIN: requests
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/maintainerr/ks.yaml
+++ b/kubernetes/apps/media/maintainerr/ks.yaml
@@ -20,9 +20,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/pinchflat/ks.yaml
+++ b/kubernetes/apps/media/pinchflat/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -25,9 +25,6 @@ spec:
       GATUS_PATH: /web/index.html
       VOLSYNC_CAPACITY: 200Gi
       VOLSYNC_CACHE_CAPACITY: 100Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -37,25 +34,25 @@ spec:
   targetNamespace: *namespace
   timeout: 5m
   wait: false
-# ---
-# # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
-# apiVersion: kustomize.toolkit.fluxcd.io/v1
-# kind: Kustomization
-# metadata:
-#   name: &app plex-tools
-#   namespace: &namespace default
-# spec:
-#   commonMetadata:
-#     labels:
-#       app.kubernetes.io/name: *app
-#   interval: 1h
-#   path: ./kubernetes/apps/default/plex/tools
-#   prune: true
-#   retryInterval: 2m
-#   sourceRef:
-#     kind: GitRepository
-#     name: flux-system
-#     namespace: flux-system
-#   targetNamespace: *namespace
-#   timeout: 5m
-#   wait: false
+  # ---
+  # # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+  # apiVersion: kustomize.toolkit.fluxcd.io/v1
+  # kind: Kustomization
+  # metadata:
+  #   name: &app plex-tools
+  #   namespace: &namespace default
+  # spec:
+  #   commonMetadata:
+  #     labels:
+  #       app.kubernetes.io/name: *app
+  #   interval: 1h
+  #   path: ./kubernetes/apps/default/plex/tools
+  #   prune: true
+  #   retryInterval: 2m
+  #   sourceRef:
+  #     kind: GitRepository
+  #     name: flux-system
+  #     namespace: flux-system
+  #   targetNamespace: *namespace
+  #   timeout: 5m
+  #   wait: false

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/radarr4k/ks.yaml
+++ b/kubernetes/apps/media/radarr4k/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/recommendarr/ks.yaml
+++ b/kubernetes/apps/media/recommendarr/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/recyclarr/ks.yaml
+++ b/kubernetes/apps/media/recyclarr/ks.yaml
@@ -20,9 +20,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/tautulli/ks.yaml
+++ b/kubernetes/apps/media/tautulli/ks.yaml
@@ -21,9 +21,6 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/certificates/ks.yaml
+++ b/kubernetes/apps/network/certificates/ks.yaml
@@ -18,7 +18,4 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: true
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -16,10 +16,7 @@ spec:
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/envoy-gateway/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/external/ks.yaml
+++ b/kubernetes/apps/network/external/ks.yaml
@@ -11,10 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/external/external-dns
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -37,10 +34,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/external/cloudflared
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -66,10 +60,7 @@ spec:
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/external/ingress-nginx
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/network/internal/ks.yaml
+++ b/kubernetes/apps/network/internal/ks.yaml
@@ -14,10 +14,7 @@ spec:
       namespace: cert-manager
   interval: 1h
   path: ./kubernetes/apps/network/internal/ingress-nginx
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -40,10 +37,7 @@ spec:
       app.kubernetes.io/name: *app
   interval: 1h
   path: ./kubernetes/apps/network/internal/k8s-gateway
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -18,9 +18,6 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: status
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -14,9 +14,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -46,9 +43,6 @@ spec:
   postBuild:
     substitute:
       APP: grafana
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/kromgo/ks.yaml
+++ b/kubernetes/apps/observability/kromgo/ks.yaml
@@ -17,9 +17,6 @@ spec:
     substitute:
       APP: *app
       GATUS_PATH: /talos_version
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/ks.yaml
@@ -20,9 +20,6 @@ spec:
     substitute:
       APP: kube-prometheus-stack
       GATUS_SUBDOMAIN: prometheus
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/smartctl-exporter/ks.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/ks.yaml
@@ -14,9 +14,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/observability/snmp-exporter/ks.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/ks.yaml
@@ -14,9 +14,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/openebs-system/openebs/ks.yaml
+++ b/kubernetes/apps/openebs-system/openebs/ks.yaml
@@ -16,10 +16,7 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/openebs-system/openebs/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -19,10 +19,7 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/rook-ceph/rook-ceph/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:
@@ -43,7 +40,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-     - ../../../../components/gatus/guarded
+    - ../../../../components/gatus/guarded
   dependsOn:
     - name: rook-ceph
       namespace: *namespace
@@ -69,9 +66,6 @@ spec:
     substitute:
       APP: *app
       GATUS_SUBDOMAIN: rook
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -19,10 +19,7 @@ spec:
       namespace: *namespace
   interval: 1h
   path: ./kubernetes/apps/volsync-system/volsync/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  postBuild: {}
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -30,6 +30,10 @@ spec:
           decryption:
             provider: sops
           deletionPolicy: WaitForTermination
+          postBuild:
+            substituteFrom:
+              - kind: Secret
+                name: cluster-secrets
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
Implement centralized postBuild.substituteFrom configuration at the cluster-apps level to automatically inject cluster-secrets into all child Kustomizations. This eliminates the need for repetitive substituteFrom configuration in each child Kustomization.

Changes:
- Add postBuild.substituteFrom patch in cluster-apps Kustomization
- Remove substituteFrom from 60 child Kustomization files
- Preserve existing postBuild.substitute sections where present

Benefits:
- Reduced configuration duplication across 60+ files
- Centralized management of cluster-wide secret substitution
- Easier maintenance and updates