### PR TITLE
chore: remove MAP resources and apiserver feature gates to prepare for k8s 1.36

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  - ./mutatingadmissionpolicy.yaml
+  # Disabled for K8s 1.36 upgrade — admissionregistration.k8s.io/v1beta1 removed.
+  # Re-enable in PR 4 once mutatingadmissionpolicy.yaml is migrated to v1.
+  # - ./mutatingadmissionpolicy.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kustomization.yaml
@@ -5,4 +5,6 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./kopiamaintenance.yaml
-  - ./mutatingadmissionpolicy.yaml
+  # Disabled for K8s 1.36 upgrade — admissionregistration.k8s.io/v1beta1 removed.
+  # Re-enable in PR 4 once mutatingadmissionpolicy.yaml is migrated to v1.
+  # - ./mutatingadmissionpolicy.yaml

--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -7,8 +7,6 @@ cluster:
     extraArgs:
       # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
       enable-aggregator-routing: true
-      feature-gates: MutatingAdmissionPolicy=true
-      runtime-config: admissionregistration.k8s.io/v1beta1=true
     resources:
       requests:
         memory: 2Gi


### PR DESCRIPTION
## Summary
**PR 2 of 4** in the Talos v1.13 + K8s v1.36 upgrade. Mirrors onedr0p/home-ops commits `09424dcc` (remove MAP) + `c4dfb92e` (remove apiserver feature gates) — minus the Intel-GPU CDI changes that don't apply to our NVIDIA-only cluster.

K8s 1.36 [removes `admissionregistration.k8s.io/v1beta1`](https://kubernetes.io/blog/2025/03/13/kubernetes-v1-32-removals/), so the existing v1beta1 MAPs and the apiserver flags enabling them must come down before the K8s upgrade. PR 4 re-enables the MAPs after they've been migrated to `v1`.

## Changes

### Comment out MAP resources (so Flux prunes them before K8s 1.36)
- `kubernetes/apps/volsync-system/volsync/app/kustomization.yaml` — disables `volsync-mover-jitter` and `volsync-mover-nfs` MAPs
- `kubernetes/apps/volsync-system/volsync/maintenance/kustomization.yaml` — disables `kopia-maintenance` MAP

### Strip apiserver flags that enable v1beta1 admissionregistration
- `talos/patches/controller/cluster.yaml`:
  - Remove `feature-gates: MutatingAdmissionPolicy=true`
  - Remove `runtime-config: admissionregistration.k8s.io/v1beta1=true`

## Post-merge: apply Talos config to nodes
Talos `cluster.yaml` is rendered into per-node machine configs. After merge, apply manually so kube-apiserver restarts with new flags before PR 3 (K8s 1.36):

```bash
just talos gen-config
just talos apply-node 10.32.8.80   # cr-talos-01
just talos apply-node 10.32.8.81   # cr-talos-02
just talos apply-node 10.32.8.82   # cr-talos-03
```

Verify with `kubectl -n kube-system get pods -l component=kube-apiserver` (or `talosctl -n <ip> service kube-apiserver`) that apiserver is back up cleanly without the v1beta1 admissionregistration flag.

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: Flux prunes `MutatingAdmissionPolicy/MutatingAdmissionPolicyBinding` for `volsync-mover-jitter`, `volsync-mover-nfs`, `kopia-maintenance`
- [ ] `kubectl get mutatingadmissionpolicy,mutatingadmissionpolicybinding -A` returns nothing
- [ ] After `apply-node` to all 3 control planes: kube-apiserver running on each, no `admissionregistration.k8s.io/v1beta1=true` in flags
- [ ] Cluster otherwise healthy (Ceph HEALTH_OK, no Pending pods, etcd quorum intact)