### PR TITLE
revert: reclaimerr external-domain exposure

### DIFF
--- a/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
@@ -69,22 +69,17 @@ spec:
           http:
             port: *port
     route:
-      internal:
+      app:
         annotations:
           gatus.home-operations.com/endpoint: |-
             group: internal
             url: http://reclaimerr.media.svc.cluster.local:8000/api/info/health
             conditions: ["[STATUS] == 200"]
         hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
           - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
-            namespace: network
-      external:
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: envoy-external
             namespace: network
     persistence:
       config:


### PR DESCRIPTION
Reverts #2229.

The original single-route with both hostnames on \`envoy-internal\` was the intended shape — `reclaimerr.\${SECRET_DOMAIN}` should resolve *internally* alongside `\${SECRET_INTERNAL_DOMAIN}`, not be publicly exposed.