### PR TITLE
ci(flux-local): fix mkdir /.cache regression — set HOME=/tmp

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -54,6 +54,7 @@ jobs:
           command: >-
             docker run --rm
             -v "${{ github.workspace }}":/github/workspace
+            -e HOME=/tmp
             -e GITHUB_TOKEN
             ghcr.io/allenporter/flux-local:v8.2.0
             test --all-namespaces --enable-helm


### PR DESCRIPTION
## Summary

Hotfix for the regression I introduced in #2332. Switching from `uses: docker://...` to `nick-fields/retry@v3` running explicit `docker run` lost the implicit `HOME=/github/home` env that GitHub Actions injects for container actions. Helm then tried to create its cache under `/.cache` (filesystem root) and failed:

```
E  Error: mkdir /.cache: permission denied
```

That broke `flux-local test` for **every** HelmRelease on **every** PR touching `kubernetes/`, surfacing on the gpu-operator v25→v26 upgrade PR (#2327) where the test ran for the full 21-minute retry window before giving up.

## Fix

One-line addition: `-e HOME=/tmp` on the `docker run` so helm caches in a writable dir. The retry behaviour and v8.2.0 bump from #2332 stay.

## Test plan

- [ ] CI on this PR passes (skipped — only touches `.github/workflows/`)
- [ ] After merge: re-run failed `Flux Local - Test` on PR #2327 — expect green pass

## Rollback

Revert; the regression returns. The cleaner long-term option is reverting #2332 entirely and accepting NGC flap retries via manual re-runs, but the one-line fix is fine for now.