### PR TITLE
feat(reclaimerr): expose on external domain

### DIFF
--- a/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
@@ -69,17 +69,22 @@ spec:
           http:
             port: *port
     route:
-      app:
+      internal:
         annotations:
           gatus.home-operations.com/endpoint: |-
             group: internal
             url: http://reclaimerr.media.svc.cluster.local:8000/api/info/health
             conditions: ["[STATUS] == 200"]
         hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
           - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
+            namespace: network
+      external:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
             namespace: network
     persistence:
       config:


### PR DESCRIPTION
## Summary

Add external access to Reclaimerr by splitting the single HTTPRoute into named `internal` and `external` routes (hookshot pattern).

- `internal`: `reclaimerr.${SECRET_INTERNAL_DOMAIN}` → `envoy-internal`
- `external`: `reclaimerr.${SECRET_DOMAIN}` → `envoy-external`

The cloudflared tunnel already wildcards `*.${SECRET_DOMAIN}` to `envoy-external`, so the public record is tunneled automatically once external-dns-cloudflare registers it.

## Test plan

- [ ] CI `flux-local` green
- [ ] CI `security-scans` green
- [ ] Post-merge: two HTTPRoutes created (`reclaimerr-internal`, `reclaimerr-external`)
- [ ] Post-merge: `https://reclaimerr.${SECRET_INTERNAL_DOMAIN}` still reachable on LAN
- [ ] Post-merge: `https://reclaimerr.${SECRET_DOMAIN}` reachable from the public internet