### PR TITLE
chore(observability): silence NGC 502 flap on nvidia HelmRepository

### DIFF
--- a/kubernetes/apps/gpu-operator/gpu-operator/app/helmrepository.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/helmrepository.yaml
@@ -5,5 +5,7 @@ kind: HelmRepository
 metadata:
   name: nvidia
 spec:
-  interval: 1h
+  # NGC's CDN flaps with transient 502s; Renovate triggers on-demand fetches
+  # when chart versions change, so a long polling interval is safe.
+  interval: 6h
   url: https://helm.ngc.nvidia.com/nvidia

--- a/kubernetes/components/alerts/alertmanager/alert.yaml
+++ b/kubernetes/components/alerts/alertmanager/alert.yaml
@@ -26,4 +26,8 @@ spec:
     - "error.*lookup raw\\.githubusercontent\\.com"
     - "dial.*tcp.*timeout"
     - "waiting.*socket"
+    # NGC's CDN flaps with transient 502s on index.yaml fetches; cluster keeps
+    # serving from cached chart artifact, and FluxHelmReleaseNotReady (15m for:)
+    # still fires if the operator actually breaks.
+    - "helm\\.ngc\\.nvidia\\.com.*502"
   suspend: false


### PR DESCRIPTION
## Summary

`helm.ngc.nvidia.com` flaps with transient 502 Bad Gateways on `index.yaml` fetches (Azure-fronted CDN issue). Each flap fires `FluxHelmRepositoryFailed` against the `nvidia` HelmRepository and resolves seconds later when NGC recovers — pure alert noise that doesn't reflect any cluster issue, since the gpu-operator HelmRelease serves from the cached chart artifact.

`helm.ngc.nvidia.com/nvidia` IS the canonical NVIDIA Helm repo per their docs — there's no public OCI alternative to switch to.

Two narrow mitigations:

- Add `helm\.ngc\.nvidia\.com.*502` to the Flux Alert `exclusionList` (same place `error.*lookup github\.com` lives). Real breakage still surfaces via `FluxHelmReleaseNotReady` (15-minute `for:`), which is independent of index-fetch flapping.
- Bump the `nvidia` HelmRepository `interval` from 1h to 6h. Renovate triggers on-demand reconciles when a new chart version is published, so the longer polling interval doesn't delay updates — it just reduces how often we can hit a 502.

## Test plan

- [ ] flux-local build clean (verified locally)
- [ ] After merge: the next time NGC 502s (likely soon, given recent frequency), no `FluxHelmRepositoryFailed` alert fires.
- [ ] Renovate's next gpu-operator chart bump still triggers a Flux fetch and merges normally.

## Rollback

Revert the PR. No state migration involved — the alert returns to flapping and the interval returns to 1h.