### PR TITLE
feat(gpu-operator): install in validation phase

### DIFF
--- a/docs/superpowers/plans/2026-04-28-talos-1.13-improvements.md
+++ b/docs/superpowers/plans/2026-04-28-talos-1.13-improvements.md
@@ -1,0 +1,1114 @@
+# Talos 1.13 Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt three Talos 1.13.0 improvements: image signature verification for Sidero registries, migration from `nvidia-device-plugin` to `nvidia/gpu-operator`, and cleanup of NVIDIA env vars made redundant by CDI-default.
+
+**Architecture:** Four sequential PRs. PR1 is independent (Talos config). PR2 → PR3 is a hard ordering (operator stand-up, then atomic cutover). PR4 is post-cutover cleanup. Per-node manual application for PR1; Flux handles PR2-4. RuntimeClass `nvidia` stays under our ownership and is moved (not recreated) in PR3 to avoid kubelet pod-admission churn.
+
+**Tech Stack:** Talos Linux v1.13.0, Kubernetes v1.36.0, Flux CD, Cilium, NVIDIA gpu-operator (Helm chart from `helm.ngc.nvidia.com/nvidia`), DCGM exporter (now embedded in gpu-operator), 3× NVIDIA L4 GPUs.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-28-talos-1.13-improvements-design.md`
+
+**Testing model:** This repo has no unit tests; "test" steps are local-validation (`yamlfmt`, `flux-local build ks`, `talhelper validate`) plus post-merge cluster gates (`kubectl`, `talosctl`, functional smoke tests).
+
+---
+
+## PR1: ImageVerificationConfig for Sidero Images
+
+**Branch:** `feat/talos-image-verification`
+**Goal of PR:** Apply sigstore/cosign keyless verification for all `ghcr.io/siderolabs/*` pulls; no impact to other registries or workloads.
+
+### Task 1.1: Author the ImageVerificationConfig patch
+
+**Files:**
+- Create: `talos/patches/global/machine-image-verification.yaml`
+- Modify: `talos/talconfig.yaml` (append to `patches:` list at line 174)
+
+- [ ] **Step 1: Create the patch file**
+
+Create `talos/patches/global/machine-image-verification.yaml`:
+
+```yaml
+---
+apiVersion: v1alpha1
+kind: ImageVerificationConfig
+rules:
+  - imagePatterns:
+      - "ghcr.io/siderolabs/*"
+    policy:
+      sigstore:
+        keyless:
+          identities:
+            - issuer: "https://token.actions.githubusercontent.com"
+              subjectRegExp: "^https://github\\.com/siderolabs/.+/\\.github/workflows/.+@refs/tags/v.+$"
+```
+
+- [ ] **Step 2: Wire the patch into `talconfig.yaml`**
+
+Edit `talos/talconfig.yaml`. Append to the global `patches:` list (currently lines 168-174):
+
+```yaml
+# Global patches
+patches:
+  - "@./patches/global/machine-files.yaml"
+  - "@./patches/global/machine-kernel.yaml"
+  - "@./patches/global/machine-kubelet.yaml"
+  - "@./patches/global/machine-network.yaml"
+  - "@./patches/global/machine-sysctls.yaml"
+  - "@./patches/global/machine-time.yaml"
+  - "@./patches/global/machine-image-verification.yaml"
+```
+
+- [ ] **Step 3: Format YAML**
+
+Run from repo root:
+```bash
+yamlfmt talos/patches/global/machine-image-verification.yaml talos/talconfig.yaml
+```
+
+Expected: no errors. (Formatter may reflow whitespace.)
+
+- [ ] **Step 4: Validate Talos config schema**
+
+Run from repo root:
+```bash
+just talos gen-config
+```
+
+Expected: `clusterconfig/` regenerates without errors. Inspect generated config:
+```bash
+grep -A 12 'kind: ImageVerificationConfig' talos/clusterconfig/kubernetes-cr-talos-01.yaml
+```
+
+Expected: the ImageVerificationConfig block appears in the generated machine config.
+
+If `talhelper` rejects the schema (field name mismatch), check the actual schema:
+```bash
+just talos -l   # confirm task runner version
+talhelper --help
+talosctl gen config --help | grep -A2 verification
+```
+
+Adjust field names in the patch to match the v1alpha1 schema as printed by `talosctl docs ImageVerificationConfig` (or the talhelper schema URL embedded at the top of `talconfig.yaml`). Re-run gen-config.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -b feat/talos-image-verification
+git add talos/patches/global/machine-image-verification.yaml talos/talconfig.yaml
+git commit -m "feat(talos): verify Sidero image signatures via cosign keyless
+
+Adds an ImageVerificationConfig rule for ghcr.io/siderolabs/* requiring
+sigstore keyless verification with identities matching Sidero's GitHub
+Actions release workflows. Other registries are unaffected (no rule =
+no verification, per Talos 1.13.0 default behavior). Factory image
+remains protected by secure boot."
+```
+
+### Task 1.2: Apply to first node and validate
+
+- [ ] **Step 1: Apply config to `cr-talos-01`**
+
+Run:
+```bash
+just talos apply-node 10.32.8.80
+```
+
+Expected: `talhelper` apply succeeds; node remains Ready.
+
+- [ ] **Step 2: Watch machined logs for verification activity**
+
+In a separate terminal:
+```bash
+talosctl -n 10.32.8.80 logs machined --follow | grep -i 'verif\|sigstore\|cosign\|image'
+```
+
+- [ ] **Step 3: Trigger a Sidero-image pull to confirm verification fires**
+
+Force kubelet to re-pull. The simplest way is to bounce a pod that uses a `ghcr.io/siderolabs/*` image — but those are system images, not workload images, so the trigger is more naturally on the next image pull during a normal operation. To force it now:
+
+```bash
+talosctl -n 10.32.8.80 image pull ghcr.io/siderolabs/installer:v1.13.0
+```
+
+Expected in the machined log stream: a verification line referencing the image and the keyless identity match. If verification line is absent on a successful pull, that suggests the image was already cached — restart machined or trigger a fresh pull.
+
+- [ ] **Step 4: Confirm node is Ready**
+
+```bash
+kubectl get node cr-talos-01
+talosctl -n 10.32.8.80 service
+```
+
+Expected: Node `Ready`; all Talos services `Running`/`Finished`/`OK`.
+
+### Task 1.3: Apply to remaining nodes
+
+- [ ] **Step 1: Apply to `cr-talos-02`**
+
+```bash
+just talos apply-node 10.32.8.81
+kubectl wait --for=condition=Ready node/cr-talos-02 --timeout=5m
+```
+
+- [ ] **Step 2: Apply to `cr-talos-03`**
+
+```bash
+just talos apply-node 10.32.8.82
+kubectl wait --for=condition=Ready node/cr-talos-03 --timeout=5m
+```
+
+- [ ] **Step 3: Open PR and merge**
+
+```bash
+git push -u origin feat/talos-image-verification
+gh pr create --title "feat(talos): verify Sidero image signatures via cosign keyless" --body "$(cat <<'EOF'
+## Summary
+- Adds ImageVerificationConfig requiring sigstore keyless verification for ghcr.io/siderolabs/*
+- Other registries unaffected; factory image still protected by secure boot
+- Already applied to all 3 nodes manually; this PR persists the change in git
+
+## Test plan
+- [x] Apply to cr-talos-01 first; verify log line on Sidero pull
+- [x] Apply to cr-talos-02
+- [x] Apply to cr-talos-03
+- [x] All 3 nodes Ready; talosctl service all OK
+EOF
+)"
+```
+
+Merge after CI is green. No post-merge action — the cluster is already in the desired state.
+
+---
+
+## PR2: gpu-operator Install (Validation Phase)
+
+**Branch:** `feat/gpu-operator-install`
+**Goal of PR:** Stand up gpu-operator with `driver`, `toolkit`, `devicePlugin`, and `dcgmExporter` disabled. Confirms GFD labels appear and CDI specs land without disturbing the running standalone device-plugin or dcgm-exporter.
+
+### Task 2.1: Create directory structure and Flux Kustomization
+
+**Files:**
+- Create: `kubernetes/apps/kube-system/gpu-operator/ks.yaml`
+- Create: `kubernetes/apps/kube-system/gpu-operator/app/kustomization.yaml`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout main && git pull
+git checkout -b feat/gpu-operator-install
+mkdir -p kubernetes/apps/kube-system/gpu-operator/app
+```
+
+- [ ] **Step 2: Create `ks.yaml`**
+
+Create `kubernetes/apps/kube-system/gpu-operator/ks.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gpu-operator
+  namespace: &namespace kube-system
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cilium
+      namespace: kube-system
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/kube-system/gpu-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m
+```
+
+> **Note:** The exact `external-secrets-stores` Kustomization name may differ — check `kubectl get kustomization -A | grep external-secrets`. If it's just `external-secrets`, drop the `-stores` suffix. We don't actually need it for PR2 (no ExternalSecrets), but matching the existing `nvidia-device-plugin` pattern keeps it consistent. If unsure, omit the external-secrets `dependsOn` entry.
+
+- [ ] **Step 3: Create app `kustomization.yaml`**
+
+Create `kubernetes/apps/kube-system/gpu-operator/app/kustomization.yaml`:
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./time-slicing-config.yaml
+```
+
+> RuntimeClass and Grafana dashboard are added in PR3.
+
+### Task 2.2: Create HelmRepository for nvidia chart
+
+**Files:**
+- Create: `kubernetes/apps/kube-system/gpu-operator/app/helmrepository.yaml`
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvidia
+spec:
+  interval: 1h
+  url: https://helm.ngc.nvidia.com/nvidia
+```
+
+### Task 2.3: Create the time-slicing ConfigMap
+
+**Files:**
+- Create: `kubernetes/apps/kube-system/gpu-operator/app/time-slicing-config.yaml`
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: time-slicing-config
+  namespace: kube-system
+data:
+  any: |
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 5
+```
+
+### Task 2.4: Create the HelmRelease (validation-phase values)
+
+**Files:**
+- Create: `kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml`
+
+- [ ] **Step 1: Create the file**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gpu-operator
+spec:
+  interval: 1h
+  chart:
+    spec:
+      # renovate: registryUrl=https://helm.ngc.nvidia.com/nvidia
+      chart: gpu-operator
+      version: v25.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: nvidia
+      interval: 1h
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    # Talos extensions provide the driver and container-toolkit
+    driver:
+      enabled: false
+    toolkit:
+      enabled: false
+    # Talos 1.13 enables CDI by default; make CDI the runtime default for nvidia.com/gpu
+    cdi:
+      enabled: true
+      default: true
+    # Validation phase — these flip to true in PR3
+    devicePlugin:
+      enabled: false
+    dcgmExporter:
+      enabled: false
+    # GPU Feature Discovery — gives us nvidia.com/gpu.* node labels
+    gfd:
+      enabled: true
+    # L4 has no MIG support
+    mig:
+      strategy: none
+    # Components we don't need
+    nodeStatusExporter:
+      enabled: false
+    sandboxWorkloads:
+      enabled: false
+    gds:
+      enabled: false
+    kataManager:
+      enabled: false
+    vgpuManager:
+      enabled: false
+    vgpuDeviceManager:
+      enabled: false
+    # We own the RuntimeClass — moved into this app dir in PR3
+    runtimeClass:
+      install: false
+      name: nvidia
+    # Operator behavior
+    operator:
+      defaultRuntime: containerd
+      runtimeClass: nvidia
+    # Validator tweaks for Talos
+    validator:
+      driver:
+        env:
+          - name: DISABLE_DEV_CHAR_SYMLINK_CREATION
+            value: "true"
+    # Until PR3 flips the device-plugin on, restrict daemonsets to nodes with the Talos extensions.
+    # Removed in PR3 — GFD's nvidia.com/gpu.present=true takes over.
+    daemonsets:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: extensions.talos.dev/nvidia-open-gpu-kernel-modules-production
+                  operator: Exists
+                - key: extensions.talos.dev/nvidia-container-toolkit-production
+                  operator: Exists
+```
+
+> **Chart version note:** `v25.3.0` is the placeholder — verify the latest stable at `https://helm.ngc.nvidia.com/nvidia` before committing. Renovate will keep it updated after merge. The exact key names (`gfd`, `nodeStatusExporter`, `runtimeClass.install`, `validator.driver.env`, `daemonsets.nodeAffinity`) need to be verified against `values.yaml` for the chosen chart version. Run `helm show values nvidia/gpu-operator --version v25.3.0 | grep -E '^(driver|toolkit|cdi|devicePlugin|dcgmExporter|gfd|mig|runtimeClass|operator|validator|daemonsets):' -A 3` if needed.
+
+### Task 2.5: Wire into kube-system parent kustomization
+
+**Files:**
+- Modify: `kubernetes/apps/kube-system/kustomization.yaml`
+
+- [ ] **Step 1: Add gpu-operator to resources list**
+
+Edit `kubernetes/apps/kube-system/kustomization.yaml`. Insert `./gpu-operator/ks.yaml` in alphabetical position (between `generic-device-plugin` and `keda`):
+
+```yaml
+resources:
+  - ./namespace.yaml
+  - ./cilium/ks.yaml
+  - ./cilium-policies/ks.yaml
+  - ./coredns/ks.yaml
+  - ./descheduler/ks.yaml
+  - ./etcd-defrag/ks.yaml
+  - ./fstrim/ks.yaml
+  - ./generic-device-plugin/ks.yaml
+  - ./gpu-operator/ks.yaml
+  - ./keda/ks.yaml
+  - ./metrics-server/ks.yaml
+  - ./multus/ks.yaml
+  - ./nvidia-device-plugin/ks.yaml
+  - ./reflector/ks.yaml
+  - ./reloader/ks.yaml
+  - ./snapshot-controller/ks.yaml
+  - ./spegel/ks.yaml
+```
+
+### Task 2.6: Local validation
+
+- [ ] **Step 1: Format YAML**
+
+```bash
+yamlfmt kubernetes/apps/kube-system/gpu-operator/
+```
+
+- [ ] **Step 2: Validate the new Flux Kustomization builds**
+
+```bash
+flux-local build ks --path kubernetes/flux/cluster gpu-operator
+```
+
+Expected: a rendered manifest including the HelmRelease, HelmRepository, and ConfigMap. No build errors.
+
+- [ ] **Step 3: Validate parent kustomize builds**
+
+```bash
+kubectl kustomize kubernetes/apps/kube-system/ | head -50
+```
+
+Expected: builds clean; no duplicate resources.
+
+### Task 2.7: Commit, open PR, merge, and verify gates
+
+- [ ] **Step 1: Commit and push**
+
+```bash
+git add kubernetes/apps/kube-system/gpu-operator kubernetes/apps/kube-system/kustomization.yaml
+git commit -m "feat(gpu-operator): install in validation phase
+
+Stands up nvidia/gpu-operator with driver, toolkit, devicePlugin,
+and dcgmExporter disabled. GFD and validator components run; CDI
+is enabled and made default. Existing standalone nvidia-device-plugin
+and dcgm-exporter remain in charge of device exposure and metrics
+until cutover (next PR)."
+git push -u origin feat/gpu-operator-install
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(gpu-operator): install in validation phase" --body "$(cat <<'EOF'
+## Summary
+- Installs nvidia/gpu-operator with driver, toolkit, devicePlugin, and dcgmExporter disabled
+- Enables GPU Feature Discovery and CDI (default) — picks up Talos 1.13 CDI-by-default
+- No impact to existing GPU workloads; standalone nvidia-device-plugin and dcgm-exporter remain in charge until cutover (PR3)
+
+## Test plan
+- [ ] After merge: gpu-operator pods Running on all 3 nodes
+- [ ] Node labels show nvidia.com/gpu.present=true and nvidia.com/gpu.product=NVIDIA-L4
+- [ ] CDI spec generated at /run/cdi/ on each node
+- [ ] All 4 existing GPU workloads (ollama, plex, jellyfin, tdarr) still healthy
+EOF
+)"
+```
+
+- [ ] **Step 3: Merge after CI green**
+
+- [ ] **Step 4: Watch reconciliation**
+
+```bash
+flux get ks -n kube-system gpu-operator -w
+```
+
+Expected: `Ready: True` within ~5 min.
+
+- [ ] **Step 5: Gate 1 — operator pods Running**
+
+```bash
+kubectl -n kube-system get pods -l app.kubernetes.io/name=gpu-operator -o wide
+```
+
+Expected: gpu-operator deployment, gpu-feature-discovery DaemonSet, nvidia-operator-validator DaemonSet — all `Running` on all 3 nodes.
+
+- [ ] **Step 6: Gate 2 — node labels appear**
+
+```bash
+kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: (.metadata.labels | with_entries(select(.key | startswith("nvidia.com/gpu"))))}'
+```
+
+Expected output shape (per node):
+```json
+{
+  "name": "cr-talos-01",
+  "gpu": {
+    "nvidia.com/gpu.present": "true",
+    "nvidia.com/gpu.product": "NVIDIA-L4",
+    "nvidia.com/gpu.count": "1",
+    "nvidia.com/gpu.memory": "23034",
+    ...
+  }
+}
+```
+
+- [ ] **Step 7: Gate 3 — CDI spec generated**
+
+```bash
+talosctl -n 10.32.8.80,10.32.8.81,10.32.8.82 ls /run/cdi/
+```
+
+Expected: a `nvidia.yaml` (or similar) file on each node.
+
+- [ ] **Step 8: Gate 4 — existing GPU workloads still healthy**
+
+```bash
+kubectl get pods -A -l gpu-workload=true -o wide
+```
+
+Expected: all pods `Running`. None went `Pending` or restarted during PR2 reconciliation.
+
+> **STOP if any gate fails.** Do not open PR3. Diagnose with `kubectl describe pod -n kube-system <pod>` and `kubectl logs -n kube-system <pod>`. Common failures: chart key name mismatch (consult `helm show values`), missing dependsOn (cilium not Ready), Talos extension labels missing on a node.
+
+---
+
+## PR3: Cut Over to gpu-operator (Atomic)
+
+**Branch:** `feat/gpu-operator-cutover`
+**Goal of PR:** Single atomic PR. Operator's device-plugin and dcgm-exporter take over; standalone Helm releases removed; workload selectors flipped; RuntimeClass moved.
+
+> **PRE-REQUIREMENT:** All four PR2 verification gates passed. Pick a low-traffic window (no active Plex streams, no Tdarr jobs, no Ollama generations).
+
+### Task 3.1: Update HelmRelease to enable devicePlugin and dcgmExporter
+
+**Files:**
+- Modify: `kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout main && git pull
+git checkout -b feat/gpu-operator-cutover
+```
+
+- [ ] **Step 2: Edit `helmrelease.yaml`**
+
+Replace the `devicePlugin` block:
+```yaml
+    devicePlugin:
+      enabled: false
+```
+with:
+```yaml
+    devicePlugin:
+      enabled: true
+      config:
+        name: time-slicing-config
+        default: any
+```
+
+Replace the `dcgmExporter` block:
+```yaml
+    dcgmExporter:
+      enabled: false
+```
+with:
+```yaml
+    dcgmExporter:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+```
+
+Remove the entire `daemonsets:` block (lines `daemonsets:` through the end of `nodeSelectorTerms`). GFD's `nvidia.com/gpu.present=true` now scopes daemonsets via the operator's built-in selector logic.
+
+### Task 3.2: Move RuntimeClass into gpu-operator app
+
+**Files:**
+- Create: `kubernetes/apps/kube-system/gpu-operator/app/runtimeclass.yaml` (copy of existing)
+- Modify: `kubernetes/apps/kube-system/gpu-operator/app/kustomization.yaml`
+- Delete: `kubernetes/apps/kube-system/nvidia-device-plugin/app/app/runtimeclass.yaml`
+
+- [ ] **Step 1: Move the file (preserves identical content)**
+
+```bash
+git mv kubernetes/apps/kube-system/nvidia-device-plugin/app/app/runtimeclass.yaml \
+       kubernetes/apps/kube-system/gpu-operator/app/runtimeclass.yaml
+```
+
+Confirm the file content is unchanged:
+```yaml
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+```
+
+- [ ] **Step 2: Add to gpu-operator app kustomization**
+
+Edit `kubernetes/apps/kube-system/gpu-operator/app/kustomization.yaml`:
+
+```yaml
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kube-system
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./runtimeclass.yaml
+  - ./time-slicing-config.yaml
+  - ./grafanadashboard.yaml
+  - ./prometheusrule.yaml
+```
+
+> Why this matters: `git mv` preserves the resource UID under flux/kustomize tracking. Kubelet sees a continuous `RuntimeClass nvidia` and never enters a window where pods using `runtimeClassName: nvidia` get rejected at admission.
+
+### Task 3.3: Move Grafana dashboard and PrometheusRule into gpu-operator app
+
+**Files:**
+- Move: `kubernetes/apps/observability/dcgm-exporter/app/grafanadashboard.yaml` → `kubernetes/apps/kube-system/gpu-operator/app/grafanadashboard.yaml`
+- Move: `kubernetes/apps/observability/dcgm-exporter/app/prometheusrule.yaml` → `kubernetes/apps/kube-system/gpu-operator/app/prometheusrule.yaml`
+
+- [ ] **Step 1: Move both files**
+
+```bash
+git mv kubernetes/apps/observability/dcgm-exporter/app/grafanadashboard.yaml \
+       kubernetes/apps/kube-system/gpu-operator/app/grafanadashboard.yaml
+git mv kubernetes/apps/observability/dcgm-exporter/app/prometheusrule.yaml \
+       kubernetes/apps/kube-system/gpu-operator/app/prometheusrule.yaml
+```
+
+> The `GrafanaDashboard` has `allowCrossNamespaceImport: true` and an `instanceSelector` matching `grafana.internal/instance: grafana` — works regardless of source namespace. The `PrometheusRule` references DCGM metric names which are stable across exporters.
+
+### Task 3.4: Delete the old nvidia-device-plugin app
+
+**Files:**
+- Delete: `kubernetes/apps/kube-system/nvidia-device-plugin/` (entire directory)
+- Modify: `kubernetes/apps/kube-system/kustomization.yaml`
+
+- [ ] **Step 1: Remove the directory**
+
+```bash
+git rm -r kubernetes/apps/kube-system/nvidia-device-plugin/
+```
+
+- [ ] **Step 2: Remove from parent kustomization**
+
+Edit `kubernetes/apps/kube-system/kustomization.yaml`. Remove the `./nvidia-device-plugin/ks.yaml` line:
+
+```yaml
+resources:
+  - ./namespace.yaml
+  - ./cilium/ks.yaml
+  - ./cilium-policies/ks.yaml
+  - ./coredns/ks.yaml
+  - ./descheduler/ks.yaml
+  - ./etcd-defrag/ks.yaml
+  - ./fstrim/ks.yaml
+  - ./generic-device-plugin/ks.yaml
+  - ./gpu-operator/ks.yaml
+  - ./keda/ks.yaml
+  - ./metrics-server/ks.yaml
+  - ./multus/ks.yaml
+  - ./reflector/ks.yaml
+  - ./reloader/ks.yaml
+  - ./snapshot-controller/ks.yaml
+  - ./spegel/ks.yaml
+```
+
+### Task 3.5: Delete the old dcgm-exporter app
+
+**Files:**
+- Delete: `kubernetes/apps/observability/dcgm-exporter/` (entire directory)
+- Modify: `kubernetes/apps/observability/kustomization.yaml`
+
+- [ ] **Step 1: Remove the directory**
+
+```bash
+git rm -r kubernetes/apps/observability/dcgm-exporter/
+```
+
+- [ ] **Step 2: Remove from parent kustomization**
+
+Edit `kubernetes/apps/observability/kustomization.yaml`. Remove the `./dcgm-exporter/ks.yaml` line.
+
+### Task 3.6: Swap workload affinity selectors (4 files)
+
+**Files:**
+- Modify: `kubernetes/apps/ai/ollama/app/helmrelease.yaml`
+- Modify: `kubernetes/apps/media/plex/app/helmrelease.yaml`
+- Modify: `kubernetes/apps/media/jellyfin/app/helmrelease.yaml`
+- Modify: `kubernetes/apps/media/tdarr/app/helmrelease.yaml`
+
+In each file, find the `nodeAffinity` block:
+
+```yaml
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: extensions.talos.dev/nvidia-open-gpu-kernel-modules-production
+                    operator: Exists
+                  - key: extensions.talos.dev/nvidia-container-toolkit-production
+                    operator: Exists
+```
+
+Replace with:
+
+```yaml
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values: ["true"]
+```
+
+- [ ] **Step 1: Edit ollama**
+
+In `kubernetes/apps/ai/ollama/app/helmrelease.yaml` (approx lines 44-51): replace the `matchExpressions` block as shown above.
+
+- [ ] **Step 2: Edit plex**
+
+In `kubernetes/apps/media/plex/app/helmrelease.yaml` (approx lines 96-103): same replacement.
+
+- [ ] **Step 3: Edit jellyfin**
+
+In `kubernetes/apps/media/jellyfin/app/helmrelease.yaml` (approx lines 61-68): same replacement.
+
+- [ ] **Step 4: Edit tdarr**
+
+In `kubernetes/apps/media/tdarr/app/helmrelease.yaml` (approx lines 72-79): same replacement.
+
+### Task 3.7: Swap dependsOn in workload Kustomizations (4 files)
+
+**Files:**
+- Modify: `kubernetes/apps/ai/ollama/ks.yaml`
+- Modify: `kubernetes/apps/media/plex/ks.yaml`
+- Modify: `kubernetes/apps/media/jellyfin/ks.yaml`
+- Modify: `kubernetes/apps/media/tdarr/ks.yaml`
+
+In each ks.yaml, find:
+
+```yaml
+  dependsOn:
+    - name: nvidia-device-plugin
+      namespace: kube-system
+```
+
+Replace with:
+
+```yaml
+  dependsOn:
+    - name: gpu-operator
+      namespace: kube-system
+```
+
+(Other entries in `dependsOn` like `volsync`, `rook-ceph-cluster` stay unchanged.)
+
+- [ ] **Step 1: Edit all four ks.yaml files** as above.
+
+### Task 3.8: Local validation
+
+- [ ] **Step 1: Format YAML**
+
+```bash
+yamlfmt kubernetes/apps/kube-system/gpu-operator/ kubernetes/apps/{ai/ollama,media/plex,media/jellyfin,media/tdarr}/{ks.yaml,app/helmrelease.yaml} kubernetes/apps/kube-system/kustomization.yaml kubernetes/apps/observability/kustomization.yaml
+```
+
+- [ ] **Step 2: Validate gpu-operator builds**
+
+```bash
+flux-local build ks --path kubernetes/flux/cluster gpu-operator
+```
+
+Expected: rendered manifest now includes `RuntimeClass`, `GrafanaDashboard`, `PrometheusRule`.
+
+- [ ] **Step 3: Validate workload Kustomizations build**
+
+```bash
+for app in ollama plex jellyfin tdarr; do
+  echo "=== $app ==="
+  flux-local build ks --path kubernetes/flux/cluster $app || break
+done
+```
+
+Expected: all four build cleanly.
+
+- [ ] **Step 4: Verify dependency order**
+
+```bash
+grep -r 'name: nvidia-device-plugin' kubernetes/
+```
+
+Expected: **no matches**. (If anything references the deleted Kustomization, fix it before merge — it'll break the dependency graph after delete.)
+
+```bash
+grep -r 'name: dcgm-exporter' kubernetes/
+```
+
+Expected: only references inside `gpu-operator/app/` (the moved files). Anything else needs investigation.
+
+### Task 3.9: Commit and open PR
+
+- [ ] **Step 1: Commit**
+
+```bash
+git add -A
+git commit -m "feat(gpu-operator): cut over from nvidia-device-plugin and standalone dcgm-exporter
+
+Atomic migration:
+- gpu-operator now manages device-plugin and dcgm-exporter
+- Time-slicing preserved at 5 replicas via ConfigMap reference
+- RuntimeClass nvidia moved (not recreated) to avoid pod-admission churn
+- Grafana dashboard and PrometheusRule moved alongside the operator
+- Workload selectors switched to nvidia.com/gpu.present=true (GFD-managed)
+- Workload dependsOn switched from nvidia-device-plugin to gpu-operator
+- Standalone nvidia-device-plugin and dcgm-exporter directories removed
+
+Brief reconciliation window expected (~30-90s/node) during which GPU
+pods may go Pending while the operator's device-plugin DaemonSet
+takes over from the standalone one. Plan deployment for a low-traffic
+window (no active transcodes / inference)."
+git push -u origin feat/gpu-operator-cutover
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(gpu-operator): cut over from device-plugin and standalone dcgm" --body "$(cat <<'EOF'
+## Summary
+- Atomic cutover from standalone nvidia-device-plugin to gpu-operator's device-plugin
+- Atomic cutover from standalone dcgm-exporter to gpu-operator's dcgm-exporter (with ServiceMonitor)
+- 4 GPU workloads (ollama, plex, jellyfin, tdarr) re-pointed at GFD-managed labels
+- Standalone Helm releases removed; Grafana dashboard and PrometheusRule preserved alongside operator
+
+## Test plan
+- [ ] kubectl -n kube-system get ds | grep nvidia → operator's DaemonSets running, standalone gone
+- [ ] kubectl get nodes -o json | jq '.items[].status.allocatable["nvidia.com/gpu"]' → "5" on each
+- [ ] kubectl get pods -A -l gpu-workload=true → all 4 workloads Running
+- [ ] Plex transcodes a 4K stream
+- [ ] Ollama answers a chat request
+- [ ] Tdarr picks up a job
+- [ ] Jellyfin transcodes
+- [ ] Grafana dashboard "NVIDIA DCGM Exporter" shows live data
+
+## Rollback
+Revert the PR. Flux re-installs nvidia-device-plugin + standalone dcgm-exporter; workload selectors revert. ~3-5 min full reconcile + 30-90s/node device-plugin reflip.
+EOF
+)"
+```
+
+### Task 3.10: Merge during low-traffic window and verify
+
+> **MERGE-WINDOW PREP:** Have two terminals open with these commands queued:
+> ```bash
+> # Terminal 1
+> watch -n 2 'kubectl -n kube-system get ds,pods -l app.kubernetes.io/name=gpu-operator'
+> # Terminal 2
+> kubectl get pods -A -l gpu-workload=true -w
+> ```
+
+- [ ] **Step 1: Merge the PR**
+
+- [ ] **Step 2: Watch reconciliation**
+
+```bash
+flux get ks -A -w | grep -E 'gpu-operator|ollama|plex|jellyfin|tdarr|nvidia-device-plugin|dcgm-exporter'
+```
+
+Expected sequence (within ~5 min):
+- `nvidia-device-plugin` Kustomization deleted (Flux removes it)
+- `dcgm-exporter` (observability) Kustomization deleted
+- `gpu-operator` Kustomization reconciles with new values (devicePlugin + dcgmExporter on)
+- 4 workload Kustomizations reconcile with new selector + dependsOn
+
+- [ ] **Step 3: Gate 1 — DaemonSets**
+
+```bash
+kubectl -n kube-system get ds | grep -i nvidia
+```
+
+Expected:
+- `nvidia-device-plugin-daemonset` (operator-owned), `READY 3/3`
+- `nvidia-dcgm-exporter` (operator-owned), `READY 3/3`
+- No standalone `nvidia-device-plugin` from `home-operations/charts-mirror`.
+
+- [ ] **Step 4: Gate 2 — Allocatable nvidia.com/gpu**
+
+```bash
+kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable["nvidia.com/gpu"]}'
+```
+
+Expected: `"5"` on each of the 3 control-plane nodes (matches time-slicing config).
+
+- [ ] **Step 5: Gate 3 — workload pods**
+
+```bash
+kubectl get pods -A -l gpu-workload=true -o wide
+```
+
+Expected: all 4 workloads `Running` and `Ready`.
+
+- [ ] **Step 6: Gate 4 — functional smoke tests**
+
+Run from a browser / API client:
+1. Plex: play a 4K HEVC video, force transcoding (set quality to 1080p 8 Mbps), confirm `(hw)` appears in the transcode dashboard.
+2. Ollama: `curl http://ollama.${SECRET_INTERNAL_DOMAIN}/api/generate -d '{"model":"<existing-model>","prompt":"hi","stream":false}'` — expect a response.
+3. Jellyfin: play a video that requires transcoding; confirm playback.
+4. Tdarr: confirm node connects in Tdarr UI; pick up a small job and confirm it processes.
+
+- [ ] **Step 7: Gate 5 — metrics still flowing**
+
+```bash
+kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 9090:9090 &
+sleep 3
+curl -s 'http://localhost:9090/api/v1/query?query=DCGM_FI_DEV_GPU_TEMP' | jq '.data.result | length'
+kill %1
+```
+
+Expected: `> 0` (3 GPUs × multiple time series).
+
+Open the Grafana dashboard `NVIDIA DCGM Exporter` — confirm panels populated with live data.
+
+> **ROLLBACK:** if any gate fails, `gh pr revert <PR-number>` and merge the revert. Recovery time ~5 min Flux reconcile + 30-90s/node device-plugin reflip back to standalone.
+
+---
+
+## PR4: Drop Redundant NVIDIA Env Vars
+
+**Branch:** `chore/gpu-cleanup-env-vars`
+**Goal of PR:** Remove `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` from workloads. With CDI default, these are silently ignored — they're now misleading config.
+
+### Task 4.1: Plex
+
+**Files:**
+- Modify: `kubernetes/apps/media/plex/app/helmrelease.yaml`
+
+- [ ] **Step 1: Create branch**
+
+```bash
+git checkout main && git pull
+git checkout -b chore/gpu-cleanup-env-vars
+```
+
+- [ ] **Step 2: Remove env lines (currently lines 57-58)**
+
+In `kubernetes/apps/media/plex/app/helmrelease.yaml`, remove these two lines from the `env:` block:
+
+```yaml
+              NVIDIA_VISIBLE_DEVICES: "all"
+              NVIDIA_DRIVER_CAPABILITIES: "all"
+```
+
+**Keep** these lines (Plex-specific, unrelated):
+```yaml
+              LD_LIBRARY_PATH: "/usr/local/glibc/usr/lib"
+              HARDWARE_DEVICE_PATH: "/dev/nvidia0"
+```
+
+### Task 4.2: Jellyfin
+
+**Files:**
+- Modify: `kubernetes/apps/media/jellyfin/app/helmrelease.yaml`
+
+- [ ] **Step 1: Remove env lines (currently lines 24-25)**
+
+In `kubernetes/apps/media/jellyfin/app/helmrelease.yaml`, remove:
+
+```yaml
+              NVIDIA_VISIBLE_DEVICES: "all"
+              NVIDIA_DRIVER_CAPABILITIES: "all"
+```
+
+### Task 4.3: Tdarr (both containers)
+
+**Files:**
+- Modify: `kubernetes/apps/media/tdarr/app/helmrelease.yaml`
+
+- [ ] **Step 1: Remove env lines from `app` container (currently lines 24-25)**
+
+```yaml
+              NVIDIA_VISIBLE_DEVICES: "all"
+              NVIDIA_DRIVER_CAPABILITIES: "all"
+```
+
+- [ ] **Step 2: Remove env lines from `node` container (currently lines 57-58)**
+
+Same two lines to remove from the second container's `env:` block.
+
+### Task 4.4: Validate, commit, PR, merge, smoke-test
+
+- [ ] **Step 1: Format YAML**
+
+```bash
+yamlfmt kubernetes/apps/media/{plex,jellyfin,tdarr}/app/helmrelease.yaml
+```
+
+- [ ] **Step 2: Validate kustomizations build**
+
+```bash
+for app in plex jellyfin tdarr; do
+  echo "=== $app ==="
+  flux-local build ks --path kubernetes/flux/cluster $app || break
+done
+```
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add kubernetes/apps/media/{plex,jellyfin,tdarr}/app/helmrelease.yaml
+git commit -m "chore(gpu): drop redundant NVIDIA_VISIBLE_DEVICES and NVIDIA_DRIVER_CAPABILITIES envs
+
+With cdi.default=true (set in gpu-operator since the migration), container
+device exposure is declared via the OCI runtime spec. These legacy env
+vars are silently ignored and only serve to mislead readers."
+git push -u origin chore/gpu-cleanup-env-vars
+```
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create --title "chore(gpu): drop redundant NVIDIA env vars" --body "$(cat <<'EOF'
+## Summary
+- Removes NVIDIA_VISIBLE_DEVICES and NVIDIA_DRIVER_CAPABILITIES from plex, jellyfin, and tdarr (both containers)
+- Ollama already doesn't set them
+- Plex's LD_LIBRARY_PATH and HARDWARE_DEVICE_PATH stay (unrelated, app-specific)
+- No functional change: CDI default makes these env vars no-ops
+
+## Test plan
+- [ ] After merge, kick each pod: kubectl rollout restart -n media deploy/plex deploy/jellyfin; kubectl rollout restart -n media deploy/tdarr
+- [ ] Plex hardware-transcodes a stream
+- [ ] Jellyfin hardware-transcodes a stream
+- [ ] Tdarr processes a job
+EOF
+)"
+```
+
+- [ ] **Step 5: Merge**
+
+- [ ] **Step 6: Restart pods to pick up the env change**
+
+```bash
+kubectl rollout restart -n media deploy/plex deploy/jellyfin deploy/tdarr
+kubectl rollout status -n media deploy/plex --timeout=5m
+kubectl rollout status -n media deploy/jellyfin --timeout=5m
+kubectl rollout status -n media deploy/tdarr --timeout=5m
+```
+
+- [ ] **Step 7: Smoke test**
+
+Same as PR3 functional smoke tests for plex / jellyfin / tdarr. Confirm hardware transcoding still active.
+
+---
+
+## Self-review
+
+### Spec coverage check
+
+| Spec section | Covered by |
+| --- | --- |
+| ImageVerificationConfig (Sidero scope) | Tasks 1.1–1.3 |
+| `talconfig.yaml` patches list update | Task 1.1 step 2 |
+| Per-node rollout (first-node validation) | Tasks 1.2–1.3 |
+| gpu-operator validation-phase install | Tasks 2.1–2.7 |
+| Time-slicing ConfigMap | Task 2.3 |
+| All 4 PR2 verification gates | Task 2.7 steps 5–8 |
+| `runtimeClass.install: false` (we own it) | Task 2.4 helmrelease values |
+| RuntimeClass `git mv` (no recreate) | Task 3.2 |
+| Grafana dashboard + PrometheusRule move | Task 3.3 |
+| Workload selector flip (4 files) | Task 3.6 |
+| Workload `dependsOn` flip (4 files) | Task 3.7 |
+| Delete `nvidia-device-plugin/` | Task 3.4 |
+| Delete `dcgm-exporter/` (observability) | Task 3.5 |
+| Parent kustomization updates | Tasks 3.4 step 2, 3.5 step 2 |
+| All 5 PR3 verification gates | Task 3.10 steps 3–7 |
+| Env-var cleanup in 3 workloads (4 containers total) | Tasks 4.1–4.3 |
+| Per-PR rollback notes | Each task block's commit/PR section |
+
+### Risk-mitigation cross-check
+
+- **PR2 → PR3 ordering enforced** by validation gates in Task 2.7 (must pass before opening PR3).
+- **Atomicity of PR3** preserved: a single PR contains all 8 file-level changes (Tasks 3.1–3.7).
+- **RuntimeClass continuity** via `git mv` in Task 3.2 — no admission-time gap.
+- **Cutover window guidance** in Task 3.10 prelude.
+
+### Open implementation-time verifications (called out in the plan, not blocking)
+
+- Exact `ImageVerificationConfig` field names against the talhelper schema (Task 1.1 step 4).
+- Exact gpu-operator chart key names against `helm show values` for the chosen version (Task 2.4 note).
+- Exact name of the `external-secrets` Kustomization in `dependsOn` (Task 2.1 step 2 note).
+- Whether DCGM `ServiceMonitor` labels under the operator differ from the standalone (PrometheusRule references metric *names*, which are stable; if labels diverge, Task 3.10 Gate 5 surfaces it).

--- a/docs/superpowers/specs/2026-04-28-talos-1.13-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-28-talos-1.13-improvements-design.md
@@ -1,0 +1,313 @@
+# Talos 1.13 Cluster Improvements — Design
+
+**Date:** 2026-04-28
+**Cluster:** `talos-cluster` (3× control-plane, Talos v1.13.0, Kubernetes v1.36.0)
+**Hardware:** 3× NVIDIA L4 24GB (one per node)
+
+## Context
+
+Talos was upgraded from 1.12.x to 1.13.0 yesterday (commit `15171448`). This design captures three opt-in improvements made possible by 1.13.0:
+
+1. Sigstore/cosign verification of pulled Sidero system images (`ImageVerificationConfig`).
+2. Migration of the GPU stack from the standalone `nvidia-device-plugin` Helm chart to the now-officially-supported `nvidia/gpu-operator` path on top of Talos's new CDI-by-default behavior.
+3. Cleanup of NVIDIA env vars rendered obsolete by CDI.
+
+Existing GPU stack (pre-design):
+
+- Talos NVIDIA system extensions: `nvidia-open-gpu-kernel-modules-production` + `nvidia-container-toolkit-production`.
+- Standalone `nvidia-device-plugin` Helm chart with time-slicing at 5 replicas per GPU.
+- Standalone `dcgm-exporter` Helm chart for metrics, with a Grafana dashboard.
+- A manually-managed `RuntimeClass` named `nvidia` (handler `nvidia`).
+- Four GPU workloads: `ai/ollama`, `media/plex`, `media/jellyfin`, `media/tdarr`. All select nodes by Talos extension labels and request `nvidia.com/gpu: 1`.
+
+Workload mix is **combo**: AI inference (Ollama, Whisper) and media transcoding (Plex/Jellyfin/Tdarr) sharing the same GPUs. Time-slicing is the right multiplexing strategy on L4 (no MIG support on Ada-gen consumer/pro cards below A30).
+
+## Goals
+
+- Stand up signature verification on Sidero-published runtime images without disrupting third-party app pulls.
+- Move to the gpu-operator path because that is the Talos-recommended pattern post-1.13 and yields richer node labels (`nvidia.com/gpu.*`) plus a single source of truth for GPU state.
+- Keep equivalent behavior end-to-end: 5-replica time-slicing, DCGM metrics scraped by kube-prometheus-stack, the same Grafana dashboard, all four workloads scheduling on any of the three nodes.
+- Preserve fast revertibility: each meaningful change is its own PR.
+
+## Non-Goals (explicitly excluded)
+
+These were considered and rejected during brainstorming. They are out of scope:
+
+- KubeSpan, VRF, `RoutingRuleConfig`, External Volumes, Flannel, `EnvironmentConfig` (no `.machine.env` is in use), `ProbeConfig` (Gatus covers connectivity assertions), Negative max volume size (Rook-Ceph backed, not local volumes).
+- `ImageVerificationConfig` for non-Sidero registries. Existing digest-pinning + Renovate cover those; broader rules were judged not worth the maintenance and outage-failure-mode tradeoffs.
+- MIG and vGPU (L4 hardware does not support either).
+- Kernel preempt model change. Default `none` keeps current behavior; switching to `voluntary` is a separable future experiment.
+- Migrating per-node patches to new doc styles. They already use `WatchdogTimerConfig`, `LinkAliasConfig`, `LinkConfig`, `Layer2VIPConfig`, `TimeSyncConfig`, `ResolverConfig` — already current.
+
+## Architecture
+
+### File layout (after all PRs)
+
+```
+talos/patches/global/machine-image-verification.yaml          # PR1 (new)
+kubernetes/apps/kube-system/gpu-operator/                     # PR2 (new)
+  ├── ks.yaml
+  └── app/
+      ├── kustomization.yaml
+      ├── helmrepository.yaml          # https://helm.ngc.nvidia.com/nvidia
+      ├── helmrelease.yaml             # values evolve PR2 → PR3
+      ├── runtimeclass.yaml            # moved here from nvidia-device-plugin/ in PR3 (kept under our ownership, not the operator's)
+      ├── time-slicing-config.yaml     # ConfigMap, referenced by HelmRelease in PR3
+      └── grafanadashboard.yaml        # moved here from observability/dcgm-exporter (PR3)
+kubernetes/apps/kube-system/nvidia-device-plugin/             # deleted in PR3
+kubernetes/apps/observability/dcgm-exporter/                  # deleted in PR3
+kubernetes/apps/{ai/ollama,media/plex,media/jellyfin,media/tdarr}/app/helmrelease.yaml
+                                                              # PR3 (selector swap), PR4 (env var removal)
+```
+
+### Cross-cutting conventions
+
+- **Affinity selector after cutover:** `nvidia.com/gpu.present=true` (added by GPU Feature Discovery). Replaces the existing `extensions.talos.dev/nvidia-open-gpu-kernel-modules-production` + `extensions.talos.dev/nvidia-container-toolkit-production` pair.
+- **RuntimeClass:** the existing `nvidia` RuntimeClass stays under our ownership. The gpu-operator chart is configured with `runtimeClass.install: false` so it never tries to take ownership. The file moves from `nvidia-device-plugin/app/app/runtimeclass.yaml` to `gpu-operator/app/runtimeclass.yaml` in PR3 — same content, different location. Avoids a Helm-ownership conflict during the PR2→PR3 transition.
+- **Flux dependency ordering:** `gpu-operator` `Kustomization` `dependsOn` cilium and external-secrets (matching existing `nvidia-device-plugin` pattern). The four GPU app `Kustomization`s `dependsOn` `gpu-operator` after PR3.
+- **Renovate:** auto-discovers via existing patterns since gpu-operator uses `HelmRepository`, mirroring the current `dcgm-exporter` source.
+
+## PRs
+
+Four PRs, in dependency order. PR1 is independent. PR2 → PR3 is a hard ordering. PR4 is independent of PR1 and lands after PR3 in practice.
+
+### PR1 — `feat(talos): add ImageVerificationConfig for Sidero system images`
+
+**New file:** `talos/patches/global/machine-image-verification.yaml`
+
+```yaml
+# Exact field names verified against the talhelper / Talos v1.13 schema at implementation time.
+---
+apiVersion: v1alpha1
+kind: ImageVerificationConfig
+rules:
+  - imagePatterns:
+      - "ghcr.io/siderolabs/*"
+    policy:
+      sigstore:
+        keyless:
+          identities:
+            - issuer: "https://token.actions.githubusercontent.com"
+              subjectRegExp: "^https://github\\.com/siderolabs/.+/\\.github/workflows/.+@refs/tags/v.+$"
+```
+
+**Wire-up:** append `"@./patches/global/machine-image-verification.yaml"` to the global `patches:` list in `talos/talconfig.yaml` (currently ends at line 174).
+
+**Why Sidero-only:**
+
+- The factory image (`factory.talos.dev/installer-secureboot/...`) is already protected by secure boot (TPM-rooted UEFI chain on `cr-talos-01/02/03`). Adding cosign on top is belt-and-suspenders and complicates upgrade flows.
+- `ghcr.io/siderolabs/installer` and `ghcr.io/siderolabs/kubelet` are the runtime images Renovate already tracks. These are exactly what this PR pins down.
+- The 1.13.0 default is "no rule = no verification", so unrelated registries (workload images) are unaffected.
+
+**Rollout:**
+
+1. `just talos gen-config`
+2. `just talos apply-node 10.32.8.80` (first node only)
+3. Watch `talosctl -n 10.32.8.80 logs machined --follow` for verification activity, trigger a Sidero-image pull (e.g., bounce kubelet pod) and confirm a verification log line appears.
+4. Apply to `10.32.8.81` and `10.32.8.82` once the first node is healthy.
+
+**Rollback:** revert the `talconfig.yaml` patches list entry, regen, apply. No state to undo.
+
+**Risk:** if Sidero's signing infra is down at the moment a node attempts a pull, that pull fails. For three nodes pulling Sidero images only during upgrades, this is near-zero impact and is exactly the security tradeoff being opted into.
+
+### PR2 — `feat(gpu): install nvidia/gpu-operator (validation phase)`
+
+**Goal:** stand up the operator with non-conflicting components only — GFD, CDI generation, validator. Do **not** enable device-plugin or dcgm-exporter yet; the standalone Helm releases stay in charge.
+
+**HelmRelease values (shape; exact key names verified against the chart's `values.yaml`):**
+
+```yaml
+driver:
+  enabled: false                # Talos extension provides driver
+toolkit:
+  enabled: false                # Talos extension provides container-toolkit
+
+cdi:
+  enabled: true
+  default: true                 # picks up Talos 1.13 CDI-by-default
+
+devicePlugin:
+  enabled: false                # flipped on in PR3
+dcgmExporter:
+  enabled: false                # flipped on in PR3
+
+gfd:
+  enabled: true                 # provides nvidia.com/gpu.* node labels
+
+mig:
+  strategy: none                # L4 has no MIG support
+
+nodeStatusExporter:
+  enabled: false
+sandboxWorkloads:
+  enabled: false
+gds:
+  enabled: false
+kataManager:
+  enabled: false
+vgpuManager:
+  enabled: false
+
+operator:
+  defaultRuntime: containerd
+  runtimeClass: nvidia
+runtimeClass:
+  install: false                # we own the RuntimeClass; do not let the operator manage it
+  name: nvidia
+
+validator:
+  driver:
+    env:
+      - name: DISABLE_DEV_CHAR_SYMLINK_CREATION
+        value: "true"
+
+# Restrict daemonsets to nodes with the Talos extensions until PR3, after which GFD owns the canonical label.
+daemonsets:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: extensions.talos.dev/nvidia-open-gpu-kernel-modules-production
+              operator: Exists
+            - key: extensions.talos.dev/nvidia-container-toolkit-production
+              operator: Exists
+```
+
+**Time-slicing ConfigMap (shipped in PR2, referenced by HelmRelease in PR3):**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: time-slicing-config
+  namespace: kube-system
+data:
+  any: |
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 5         # matches existing nvidia-device-plugin config
+```
+
+**Verification gates (must all pass before PR3 is opened):**
+
+1. `kubectl -n kube-system get pods | grep gpu-operator` — operator pod, GFD daemonset, validator daemonset all `Running` on all three nodes.
+2. `kubectl get nodes -o json | jq '.items[].metadata.labels | with_entries(select(.key | startswith("nvidia.com/gpu")))'` — expect `nvidia.com/gpu.present=true`, `nvidia.com/gpu.product` (likely `NVIDIA-L4`), `nvidia.com/gpu.count=1`, `nvidia.com/gpu.memory` populated on all three nodes.
+3. `talosctl -n 10.32.8.80 ls /run/cdi/` — expect a generated CDI spec file (e.g. `nvidia.yaml`).
+4. Existing four GPU workloads still healthy. Their selectors are untouched in this PR; they should be unaffected.
+
+**Rollback:** delete the Kustomization (`just kube delete-ks kube-system gpu-operator`). Standalone device-plugin and dcgm-exporter are untouched.
+
+**Risk:** GFD or validator daemonsets failing to schedule (caught in gate 1). Existing workloads are insulated by the disabled `devicePlugin` and `dcgmExporter` flags.
+
+### PR3 — `feat(gpu): cut over to gpu-operator device plugin and dcgm`
+
+**This PR must be atomic.** Both implementations register `nvidia.com/gpu`; co-existence is not safe. Brief reconciliation window (30–90s per node) during which GPU pods may go `Pending` and reschedule.
+
+**Changes:**
+
+1. **`kubernetes/apps/kube-system/gpu-operator/app/helmrelease.yaml`**
+
+   ```yaml
+   devicePlugin:
+     enabled: true
+     config:
+       name: time-slicing-config
+       default: any
+   dcgmExporter:
+     enabled: true
+     serviceMonitor:
+       enabled: true       # picked up by kube-prometheus-stack
+   ```
+
+   Remove the `daemonsets.nodeAffinity` block — GFD's `nvidia.com/gpu.present=true` is now the canonical label.
+
+2. **Move and delete:** move `kubernetes/apps/kube-system/nvidia-device-plugin/app/app/runtimeclass.yaml` to `kubernetes/apps/kube-system/gpu-operator/app/runtimeclass.yaml` (same content; add it to the gpu-operator app's `kustomization.yaml` `resources:` list). **Then** delete the rest of `kubernetes/apps/kube-system/nvidia-device-plugin/` (HelmRelease, OCIRepository, ks.yaml, kustomization.yaml). Remove its entry from `kubernetes/apps/kube-system/kustomization.yaml`. Because the RuntimeClass is moved (not deleted-then-recreated), no kubelet pod-admission churn happens.
+
+3. **Delete `kubernetes/apps/observability/dcgm-exporter/`** (entire directory: HelmRelease, HelmRepository, dashboard, ks.yaml). Remove its entry from the parent kustomization. **Move** the `grafanadashboard.yaml` ConfigMap to `kubernetes/apps/kube-system/gpu-operator/app/`. DCGM metric names are stable; no panel changes needed.
+
+4. **Workload selector swap (4 files).** In each of `ollama`, `plex`, `jellyfin`, `tdarr` `app/helmrelease.yaml`, replace:
+
+   ```yaml
+   - matchExpressions:
+       - key: extensions.talos.dev/nvidia-open-gpu-kernel-modules-production
+         operator: Exists
+       - key: extensions.talos.dev/nvidia-container-toolkit-production
+         operator: Exists
+   ```
+
+   with:
+
+   ```yaml
+   - matchExpressions:
+       - key: nvidia.com/gpu.present
+         operator: In
+         values: ["true"]
+   ```
+
+5. **Tighten Flux ordering:** add `dependsOn: [{name: gpu-operator}]` to each of the four GPU app `ks.yaml` files.
+
+**Verification gates after merge:**
+
+1. `kubectl -n kube-system get ds | grep nvidia` — operator's `nvidia-device-plugin-daemonset` and `nvidia-dcgm-exporter` running; standalone `nvidia-device-plugin` gone.
+2. `kubectl get nodes -o json | jq '.items[].status.allocatable["nvidia.com/gpu"]'` — `"5"` on each node (time-slicing replicas preserved).
+3. `kubectl get pods -A -l gpu-workload=true` — all four workloads `Running`.
+4. Functional smoke test: Plex transcodes a 4K stream, Ollama answers a chat request, Tdarr picks up a job, Jellyfin transcodes.
+5. dcgm Grafana dashboard shows live data; `kubectl -n observability get servicemonitor | grep dcgm` shows the operator's exporter being scraped.
+
+**Rollback (if cutover goes wrong):**
+
+- Revert the PR — Flux re-installs `nvidia-device-plugin` and standalone `dcgm-exporter`, reverts the four workload selectors, returns operator to PR2 state.
+- Recovery time: ~3–5 min Flux reconcile + 30–90s/node device-plugin reflip.
+
+**Operational guidance:**
+
+- Pick a low-traffic window. Have `kubectl logs -n kube-system -l app=nvidia-device-plugin-daemonset --tail=200` and `talosctl -n <node> dmesg --tail` ready in two terminals.
+- Do not merge PR3 if any of the three nodes failed a PR2 gate.
+
+### PR4 — `chore(gpu): drop redundant NVIDIA env vars`
+
+**Goal:** remove `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` from workloads that still set them. With `cdi.default=true` from PR2, devices are declared via the OCI runtime spec; these env vars are silently ignored when CDI is the source of truth.
+
+**Touched files (3; ollama already does not set them):**
+
+| File | Remove |
+| --- | --- |
+| `kubernetes/apps/media/plex/app/helmrelease.yaml` | `NVIDIA_VISIBLE_DEVICES: "all"`, `NVIDIA_DRIVER_CAPABILITIES: "all"` (lines 57–58) |
+| `kubernetes/apps/media/jellyfin/app/helmrelease.yaml` | both env vars |
+| `kubernetes/apps/media/tdarr/app/helmrelease.yaml` | both env vars in **both** `app` and `node` containers |
+
+**Keep (do not touch):**
+
+- Plex's `LD_LIBRARY_PATH: "/usr/local/glibc/usr/lib"` — Plex-specific glibc workaround, unrelated.
+- Plex's `HARDWARE_DEVICE_PATH: "/dev/nvidia0"` — Plex reads this directly; CDI exposes the device but Plex still needs to be told the path.
+- `runtimeClassName: nvidia` on every GPU workload — kept; CDI works regardless of runtime class, but the `nvidia` RuntimeClass is the canonical attach point for CDI annotations.
+
+**Verification:** restart each pod after merge; confirm transcoding/inference still works (same gates as PR3).
+
+**Rollback:** trivial revert.
+
+## Risk concentration map
+
+| PR | Blast radius | Reversibility | Pre-merge gates |
+| --- | --- | --- | --- |
+| PR1 (image verification) | Single talconfig patch; per-node apply | Trivial revert | First-node-only validation |
+| PR2 (operator install) | New app, no cutover | Delete Kustomization | 4 verification checks before opening PR3 |
+| PR3 (cutover) | High — touches all four GPU workloads | Full revert restores prior state in ~5 min | 5 verification checks; pick a low-traffic window |
+| PR4 (env cleanup) | 3 workloads, no functional change | Trivial revert | Per-app smoke test |
+
+## Effort estimate
+
+- PR1: ~30 min author + one node-apply round-trip.
+- PR2: ~1–2 hr author + ~10 min Flux reconcile + ~15 min validation.
+- PR3: ~1 hr author + 30–90 min monitored cutover window.
+- PR4: ~15 min author + smoke test.
+
+## Open questions
+
+Items that may surface during implementation and would warrant follow-up rather than blocking this design:
+
+- Whether `serviceMonitor.enabled=true` on the operator's `dcgmExporter` produces a different label set than the standalone chart (could affect existing `PrometheusRule`s referencing `dcgm_*` metrics — DCGM metric names are stable, but the `service` and `pod` labels may change). If labels differ, either re-label via `ServiceMonitor.metricRelabelings` or update consuming rules.

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/helmrelease.yaml
@@ -1,0 +1,65 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: gpu-operator
+spec:
+  interval: 1h
+  chart:
+    spec:
+      # renovate: registryUrl=https://helm.ngc.nvidia.com/nvidia
+      chart: gpu-operator
+      version: v25.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: nvidia
+      interval: 1h
+  values:
+    driver:
+      enabled: false
+    toolkit:
+      enabled: false
+    cdi:
+      enabled: true
+      default: true
+    devicePlugin:
+      enabled: false
+    dcgmExporter:
+      enabled: false
+    gfd:
+      enabled: true
+    mig:
+      strategy: none
+    nodeStatusExporter:
+      enabled: false
+    sandboxWorkloads:
+      enabled: false
+    gds:
+      enabled: false
+    kataManager:
+      enabled: false
+    vgpuManager:
+      enabled: false
+    vgpuDeviceManager:
+      enabled: false
+    runtimeClass:
+      install: false
+      name: nvidia
+    operator:
+      defaultRuntime: containerd
+      runtimeClass: nvidia
+    validator:
+      driver:
+        env:
+          - name: DISABLE_DEV_CHAR_SYMLINK_CREATION
+            value: "true"
+    daemonsets:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: extensions.talos.dev/nvidia-open-gpu-kernel-modules-production
+                  operator: Exists
+                - key: extensions.talos.dev/nvidia-container-toolkit-production
+                  operator: Exists

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/helmrepository.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nvidia
+spec:
+  interval: 1h
+  url: https://helm.ngc.nvidia.com/nvidia

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/kustomization.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./time-slicing-config.yaml

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/time-slicing-config.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/time-slicing-config.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: time-slicing-config
+  namespace: gpu-operator
+data:
+  any: |-
+    version: v1
+    sharing:
+      timeSlicing:
+        renameByDefault: false
+        resources:
+          - name: nvidia.com/gpu
+            replicas: 5

--- a/kubernetes/apps/gpu-operator/gpu-operator/ks.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app gpu-operator
+  namespace: &namespace gpu-operator
+spec:
+  targetNamespace: *namespace
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: cilium
+      namespace: kube-system
+  path: ./kubernetes/apps/gpu-operator/gpu-operator/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+  interval: 30m
+  timeout: 5m

--- a/kubernetes/apps/gpu-operator/kustomization.yaml
+++ b/kubernetes/apps/gpu-operator/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: gpu-operator
+components:
+  - ../../components/global-vars
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./gpu-operator/ks.yaml

--- a/kubernetes/apps/gpu-operator/namespace.yaml
+++ b/kubernetes/apps/gpu-operator/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
- Installs nvidia/gpu-operator with `devicePlugin.enabled: false` and `dcgmExporter.enabled: false`
- Talos NVIDIA system extensions provide driver and container-toolkit, so `driver.enabled: false` and `toolkit.enabled: false`
- Enables CDI (`cdi.enabled: true`, `cdi.default: true`) — picks up Talos 1.13's new CDI-by-default
- Enables GPU Feature Discovery (gfd) so `nvidia.com/gpu.*` node labels appear
- Existing standalone `nvidia-device-plugin` and `dcgm-exporter` apps remain in charge of device exposure and metrics until cutover (next PR)

## Why a validation phase before the cutover
Both device-plugin implementations register `nvidia.com/gpu` as a node resource — running them concurrently is unsafe. PR2 stages the non-conflicting parts of the operator (GFD, validator, CDI) so the GFD labels and CDI specs can be confirmed before PR3 atomically swaps device-plugin and dcgm-exporter ownership.

## Why we own the RuntimeClass
\`runtimeClass.install: false\` in operator values — we keep ownership of the existing \`RuntimeClass nvidia\`. PR3 will \`git mv\` the file into this app dir to preserve continuity for kubelet pod admission.

## Verification gates (after Flux reconciles, before opening PR3)

1. \`kubectl -n kube-system get pods -l app.kubernetes.io/name=gpu-operator\` — operator + GFD daemonset + validator daemonset all Running on all 3 nodes
2. \`kubectl get nodes -o json | jq '.items[].metadata.labels | with_entries(select(.key | startswith(\"nvidia.com/gpu\")))'\` — expect \`nvidia.com/gpu.present=true\`, \`nvidia.com/gpu.product=NVIDIA-L4\`, \`nvidia.com/gpu.count=1\`, \`nvidia.com/gpu.memory\` populated on all 3 nodes
3. \`talosctl -n 10.32.8.80,10.32.8.81,10.32.8.82 ls /run/cdi/\` — expect a generated CDI spec file
4. \`kubectl get pods -A -l gpu-workload=true\` — all 4 existing GPU workloads still Running, no Pending or restarts

## Rollback
\`just kube delete-ks kube-system gpu-operator\` — standalone device-plugin and dcgm-exporter are untouched, so the cluster falls back cleanly.

## Spec
See \`docs/superpowers/specs/2026-04-28-talos-1.13-improvements-design.md\` and \`docs/superpowers/plans/2026-04-28-talos-1.13-improvements.md\` PR2.