### PR TITLE
fix(n8n): raise HelmRelease timeout to 15m for slow image pull

### DIFF
--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app n8n
 spec:
   interval: 1h
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: n8n


### PR DESCRIPTION
## Summary

- Same pattern as #2255 (giteamirror): 310 MB image on a slow GHCR link times out the default 5 min Helm upgrade
- `n8n` HR is currently `Stalled=True` (`RetriesExceeded`) after 3 failed attempts to upgrade 2.18.0 → 2.18.1
- Raise `spec.timeout` to 15 min so the pull can complete before Flux remediates

## Test plan

- [ ] Flux-local CI passes
- [ ] After merge + reconcile, HR leaves `Stalled`, upgrade succeeds, pod runs 2.18.1