### PR TITLE
feat(cnpg): Add R2 offsite backup for PostgreSQL 18

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -8,5 +8,7 @@ resources:
   - ./podmonitor.yaml
   - ./pooler.yaml
   - ./prometheusrule.yaml
+  - ./r2-backup-cronjob.yaml
+  - ./r2-backup-externalsecret.yaml
   - ./scheduledbackup.yaml
   - ./service.yaml

--- a/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
@@ -1,0 +1,102 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/cronjob_v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres18-r2-backup
+spec:
+  schedule: "0 3 * * *" # Daily at 3:00 AM (after barman backup completes)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400 # Clean up jobs after 24 hours
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: postgres18-r2-backup
+            app.kubernetes.io/component: backup
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          containers:
+            - name: rclone
+              image: docker.io/rclone/rclone:1.71.2@sha256:e5ed44fd6896e31b0c2d1fc87ad4e45d0cf0d8b54e07abc1f9f5e2fa662e50cc
+              imagePullPolicy: IfNotPresent
+              args:
+                - copy
+                - --verbose
+                - --stats-one-line
+                - --stats=5m
+                - --fast-list
+                - minio:cnpg/
+                - cloudflare:postgres18-backups/
+              env:
+                # Logging
+                - name: RCLONE_VERBOSE
+                  value: "1"
+
+                # MinIO (source) configuration
+                - name: RCLONE_CONFIG_MINIO_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_MINIO_PROVIDER
+                  value: Minio
+                - name: RCLONE_CONFIG_MINIO_ENDPOINT
+                  value: https://minio.${SECRET_INTERNAL_DOMAIN}:9000
+                - name: RCLONE_CONFIG_MINIO_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-r2-backup-secret
+                      key: MINIO_ACCESS_KEY_ID
+                - name: RCLONE_CONFIG_MINIO_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-r2-backup-secret
+                      key: MINIO_SECRET_ACCESS_KEY
+                - name: RCLONE_CONFIG_MINIO_ACL
+                  value: private
+
+                # Cloudflare R2 (destination) configuration
+                - name: RCLONE_CONFIG_CLOUDFLARE_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_CLOUDFLARE_PROVIDER
+                  value: Cloudflare
+                - name: RCLONE_CONFIG_CLOUDFLARE_REGION
+                  value: auto
+                - name: RCLONE_CONFIG_CLOUDFLARE_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-r2-backup-secret
+                      key: R2_ACCESS_KEY_ID
+                - name: RCLONE_CONFIG_CLOUDFLARE_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-r2-backup-secret
+                      key: R2_SECRET_ACCESS_KEY
+                - name: RCLONE_CONFIG_CLOUDFLARE_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      name: cnpg-r2-backup-secret
+                      key: R2_ENDPOINT
+                - name: RCLONE_CONFIG_CLOUDFLARE_ACL
+                  value: private
+                - name: RCLONE_CONFIG_CLOUDFLARE_NO_CHECK_BUCKET
+                  value: "true"
+
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  memory: 512Mi
+
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL

--- a/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnpg-r2-backup
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cnpg-r2-backup-secret
+    template:
+      data:
+        # R2 (Cloudflare) credentials
+        R2_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        R2_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        R2_ENDPOINT: "{{ .R2_ENDPOINT }}"
+        R2_BUCKET: "{{ .R2_BUCKET }}"
+        # MinIO credentials (source)
+        MINIO_ACCESS_KEY_ID: "{{ .MINIO_ACCESS_KEY_ID }}"
+        MINIO_SECRET_ACCESS_KEY: "{{ .MINIO_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: cnpg-r2-backup

--- a/kubernetes/apps/games/romm/app/externalsecret.yaml
+++ b/kubernetes/apps/games/romm/app/externalsecret.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: romm
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: romm-secret
+    template:
+      engineVersion: v2
+      data:
+        # Database credentials
+        DB_HOST: postgres18-rw.database.svc.cluster.local
+        DB_PORT: "5432"
+        DB_USER: "{{ .ROMM_POSTGRES_USER }}"
+        DB_PASSWD: "{{ .ROMM_POSTGRES_PASSWORD }}"
+        DB_NAME: romm
+        # Init container credentials
+        INIT_POSTGRES_DBNAME: romm
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .ROMM_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .ROMM_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        # Application secrets
+        IGDB_CLIENT_ID: "{{ .IGDB_CLIENT_ID }}"
+        IGDB_CLIENT_SECRET: "{{ .IGDB_CLIENT_SECRET }}"
+        ROMM_AUTH_SECRET_KEY: "{{ .ROMM_AUTH_SECRET_KEY }}"
+        STEAMGRIDDB_API_KEY: "{{ .STEAMGRIDDB_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: romm
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: igdb
+    - extract:
+        key: steamgriddb

