### PR TITLE
chore(talos): roll back ImageVerificationConfig

### DIFF
--- a/talos/patches/global/machine-image-verification.yaml
+++ b/talos/patches/global/machine-image-verification.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1alpha1
-kind: ImageVerificationConfig
-rules:
-  - image: "ghcr.io/siderolabs/*"
-    keyless:
-      issuer: "https://token.actions.githubusercontent.com"
-      subjectRegex: "^https://github\\.com/siderolabs/[^/]+/\\.github/workflows/[^/]+@refs/(tags/v[0-9].+|heads/release-[0-9].+)$"

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -172,7 +172,6 @@ patches:
   - "@./patches/global/machine-network.yaml"
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
-  - "@./patches/global/machine-image-verification.yaml"
 
 # Controller patches
 controlPlane:


### PR DESCRIPTION
## Summary
Reverts PR #2315 (ImageVerificationConfig for Sidero images) and #2337 (schema fix). Removes both the patch file and the talconfig entry.

## Why
Real-world signing inspection during rollout showed:
- Only `installer`/`imager`/`talosctl` under `ghcr.io/siderolabs/*` are cosign-signed; `kubelet`, `flannel`, `extensions` are unsigned. A broad `ghcr.io/siderolabs/*` rule would block legitimate unsigned pulls.
- Sidero signs releases via Google OIDC keyless tied to an engineer's personal email (currently `mateusz.urbanek@siderolabs.com`), not GitHub Actions workflow OIDC as we'd assumed.
- The cluster's actual boot path is `factory.talos.dev/installer-secureboot/...`, already protected by secure boot. The signed `ghcr.io/siderolabs/installer*` images aren't pulled in normal operation.

A correctly-narrowed rule (e.g. `ghcr.io/siderolabs/installer*` with Google OIDC + `.+@siderolabs\.com`) would only fire on manual `talosctl image pull`, providing marginal additional defense over secure boot + digest pinning. Not worth the maintenance.

## Post-merge
- [ ] `just talos gen-config`
- [ ] `just talos apply-node 10.32.8.80` (only cr-talos-01 had the rule applied; 02/03 were untouched)
- [ ] Confirm `talosctl get imageverificationrules` returns nothing on all 3 nodes
- [ ] Confirm a Sidero pull is no longer blocked: `talosctl image pull ghcr.io/siderolabs/installer:v1.13.0`