### PR TITLE
fix(seasonpackerr): add /config emptyDir to fix CrashLoop under readOnlyRootFilesystem

### DIFF
--- a/kubernetes/apps/downloads/seasonpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/seasonpackerr/app/helmrelease.yaml
@@ -87,6 +87,8 @@ spec:
           - name: envoy-internal
             namespace: network
     persistence:
+      config:
+        type: emptyDir
       tmp:
         type: emptyDir
       media:


### PR DESCRIPTION
## Summary
Pod is in `CrashLoopBackOff` (10 restarts in 27m) since the original deploy. Logs show:
```
config write error: "open /config/config.yaml: permission denied"
```

Root cause: container has `readOnlyRootFilesystem: true` and no volume mounted at `/config`, so the app can't write its derived config file. Siblings (qbittorrent, prowlarr, sabnzbd) use a `volsync`-backed PVC for `/config`, but seasonpackerr is effectively stateless (all behavior driven by `SEASONPACKARR__*` env vars), so a `emptyDir` is sufficient.

## Change
Add `config: type: emptyDir` to `persistence`. bjw-s app-template auto-mounts the `config` key at `/config`.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge, HelmRelease reconciles successfully (no `Helm upgrade failed` error)
- [ ] Pod becomes `1/1 Ready` with no further restarts
- [ ] `/config/config.yaml` written successfully on container start