### PR TITLE
feat(netpol): add CiliumNetworkPolicies for namespace isolation

### DIFF
--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml
   - ./openaiwhisper/ks.yaml

--- a/kubernetes/apps/ai/netpol.yaml
+++ b/kubernetes/apps/ai/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./cloudnative-pg/ks.yaml
   - ./dragonfly/ks.yaml
   - ./pgadmin/ks.yaml

--- a/kubernetes/apps/database/netpol.yaml
+++ b/kubernetes/apps/database/netpol.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from app namespaces that use postgres and dragonfly"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: media
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads
+        - matchLabels:
+            io.kubernetes.pod.namespace: home
+        - matchLabels:
+            io.kubernetes.pod.namespace: default
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+        - matchLabels:
+            io.kubernetes.pod.namespace: games
+        - matchLabels:
+            io.kubernetes.pod.namespace: infrastructure
+        - matchLabels:
+            io.kubernetes.pod.namespace: security
+        - matchLabels:
+            io.kubernetes.pod.namespace: flux-system
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./actual/ks.yaml
   - ./apprise/ks.yaml
   - ./atuin/ks.yaml

--- a/kubernetes/apps/default/netpol.yaml
+++ b/kubernetes/apps/default/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./nzbget/ks.yaml
   - ./qbittorrent/ks.yaml
   - ./qui/ks.yaml

--- a/kubernetes/apps/downloads/netpol.yaml
+++ b/kubernetes/apps/downloads/netpol.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway, media (arr apps)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+        - matchLabels:
+            io.kubernetes.pod.namespace: media

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -8,5 +8,6 @@ components:
   - ../../components/global-vars
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml

--- a/kubernetes/apps/flux-system/netpol.yaml
+++ b/kubernetes/apps/flux-system/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/games/kustomization.yaml
+++ b/kubernetes/apps/games/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./epicgames/ks.yaml
   - ./free-game-notifier/ks.yaml
   - ./gameyfin/ks.yaml

--- a/kubernetes/apps/games/netpol.yaml
+++ b/kubernetes/apps/games/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./esphome/ks.yaml
   - ./go2rtc/ks.yaml
   - ./homeassistanttimemachine/ks.yaml

--- a/kubernetes/apps/home/netpol.yaml
+++ b/kubernetes/apps/home/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/infrastructure/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./certwarden/ks.yaml
   - ./certwarden/cert-deployment-ks.yaml
   - ./cupdate/ks.yaml

--- a/kubernetes/apps/infrastructure/netpol.yaml
+++ b/kubernetes/apps/infrastructure/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network

--- a/kubernetes/apps/kube-system/cilium-policies/app/allow-all-egress.yaml
+++ b/kubernetes/apps/kube-system/cilium-policies/app/allow-all-egress.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumclusterwidenetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-all-egress
+spec:
+  description: "Allow all egress traffic (phase 1: ingress-only isolation)"
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - kube-system
+          - cert-manager
+          - external-secrets
+          - rook-ceph
+          - openebs-system
+          - volsync-system
+          - system-upgrade
+  egress:
+    - {}

--- a/kubernetes/apps/kube-system/cilium-policies/app/allow-prometheus-scraping.yaml
+++ b/kubernetes/apps/kube-system/cilium-policies/app/allow-prometheus-scraping.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumclusterwidenetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-prometheus-scraping
+spec:
+  description: "Allow ingress from observability namespace for Prometheus scraping"
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - kube-system
+          - cert-manager
+          - external-secrets
+          - rook-ceph
+          - openebs-system
+          - volsync-system
+          - system-upgrade
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability

--- a/kubernetes/apps/kube-system/cilium-policies/app/allow-same-namespace.yaml
+++ b/kubernetes/apps/kube-system/cilium-policies/app/allow-same-namespace.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumclusterwidenetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-same-namespace
+spec:
+  description: "Allow ingress from pods in the same namespace"
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - kube-system
+          - cert-manager
+          - external-secrets
+          - rook-ceph
+          - openebs-system
+          - volsync-system
+          - system-upgrade
+  ingress:
+    - fromEndpoints:
+        - {}

--- a/kubernetes/apps/kube-system/cilium-policies/app/default-deny-ingress.yaml
+++ b/kubernetes/apps/kube-system/cilium-policies/app/default-deny-ingress.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumclusterwidenetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  description: "Default deny all ingress traffic for app namespaces"
+  endpointSelector:
+    matchExpressions:
+      - key: io.kubernetes.pod.namespace
+        operator: NotIn
+        values:
+          - kube-system
+          - cert-manager
+          - external-secrets
+          - rook-ceph
+          - openebs-system
+          - volsync-system
+          - system-upgrade
+  ingress: []

