### PR TITLE
fix(invio): point HTTPRoute backendRef at the actual service name

### DIFF
--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -101,7 +101,7 @@ spec:
             namespace: network
         rules:
           - backendRefs:
-              - name: invio-app
+              - name: invio
                 port: 8000
 
     persistence:


### PR DESCRIPTION
## Summary

Final v2 fixup. Route's backendRef was `invio-app` (carried from v1's two-service helmrelease) but the rendered service name is just `invio` — bjw-s app-template's behavior when there's a single service block. Route therefore never actually reached the pod.

App is otherwise healthy: deno backend on :3000 and bun frontend on :8000 both responding (302/303), v2 auto-migration of v1 sqlite ran cleanly with backup at `/app/data/invio_backup_2026-04-30T08-45-59.db`.

## Test plan

- [ ] After merge, `kubectl get httproute invio -o jsonpath='{...backendRefs}'` shows `invio:8000`
- [ ] Browse to `https://invio.${SECRET_INTERNAL_DOMAIN}` — login screen renders