### PR TITLE
feat(database): Add CloudNative-PG PostgreSQL 18 cluster with HA

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/README.md
+++ b/kubernetes/apps/database/cloudnative-pg/README.md
@@ -1,0 +1,481 @@
+# CloudNative-PG PostgreSQL 18 Implementation
+
+## Overview
+
+This directory contains a complete CloudNative-PG deployment for PostgreSQL 18 with high availability, dual backup strategies, comprehensive monitoring, and connection pooling.
+
+## Architecture
+
+### Directory Structure
+
+```
+cloudnative-pg/
+├── README.md                 # This file
+├── ks.yaml                   # Flux Kustomizations (deployment orchestration)
+├── app/                      # CloudNative-PG Operator
+│   ├── externalsecret.yaml   # 1Password integration for credentials
+│   ├── helmrelease.yaml      # Operator deployment (v0.23.0)
+│   ├── ocirepository.yaml    # OCI source for operator chart
+│   └── kustomization.yaml
+├── cluster/                  # PostgreSQL 18 Cluster
+│   ├── cluster.yaml          # Main cluster config (3 instances, 20Gi, PG18)
+│   ├── scheduledbackup.yaml  # Daily Barman Cloud S3 backups
+│   ├── pooler.yaml           # pgBouncer connection pooling
+│   ├── podmonitor.yaml       # Prometheus metrics collection
+│   ├── prometheusrule.yaml   # 7 critical alerts
+│   ├── gatus.yaml            # TCP health checks
+│   ├── service.yaml          # LoadBalancer at 192.168.222.18
+│   └── kustomization.yaml
+└── backup/                   # NFS Database Dumps
+    ├── helmrelease.yaml      # Daily cronjob (2 AM)
+    ├── ocirepository.yaml    # bjw-s app-template chart
+    └── kustomization.yaml
+```
+
+## Design Decisions
+
+### PostgreSQL Configuration
+
+- **Version**: PostgreSQL 18.0 (latest stable)
+- **Instances**: 3 for high availability with automatic failover
+- **Storage**: 20Gi using `openebs-hostpath`
+- **Resources**:
+  - Requests: 500m CPU, 2Gi memory
+  - Limits: 4Gi memory
+- **Tuning**: Optimized for mixed workloads
+  - `max_connections: 300`
+  - `shared_buffers: 512MB`
+  - `effective_cache_size: 1536MB`
+  - Transaction-level checkpoint completion
+
+### Backup Strategy
+
+We implemented a **dual backup approach** for redundancy:
+
+#### 1. Barman Cloud (S3/MinIO) - Primary
+- **Method**: Continuous WAL archiving via Barman Object Store
+- **Schedule**: Daily scheduled backups via `ScheduledBackup` CR
+- **Retention**: 30 days
+- **Compression**: bzip2 for both WAL and data
+- **Performance**: 8 parallel WAL transfers, 2 parallel data jobs
+- **Location**: `s3://cloudnative-pg/` at `https://${SECRET_STORAGE_SERVER}:9000`
+- **Use Case**: Point-in-time recovery (PITR), cluster bootstrap/migration
+
+#### 2. NFS Database Dumps - Secondary
+- **Method**: `pg_dump` via tiredofit/docker-db-backup
+- **Schedule**: Daily at 2 AM (cronjob)
+- **Retention**: 7 days (10080 minutes)
+- **Compression**: gzip level 9
+- **Location**: NAS via NFS mount at `/backups/database/postgresql`
+- **Use Case**: Simple database-level restores, offsite backups
+
+**Why Both?**
+- Barman provides PITR and cluster-level recovery
+- NFS dumps provide simple SQL-level restores and additional redundancy
+- Different failure domains (object storage vs. file storage)
+
+### Connection Pooling
+
+- **Pooler**: pgBouncer (3 instances for HA)
+- **Mode**: Transaction-level pooling
+- **Capacity**: 1000 max client connections, 100 default pool size
+- **Monitoring**: PodMonitor enabled for metrics
+
+### Monitoring Stack
+
+#### Metrics Collection
+- **PodMonitor**: Scrapes PostgreSQL metrics from all instances
+- **Metrics Port**: Standard CNPG metrics endpoint
+- **Label Relabeling**: Converts `cluster` → `cnpg_cluster` for clarity
+
+#### Alerting (PrometheusRule)
+Seven critical alerts configured:
+
+1. **LongRunningTransaction**: Transactions > 5 minutes
+2. **BackendsWaiting**: Backends waiting > 5 minutes
+3. **PGDatabase**: Transaction age > 300M (vacuum/wraparound risk)
+4. **PGReplication**: Replication lag > 5 minutes
+5. **LastFailedArchiveTime**: WAL archiving failures
+6. **DatabaseDeadlockConflicts**: > 10 deadlocks detected
+7. **ReplicaFailingReplication**: Replica replication failures
+
+#### Health Checks
+- **Gatus**: TCP connectivity checks every minute
+- **Endpoint**: `postgres18-rw.database.svc.cluster.local:5432`
+- **Alerts**: Gotify notifications on failure
+
+#### Dashboards
+- **Grafana**: Auto-deployed with operator (`grafanaDashboard.create: true`)
+
+### External Access
+
+- **Service Type**: LoadBalancer
+- **IP**: `192.168.222.18` (Cilium IPAM)
+- **DNS**: `postgres18.${SECRET_DOMAIN_INT}` (External DNS)
+- **Target**: Primary instance only (read-write)
+
+## Deployment Flow
+
+Flux will deploy components in this order (via `dependsOn`):
+
+```
+1. external-secrets-onepassword (pre-existing)
+   ↓
+2. cloudnative-pg (operator)
+   ↓ (also depends on openebs)
+3. cloudnative-pg-cluster (PostgreSQL 18)
+   ↓
+4. cloudnative-pg-backup (NFS cronjob)
+```
+
+Each Flux Kustomization has:
+- 1h reconciliation interval
+- 2m retry interval
+- 5m timeout
+- Health checks on the Cluster CR
+
+## Current Status
+
+### ✅ Completed
+
+- [x] Operator deployment configuration
+- [x] PostgreSQL 18 cluster manifests (3 instances)
+- [x] Barman Cloud S3 backup configuration
+- [x] NFS backup cronjob setup
+- [x] PodMonitor for metrics
+- [x] PrometheusRule with 7 alerts
+- [x] Gatus health checks
+- [x] pgBouncer connection pooling
+- [x] LoadBalancer service configuration
+- [x] Flux Kustomizations with dependency chain
+- [x] All manifests validated with `kubectl kustomize`
+
+### ⚠️ Pre-Deployment Requirements
+
+Before merging/deploying, you **must** complete:
+
+#### 1. 1Password Configuration
+
+Create a vault item named **`cloudnative-pg`** with:
+
+```
+POSTGRES_SUPER_USER: postgres
+POSTGRES_SUPER_PASS: <generate-strong-password>
+```
+
+**Note**: MinIO credentials are pulled from the existing `minio` vault item:
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+#### 2. NFS Backup Configuration
+
+Edit `backup/helmrelease.yaml` lines 105-106:
+
+```yaml
+backups:
+  type: nfs
+  server: nas01.${SECRET_DOMAIN_INT}  # TODO: Replace with your NAS
+  path: /mnt/data/backup               # TODO: Replace with your NFS path
+```
+
+**Required**:
+- NFS server must be accessible from the cluster
+- Export path must exist and be writable
+- Verify with: `showmount -e <nas-server>`
+
+#### 3. MinIO S3 Bucket
+
+Create the S3 bucket in MinIO:
+
+```bash
+# Using mc (MinIO Client)
+mc mb minio/cloudnative-pg
+
+# Or via MinIO UI
+# Navigate to https://${SECRET_STORAGE_SERVER}:9000
+# Create bucket: cloudnative-pg
+```
+
+Verify credentials in the `minio` 1Password vault have access.
+
+## Post-Deployment Verification
+
+### Check Operator
+
+```bash
+kubectl get pods -n database -l app.kubernetes.io/name=cloudnative-pg
+# Expected: 2 operator pods (replicaCount: 2)
+```
+
+### Check Cluster
+
+```bash
+# Cluster status
+kubectl get cluster -n database postgres18
+# Expected: STATUS=Cluster in healthy state (3/3)
+
+# Pod status
+kubectl get pods -n database -l cnpg.io/cluster=postgres18
+# Expected: 3 pods running (postgres18-1, postgres18-2, postgres18-3)
+
+# Check which is primary
+kubectl get cluster -n database postgres18 -o jsonpath='{.status.currentPrimary}'
+```
+
+### Check Pooler
+
+```bash
+kubectl get pooler -n database
+kubectl get pods -n database -l cnpg.io/pooler=postgres18-pgbouncer-rw
+# Expected: 3 pgbouncer pods
+```
+
+### Check Backups
+
+```bash
+# Scheduled backup
+kubectl get scheduledbackup -n database
+# Expected: postgres18 (next run time shown)
+
+# Actual backups
+kubectl get backup -n database
+# Expected: After first daily run, backups listed
+
+# NFS backup cronjob
+kubectl get cronjob -n database
+# Expected: postgres18-backup-postgres-backup
+```
+
+### Test Connectivity
+
+#### Internal (via service)
+
+```bash
+kubectl run -it --rm psql --image=postgres:18 --restart=Never -- \
+  psql -h postgres18-rw.database.svc.cluster.local -U postgres -d postgres
+```
+
+#### External (via LoadBalancer)
+
+```bash
+psql -h 192.168.222.18 -U postgres -d postgres
+# Or via DNS
+psql -h postgres18.${SECRET_DOMAIN_INT} -U postgres -d postgres
+```
+
+### Check Monitoring
+
+```bash
+# Prometheus metrics
+kubectl port-forward -n database postgres18-1 9187:9187
+curl localhost:9187/metrics | grep cnpg
+
+# Gatus status
+# Check your Gatus dashboard for postgres18 endpoint
+
+# Prometheus alerts
+# Check AlertManager for any firing CloudNative-PG alerts
+```
+
+## Accessing the Database
+
+### Connection Strings
+
+#### Read-Write (Primary)
+
+```bash
+# Via service
+postgres://postgres:<password>@postgres18-rw.database.svc.cluster.local:5432/postgres
+
+# Via LoadBalancer
+postgres://postgres:<password>@192.168.222.18:5432/postgres
+
+# Via pooler (recommended for apps)
+postgres://postgres:<password>@postgres18-pgbouncer-rw.database.svc.cluster.local:5432/postgres
+```
+
+#### Read-Only (Replicas)
+
+```bash
+postgres://postgres:<password>@postgres18-ro.database.svc.cluster.local:5432/postgres
+```
+
+### Creating Databases/Users
+
+```bash
+# Connect to primary
+kubectl exec -it -n database postgres18-1 -- psql -U postgres
+
+# Create database
+CREATE DATABASE myapp;
+
+# Create user
+CREATE USER myapp_user WITH PASSWORD 'secure_password';
+GRANT ALL PRIVILEGES ON DATABASE myapp TO myapp_user;
+```
+
+## Backup & Recovery
+
+### Manual Backup (Barman)
+
+```bash
+# Trigger backup immediately
+kubectl create -f - <<EOF
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: postgres18-manual-$(date +%Y%m%d-%H%M%S)
+  namespace: database
+spec:
+  cluster:
+    name: postgres18
+  method: barmanObjectStore
+EOF
+
+# Check backup status
+kubectl get backup -n database
+```
+
+### Restore from Barman Backup
+
+To restore from a backup, modify `cluster/cluster.yaml`:
+
+```yaml
+spec:
+  bootstrap:
+    recovery:
+      source: postgres18
+      recoveryTarget:
+        targetTime: "2025-11-13 12:00:00.00000+00"  # PITR
+  externalClusters:
+    - name: postgres18
+      barmanObjectStore:
+        destinationPath: s3://cloudnative-pg/
+        endpointURL: https://${SECRET_STORAGE_SERVER}:9000
+        s3Credentials:
+          accessKeyId:
+            name: cloudnative-pg-secret
+            key: AWS_ACCESS_KEY_ID
+          secretAccessKey:
+            name: cloudnative-pg-secret
+            key: AWS_SECRET_ACCESS_KEY
+        wal:
+          compression: bzip2
+```
+
+### Restore from NFS Dump
+
+```bash
+# List available backups on NAS
+ls -lh /mnt/data/backup/database/postgresql/
+
+# Restore specific database
+gunzip < /mnt/data/backup/database/postgresql/mydb_YYYYMMDD.sql.gz | \
+  kubectl exec -i postgres18-1 -n database -- psql -U postgres -d mydb
+```
+
+## Troubleshooting
+
+### Cluster Won't Start
+
+```bash
+# Check operator logs
+kubectl logs -n database -l app.kubernetes.io/name=cloudnative-pg
+
+# Check cluster events
+kubectl describe cluster -n database postgres18
+
+# Check pod logs
+kubectl logs -n database postgres18-1
+```
+
+### Backup Failures
+
+```bash
+# Check scheduled backup
+kubectl describe scheduledbackup -n database postgres18
+
+# Check backup CR events
+kubectl get backup -n database
+kubectl describe backup -n database <backup-name>
+
+# Verify S3 credentials
+kubectl get secret -n database cloudnative-pg-secret -o yaml
+```
+
+### Replication Issues
+
+```bash
+# Check replication status
+kubectl exec -n database postgres18-1 -- psql -U postgres -c \
+  "SELECT * FROM pg_stat_replication;"
+
+# Check cluster status
+kubectl get cluster -n database postgres18 -o yaml
+```
+
+## Maintenance
+
+### Upgrading PostgreSQL
+
+CloudNative-PG supports in-place major version upgrades:
+
+1. Update `imageName` in `cluster/cluster.yaml`
+2. Set `primaryUpdateStrategy: unsupervised` (already set)
+3. Apply changes - operator handles rolling upgrade
+
+### Scaling Instances
+
+```bash
+# Edit cluster
+kubectl edit cluster -n database postgres18
+
+# Change instances: 3 -> 5
+spec:
+  instances: 5
+```
+
+### Vacuuming
+
+CloudNative-PG includes autovacuum by default. For manual vacuum:
+
+```bash
+kubectl exec -n database postgres18-1 -- psql -U postgres -d mydb -c "VACUUM ANALYZE;"
+```
+
+## References
+
+### Implementation Sources
+
+This implementation is based on:
+- [drag0n141/home-ops](https://github.com/drag0n141/home-ops/tree/master/kubernetes/apps/database/cloudnative-pg) - Primary reference for cluster config
+- [jfroy/flatops](https://github.com/jfroy/flatops/tree/main/kubernetes/apps/database/cnpg) - PodMonitor configuration
+- Previous implementation: [talos-cluster-pw](https://github.com/LukeEvansTech/talos-cluster-pw/tree/main/kubernetes/apps/database/cloudnative-pg)
+
+### Documentation
+
+- [CloudNative-PG Official Docs](https://cloudnative-pg.io/)
+- [CloudNative-PG GitHub](https://github.com/cloudnative-pg/cloudnative-pg)
+- [Backup & Recovery Guide](https://cloudnative-pg.io/documentation/current/backup_recovery/)
+- [Monitoring Guide](https://cloudnative-pg.io/documentation/current/monitoring/)
+
+## Notes
+
+- **Storage Class**: Using `openebs-hostpath` - data is local to nodes
+- **Network Policy**: Not implemented - assume cluster network isolation
+- **TLS**: Not configured - rely on cluster network security (consider adding for production)
+- **Resource Limits**: Conservative - adjust based on workload monitoring
+- **Timezone**: Backup cronjob uses `America/New_York`
+
+## Next Steps
+
+After successful deployment:
+
+1. Monitor cluster health for 24h
+2. Verify first backup completes successfully (S3 + NFS)
+3. Test restore procedure in non-prod namespace
+4. Create application databases/users
+5. Update app configurations to use pooler endpoint
+6. Consider adding TLS for external connections
+7. Tune PostgreSQL parameters based on workload
+8. Set up backup restore testing schedule

--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -17,8 +17,10 @@ spec:
       data:
         username: "{{ .POSTGRES_SUPER_USER }}"
         password: "{{ .POSTGRES_SUPER_PASS }}"
-        AWS_ACCESS_KEY_ID: "{{ .CNPG_AWS_ACCESS_KEY_ID }}"
-        AWS_SECRET_ACCESS_KEY: "{{ .CNPG_AWS_SECRET_ACCESS_KEY }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
   dataFrom:
     - extract:
         key: cloudnative-pg
+    - extract:
+        key: minio

--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudnative-pg
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cloudnative-pg-secret
+    template:
+      metadata:
+        labels:
+          cnpg.io/reload: "true"
+      data:
+        username: "{{ .POSTGRES_SUPER_USER }}"
+        password: "{{ .POSTGRES_SUPER_PASS }}"
+        AWS_ACCESS_KEY_ID: "{{ .CNPG_AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .CNPG_AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: cloudnative-pg
+    namespace: database
+  values:
+    crds:
+      create: true
+    replicaCount: 2
+    monitoring:
+      podMonitorEnabled: true
+      grafanaDashboard:
+        create: true

--- a/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/cloudnative-pg/app/ocirepository.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg
+  ref:
+    tag: 0.23.0
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy

--- a/kubernetes/apps/database/cloudnative-pg/backup/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/backup/helmrelease.yaml
@@ -1,0 +1,108 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: postgres18-backup
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: postgres18-backup
+    namespace: database
+  values:
+    controllers:
+      postgres-backup:
+        type: cronjob
+        cronjob:
+          schedule: "0 2 * * *" # 2 AM daily
+          concurrencyPolicy: Forbid
+          successfulJobsHistory: 1
+          failedJobsHistory: 1
+
+        initContainers:
+          generate-db-list:
+            image:
+              repository: ghcr.io/cloudnative-pg/postgresql
+              tag: 18.0
+            command:
+              - /bin/bash
+              - -c
+              - |
+                psql -h postgres18-rw.database.svc.cluster.local -U $POSTGRES_USER -d postgres -tAc \
+                "SELECT datname FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres', 'template0', 'template1', 'app');" \
+                > /config/db_list || echo "app" > /config/db_list
+            env:
+              - name: POSTGRES_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: cloudnative-pg-secret
+                    key: username
+              - name: PGPASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: cloudnative-pg-secret
+                    key: password
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/tiredofit/docker-db-backup
+              tag: 4.1.9
+            env:
+              - name: DB_TYPE
+                value: pgsql
+              - name: DB_HOST
+                value: postgres18-rw.database.svc.cluster.local
+              - name: DB_PORT
+                value: "5432"
+              - name: DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: cloudnative-pg-secret
+                    key: username
+              - name: DB_PASS
+                valueFrom:
+                  secretKeyRef:
+                    name: cloudnative-pg-secret
+                    key: password
+              - name: DB_NAME
+                value: ALL
+              - name: DB_BACKUP_LOCATION
+                value: FILESYSTEM
+              - name: DB_DUMP_TARGET
+                value: /backups/database/postgresql
+              - name: DB_CLEANUP_TIME
+                value: "10080" # 7 days in minutes
+              - name: DB_COMPRESSION
+                value: GZ
+              - name: DB_COMPRESSION_LEVEL
+                value: "9"
+              - name: CHECKSUM
+                value: SHA1
+              - name: TIMEZONE
+                value: America/New_York
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    persistence:
+      config:
+        type: emptyDir
+      backups:
+        type: nfs
+        server: nas01.${SECRET_DOMAIN_INT} # TODO: Update with your NAS server
+        path: /mnt/data/backup # TODO: Update with your NFS path
+        globalMounts:
+          - path: /backups

--- a/kubernetes/apps/database/cloudnative-pg/backup/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/backup/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/cloudnative-pg/backup/ocirepository.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/backup/ocirepository.yaml
@@ -10,7 +10,7 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 3.6.0
+    tag: 4.4.0
   url: oci://ghcr.io/bjw-s-labs/helm/app-template
   verify:
     provider: cosign

--- a/kubernetes/apps/database/cloudnative-pg/backup/ocirepository.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/backup/ocirepository.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: postgres18-backup
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.6.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres18
+spec:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.0
+
+  primaryUpdateStrategy: unsupervised
+
+  storage:
+    size: 20Gi
+    storageClass: openebs-hostpath
+
+  superuserSecret:
+    name: cloudnative-pg-secret
+
+  enableSuperuserAccess: true
+
+  postgresql:
+    parameters:
+      max_connections: "300"
+      shared_buffers: 512MB
+      effective_cache_size: 1536MB
+      maintenance_work_mem: 128MB
+      checkpoint_completion_target: "0.9"
+      wal_buffers: 16MB
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: 2621kB
+      huge_pages: "off"
+      min_wal_size: 1GB
+      max_wal_size: 4GB
+
+  resources:
+    requests:
+      cpu: 500m
+      memory: 2Gi
+    limits:
+      memory: 4Gi
+
+  monitoring:
+    enablePodMonitor: true
+
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://cloudnative-pg/
+      endpointURL: https://minio.${SECRET_DOMAIN_INT}
+      serverName: postgres18
+      s3Credentials:
+        accessKeyId:
+          name: cloudnative-pg-secret
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: cloudnative-pg-secret
+          key: AWS_SECRET_ACCESS_KEY
+      wal:
+        compression: bzip2
+        maxParallel: 8
+      data:
+        compression: bzip2
+        jobs: 2

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -49,7 +49,7 @@ spec:
     retentionPolicy: 30d
     barmanObjectStore:
       destinationPath: s3://cloudnative-pg/
-      endpointURL: https://minio.${SECRET_DOMAIN_INT}
+      endpointURL: https://${SECRET_STORAGE_SERVER}:9000
       serverName: postgres18
       s3Credentials:
         accessKeyId:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/gatus.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/gatus.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/TwiN/gatus/master/.schema/config.schema.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres18-gatus-ep
+  labels:
+    gatus.io/enabled: "true"
+data:
+  config.yaml: |-
+    endpoints:
+      - name: postgres18
+        group: infrastructure
+        url: "tcp://postgres18-rw.database.svc.cluster.local:5432"
+        interval: 1m
+        ui:
+          hide-hostname: true
+          hide-url: true
+        conditions:
+          - "[CONNECTED] == true"
+        alerts:
+          - type: gotify

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cluster.yaml
+  - ./gatus.yaml
+  - ./podmonitor.yaml
+  - ./pooler.yaml
+  - ./prometheusrule.yaml
+  - ./scheduledbackup.yaml
+  - ./service.yaml

--- a/kubernetes/apps/database/cloudnative-pg/cluster/podmonitor.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/podmonitor.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: postgres18
+  labels:
+    cnpg.io/cluster: postgres18
+spec:
+  podMetricsEndpoints:
+    - metricRelabelings:
+        - action: replace
+          sourceLabels:
+            - cluster
+          targetLabel: cnpg_cluster
+        - action: labeldrop
+          regex: cluster
+      port: metrics
+  selector:
+    matchLabels:
+      cnpg.io/cluster: postgres18
+      cnpg.io/podRole: instance

--- a/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/pooler.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/pooler_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgres18-pgbouncer-rw
+spec:
+  cluster:
+    name: postgres18
+  instances: 3
+  type: rw
+  monitoring:
+    enablePodMonitor: true
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "1000"
+      default_pool_size: "100"

--- a/kubernetes/apps/database/cloudnative-pg/cluster/prometheusrule.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/prometheusrule.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: cloudnative-pg
+spec:
+  groups:
+    - name: cloudnative-pg.rules
+      rules:
+        - alert: LongRunningTransaction
+          expr: cnpg_backends_max_tx_duration_seconds > 300
+          for: 5m
+          annotations:
+            summary: Pod {{ $labels.pod }} is taking more than {{ $value }} seconds
+          labels:
+            severity: critical
+
+        - alert: BackendsWaiting
+          expr: cnpg_backends_waiting_total > 300
+          for: 5m
+          annotations:
+            summary: Pod {{ $labels.pod }} has been waiting longer than {{ $value }}
+          labels:
+            severity: critical
+
+        - alert: PGDatabase
+          expr: cnpg_pg_database_xid_age > 300000000
+          for: 5m
+          annotations:
+            summary: Over {{ $value }} transactions from frozen xid on {{ $labels.pod }}
+          labels:
+            severity: critical
+
+        - alert: PGReplication
+          expr: cnpg_pg_replication_lag > 300
+          for: 5m
+          annotations:
+            summary: Standby is lagging behind by over {{ $value }} seconds
+          labels:
+            severity: critical
+
+        - alert: LastFailedArchiveTime
+          expr: (cnpg_pg_stat_archiver_last_failed_time - cnpg_pg_stat_archiver_last_archived_time) > 1
+          for: 5m
+          annotations:
+            summary: Archiving failed for {{ $labels.pod }}
+          labels:
+            severity: critical
+
+        - alert: DatabaseDeadlockConflicts
+          expr: cnpg_pg_stat_database_deadlocks > 10
+          for: 5m
+          annotations:
+            summary: Over {{ $value }} deadlock conflicts in {{ $labels.pod }}
+          labels:
+            severity: critical
+
+        - alert: ReplicaFailingReplication
+          expr: cnpg_pg_replication_in_recovery > cnpg_pg_replication_is_wal_receiver_up
+          for: 5m
+          annotations:
+            summary: Replica {{ $labels.pod }} is failing to replicate
+          labels:
+            severity: critical

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres18
+spec:
+  backupOwnerReference: self
+  cluster:
+    name: postgres18
+  immediate: true
+  schedule: "@daily"
+  method: barmanObjectStore

--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres18-lb
+  annotations:
+    io.cilium/lb-ipam-ips: 192.168.222.18
+    external-dns.alpha.kubernetes.io/hostname: postgres18.${SECRET_DOMAIN_INT}
+spec:
+  type: LoadBalancer
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+  selector:
+    cnpg.io/cluster: postgres18
+    cnpg.io/instanceRole: primary

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg-cluster
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: database
+    - name: openebs
+      namespace: openebs-system
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/cluster
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true
+  healthChecks:
+    - apiVersion: postgresql.cnpg.io/v1
+      kind: Cluster
+      name: postgres18
+      namespace: database
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cloudnative-pg-backup
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/backup
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -10,7 +10,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: external-secrets-onepassword
+    - name: onepassword
       namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/database/cloudnative-pg/app

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+components:
+  - ../../components/common
+resources:
+  - ./namespace.yaml
+  - ./cloudnative-pg/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -121,6 +121,7 @@ spec:
   compression:
     - type: Brotli
     - type: Gzip
+    - type: Zstd
   connection:
     bufferLimit: 8Mi
   targetSelectors:


### PR DESCRIPTION
## Summary

This PR adds a complete CloudNative-PG deployment with PostgreSQL 18, featuring high availability, automated backups, monitoring, and connection pooling.

## Pre-Deployment Checklist

### Required Configuration

1. **1Password Secrets** - Create vault item `cloudnative-pg` with:
   - `POSTGRES_SUPER_USER`
   - `POSTGRES_SUPER_PASS`

2. **MinIO S3 Credentials** - Ensure `minio` vault has:
   - `AWS_ACCESS_KEY_ID`
   - `AWS_SECRET_ACCESS_KEY`

3. **Cluster Variables** - Set in cluster secrets:
   - `SVC_POSTGRES_ADDR` - LoadBalancer IP address

4. **NFS Configuration** - Update backup helmrelease with your NAS server/path

5. **MinIO S3** - Create `cloudnative-pg` bucket

## Features

- PostgreSQL 18 with 3 instances (HA)
- Barman Cloud + NFS backups
- PodMonitor, PrometheusRule for Prometheus monitoring (alerts via Pushover)
- Gatus health check monitoring
- pgBouncer connection pooling
- LoadBalancer with external-dns at postgres18.${SECRET_DOMAIN}

See commit message for full details.