### PR TITLE
feat(talos): migrate to v1.12 modular network configuration

### DIFF
--- a/talos/patches/controller/machine-vip.yaml
+++ b/talos/patches/controller/machine-vip.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1alpha1
+kind: Layer2VIPConfig
+name: 10.32.8.85
+link: wan

--- a/talos/patches/controller/machine-vip.yaml
+++ b/talos/patches/controller/machine-vip.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1alpha1
-kind: Layer2VIPConfig
-name: 10.32.8.85
-link: wan

--- a/talos/patches/global/machine-network.yaml
+++ b/talos/patches/global/machine-network.yaml
@@ -1,9 +1,7 @@
 ---
-machine:
-  network:
-    disableSearchDomain: true
----
 apiVersion: v1alpha1
 kind: ResolverConfig
 nameservers:
   - address: 10.32.8.10
+searchDomains:
+  domains: []

--- a/talos/patches/global/machine-network.yaml
+++ b/talos/patches/global/machine-network.yaml
@@ -5,5 +5,5 @@ machine:
 ---
 apiVersion: v1alpha1
 kind: ResolverConfig
-dnsServers:
-  - 10.32.8.10
+nameservers:
+  - address: 10.32.8.10

--- a/talos/patches/global/machine-time.yaml
+++ b/talos/patches/global/machine-time.yaml
@@ -1,6 +1,7 @@
 ---
 apiVersion: v1alpha1
-kind: TimeServerConfig
-servers:
-  - 162.159.200.1
-  - 162.159.200.123
+kind: TimeSyncConfig
+ntp:
+  servers:
+    - 162.159.200.1
+    - 162.159.200.123

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -67,10 +67,9 @@ nodes:
         kind: LinkConfig
         name: wan
         addresses:
-          - 10.32.8.80/24
+          - address: 10.32.8.80/24
         routes:
-          - network: 0.0.0.0/0
-            gateway: 10.32.8.10
+          - gateway: 10.32.8.10
         mtu: 1500
   - hostname: "cr-talos-02"
     ipAddress: "10.32.8.81"
@@ -114,10 +113,9 @@ nodes:
         kind: LinkConfig
         name: wan
         addresses:
-          - 10.32.8.81/24
+          - address: 10.32.8.81/24
         routes:
-          - network: 0.0.0.0/0
-            gateway: 10.32.8.10
+          - gateway: 10.32.8.10
         mtu: 1500
   - hostname: "cr-talos-03"
     ipAddress: "10.32.8.82"
@@ -161,10 +159,9 @@ nodes:
         kind: LinkConfig
         name: wan
         addresses:
-          - 10.32.8.82/24
+          - address: 10.32.8.82/24
         routes:
-          - network: 0.0.0.0/0
-            gateway: 10.32.8.10
+          - gateway: 10.32.8.10
         mtu: 1500
 
 # Global patches

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -33,6 +33,18 @@ nodes:
       secureboot: true
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
+    networkInterfaces:
+      - deviceSelector:
+          hardwareAddr: "0c:c4:7a:ea:bf:0e"
+        dhcp: false
+        addresses:
+          - "10.32.8.80/24"
+        routes:
+          - network: "0.0.0.0/0"
+            gateway: "10.32.8.10"
+        mtu: 1500
+        vip:
+          ip: "10.32.8.85"
     patches:
       # Encrypt system disk with TPM
       - |-
@@ -54,23 +66,6 @@ nodes:
         kind: WatchdogTimerConfig
         device: /dev/watchdog0
         timeout: 5m
-      # Network: Link alias for WAN interface
-      - |-
-        apiVersion: v1alpha1
-        kind: LinkAliasConfig
-        name: wan
-        selector:
-          match: mac(link.permanent_addr) == "0c:c4:7a:ea:bf:0e"
-      # Network: Static IP configuration
-      - |-
-        apiVersion: v1alpha1
-        kind: LinkConfig
-        name: wan
-        addresses:
-          - address: 10.32.8.80/24
-        routes:
-          - gateway: 10.32.8.10
-        mtu: 1500
   - hostname: "cr-talos-02"
     ipAddress: "10.32.8.81"
     installDiskSelector:
@@ -79,6 +74,18 @@ nodes:
       secureboot: true
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
+    networkInterfaces:
+      - deviceSelector:
+          hardwareAddr: "0c:c4:7a:ea:be:7a"
+        dhcp: false
+        addresses:
+          - "10.32.8.81/24"
+        routes:
+          - network: "0.0.0.0/0"
+            gateway: "10.32.8.10"
+        mtu: 1500
+        vip:
+          ip: "10.32.8.85"
     patches:
       # Encrypt system disk with TPM
       - |-
@@ -100,23 +107,6 @@ nodes:
         kind: WatchdogTimerConfig
         device: /dev/watchdog0
         timeout: 5m
