### PR TITLE
feat(talos): verify Sidero image signatures via cosign keyless

### DIFF
--- a/talos/patches/global/machine-image-verification.yaml
+++ b/talos/patches/global/machine-image-verification.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1alpha1
+kind: ImageVerificationConfig
+rules:
+  - imagePatterns:
+      - "ghcr.io/siderolabs/*"
+    policy:
+      sigstore:
+        keyless:
+          identities:
+            - issuer: "https://token.actions.githubusercontent.com"
+              subjectRegExp: "^https://github\\.com/siderolabs/[^/]+/\\.github/workflows/[^/]+@refs/(tags/v[0-9].+|heads/release-[0-9].+)$"

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -172,6 +172,7 @@ patches:
   - "@./patches/global/machine-network.yaml"
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
+  - "@./patches/global/machine-image-verification.yaml"
 
 # Controller patches
 controlPlane:


### PR DESCRIPTION
## Summary
- Adds an `ImageVerificationConfig` Talos machine-config doc requiring sigstore/cosign keyless verification for `ghcr.io/siderolabs/*`
- Other registries are unaffected (Talos 1.13.0 default: no rule = no verification)
- Factory image (`factory.talos.dev/installer-secureboot/...`) remains protected by secure boot
- Identity regex matches Sidero release workflows on both tag refs (`refs/tags/v...`) and release branch refs (`refs/heads/release-...`) to avoid false-negatives

## Why scoped to Sidero only
Existing digest-pinning + Renovate already lock down the rest. Broader rules add maintenance and the failure mode (signing-infra outage halts node startup) isn't worth it for a home cluster.

## Deployment

This is a Talos config change — merging this PR does **not** auto-deploy. After merge:

1. \`just talos gen-config\`
2. \`just talos apply-node 10.32.8.80\` (first node only)
3. Watch \`talosctl -n 10.32.8.80 logs machined --follow | grep -i 'verif\\|sigstore\\|cosign\\|image'\`
4. Trigger a Sidero pull: \`talosctl -n 10.32.8.80 image pull ghcr.io/siderolabs/installer:v1.13.0\`
5. Confirm verification log line appears
6. Apply to remaining nodes: \`just talos apply-node 10.32.8.81\` then \`10.32.8.82\`

## Rollback
Revert the PR, regenerate, re-apply per node. No state to undo.

## Test plan
- [ ] talhelper gen-config succeeds
- [ ] cr-talos-01 stays Ready after apply
- [ ] Verification log line observed on Sidero pull
- [ ] cr-talos-02 / cr-talos-03 applied and Ready

## Spec
See \`docs/superpowers/specs/2026-04-28-talos-1.13-improvements-design.md\` and \`docs/superpowers/plans/2026-04-28-talos-1.13-improvements.md\` PR1.