### PR TITLE
feat(reclaimerr): mount media NFS share

### DIFF
--- a/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
@@ -86,6 +86,12 @@ spec:
         existingClaim: "{{ .Release.Name }}"
         globalMounts:
           - path: /app/data
+      media:
+        type: nfs
+        server: ${SECRET_STORAGE_SERVER:-localhost}
+        path: /mnt/pool/media
+        globalMounts:
+          - path: /media
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
Mounts the `media` NFS share at `/media` inside the Reclaimerr pod so it has direct filesystem access to the library it is reclaiming from. Follows the sonarr/radarr/bazarr pattern:

- server: \`\${SECRET_STORAGE_SERVER}\`
- export: \`/mnt/pool/media\`
- container path: \`/media\` (read-write)