### PR TITLE
fix(certwarden): detect Job failures fast in Supermicro deploy wrapper

### DIFF
--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 data:
   certwarden-supermicro-deploy.sh: |
@@ -125,24 +126,46 @@ data:
                 secretName: ${CERT_SECRET_NAME}
     EOF
 
-    # Wait for the job to complete
+    # Wait for the Job to reach a terminal condition (Complete or Failed).
+    # kubectl wait --for=condition=complete ignores Failed, so on a fast pod
+    # failure it would block the full --timeout instead of surfacing the real
+    # error. Poll both conditions explicitly so failures are caught quickly.
     echo "Waiting for Job to complete..."
-    kubectl wait --for=condition=complete --timeout=5m "job/${JOB_NAME}" -n "${NAMESPACE}"
+    JOB_TIMEOUT=300
+    DEADLINE=$(( $(date +%s) + JOB_TIMEOUT ))
+    JOB_RESULT=""
+    while [[ $(date +%s) -lt ${DEADLINE} ]]; do
+        COMPLETE=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)
+        FAILED=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+        if [[ "${COMPLETE}" == "True" ]]; then
+            JOB_RESULT="complete"
+            break
+        fi
+        if [[ "${FAILED}" == "True" ]]; then
+            JOB_RESULT="failed"
+            break
+        fi
+        sleep 5
+    done
 
-    # Get the job logs
+    # Always dump pod logs so Certwarden captures them on success and failure
     echo "=== Job Logs ==="
-    kubectl logs "job/${JOB_NAME}" -n "${NAMESPACE}"
+    kubectl logs "job/${JOB_NAME}" -n "${NAMESPACE}" --all-containers --tail=-1 || true
 
-    # Check if the job succeeded
-    JOB_STATUS=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
-    if [[ "${JOB_STATUS}" == "True" ]]; then
-        echo "✅ Certificate deployed successfully to ${SUPERMICRO_HOST} (containerized)"
-        exit 0
-    else
-        echo "❌ Failed to deploy certificate to ${SUPERMICRO_HOST} (containerized)"
-        kubectl logs "job/${JOB_NAME}" -n "${NAMESPACE}"
-        exit 1
-    fi
+    case "${JOB_RESULT}" in
+        complete)
+            echo "✅ Certificate deployed successfully to ${SUPERMICRO_HOST} (containerized)"
+            exit 0
+            ;;
+        failed)
+            echo "❌ Failed to deploy certificate to ${SUPERMICRO_HOST} (containerized)"
+            exit 1
+            ;;
+        *)
+            echo "❌ Job did not reach a terminal state within ${JOB_TIMEOUT}s on ${SUPERMICRO_HOST}"
+            exit 1
+            ;;
+    esac
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
## Summary

- Replaces `kubectl wait --for=condition=complete --timeout=5m` with a 5s poll loop that breaks on either `Complete=True` or `Failed=True`, so a failing pod surfaces in seconds instead of waiting out the full timeout.
- Always dumps pod logs (success and failure) so Certwarden captures the actual stdout/stderr from the deploy pod, instead of only the wrapper's misleading wait timeout.

This was the masking bug behind a 5-week silent regression where every Supermicro cert push failed in <30s but the wrapper sat blocking 5 min and Certwarden logged only `error: timed out waiting for the condition on jobs/...` — see #2323 for the full incident write-up.

## Test plan

- [ ] Renovate / manual cert renewal triggers post-process and the wrapper still succeeds end-to-end on a healthy push.
- [ ] Force a failure (e.g. break IPMI creds in the secret) and verify the wrapper exits non-zero in <30s and that pod logs appear in Certwarden's stderr.
- [ ] `flux-local build ks --path kubernetes/flux/cluster certwarden-cert-deployment` succeeds.
- [ ] yamlfmt + shellcheck of the extracted script pass.

Closes #2323