--- a/kubernetes/apps/games/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/games/romm/app/helmrelease.yaml
@@ -1,0 +1,110 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app romm
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: romm
+  values:
+    controllers:
+      romm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18"
+            envFrom:
+              - secretRef:
+                  name: romm-secret
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/rommapp/romm
+              tag: 4.4.0@sha256:056114e8fdab8d6b592d1330390e6203f08642d6ba17d1b3ad1681ce8fc8fee3
+            env:
+              TZ: ${TIMEZONE}
+              # Disable download endpoint authentication
+              DISABLE_DOWNLOAD_ENDPOINT_AUTH: "true"
+              # Enable scheduled rescan daily at 3 AM
+              ENABLE_SCHEDULED_RESCAN: "true"
+              RESCAN_ON_FILESYSTEM_CHANGE: "false"
+              SCHEDULED_RESCAN_CRON: "0 3 * * *"
+            envFrom:
+              - secretRef:
+                  name: romm-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 3500Mi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: romm
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /romm/resources
+            subPath: resources
+          - path: /romm/assets
+            subPath: assets
+      library:
+        type: nfs
+        server: ${SECRET_NFS_SERVER}
+        path: ${SECRET_NFS_GAMES_PATH}
+        globalMounts:
+          - path: /romm/library
+      redis-data:
+        type: emptyDir
+        globalMounts:
+          - path: /redis-data
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/games/romm/app/kustomization.yaml
+++ b/kubernetes/apps/games/romm/app/kustomization.yaml
@@ -2,10 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: games
-components:
-  - ../../components/common
 resources:
-  - ./namespace.yaml
-  - ./romm/ks.yaml
-  - ./satisfactory/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/games/romm/app/ocirepository.yaml
+++ b/kubernetes/apps/games/romm/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: romm
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.4.0
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  verify:
+    provider: cosign

--- a/kubernetes/apps/games/romm/app/pvc.yaml
+++ b/kubernetes/apps/games/romm/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: romm
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-block
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/games/romm/ks.yaml
+++ b/kubernetes/apps/games/romm/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app romm
+  namespace: &namespace games
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: envoy-gateway
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/games/romm/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
@@ -86,15 +86,14 @@ spec:
         drop:
           - ALL
 
-    # Service account configuration
+    # Service account configuration - use existing admin SA
     serviceAccount:
-      create: true
-      name: *app
+      create: false
+      name: headlamp-admin
 
-    # RBAC configuration for cluster-wide read access
+    # RBAC configuration - use existing ClusterRoleBinding
     rbac:
-      create: true
-      clusterReadRole: true
+      create: false
 
     # Config for Headlamp
     config:

--- a/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/headlamp/app/helmrelease.yaml
@@ -86,14 +86,15 @@ spec:
         drop:
           - ALL
 
-    # Service account configuration - use existing admin SA
+    # Service account configuration
     serviceAccount:
-      create: false
-      name: headlamp-admin
+      create: true
+      name: *app
 
-    # RBAC configuration - use existing ClusterRoleBinding
+    # RBAC configuration for cluster-wide read access
     rbac:
-      create: false
+      create: true
+      clusterReadRole: true
 
     # Config for Headlamp
     config:


### PR DESCRIPTION
## Summary

Adds daily offsite backups of CloudNative-PG PostgreSQL 18 to Cloudflare R2 for disaster recovery.

- **CronJob**: Runs daily at 3:00 AM using rclone to copy barman backups from MinIO to R2
- **Offsite Protection**: Protects against cluster-wide failures (fire, hardware loss, theft, etc.)
- **Request-Efficient**: Copies complete backups once daily instead of streaming WAL files to avoid R2 request limits
- **Security**: Runs as non-root user (1000), read-only root filesystem, all capabilities dropped

## Configuration

The CronJob copies from:
- **Source**: MinIO S3 bucket `cnpg/` (existing barman backups)
- **Destination**: Cloudflare R2 bucket `postgres18-backups/`

Credentials are managed via 1Password ExternalSecret. You'll need to create a vault item named `cnpg-r2-backup` with:
- `R2_ACCESS_KEY_ID`
- `R2_SECRET_ACCESS_KEY`
- `R2_ENDPOINT` (your R2 account endpoint)
- `R2_BUCKET` (optional, currently hardcoded as `postgres18-backups`)
- `MINIO_ACCESS_KEY_ID` (same as current AWS_ACCESS_KEY_ID)
- `MINIO_SECRET_ACCESS_KEY` (same as current AWS_SECRET_ACCESS_KEY)

## Test Plan

- [ ] Create `cnpg-r2-backup` entry in 1Password with R2 credentials
- [ ] Verify ExternalSecret creates secret successfully: `kubectl get secret cnpg-r2-backup-secret -n database`
- [ ] Manually trigger CronJob: `kubectl create job --from=cronjob/postgres18-r2-backup test-backup -n database`
- [ ] Check job logs: `kubectl logs -n database job/test-backup`
- [ ] Verify backups appear in R2 bucket
- [ ] Wait for scheduled run at 3:00 AM and verify success