### PR TITLE
feat(invio)!: migrate to v2.0.0 single-image deployment

### DIFF
--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -19,17 +19,26 @@ spec:
       strategy: rollback
   values:
     controllers:
-      backend:
+      app:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
           app:
             image:
-              repository: ghcr.io/kittendevv/invio-backend
-              tag: v1.15.1@sha256:e5dfe33867cc833a78d875f37327d390aa7366d573b1b82f201ad53c23ae2b4f
+              # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
+              repository: ghcr.io/kittendevv/invio
+              tag: v2.0.0@sha256:ee5f20a4e74aae0610148e405c14d1be6a98b10de1c8eac97d42ac5c3f3324e3
             env:
               TZ: ${TIMEZONE}
               DATABASE_PATH: /app/data/invio.db
+              # SvelteKit CSRF: canonical origin for the app. Internal hostname
+              # is the primary access path; the SECRET_DOMAIN alias on the same
+              # internal listener will CSRF-reject if used for state-changing
+              # requests — switch to it here if that becomes the preferred URL.
+              ORIGIN: https://invio.${SECRET_INTERNAL_DOMAIN}
+              # Envoy terminates TLS upstream; backend pod sees HTTP. Without
+              # this, SvelteKit refuses to set login cookies.
+              COOKIE_SECURE: "false"
             envFrom:
               - secretRef:
                   name: invio-secret
@@ -42,36 +51,6 @@ spec:
               requests:
                 cpu: 10m
                 memory: 256Mi
-              limits:
-                memory: 512Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                  - ALL
-              readOnlyRootFilesystem: false
-
-      frontend:
-        annotations:
-          reloader.stakater.com/auto: "true"
-        containers:
-          app:
-            image:
-              repository: ghcr.io/kittendevv/invio-frontend
-              tag: v1.15.1@sha256:a159c3c82613db03f3e4183769386329e1af76ce4077e30d607c57f14458691b
-            env:
-              TZ: ${TIMEZONE}
-              PORT: "8000"
-              BACKEND_URL: http://invio-backend.default.svc.cluster.local:3000
-            probes:
-              liveness:
-                enabled: true
-              readiness:
-                enabled: true
-            resources:
-              requests:
-                cpu: 10m
-                memory: 128Mi
               limits:
                 memory: 512Mi
             securityContext:
@@ -94,15 +73,10 @@ spec:
 
     service:
       app:
-        controller: frontend
+        controller: app
         ports:
           http:
             port: 8000
-      backend:
-        controller: backend
-        ports:
-          http:
-            port: 3000
 
     route:
       app:
@@ -123,12 +97,6 @@ spec:
       data:
         existingClaim: "{{ .Release.Name }}"
         advancedMounts:
-          backend:
+          app:
             app:
               - path: /app/data
-      cache:
-        type: emptyDir
-        advancedMounts:
-          backend:
-            app:
-              - path: /.cache


### PR DESCRIPTION
## Summary

Supersedes #2314 (which only bumped image tags). v2 ships as a **combined image** (`ghcr.io/kittendevv/invio:v2.0.0`) with backend + frontend running together under supervisord, replacing v1's split `invio-backend` + `invio-frontend` images.

## Changes

- One controller `app`, one container, one service on `:8000`. Drops the separate `backend` controller / service.
- Image: `ghcr.io/kittendevv/invio@v2.0.0` (multi-arch index digest pinned).
- New env vars required by v2's SvelteKit frontend:
  - `ORIGIN=https://invio.${SECRET_INTERNAL_DOMAIN}` — SvelteKit CSRF canonical origin.
  - `COOKIE_SECURE=false` — envoy terminates TLS upstream of the pod; without this v2 won't set login cookies on the HTTP backend connection.
- Route `backendRefs` unchanged (already `invio-app`).
- Persistence unchanged: existing `invio` PVC mounts at `/app/data`.

## Caveats

- The SECRET_DOMAIN hostname alias still points to the same internal listener but isn't the canonical ORIGIN. State-changing requests issued against that alias may CSRF-reject. Switch the ORIGIN env if you settle on that hostname.
- v2's release notes don't document v1→v2 schema migration. Accepting whatever v2 does to the v1 SQLite at `/app/data/invio.db`. No real data to lose per the user.

## Test plan

- [ ] `flux-local build ks invio` clean (verified locally — 408-line manifest with single `invio-app:8000` service)
- [ ] Post-merge: HelmRelease upgrades to v2.0.0, single pod (`invio-XXXX-XXXX`) Running, no CrashLoopBackOff
- [ ] Browse to `https://invio.${SECRET_INTERNAL_DOMAIN}` — login screen renders
- [ ] Sign in with `ADMIN_USER`/`ADMIN_PASS` — succeeds
- [ ] If anything breaks, the existing VolSync snapshot of the PVC is the rollback point

Closes #2314.