### PR TITLE
ci(flux-local): retry transient NGC chart-fetch failures and bump v8.2.0

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -39,17 +39,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # NGC's CDN flaps with transient 502s on `helm.ngc.nvidia.com/nvidia/index.yaml`,
+      # which makes `flux-local test` blow up on the gpu-operator HelmRelease even
+      # though every other test passes and the cluster's running fine off the cached
+      # chart artifact. Retry covers most outage windows (typically <2 min).
       - name: Run flux-local test
-        uses: docker://ghcr.io/allenporter/flux-local:v8.1.0
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: >-
-            test
-            --all-namespaces
-            --enable-helm
-            --path /github/workspace/kubernetes/flux/cluster
-            --verbose
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: >-
+            docker run --rm
+            -v "${{ github.workspace }}":/github/workspace
+            -e GITHUB_TOKEN
+            ghcr.io/allenporter/flux-local:v8.2.0
+            test --all-namespaces --enable-helm
+            --path /github/workspace/kubernetes/flux/cluster --verbose
 
   diff:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
@@ -78,7 +86,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
 
       - name: Run flux-local diff
-        uses: docker://ghcr.io/allenporter/flux-local:v8.1.0
+        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Wraps the `flux-local test` step in `nick-fields/retry@v3` (3 attempts, 60s gap, 10-min cap) and bumps `flux-local` v8.1.0 → v8.2.0.

**Why:** `flux-local test` runs `helm template` against every HelmRelease's source. NGC (`helm.ngc.nvidia.com/nvidia`) — the only canonical Helm repo for the gpu-operator chart per NVIDIA's docs — returns transient 502 Bad Gateways from its Azure CDN. That fails the whole CI run even when the cluster is running fine off the cached chart artifact and every other test passes. We've now hit it on PR #2328, #2330, and #2331.

NGC outage windows are typically <2 min, so retrying covers the vast majority of flaps without admin merges.

If NGC ever stays down for hours rather than minutes, mirroring the chart to ghcr.io is still on the table — but that's medium-effort and this is near-zero.

## Diff scope

- `nick-fields/retry@v3.0.2` wraps `docker run` of the flux-local image — same args, just under retry control.
- Both `test` and `diff` steps bumped v8.1.0 → v8.2.0 (matches `jfroy/flatops`).

## Test plan

- [ ] CI passes on this PR (a green test step on first attempt confirms the rewrite works; a green test on attempt 2-3 confirms retry catches NGC flaps)
- [ ] After merge, the next gpu-operator-touching PR (e.g. a renovate bump) doesn't require manual re-runs when NGC is misbehaving

## Rollback

Revert the PR — `docker://ghcr.io/allenporter/flux-local:v8.1.0` returns and we go back to manual re-runs on flake.