### PR TITLE
fix(talos): correct ImageVerificationConfig schema for v1.13

### DIFF
--- a/talos/patches/global/machine-image-verification.yaml
+++ b/talos/patches/global/machine-image-verification.yaml
@@ -2,11 +2,7 @@
 apiVersion: v1alpha1
 kind: ImageVerificationConfig
 rules:
-  - imagePatterns:
-      - "ghcr.io/siderolabs/*"
-    policy:
-      sigstore:
-        keyless:
-          identities:
-            - issuer: "https://token.actions.githubusercontent.com"
-              subjectRegExp: "^https://github\\.com/siderolabs/[^/]+/\\.github/workflows/[^/]+@refs/(tags/v[0-9].+|heads/release-[0-9].+)$"
+  - image: "ghcr.io/siderolabs/*"
+    keyless:
+      issuer: "https://token.actions.githubusercontent.com"
+      subjectRegex: "^https://github\\.com/siderolabs/[^/]+/\\.github/workflows/[^/]+@refs/(tags/v[0-9].+|heads/release-[0-9].+)$"


### PR DESCRIPTION
## Summary
- The patch shipped in #2315 used fabricated keys (`imagePatterns`, `policy.sigstore.keyless.identities[]`, `subjectRegExp`) that don't exist in the Talos v1.13 `ImageVerificationConfig` schema
- talhelper rejects it with `unknown keys found during decoding` — `just talos gen-config` fails, blocking any node apply
- The actual schema (per [Talos v1.13 docs](https://github.com/siderolabs/talos/blob/v1.13.0/website/content/v1.13/reference/configuration/security/imageverificationconfig.md)) is much flatter: `rules[].image` is a single string, `keyless` sits directly under the rule, and the field is `subjectRegex` (camelCase, no `Exp`)

## Test plan
- [x] `just talos gen-config` succeeds (was failing before)
- [x] `ImageVerificationConfig` renders into all 3 node configs (`kubernetes-cr-talos-0{1,2,3}.yaml`)
- [ ] After merge: apply to `cr-talos-01`, watch verification on a Sidero image pull, then roll to `02`/`03`

## Why this didn't fail CI on #2315
The original PR's CI ran `flux-local` (which validates Kustomize/Helm) and Trivy/Checkov, none of which validate Talos machine-config schemas. Schema validation requires `talhelper genconfig`, which needs SOPS-decrypted secrets that CI doesn't have. The plan flagged this as an implementation-time check; we hit it locally during the rollout.