### PR TITLE
feat(seasonpackerr): deploy automated Sonarr season pack upgrader

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./qui/ks.yaml
   - ./prowlarr/ks.yaml
   - ./sabnzbd/ks.yaml
+  - ./seasonpackerr/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./byparr/ks.yaml
   - ./stacks/ks.yaml

--- a/kubernetes/apps/downloads/seasonpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/seasonpackerr/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: seasonpackerr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: seasonpackerr
+  values:
+    controllers:
+      seasonpackerr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/nuxencs/seasonpackarr
+              tag: v0.14.0
+            env:
+              SEASONPACKARR__HOST: 0.0.0.0
+              SEASONPACKARR__PORT: &port 80
+              SEASONPACKARR__SMART_MODE: "true"
+              SEASONPACKARR__SMART_MODE_THRESHOLD: "0.75"
+              SEASONPACKARR__TIMEZONE: ${TIMEZONE}
+              SEASONPACKARR__CLIENTS__QBITTORRENT__HOST: qbittorrent-app.downloads.svc.cluster.local
+              SEASONPACKARR__CLIENTS__QBITTORRENT__PORT: "80"
+              SEASONPACKARR__SONARR__0__DOWNLOAD_PATH: /media/Downloads/qbittorrent/complete/sonarr
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz/readiness
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz/readiness
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz/readiness
+                    port: *port
+                  periodSeconds: 5
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: seasonpackerr
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      tmp:
+        type: emptyDir
+      media:
+        type: nfs
+        server: ${SECRET_STORAGE_SERVER:-localhost}
+        path: /mnt/pool/media
+        globalMounts:
+          - path: /media

--- a/kubernetes/apps/downloads/seasonpackerr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/seasonpackerr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/downloads/seasonpackerr/app/ocirepository.yaml
+++ b/kubernetes/apps/downloads/seasonpackerr/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: seasonpackerr
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/downloads/seasonpackerr/ks.yaml
+++ b/kubernetes/apps/downloads/seasonpackerr/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app seasonpackerr
+  namespace: &namespace downloads
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: qbittorrent
+      namespace: downloads
+  interval: 1h
+  path: ./kubernetes/apps/downloads/seasonpackerr/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- Add `seasonpackerr` (the [seasonpackarr](https://github.com/nuxencs/seasonpackarr) tool) to the `downloads` namespace.
- Auto-upgrades single-episode torrents to season packs when complete packs become available, talking to qbittorrent (`qbittorrent-app.downloads.svc`) and Sonarr.
- Internal-only HTTPRoute on `envoy-internal` (both `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}` hostnames).
- bjw-s app-template `4.6.2`; image `ghcr.io/nuxencs/seasonpackarr:v0.14.0`.
- Smart mode enabled with `0.75` threshold.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge, Flux reconciles `seasonpackerr` Kustomization in `downloads` namespace
- [ ] Pod becomes Ready, healthz endpoint returns 200
- [ ] HTTPRoute resolves on internal DNS
- [ ] Verify it can talk to qbittorrent + Sonarr