### PR TITLE
chore(gpu): drop redundant NVIDIA env vars

### DIFF
--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -34,8 +34,6 @@ spec:
               tag: 0.23.0@sha256:b5771d12e826ca9fabd7025a2f77f53a83baf0ea951aab733900dc6d96792bcd
             env:
               TZ: ${TIMEZONE}
-              NVIDIA_VISIBLE_DEVICES: "all"
-              NVIDIA_DRIVER_CAPABILITIES: "all"
               CELERY_BROKER_URL: redis://dragonfly.database.svc.cluster.local:6379/0
               DISPATCHARR_ENV: aio
               DISPATCHARR_LOG_LEVEL: info

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
               tag: 10.11.8@sha256:93227545077893cc9516f28b3adb733b67bc4691f41b6167428a2a0e3220b81c
             env:
               TZ: "${TIMEZONE}"
-              NVIDIA_VISIBLE_DEVICES: "all"
-              NVIDIA_DRIVER_CAPABILITIES: "all"
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -54,8 +54,6 @@ spec:
               PLEX_PREFERENCE_13: "logDebug=0"
               # Limit remote streams to 20 Mbps (forces 4K to transcode)
               PLEX_PREFERENCE_14: "WanPerStreamMaxUploadRate=20000"
-              NVIDIA_VISIBLE_DEVICES: "all"
-              NVIDIA_DRIVER_CAPABILITIES: "all"
               LD_LIBRARY_PATH: "/usr/local/glibc/usr/lib"
               HARDWARE_DEVICE_PATH: "/dev/nvidia0"
             probes:

--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -21,8 +21,6 @@ spec:
               tag: 2.70.01@sha256:4d48a46fb984b29e07cf4fd66cf7d3c8bd7c2c8dd662d09b4e20e11ae93e52fc
             env:
               TZ: ${TIMEZONE}
-              NVIDIA_VISIBLE_DEVICES: "all"
-              NVIDIA_DRIVER_CAPABILITIES: "all"
             probes:
               liveness: &probes
                 enabled: true
@@ -54,8 +52,6 @@ spec:
                     fieldPath: spec.nodeName
               serverIP: localhost
               serverPort: "8266"
-              NVIDIA_VISIBLE_DEVICES: "all"
-              NVIDIA_DRIVER_CAPABILITIES: "all"
             resources:
               requests:
                 cpu: 500m


### PR DESCRIPTION
## Summary

With `cdi.default=true` on the now-active gpu-operator (PR #2328), container device exposure is declared via the OCI runtime spec — `NVIDIA_VISIBLE_DEVICES` and `NVIDIA_DRIVER_CAPABILITIES` are silently ignored and only serve to mislead readers.

Removed from:
- `media/plex` (single container)
- `media/jellyfin` (single container)
- `media/tdarr` (both `app` and `node` containers)
- `media/dispatcharr` (single container)

Plex's `LD_LIBRARY_PATH` and `HARDWARE_DEVICE_PATH` stay — they're Plex-specific, not legacy NVIDIA wiring. `ollama`, `openaiwhisper`, `whisper`, and `pinchflat` already didn't set these envs.

## Test plan

After merge, kick each pod so the new env block takes effect, then sanity-check hardware accel:

```bash
kubectl rollout restart -n media deploy/plex deploy/jellyfin deploy/tdarr deploy/dispatcharr
for d in plex jellyfin tdarr dispatcharr; do
  kubectl rollout status -n media deploy/$d --timeout=5m
done
```

- [ ] Plex hardware-transcodes a stream (forced 1080p 8 Mbps from a 4K source; `(hw)` in dashboard)
- [ ] Jellyfin hardware-transcodes a stream
- [ ] Tdarr picks up a job and hardware-encodes it
- [ ] Dispatcharr stays healthy post-restart (no GPU work, just sanity)

## Rollback

Revert the PR; the env vars come back as no-ops. No state change.