### PR TITLE
feat(cilium): enable Hubble for network flow visibility

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -33,7 +33,13 @@ gatewayAPI:
   enableAlpn: false
   xffNumTrustedHops: 1
 hubble:
-  enabled: false
+  enabled: true
+  relay:
+    enabled: true
+    rollOutPods: true
+  ui:
+    enabled: true
+    rollOutPods: true
 ipam:
   mode: kubernetes
 ipv4NativeRoutingCIDR: 10.42.0.0/16


### PR DESCRIPTION
## Summary
- Enables Hubble relay and UI in Cilium for network flow observability
- Prerequisite for rolling out CiliumNetworkPolicies — allows monitoring traffic flows and debugging denied connections before policies are enforced

## Test plan
- [ ] Verify Hubble relay and UI pods start successfully
- [ ] Confirm `hubble observe` works from Cilium pods: `kubectl -n kube-system exec ds/cilium -- hubble observe --last 10`
- [ ] Verify no disruption to existing network traffic
- [ ] Once confirmed, merge and proceed with PR 2 (network policies)