-      # Network: Link alias for WAN interface
-      - |-
-        apiVersion: v1alpha1
-        kind: LinkAliasConfig
-        name: wan
-        selector:
-          match: mac(link.permanent_addr) == "0c:c4:7a:ea:be:7a"
-      # Network: Static IP configuration
-      - |-
-        apiVersion: v1alpha1
-        kind: LinkConfig
-        name: wan
-        addresses:
-          - address: 10.32.8.81/24
-        routes:
-          - gateway: 10.32.8.10
-        mtu: 1500
   - hostname: "cr-talos-03"
     ipAddress: "10.32.8.82"
     installDiskSelector:
@@ -163,6 +153,12 @@ nodes:
         routes:
           - gateway: 10.32.8.10
         mtu: 1500
+      # Network: VIP configuration (testing new v1.12 modular config)
+      - |-
+        apiVersion: v1alpha1
+        kind: Layer2VIPConfig
+        name: 10.32.8.85
+        link: wan
 
 # Global patches
 patches:
@@ -178,4 +174,3 @@ controlPlane:
   patches:
     - "@./patches/controller/cluster.yaml"
     - "@./patches/controller/machine-features.yaml"
-    - "@./patches/controller/machine-vip.yaml"

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -59,8 +59,8 @@ nodes:
         apiVersion: v1alpha1
         kind: LinkAliasConfig
         name: wan
-        match:
-          selector: link.hardware_addr == "0c:c4:7a:ea:bf:0e"
+        selector:
+          match: mac(link.permanent_addr) == "0c:c4:7a:ea:bf:0e"
       # Network: Static IP configuration
       - |-
         apiVersion: v1alpha1
@@ -106,8 +106,8 @@ nodes:
         apiVersion: v1alpha1
         kind: LinkAliasConfig
         name: wan
-        match:
-          selector: link.hardware_addr == "0c:c4:7a:ea:be:7a"
+        selector:
+          match: mac(link.permanent_addr) == "0c:c4:7a:ea:be:7a"
       # Network: Static IP configuration
       - |-
         apiVersion: v1alpha1
@@ -153,8 +153,8 @@ nodes:
         apiVersion: v1alpha1
         kind: LinkAliasConfig
         name: wan
-        match:
-          selector: link.hardware_addr == "0c:c4:7a:ea:bf:0f"
+        selector:
+          match: mac(link.permanent_addr) == "0c:c4:7a:ea:bf:0f"
       # Network: Static IP configuration
       - |-
         apiVersion: v1alpha1

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -33,18 +33,6 @@ nodes:
       secureboot: true
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
-    networkInterfaces:
-      - deviceSelector:
-          hardwareAddr: "0c:c4:7a:ea:bf:0e"
-        dhcp: false
-        addresses:
-          - "10.32.8.80/24"
-        routes:
-          - network: "0.0.0.0/0"
-            gateway: "10.32.8.10"
-        mtu: 1500
-        vip:
-          ip: "10.32.8.85"
     patches:
       # Encrypt system disk with TPM
       - |-
@@ -66,6 +54,23 @@ nodes:
         kind: WatchdogTimerConfig
         device: /dev/watchdog0
         timeout: 5m
+      # Network: Link alias for WAN interface
+      - |-
+        apiVersion: v1alpha1
+        kind: LinkAliasConfig
+        name: wan
+        selector:
+          match: mac(link.permanent_addr) == "0c:c4:7a:ea:bf:0e"
+      # Network: Static IP configuration
+      - |-
+        apiVersion: v1alpha1
+        kind: LinkConfig
+        name: wan
+        addresses:
+          - address: 10.32.8.80/24
+        routes:
+          - gateway: 10.32.8.10
+        mtu: 1500
   - hostname: "cr-talos-02"
     ipAddress: "10.32.8.81"
     installDiskSelector:
@@ -74,18 +79,6 @@ nodes:
       secureboot: true
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
-    networkInterfaces:
-      - deviceSelector:
-          hardwareAddr: "0c:c4:7a:ea:be:7a"
-        dhcp: false
-        addresses:
-          - "10.32.8.81/24"
-        routes:
-          - network: "0.0.0.0/0"
-            gateway: "10.32.8.10"
-        mtu: 1500
-        vip:
-          ip: "10.32.8.85"
     patches:
       # Encrypt system disk with TPM
       - |-
@@ -107,6 +100,23 @@ nodes:
         kind: WatchdogTimerConfig
         device: /dev/watchdog0
         timeout: 5m
