### PR TITLE
fix(invio): redirect supervisord main log out of /app

### DIFF
--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -28,6 +28,17 @@ spec:
               # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
               repository: ghcr.io/kittendevv/invio
               tag: v2.0.0@sha256:ee5f20a4e74aae0610148e405c14d1be6a98b10de1c8eac97d42ac5c3f3324e3
+            # The image's default Cmd lets supervisord default its main logfile
+            # to $CWD/supervisord.log = /app/supervisord.log, which user 1000
+            # cannot write to. `-l /tmp/supervisord.log` redirects it.
+            command:
+              - "/usr/bin/supervisord"
+            args:
+              - "-n"
+              - "-c"
+              - "/etc/supervisor/conf.d/supervisord.conf"
+              - "-l"
+              - "/tmp/supervisord.log"
             env:
               TZ: ${TIMEZONE}
               DATABASE_PATH: /app/data/invio.db


### PR DESCRIPTION
## Summary

v2's image runs as root by default but our security context runs it as user 1000. Supervisord (no `[supervisord] logfile=` in the bundled conf) defaults to writing `$CWD/supervisord.log` = `/app/supervisord.log`, which user 1000 doesn't own. PermissionError → crash before binding `:8000` → Helm upgrade timeout → rollback loop.

Fix: override the container's `command`/`args` to pass `-l /tmp/supervisord.log`, redirecting supervisord's own log to a writable tmpfs path. Application logs stay on stdout/stderr per the image's bundled `supervisord.conf` — no change needed there.

The HR was suspended during diagnosis to stop the rollback churn; merging this resumes it cleanly.

## Test plan

- [ ] flux-local build clean
- [ ] After merge: resume HR → upgrade succeeds → single `invio-XXX` pod Running 1/1
- [ ] Browse to `https://invio.${SECRET_INTERNAL_DOMAIN}` and login

## Captured root cause

Pod logs from a manual debug pod with the v2 image:

```
Traceback (most recent call last):
  File "/usr/bin/supervisord", line 33, in <module>
    sys.exit(load_entry_point('supervisor==4.2.5', 'console_scripts', 'supervisord')())
  ...
PermissionError: [Errno 13] Permission denied: '/app/supervisord.log'
```

Image config: `User: null` (root), `WorkingDir: /app`. Supervisord defaults `logfile` to `$CWD/supervisord.log`.