### PR TITLE
feat(container): update image ghcr.io/siderolabs/kubelet ( v1.35.3 → v1.36.0 )

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.3
+    version: v1.36.0
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.3
+kubernetesVersion: v1.36.0
 
 clusterName: kubernetes
 endpoint: https://10.32.8.85:6443

--- a/talos/talenv.yaml
+++ b/talos/talenv.yaml
@@ -3,4 +3,4 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.3
+kubernetesVersion: v1.36.0


### PR DESCRIPTION
## Summary
**PR 3 of 4** in the Talos v1.13 + K8s v1.36 upgrade. Mirrors onedr0p/home-ops commit `4151911c`.

## Prerequisites (already done)
- ✅ PR 1 (#2292) — Talos v1.12.6 → v1.13.0, all 3 nodes on v1.13.0
- ✅ PR 2 (#2295) — MAP resources pruned, apiserver flags `MutatingAdmissionPolicy=true` + `runtime-config: ...v1beta1=true` removed via `talosctl edit machineconfig`
- ✅ Verified: all 3 apiservers running cleanly with the new flags

## Files
- `kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml` — tuppr `KubernetesUpgrade.spec.kubernetes.version`
- `talos/talconfig.yaml` — `kubernetesVersion`
- `talos/talenv.yaml` — `kubernetesVersion`

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: tuppr's `KubernetesUpgrade` CR picks up v1.36.0 and rolls all 3 nodes (kubelet + control-plane images bumped, no full reboot — k8s-style restart) with health gates (VolSync `Synchronizing=False`, Ceph `HEALTH_OK`)
- [ ] `kubectl get nodes` reports `v1.36.0` on cr-talos-01/02/03
- [ ] No failed pods, Ceph healthy
- [ ] Talos still v1.13.0
- [ ] **Next: PR 4 re-enables MAPs migrated to `admissionregistration.k8s.io/v1`**

## K8s v1.36 release notes
https://github.com/kubernetes/kubernetes/releases/tag/v1.36.0

Notable removals: `admissionregistration.k8s.io/v1beta1` (already addressed in PR 2). MAP feature gate promoted to GA (already removed from apiserver flags in PR 2).