+      # Network: Link alias for WAN interface
+      - |-
+        apiVersion: v1alpha1
+        kind: LinkAliasConfig
+        name: wan
+        selector:
+          match: mac(link.permanent_addr) == "0c:c4:7a:ea:be:7a"
+      # Network: Static IP configuration
+      - |-
+        apiVersion: v1alpha1
+        kind: LinkConfig
+        name: wan
+        addresses:
+          - address: 10.32.8.81/24
+        routes:
+          - gateway: 10.32.8.10
+        mtu: 1500
   - hostname: "cr-talos-03"
     ipAddress: "10.32.8.82"
     installDiskSelector:
@@ -153,12 +163,6 @@ nodes:
         routes:
           - gateway: 10.32.8.10
         mtu: 1500
-      # Network: VIP configuration (testing new v1.12 modular config)
-      - |-
-        apiVersion: v1alpha1
-        kind: Layer2VIPConfig
-        name: 10.32.8.85
-        link: wan
 
 # Global patches
 patches:
@@ -174,3 +178,4 @@ controlPlane:
   patches:
     - "@./patches/controller/cluster.yaml"
     - "@./patches/controller/machine-features.yaml"
+    - "@./patches/controller/machine-vip.yaml"


### PR DESCRIPTION
### **User description**
Migrate from the legacy networkInterfaces format to the new Talos v1.12
modular configuration using declarative resource kinds:

- Convert nameservers to ResolverConfig
- Convert NTP servers to TimeServerConfig
- Convert per-node network interfaces to LinkAliasConfig + LinkConfig
- Add VIPConfig for the control plane VIP

This follows the upstream documentation changes from siderolabs/docs#196.


___

### **PR Type**
Enhancement


___

### **Description**
- Migrate from legacy networkInterfaces to Talos v1.12 modular configuration

- Convert nameservers to ResolverConfig declarative resource

- Convert NTP servers to TimeServerConfig declarative resource

- Replace per-node network config with LinkAliasConfig and LinkConfig patches

- Add VIPConfig for control plane virtual IP management


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Legacy networkInterfaces"] -->|"LinkAliasConfig + LinkConfig"| B["Per-node network patches"]
  C["Inline nameservers"] -->|"ResolverConfig"| D["Global DNS resolver"]
  E["Inline NTP servers"] -->|"TimeServerConfig"| F["Global time servers"]
  G["Inline VIP config"] -->|"VIPConfig"| H["Controller VIP patch"]
  B --> I["Talos v1.12 modular config"]
  D --> I
  F --> I
  H --> I
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>machine-vip.yaml</strong><dd><code>Add VIPConfig for control plane virtual IP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

talos/patches/controller/machine-vip.yaml

<ul><li>New file creating VIPConfig resource for control plane virtual IP<br> <li> Configures shared IP address 10.32.8.85 for the WAN interface</ul>


</details>


  </td>
  <td><a href="https://github.com/LukeEvansTech/talos-cluster/pull/1062/files#diff-312c4948c05da8036aebfdb9e1afabb64c5963e1496ccffe307a97ef51957b19">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>machine-network.yaml</strong><dd><code>Convert nameservers to ResolverConfig resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

talos/patches/global/machine-network.yaml

<ul><li>Converts inline nameservers to declarative ResolverConfig resource<br> <li> Maintains disableSearchDomain setting in machine network config<br> <li> Separates DNS configuration into modular format</ul>


</details>


  </td>
  <td><a href="https://github.com/LukeEvansTech/talos-cluster/pull/1062/files#diff-5fa0d347b3f3b65c870e1f60df0cc80af71c0abcfc7e9ec593ae974b625711f9">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>machine-time.yaml</strong><dd><code>Convert NTP servers to TimeServerConfig resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

talos/patches/global/machine-time.yaml

<ul><li>Replaces legacy machine.time configuration with TimeServerConfig <br>resource<br> <li> Maintains same NTP servers (162.159.200.1, 162.159.200.123)<br> <li> Converts to declarative v1alpha1 resource format</ul>


</details>


  </td>
  <td><a href="https://github.com/LukeEvansTech/talos-cluster/pull/1062/files#diff-623faf25b88c8a346454fc3e3a6d56cf70c86041095730df29dbd4b883c72afb">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>talconfig.yaml</strong><dd><code>Replace networkInterfaces with modular network patches</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

talos/talconfig.yaml

<ul><li>Removes legacy networkInterfaces configuration from all three control <br>plane nodes<br> <li> Adds LinkAliasConfig patches to identify network interfaces by <br>hardware address<br> <li> Adds LinkConfig patches for static IP, routes, and MTU configuration <br>per node<br> <li> Adds reference to new machine-vip.yaml patch in controlPlane patches <br>section<br> <li> Maintains per-node network customization through modular patches <br>instead of inline config</ul>


</details>


  </td>
  <td><a href="https://github.com/LukeEvansTech/talos-cluster/pull/1062/files#diff-c3b37a9258729c66411c2129691075d10b1561ecc088f16e2a204be8354b6272">+55/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

