### PR TITLE
fix(container): update image ghcr.io/siderolabs/kubelet ( v1.35.3 → v1.35.4 )

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.3
+    version: v1.35.4
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.3
+kubernetesVersion: v1.35.4
 
 clusterName: kubernetes
 endpoint: https://10.32.8.85:6443

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -3,4 +3,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.6
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.3
+kubernetesVersion: v1.35.4


### PR DESCRIPTION
## Summary
- Manual replacement for #2190 (closed): bumps Kubernetes from `v1.35.3` to `v1.35.4` (latest 1.35.x patch).
- Avoids the v1.36.0 minor jump that Renovate's open PR proposed — Talos v1.12.7 caps Kubernetes at v1.35.x in this cluster.
- Mirrors what Renovate would produce: same 3 files marked with the `# renovate: ... depName=ghcr.io/siderolabs/kubelet` annotation.

## Files
- `kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml` — tuppr `KubernetesUpgrade` target version
- `talos/talconfig.yaml` — `kubernetesVersion` for talhelper config generation
- `talos/talenv.yaml` — `kubernetesVersion` for Taskfile helpers

## Test plan
- [ ] flux-local CI passes
- [ ] **Merge AFTER Talos upgrade (#2268) completes successfully** — keeps Talos→K8s ordering
- [ ] After merge, tuppr's `KubernetesUpgrade` CR picks up new version and rolls all 3 nodes
- [ ] All nodes report `v1.35.4` via `kubectl get nodes`