--- a/kubernetes/apps/kube-system/cilium-policies/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium-policies/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./default-deny-ingress.yaml
+  - ./allow-same-namespace.yaml
+  - ./allow-all-egress.yaml
+  - ./allow-prometheus-scraping.yaml

--- a/kubernetes/apps/kube-system/cilium-policies/ks.yaml
+++ b/kubernetes/apps/kube-system/cilium-policies/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app cilium-policies
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cilium
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/cilium-policies/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -98,3 +98,4 @@ securityContext:
       - NET_ADMIN
       - SYS_ADMIN
       - SYS_RESOURCE
+policyEnforcement: default

--- a/kubernetes/apps/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble-ui
+spec:
+  hostnames:
+    - hubble.${SECRET_INTERNAL_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: hubble-ui
+          port: 80

--- a/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./ocirepository.yaml
   - ./networks.yaml
   - ./grafanadashboard.yaml
+  - ./httproute.yaml
 configMapGenerator:
   - name: cilium-values
     files:

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./cilium/ks.yaml
+  - ./cilium-policies/ks.yaml
   - ./coredns/ks.yaml
   - ./descheduler/ks.yaml
   - ./etcd-defrag/ks.yaml

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./agregarr/ks.yaml
   - ./audiobookshelf/ks.yaml
   # TODO: Update externalsecret with autopulse config before enabling

--- a/kubernetes/apps/media/netpol.yaml
+++ b/kubernetes/apps/media/netpol.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway, downloads (arr apps)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network
+        - matchLabels:
+            io.kubernetes.pod.namespace: downloads

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -8,6 +8,7 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
+  - ./netpol.yaml
   - ./acinfinity-exporter/ks.yaml
   - ./blackbox-exporter/ks.yaml
   - ./dcgm-exporter/ks.yaml

--- a/kubernetes/apps/observability/netpol.yaml
+++ b/kubernetes/apps/observability/netpol.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cross-namespace-ingress
+spec:
+  description: "Allow ingress from gateway (network namespace)"
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: network


### PR DESCRIPTION
## Summary
- Adds `CiliumClusterwideNetworkPolicy` resources for baseline ingress isolation across all app namespaces
- Adds per-namespace `CiliumNetworkPolicy` resources for cross-namespace ingress exceptions
- Sets `policyEnforcement: default` so policies only enforce on endpoints with a selecting policy
- Phase 1: ingress-only isolation (all egress allowed) to prevent lateral pod movement

### Cluster-wide baseline (4 CCNPs in `cilium-policies` app)
- **default-deny-ingress** — blocks all ingress to app namespace pods
- **allow-same-namespace** — permits intra-namespace traffic
- **allow-prometheus-scraping** — permits ingress from `observability` namespace
- **allow-all-egress** — permits all egress (phase 1)

### Per-namespace cross-namespace allows (10 CNPs)
- `database` — allows ingress from all app namespaces (postgres/dragonfly consumers)
- `media` — allows ingress from `network` (gateway) + `downloads` (arr apps)
- `downloads` — allows ingress from `network` (gateway) + `media` (arr apps)
- `observability`, `default`, `home`, `ai`, `games`, `infrastructure`, `flux-system` — allows ingress from `network` (gateway)

### Excluded namespaces (remain fully open)
kube-system, cert-manager, external-secrets, rook-ceph, openebs-system, volsync-system, system-upgrade

## Dependencies
- Merge #1867 first (Hubble) for network flow visibility

## Rollback
Remove `./cilium-policies/ks.yaml` from `kubernetes/apps/kube-system/kustomization.yaml` — Flux prunes all cluster-wide policies within minutes.

## Test plan
- [ ] Merge #1867 first, verify Hubble is working
- [ ] Merge this PR, wait for Flux reconciliation
- [ ] Verify CCNPs deployed: `kubectl get ccnp`
- [ ] Verify CNPs deployed: `kubectl get cnp -A`
- [ ] Watch for dropped traffic: `kubectl -n kube-system exec ds/cilium -- hubble observe --verdict DROPPED --last 50`
- [ ] Test same-namespace connectivity (should work): `kubectl -n media exec deploy/radarr -- curl -s --max-time 3 http://sonarr.media.svc:8989`
- [ ] Test allowed cross-namespace (should work): `kubectl -n media exec deploy/radarr -- curl -s --max-time 3 http://sabnzbd.downloads.svc:8080`
- [ ] Test blocked cross-namespace (should timeout): `kubectl -n media exec deploy/radarr -- curl -s --max-time 3 http://satisfactory.games.svc:7777`
- [ ] Verify Prometheus targets remain healthy
- [ ] Verify gateway routes still work (grafana, sonarr, etc.)