### PR TITLE
fix(epicgames): raise HelmRelease timeout to 15m for slow image pull

### DIFF
--- a/kubernetes/apps/games/epicgames/app/helmrelease.yaml
+++ b/kubernetes/apps/games/epicgames/app/helmrelease.yaml
@@ -6,6 +6,7 @@ metadata:
   name: &app epicgames
 spec:
   interval: 1h
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: epicgames


### PR DESCRIPTION
## Summary
- Raise `spec.timeout` on the `epicgames` HelmRelease from the default (5m) to `15m`.
- Same pattern already applied to `giteamirror` (#2255) and `n8n` (#2258) for >250MB image pulls that exceed the default upgrade window on slow GHCR fetches.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge, observe HelmRelease reconciles cleanly on next image bump (no `upgrade retries exhausted` from image-pull timeout)