### PR TITLE
chore(seasonpackerr): disable in downloads kustomization until config sorted

### DIFF
--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -14,7 +14,8 @@ resources:
   - ./qui/ks.yaml
   - ./prowlarr/ks.yaml
   - ./sabnzbd/ks.yaml
-  - ./seasonpackerr/ks.yaml
+  # TODO: re-enable seasonpackerr — initial deploy CrashLoopBackOff'd; needs `preImportPath` per client and possibly client renamed from QBITTORRENT → DEFAULT. See ./seasonpackerr/ for the manifests, kept in-tree for follow-up.
+  # - ./seasonpackerr/ks.yaml
   - ./flaresolverr/ks.yaml
   - ./byparr/ks.yaml
   - ./stacks/ks.yaml


### PR DESCRIPTION
## Summary
The seasonpackerr deploy from #2286 ended up in CrashLoopBackOff. PR #2290 fixed the first issue (missing `/config` emptyDir under `readOnlyRootFilesystem`), but the next failure is upstream config:

```
preImportPath for client "default" can't be empty,
please provide a valid path to the directory you want seasonpacks to be hardlinked to
```

The HelmRelease has gone `Stalled / MissingRollbackTarget` (no successful prior install to roll back to), so Flux won't keep retrying.

Rather than chase the config blind, comment out the resource line in `kubernetes/apps/downloads/kustomization.yaml` so Flux prunes it. The `seasonpackerr/` directory stays in-tree (manifests intact) for follow-up.

## To re-enable later
1. Decide `preImportPath` (e.g. `/media/Downloads/qbittorrent/complete/seasonpacks`)
2. Verify whether client must be named `default` (i.e. rename `SEASONPACKARR__CLIENTS__QBITTORRENT__*` → `__DEFAULT__*`)
3. Uncomment the resource line + push

## Post-merge
- Flux Kustomization for seasonpackerr should be pruned along with the HR, Deployment, RS, Pod, Svc, HTTPRoute.
- May need a manual `kubectl delete hr -n downloads seasonpackerr` if the Stalled state blocks normal pruning.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge, `kubectl get all -n downloads -l app.kubernetes.io/name=seasonpackerr` returns nothing
- [ ] No errant resources left over (HR/Kustomization/Deployment all gone)