### PR TITLE
fix(invio): add /.cache emptyDir for deno npm cache

### DIFF
--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -111,3 +111,11 @@ spec:
           app:
             app:
               - path: /app/data
+      # Deno's npm cache lives at /.cache/deno; bare image runs as user 1000
+      # which can't write to /.cache. emptyDir gives it somewhere writable.
+      cache:
+        type: emptyDir
+        advancedMounts:
+          app:
+            app:
+              - path: /.cache


### PR DESCRIPTION
## Summary

Second permission issue uncovered after #2345 fixed supervisord's logfile path. The bundled deno backend caches npm packages under `/.cache/deno`, which user 1000 can't write to. Backend exits 1 → supervisord stops the pod → CrashLoopBackOff → upgrade timeout → rollback.

The v1 helmrelease had this exact `cache` emptyDir at `/.cache` for the same reason; lost during the v1→v2 controller consolidation. Adding it back.

## Captured logs

```
error: Failed caching npm package 'daisyui@5.0.54'
  Caused by:
    0: Failed creating '/.cache/deno/npm/registry.npmjs.org/daisyui/5.0.a469dc4a.tmp'
    1: Permission denied (os error 13)
2026-04-30 09:41:11,826 WARN exited: backend (exit status 1; not expected)
```

## Test plan

- [ ] flux-local build clean
- [ ] After merge, resume HR → upgrade succeeds → single `invio-XXX` pod Running 1/1
- [ ] Browse to `https://invio.${SECRET_INTERNAL_DOMAIN}` and login

The HR is currently suspended pending this fix.