### PR TITLE
chore: migrate volsync MutatingAdmissionPolicies to v1 and re-enable

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/kustomization.yaml
@@ -6,7 +6,5 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
-  # Disabled for K8s 1.36 upgrade — admissionregistration.k8s.io/v1beta1 removed.
-  # Re-enable in PR 4 once mutatingadmissionpolicy.yaml is migrated to v1.
-  # - ./mutatingadmissionpolicy.yaml
+  - ./mutatingadmissionpolicy.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -1,14 +1,14 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.32.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-jitter
 spec:
   policyName: volsync-mover-jitter
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.32.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-jitter
@@ -16,10 +16,15 @@ metadata:
 spec:
   matchConstraints:
     resourceRules:
-      - apiGroups: ["batch"]
-        apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
-        resources: ["jobs"]
+      - apiGroups:
+          - "batch"
+        apiVersions:
+          - "v1"
+        operations:
+          - "CREATE"
+          - "UPDATE"
+        resources:
+          - "jobs"
   matchConditions:
     - name: has-volsync-job-name-prefix
       expression: >
@@ -49,26 +54,31 @@ spec:
             }
           ]
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.32.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: volsync-mover-nfs
 spec:
   policyName: volsync-mover-nfs
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.32.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: volsync-mover-nfs
 spec:
   matchConstraints:
     resourceRules:
-      - apiGroups: ["batch"]
-        apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
-        resources: ["jobs"]
+      - apiGroups:
+          - "batch"
+        apiVersions:
+          - "v1"
+        operations:
+          - "CREATE"
+          - "UPDATE"
+        resources:
+          - "jobs"
   matchConditions:
     - name: has-volsync-job-name-prefix
       expression: >
@@ -84,7 +94,7 @@ spec:
   mutations:
     - patchType: JSONPatch
       jsonPatch:
-        expression: >
+        expression: >-
           [
             JSONPatch{
               op: "add", path: "/spec/template/spec/containers/0/volumeMounts/-",

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kustomization.yaml
@@ -5,6 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./kopiamaintenance.yaml
-  # Disabled for K8s 1.36 upgrade — admissionregistration.k8s.io/v1beta1 removed.
-  # Re-enable in PR 4 once mutatingadmissionpolicy.yaml is migrated to v1.
-  # - ./mutatingadmissionpolicy.yaml
+  - ./mutatingadmissionpolicy.yaml

--- a/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
@@ -1,14 +1,14 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicybinding_v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicybinding_v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: kopia-maintenance
 spec:
   policyName: kopia-maintenance
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicy_v1beta1.json
-apiVersion: admissionregistration.k8s.io/v1beta1
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/admissionregistration.k8s.io/mutatingadmissionpolicy_v1.json
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingAdmissionPolicy
 metadata:
   name: kopia-maintenance


### PR DESCRIPTION
## Summary
**PR 4 of 4** — final step. Mirrors onedr0p/home-ops commit `8c818b70`.

K8s v1.36 promoted `MutatingAdmissionPolicy` to GA (`admissionregistration.k8s.io/v1`). PR 2 disabled the v1beta1 MAPs to clear the way for the upgrade; this PR migrates them to v1 and re-enables.

## Changes
- `kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml`
  - `volsync-mover-jitter` (Binding + Policy): apiVersion `v1beta1` → `v1`
  - `volsync-mover-nfs` (Binding + Policy): apiVersion `v1beta1` → `v1`
  - Schema URLs bumped from `v1.32.0/...v1beta1.json` → `v1.36.0/...v1.json`
- `kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml`
  - `kopia-maintenance` (Binding + Policy): apiVersion `v1beta1` → `v1`
  - Schema URLs (kubernetes-schemas.pages.dev) bumped to `_v1.json`
- `kubernetes/apps/volsync-system/volsync/app/kustomization.yaml` — uncomment `./mutatingadmissionpolicy.yaml`
- `kubernetes/apps/volsync-system/volsync/maintenance/kustomization.yaml` — uncomment `./mutatingadmissionpolicy.yaml`

## Test plan
- [ ] flux-local CI passes
- [ ] After merge: Flux applies the MAPs successfully on K8s v1.36
- [ ] `kubectl get mutatingadmissionpolicy,mutatingadmissionpolicybinding -A` returns:
  - `volsync-mover-jitter` (Binding + Policy)
  - `volsync-mover-nfs` (Binding + Policy)
  - `kopia-maintenance` (Binding + Policy)
- [ ] All `apiVersion: admissionregistration.k8s.io/v1` (no v1beta1 anywhere)
- [ ] Next VolSync mover Job gets the `repository` NFS volume injected; next jitter run gets the busybox sleep init-container

## Upgrade complete
After this PR, the cluster is fully on **Talos v1.13.0 + Kubernetes v1.36.0** with house-style MAPs back in place. Mirrors onedr0p/home-ops 5-commit pattern from 2026-04-27.