### PR TITLE
fix(giteamirror): raise HelmRelease timeout to 15m for slow image pull

### DIFF
--- a/kubernetes/apps/default/giteamirror/app/helmrelease.yaml
+++ b/kubernetes/apps/default/giteamirror/app/helmrelease.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app giteamirror
 spec:
   interval: 1h
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: giteamirror


### PR DESCRIPTION
## Summary

- 244 MB gitea-mirror image pulls from GHCR at ~1 MB/s, exceeding the default 5 min Helm upgrade timeout
- On every renovate bump the upgrade times out, rolls back to the previous revision, and the new image is never deployed
- Raise `spec.timeout` to 15 min so the pull can complete before Flux remediates

## Test plan

- [ ] Flux-local CI passes
- [ ] Patch applied live; reconcile HelmRelease; pod comes up on v3.15.5
- [ ] Confirm HR becomes `Ready=True`, `Released=InstallSucceeded`