### PR TITLE
feat(container): update image ghcr.io/siderolabs/installer ( v1.12.6 → v1.13.0 )

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.12.6
+    version: v1.13.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/budimanjojo/talhelper/master/pkg/config/schemas/talconfig.json
 ---
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.12.6
+talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.35.3
 

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -1,6 +1,6 @@
 ---
 # Versions used by Taskfile helpers
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-talosVersion: v1.12.6
+talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
 kubernetesVersion: v1.35.3


### PR DESCRIPTION
## Summary
First PR in a 4-step Talos v1.13 + Kubernetes v1.36 upgrade, mirroring the [onedr0p/home-ops sequence from 2026-04-27](https://github.com/onedr0p/home-ops/commits/main/) (commits `9c46b802` → `09424dcc` → `c4dfb92e` → `4151911c` → `8c818b70`).

## Plan (4 PRs total)
1. **This PR** — Talos v1.12.6 → v1.13.0 (skips v1.12.7 as a stepping stone)
2. **PR 2** — MAP cleanup before K8s 1.36: comment out volsync MAPs, strip `MutatingAdmissionPolicy=true` + `runtime-config: ...v1beta1=true` from apiserver flags. Apply talos config to nodes after merge.
3. **PR 3** — K8s v1.35.3 → v1.36.0
4. **PR 4** — Re-enable MAPs with `admissionregistration.k8s.io/v1`

## Files
- `kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml` — tuppr `TalosUpgrade.spec.talos.version`
- `talos/talconfig.yaml` — `talosVersion`
- `talos/talenv.yaml` — `talosVersion`

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: tuppr's `TalosUpgrade` CR picks up v1.13.0 and rolls all 3 control plane nodes (drain → powercycle → ready) with health gates (VolSync `Synchronizing=False`, Ceph `HEALTH_OK`)
- [ ] `kubectl get nodes -o custom-columns='NAME:.metadata.name,OS:.status.nodeInfo.osImage'` reports `Talos (v1.13.0)` for cr-talos-01/02/03
- [ ] No failed pods, Ceph healthy
- [ ] Kubernetes still on v1.35.3 (k8s upgrade is PR 3, separate)

## Talos v1.13 release notes
https://github.com/siderolabs/talos/releases/tag/v1.13.0