### PR TITLE
feat(oxidized): network device config backup in observability

### DIFF
--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -64,7 +64,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
           scanners: 'vuln,secret,misconfig'
-          trivy-ignores: '.trivyignore.yaml'
+          trivyignores: '.trivyignore.yaml'
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -3,9 +3,11 @@ name: security-scans
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
   schedule:
     - cron: "0 3 * * *" # nightly at 3 AM UTC
 
@@ -62,6 +64,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH,MEDIUM'
           scanners: 'vuln,secret,misconfig'
+          trivy-ignores: '.trivyignore.yaml'
 
       - name: Upload Trivy SARIF
         uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,21 @@
+---
+# Trivy SARIF filter — path-scoped suppressions for known false positives.
+# See: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
+misconfigurations:
+  - id: AVD-KSV-0109
+    paths:
+      - "kubernetes/apps/observability/oxidized/app/configmap.yaml"
+    statement: |
+      False positive. The oxidized YAML schema requires top-level 'username'
+      and 'password' keys; the values here are literal 'placeholder' strings,
+      not secrets. Real device credentials come from oxidized-secret (rendered
+      by the ExternalSecret) into a Secret-mounted router.db. The 'token=' is
+      a curl --form-string flag in a Pushover hook, not a secret value.
+
+  - id: AVD-KSV-01010
+    paths:
+      - "kubernetes/apps/observability/oxidized/app/configmap.yaml"
+    statement: |-
+      False positive. Flagged keys (username, email, remote_repo) are config
+      field names, not sensitive content. The git commit author email and the
+      public GitHub remote URL for the network-configs repo are non-sensitive.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -2,7 +2,7 @@
 # Trivy SARIF filter — path-scoped suppressions for known false positives.
 # See: https://aquasecurity.github.io/trivy/latest/docs/configuration/filtering/
 misconfigurations:
-  - id: AVD-KSV-0109
+  - id: KSV-0109
     paths:
       - "kubernetes/apps/observability/oxidized/app/configmap.yaml"
     statement: |
@@ -12,7 +12,7 @@ misconfigurations:
       by the ExternalSecret) into a Secret-mounted router.db. The 'token=' is
       a curl --form-string flag in a Pushover hook, not a secret value.
 
-  - id: AVD-KSV-01010
+  - id: KSV-01010
     paths:
       - "kubernetes/apps/observability/oxidized/app/configmap.yaml"
     statement: |-

--- a/docs/superpowers/plans/2026-04-29-oxidized-RESUME.md
+++ b/docs/superpowers/plans/2026-04-29-oxidized-RESUME.md
@@ -1,0 +1,112 @@
+# Oxidized — Session Resume Notes (paused 2026-04-29 evening)
+
+> **Pick this up tomorrow.** Read this file first, then continue from the "Next steps" section at the bottom.
+
+## What's done
+
+✅ **Spec** — `docs/superpowers/specs/2026-04-29-oxidized-design.md` — committed.
+✅ **Implementation plan** — `docs/superpowers/plans/2026-04-29-oxidized.md` — committed.
+✅ **Spec + plan corrections committed** — exporter port (8080 not 9001), CLI flag (`--url` not `--oxidized-url`), and metric name (`oxidized_device_status != 2 for: 48h`, replacing the non-existent `oxidized_node_last_success_timestamp_seconds`).
+✅ **Branch:** `feat/observability-oxidized` in talos-cluster, three commits.
+✅ **Phase 0 / Task 0.2** — exporter metric semantics resolved during planning by reading the akquinet/oxidized-exporter source. Recorded in plan.
+🟡 **Phase 0 / Task 0.3** — image digests partially resolved:
+
+```
+OXIDIZED_DIGEST=sha256:12c0155d7f7c827fd884cb9d33b8aac44fa6291a9e54499cca6e3122e90c47b9
+EXPORTER_DIGEST=<unresolved — see "Open issues" below>
+ALPINE_DIGEST=sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+BUSYBOX_DIGEST=sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+```
+
+Saved to `~/tmp/oxidized-resolved.env`.
+
+## What's not done
+
+⏸ **Phase 0 / Task 0.1** — Ruckus model. **Assumed `ruckusunleashed`** based on "ruckus r770". To be confirmed by SSHing the device or just trying it during validation deploy.
+⏸ **Phase 0 / Task 0.4** — GitHub repo + deploy key. NOT created yet.
+⏸ **Phase 0 / Task 0.5** — Consolidated `oxidized` 1Password item. NOT created yet.
+⏸ **Phase 1, 2, 3, 4** — not started.
+
+## Open issues / decisions needed
+
+### Issue 1: Exporter image tag `v1.0.7` does not exist on GHCR
+
+The README mentions v1.0.7 as the latest release, but `ghcr.io/akquinet/oxidized-exporter` only publishes tags up through **`v1.0.5`** (plus various `sha-...` tags). The "v1.0.7 release" on GitHub may not have a corresponding container image, or the publishing pipeline failed.
+
+**Resolution options for tomorrow:**
+- **A)** Use `v1.0.5` instead. Plan/spec mention `v1.0.7` and need updating.
+- **B)** Re-check the upstream — perhaps the v1.0.7 image was published with delay.
+- **C)** Use one of the `sha-...` floating tags. Not ideal — Renovate won't track them.
+
+Recommendation: **A** — switch to `v1.0.5`, fetch its digest, update spec/plan accordingly. Renovate will then auto-PR upgrades to v1.0.6+ as they land.
+
+### Issue 2: GLiNet has no credentials in 1Password
+
+Searched both `Home Operations` and `Talos` vaults — no `Network-GLiNet` or similar item exists. The `network-ops/.env.example` references `op://Home Operations/Network-GLiNet/...` paths, but the item itself was never created.
+
+**Decision needed:**
+- **A)** Drop GLiNet from Oxidized scope (5 devices instead of 6) — simplest.
+- **B)** Create the `Network-GLiNet` 1Password item now (you'd need to populate user/pass).
+- **C)** Skip until later — leave a `# TODO` placeholder in `router.db` and add when ready.
+
+Recommendation: **A**. Adding back later is one ConfigMap edit away.
+
+### Issue 3: Pushover application token needed
+
+Existing `Talos/pushover` item only has `PUSHOVER_USER_KEY` and `PUSHOVER_USER_EMAIL`. Pushover requires a per-application **token** which is created by you at <https://pushover.net/apps/build> — can't be created via API.
+
+**Action for tomorrow:**
+1. Go to <https://pushover.net/apps/build>.
+2. Create an app named "Oxidized" — note the application API token.
+3. Decide where to store it:
+   - Add a `PUSHOVER_TOKEN` field to the existing `Talos/pushover` item, OR
+   - Put it directly in the new `Talos/oxidized` item we'll create.
+
+## Discoveries from today (don't re-research these)
+
+| Finding | Location |
+|---|---|
+| Cluster's ESO reads only from `Talos` 1Password vault (not `Home Operations`) | `kubernetes/apps/external-secrets/onepassword-connect/app/clustersecretstore.yaml` line 12 |
+| `Network-OPNsense` already has `username` + `password` fields (so SSH access is viable, no new creds needed) | `op item get "Network-OPNsense" --vault "Home Operations"` |
+| Ruckus item is titled `Network-Ops - Ruckus` (note spaces around the dash) — not `Network-Ruckus` | `op item list --vault "Home Operations"` |
+| MikroTik has SEPARATE per-device creds: `Network-MikroTik-PoE` and `Network-MikroTik-NonPoE` | (spec/plan currently assume shared `MIKROTIK_USERNAME/PASSWORD` — needs splitting into `MIKROTIK_POE_*` + `MIKROTIK_NONPOE_*`) |
+| Exporter listens on port `8080`, flag `--url` / `-U`, metric is `oxidized_device_status` (2/1/0) | akquinet/oxidized-exporter source (already corrected in spec/plan) |
+| The user's `crane` and `skopeo` aren't in the project mise toolchain — use `docker buildx imagetools` for digests, registry API + bearer token for GHCR | `~/.mise.toml` and tested today |
+| Docker daemon (OrbStack) wasn't running during today's session — `docker buildx imagetools inspect` worked anyway because it goes registry-direct, but `docker pull` did not | OrbStack — start it before running digest commands tomorrow |
+
+## Plan adjustments needed in `2026-04-29-oxidized.md` before proceeding
+
+Spotted today but not yet edited into the plan:
+
+1. **Remove `MIKROTIK_USERNAME`/`MIKROTIK_PASSWORD`, replace with `MIKROTIK_POE_USERNAME`/`MIKROTIK_POE_PASSWORD` + `MIKROTIK_NONPOE_USERNAME`/`MIKROTIK_NONPOE_PASSWORD`** — affects Task 1.5 (router.db template), Task 1.6 (ExternalSecret), Task 1.7 (init container env vars).
+2. **Update exporter image tag** if Issue 1 resolves to v1.0.5 — affects Task 1.7.
+3. **Drop GLiNet line from `router.db` template** if Issue 2 resolves to drop scope — affects Task 1.5.
+4. **The `oxidized` 1Password item must live in `Talos` vault, not `Home Operations`** — affects Task 0.5 (one-line clarification).
+
+## Next steps when resuming
+
+In order:
+
+1. **Decide on the three open issues** (exporter tag, GLiNet scope, Pushover app token) — small block of decisions, ~5 min.
+2. **Edit the plan** to reflect those decisions + the four spec adjustments above. One commit.
+3. **Finish Phase 0:**
+   - Get the v1.0.5 (or whichever) exporter digest.
+   - Create Pushover app + record token.
+   - Create GitHub repo + deploy key (Task 0.4).
+   - Create `Talos/oxidized` 1Password item using `op item create` with cross-vault `op read` for device creds (Task 0.5).
+4. **Dispatch first Phase 1 subagent** for Task 1.1 (directory + namespace registration). From then on, subagent-driven flow runs as planned.
+
+## Quick start commands for tomorrow
+
+```bash
+# 1. Make sure Docker is running (for re-fetching digests if needed)
+open -a OrbStack   # or whichever Docker provider
+
+# 2. Get back to where we were
+cd ~/GIT/LukeEvansTech/talos-cluster
+git checkout feat/observability-oxidized
+git log --oneline -5
+
+# 3. Re-read this file, then the plan, then start chipping away at "Next steps"
+cat docs/superpowers/plans/2026-04-29-oxidized-RESUME.md
+```

--- a/docs/superpowers/plans/2026-04-29-oxidized.md
+++ b/docs/superpowers/plans/2026-04-29-oxidized.md
@@ -1,0 +1,1571 @@
+# Oxidized Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Oxidized into the `observability` namespace to back up six homelab network device configs to a private GitHub repo daily, with Pushover drift alerts.
+
+**Architecture:** Single-pod app deployed via `bjw-s/app-template` HelmRelease. Two init containers (one renders SSH deploy key to tmpfs, the other `envsubst`-renders `router.db` with credentials to tmpfs). Sidecar `oxidized-exporter` exposes per-device last-success metrics. State persisted on a Ceph PVC; secrets only in Kubernetes Secret + tmpfs.
+
+**Tech Stack:** Talos Linux · Kubernetes · Flux CD · `bjw-s/app-template` v4.6.2 · ExternalSecrets (1Password Connect) · Gateway API · kube-prometheus-stack · VolSync · Renovate.
+
+**Spec:** [`docs/superpowers/specs/2026-04-29-oxidized-design.md`](../specs/2026-04-29-oxidized-design.md)
+
+**Working branch:** `feat/observability-oxidized` (already created in talos-cluster).
+
+---
+
+## Phase 0 — Resolve open items
+
+Five facts are unknown at design time and must be filled in before manifests are committed. Each one is a small lookup.
+
+### Task 0.1: Confirm Ruckus product variant
+
+The spec assumes `ruckusunleashed`. The Oxidized model must match the actual product (Unleashed / SmartZone / ZoneDirector / generic Ruckus).
+
+**Files:** None — research only.
+
+- [ ] **Step 1: Identify the Ruckus product**
+
+```bash
+# From a workstation with network access:
+ssh "$RUCKUS_USERNAME@ruckus.lan"
+# At the Ruckus prompt, run:
+ruckus> show version
+```
+
+The output mentions one of: "Unleashed", "SmartZone (vSZ)", "ZoneDirector". Note which.
+
+- [ ] **Step 2: Pick the Oxidized model**
+
+Map product → Oxidized model name (used as the `model:` column in `router.db`):
+
+| Product | Oxidized model |
+|---|---|
+| Unleashed | `ruckusunleashed` |
+| SmartZone | `ruckussmartzone` |
+| ZoneDirector | `ruckus` |
+
+Record the chosen value. It will be used in **Task 1.5**.
+
+- [ ] **Step 3: Update spec if it differs from default**
+
+If the chosen value is **not** `ruckusunleashed`, edit `docs/superpowers/specs/2026-04-29-oxidized-design.md`:
+- Update the Ruckus row in the **Scope** table.
+- Update the example `router.db` line in the **`router.db` template** section.
+- Commit: `docs(oxidized): correct ruckus oxidized model`
+
+### Task 0.2: Confirm exporter metric name
+
+The PrometheusRule `expr:` uses `oxidized_node_last_success_timestamp_seconds`. Verify the actual metric name from the exporter.
+
+**Files:** None — research only.
+
+- [ ] **Step 1: Read the exporter README**
+
+```bash
+gh repo view akquinet/oxidized-exporter -w
+# OR
+curl -s https://raw.githubusercontent.com/akquinet/oxidized-exporter/main/README.md
+```
+
+Search for the metrics table. Note the exact metric that represents "last successful run timestamp per node" — common names are `oxidized_last_run_timestamp`, `oxidized_node_status`, etc.
+
+- [ ] **Step 2: Record the actual metric name**
+
+Save it as a note for **Task 1.7** (PrometheusRule). If it differs from `oxidized_node_last_success_timestamp_seconds`, the alert `expr` must be adjusted.
+
+### Task 0.3: Resolve image digests + record open-item values
+
+Both container images need a `@sha256:...` digest pinned per repo convention. Also record the values from Tasks 0.1 and 0.2 in a single scratch file so Task 1.7 and 1.9 can paste from one place.
+
+**Files:**
+- Create (workstation, gitignored): `~/tmp/oxidized-resolved.env`
+
+- [ ] **Step 1: Pull digests**
+
+```bash
+mkdir -p ~/tmp
+{
+  echo "OXIDIZED_DIGEST=$(crane digest oxidized/oxidized:0.36.0)"
+  echo "EXPORTER_DIGEST=$(crane digest ghcr.io/akquinet/oxidized-exporter:v1.0.7)"
+  echo "ALPINE_DIGEST=$(crane digest alpine:3.21)"
+  echo "BUSYBOX_DIGEST=$(crane digest busybox:1.37)"
+} > ~/tmp/oxidized-resolved.env
+cat ~/tmp/oxidized-resolved.env
+```
+
+Expected: 4 lines, each `<NAME>=sha256:abc123...`.
+
+- [ ] **Step 2: Append the values from Tasks 0.1 and 0.2**
+
+```bash
+cat <<EOF >> ~/tmp/oxidized-resolved.env
+RUCKUS_MODEL=<value-from-Task-0.1>
+EXPORTER_METRIC_NAME=<value-from-Task-0.2>
+EOF
+cat ~/tmp/oxidized-resolved.env
+```
+
+Hand-edit the two `<value-...>` placeholders to the actual values from those tasks. This single file is the source of truth for Tasks 1.5, 1.7, and 1.9.
+
+- [ ] **Step 3: Verify the file contents**
+
+```bash
+grep -c "^[A-Z_]*=sha256:\|^[A-Z_]*=[a-z_]" ~/tmp/oxidized-resolved.env
+```
+
+Expected: `6` (4 digests + RUCKUS_MODEL + EXPORTER_METRIC_NAME).
+
+### Task 0.4: Create GitHub repo + deploy key
+
+The repo and key must exist before Oxidized first runs.
+
+**Files:** None — out-of-cluster setup.
+
+- [ ] **Step 1: Create the private repo**
+
+```bash
+gh repo create LukeEvansTech/network-configs \
+  --private \
+  --description "Oxidized-managed network device config backups (auto-generated)" \
+  --add-readme
+```
+
+Expected: `https://github.com/LukeEvansTech/network-configs created`.
+
+- [ ] **Step 2: Generate a dedicated SSH deploy key (ed25519, no passphrase)**
+
+```bash
+mkdir -p ~/tmp/oxidized-key && cd ~/tmp/oxidized-key
+ssh-keygen -t ed25519 -C "oxidized@network-configs" -f ./id_ed25519 -N ""
+ls -la
+# Should show id_ed25519 and id_ed25519.pub
+```
+
+- [ ] **Step 3: Attach the public key to the repo with WRITE access**
+
+```bash
+gh repo deploy-key add ~/tmp/oxidized-key/id_ed25519.pub \
+  --repo LukeEvansTech/network-configs \
+  --title "oxidized-cluster" \
+  --allow-write
+```
+
+Expected: `✓ Deploy key created in LukeEvansTech/network-configs`.
+
+- [ ] **Step 4: Capture the GitHub `known_hosts` line**
+
+```bash
+ssh-keyscan -t ed25519 github.com 2>/dev/null
+# Capture the single line of output (starts with "github.com")
+```
+
+Record this line as `GITHUB_KNOWN_HOSTS`.
+
+- [ ] **Step 5: Stash the private key contents for use in Task 0.5**
+
+```bash
+cat ~/tmp/oxidized-key/id_ed25519
+# Capture the multi-line content (-----BEGIN OPENSSH PRIVATE KEY----- ... END ...)
+```
+
+Will be entered into 1Password in **Task 0.5**. Do **not** commit this anywhere.
+
+### Task 0.5: Create the `oxidized` 1Password item
+
+ExternalSecret pulls 14 fields from a single 1Password item. Create it now.
+
+**Files:** None — out-of-cluster setup.
+
+- [ ] **Step 1: Identify the correct vault**
+
+The same vault used by other apps (e.g., `gitea`, `forgejo`). Inspect another app's externalsecret.yaml to confirm:
+
+```bash
+cat ~/GIT/LukeEvansTech/talos-cluster/kubernetes/apps/default/gitea/app/externalsecret.yaml
+```
+
+The `dataFrom.extract.key` value (e.g., `gitea`) corresponds to the 1Password item title in the connected vault.
+
+- [ ] **Step 2: Create the `oxidized` item**
+
+In the 1Password UI (or via CLI), create a new **Secure Note** or **Login** item titled exactly `oxidized` in that vault, with these custom fields (text):
+
+| Field name | Value |
+|---|---|
+| `OPNSENSE_USERNAME` | A user with **shell access** on OPNsense (not just GUI) |
+| `OPNSENSE_PASSWORD` | Their password |
+| `ONYX_USERNAME` | Reuse from existing 1Password Onyx item |
+| `ONYX_PASSWORD` | Reuse from existing 1Password Onyx item |
+| `MIKROTIK_USERNAME` | Reuse from existing MikroTik item |
+| `MIKROTIK_PASSWORD` | Reuse from existing MikroTik item |
+| `RUCKUS_USERNAME` | Reuse from existing Ruckus item |
+| `RUCKUS_PASSWORD` | Reuse from existing Ruckus item |
+| `GLINET_USERNAME` | Reuse from existing GL.iNet item |
+| `GLINET_PASSWORD` | Reuse from existing GL.iNet item |
+| `GITHUB_DEPLOY_KEY` | Multi-line — full content of `id_ed25519` from Task 0.4 step 5 |
+| `GITHUB_KNOWN_HOSTS` | The `ssh-keyscan` line from Task 0.4 step 4 |
+| `PUSHOVER_TOKEN` | Pushover **app token** (not user key) — create a new app at <https://pushover.net/apps/build> named "Oxidized" |
+| `PUSHOVER_USER_KEY` | Pushover **user key** (visible at <https://pushover.net>) |
+
+- [ ] **Step 3: Smoke test that 1Password Connect can read the item**
+
+```bash
+op item get oxidized --vault <vault-name> --format json | jq -r '.fields[] | "\(.label): \(if .value then "✓" else "✗ EMPTY" end)"'
+```
+
+Expected: 14 lines, all `✓`. Any `✗ EMPTY` means the field was not saved correctly.
+
+- [ ] **Step 4: Securely shred the local private key files**
+
+```bash
+rm -P ~/tmp/oxidized-key/id_ed25519 ~/tmp/oxidized-key/id_ed25519.pub
+rmdir ~/tmp/oxidized-key
+```
+
+(Private key now lives only in 1Password and the deploy-key public half on GitHub.)
+
+---
+
+## Phase 1 — Author manifest files
+
+Each manifest is one task: write the file, run `flux-local build`, commit. Files are created in dependency order (skeleton first → resources → registration).
+
+### Task 1.1: Create directory + register in observability kustomization
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/` (directory)
+- Modify: `kubernetes/apps/observability/kustomization.yaml`
+
+- [ ] **Step 1: Create the directory tree**
+
+```bash
+cd ~/GIT/LukeEvansTech/talos-cluster
+mkdir -p kubernetes/apps/observability/oxidized/app
+```
+
+- [ ] **Step 2: Add `./oxidized/ks.yaml` to the namespace kustomization**
+
+Edit `kubernetes/apps/observability/kustomization.yaml`. Insert `- ./oxidized/ks.yaml` alphabetically — between `./nut-exporter/ks.yaml` and `./peanut/ks.yaml`:
+
+```yaml
+  - ./nut-exporter/ks.yaml
+  - ./oxidized/ks.yaml
+  - ./peanut/ks.yaml
+```
+
+- [ ] **Step 3: Verify yamlfmt passes**
+
+```bash
+yamlfmt kubernetes/apps/observability/kustomization.yaml
+git diff kubernetes/apps/observability/kustomization.yaml
+```
+
+Expected: only the one new line added; no other formatting drift. (If yamlfmt rewrote anything else, leave the unrelated changes uncommitted.)
+
+- [ ] **Step 4: Commit**
+
+(We commit even though no `ks.yaml` exists yet — flux-local's full build will fail until Task 1.2 commits ks.yaml. We accept that briefly.)
+
+```bash
+git add kubernetes/apps/observability/kustomization.yaml
+git commit -m "feat(oxidized): register kustomization (skeleton)"
+```
+
+### Task 1.2: Create `ks.yaml` (Flux Kustomization)
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/ks.yaml`
+
+- [ ] **Step 1: Write the Flux Kustomization**
+
+`kubernetes/apps/observability/oxidized/ks.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oxidized
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: external-secrets-stores
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/observability/oxidized/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+```
+
+- [ ] **Step 2: Run yamlfmt**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/ks.yaml
+```
+
+Expected: file unchanged (already correct).
+
+- [ ] **Step 3: Validate with flux-local (will fail until app/ has at least kustomization.yaml — proceed anyway)**
+
+```bash
+flux-local build ks --path kubernetes/flux/cluster oxidized 2>&1 | head -20
+```
+
+Expected: error mentioning the `app/` path doesn't have a `kustomization.yaml` yet. That's fine — fixed in Task 1.3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/apps/observability/oxidized/ks.yaml
+git commit -m "feat(oxidized): add flux kustomization"
+```
+
+### Task 1.3: Create `app/kustomization.yaml`
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/kustomization.yaml`
+
+- [ ] **Step 1: Write the kustomization**
+
+`kubernetes/apps/observability/oxidized/app/kustomization.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/volsync
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml
+```
+
+- [ ] **Step 2: Run yamlfmt**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/kustomization.yaml
+```
+
+- [ ] **Step 3: flux-local will still fail (resources missing); skip it**
+
+Expected behavior — moving on.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/apps/observability/oxidized/app/kustomization.yaml
+git commit -m "feat(oxidized): add app kustomization"
+```
+
+### Task 1.4: Create `ocirepository.yaml`
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/ocirepository.yaml`
+
+- [ ] **Step 1: Write the file**
+
+`kubernetes/apps/observability/oxidized/app/ocirepository.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+```
+
+- [ ] **Step 2: yamlfmt + commit**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/ocirepository.yaml
+git add kubernetes/apps/observability/oxidized/app/ocirepository.yaml
+git commit -m "feat(oxidized): add app-template OCI repository"
+```
+
+### Task 1.5: Create `configmap.yaml` (Oxidized config + router.db template)
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/configmap.yaml`
+
+- [ ] **Step 1: Write the file**
+
+Use the **Oxidized model name from Task 0.1** in place of `ruckusunleashed` if it differs. Replace `${SECRET_DOMAIN}` placeholder is left literal — Flux substitutes it at apply time from the cluster-secrets postBuild.
+
+`kubernetes/apps/observability/oxidized/app/configmap.yaml`:
+
+```yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oxidized-config
+data:
+  config: |
+    ---
+    username: placeholder
+    password: placeholder
+    model: routeros
+    interval: 86400
+    log: /home/oxidized/.config/oxidized/oxidized.log
+    debug: false
+    threads: 6
+    timeout: 30
+    retries: 2
+    rest: 0.0.0.0:8888
+    prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/
+
+    input:
+      default: ssh
+      ssh:
+        secure: false
+
+    output:
+      default: git
+      git:
+        user: Oxidized
+        email: oxidized@${SECRET_DOMAIN}
+        repo: /home/oxidized/.config/oxidized/devices.git
+
+    source:
+      default: csv
+      csv:
+        file: /etc/oxidized/router.db.d/router.db
+        delimiter: !ruby/regexp /:/
+        map:
+          name: 0
+          ip: 1
+          model: 2
+          username: 3
+          password: 4
+
+    hooks:
+      push_to_github:
+        type: githubrepo
+        events: [post_store]
+        remote_repo: git@github.com:LukeEvansTech/network-configs.git
+        publickey_file: /home/oxidized/.ssh/id_ed25519.pub
+        privatekey_file: /home/oxidized/.ssh/id_ed25519
+      pushover_drift:
+        type: exec
+        events: [post_store]
+        cmd: |
+          curl -s --form-string "token=$PUSHOVER_TOKEN" \
+                  --form-string "user=$PUSHOVER_USER_KEY" \
+                  --form-string "title=Oxidized: config drift" \
+                  --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) changed" \
+                  https://api.pushover.net/1/messages.json
+      pushover_fail:
+        type: exec
+        events: [node_fail]
+        cmd: |
+          curl -s --form-string "token=$PUSHOVER_TOKEN" \
+                  --form-string "user=$PUSHOVER_USER_KEY" \
+                  --form-string "title=Oxidized: poll failed" \
+                  --form-string "priority=1" \
+                  --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) — $OX_NODE_MSG" \
+                  https://api.pushover.net/1/messages.json
+  router.db: |
+    opnsense:opnsense.lan:opnsense:${OPNSENSE_USERNAME}:${OPNSENSE_PASSWORD}
+    onyx:onyx.lan:onyx:${ONYX_USERNAME}:${ONYX_PASSWORD}
+    mikrotik_poe:mikrotik-poe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
+    mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
+    ruckus:ruckus.lan:ruckusunleashed:${RUCKUS_USERNAME}:${RUCKUS_PASSWORD}
+    glinet:glinet.lan:openwrt:${GLINET_USERNAME}:${GLINET_PASSWORD}
+```
+
+> **Note on Flux postBuild substitution scope**: Flux's postBuild substitutes `${VARNAME}` against the cluster-secrets ConfigMap. The `${OPNSENSE_USERNAME}` etc. placeholders in `router.db` would be substituted by Flux **only if they exist in cluster-secrets** — they don't, so Flux leaves them literal (good, that's what we want). The `envsubst` init container then substitutes them against env vars from the Secret.
+>
+> However, `${SECRET_DOMAIN}` IS in cluster-secrets and **will** be substituted by Flux at apply time. That's correct.
+>
+> If Flux warns about undefined variables for the device creds, the fix is `postBuild.substituteFrom` not affecting unmatched names by default. If a strict mode does throw, escape with `$${OPNSENSE_USERNAME}` in this file (and update the `envsubst` invocation in Task 1.7 accordingly to handle the doubled `$`).
+
+- [ ] **Step 2: yamlfmt + commit**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/configmap.yaml
+git add kubernetes/apps/observability/oxidized/app/configmap.yaml
+git commit -m "feat(oxidized): add config + router.db template"
+```
+
+### Task 1.6: Create `externalsecret.yaml`
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/externalsecret.yaml`
+
+- [ ] **Step 1: Write the file**
+
+`kubernetes/apps/observability/oxidized/app/externalsecret.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oxidized
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: oxidized-secret
+    template:
+      engineVersion: v2
+      data:
+        OPNSENSE_USERNAME: "{{ .OPNSENSE_USERNAME }}"
+        OPNSENSE_PASSWORD: "{{ .OPNSENSE_PASSWORD }}"
+        ONYX_USERNAME: "{{ .ONYX_USERNAME }}"
+        ONYX_PASSWORD: "{{ .ONYX_PASSWORD }}"
+        MIKROTIK_USERNAME: "{{ .MIKROTIK_USERNAME }}"
+        MIKROTIK_PASSWORD: "{{ .MIKROTIK_PASSWORD }}"
+        RUCKUS_USERNAME: "{{ .RUCKUS_USERNAME }}"
+        RUCKUS_PASSWORD: "{{ .RUCKUS_PASSWORD }}"
+        GLINET_USERNAME: "{{ .GLINET_USERNAME }}"
+        GLINET_PASSWORD: "{{ .GLINET_PASSWORD }}"
+        GITHUB_DEPLOY_KEY: "{{ .GITHUB_DEPLOY_KEY }}"
+        GITHUB_KNOWN_HOSTS: "{{ .GITHUB_KNOWN_HOSTS }}"
+        PUSHOVER_TOKEN: "{{ .PUSHOVER_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+  dataFrom:
+    - extract:
+        key: oxidized
+```
+
+- [ ] **Step 2: yamlfmt + commit**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+git add kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+git commit -m "feat(oxidized): add externalsecret"
+```
+
+### Task 1.7: Create `helmrelease.yaml`
+
+This is the largest single file. Use the digests captured in **Task 0.3**.
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/helmrelease.yaml`
+
+- [ ] **Step 1: Write the file**
+
+Replace `<OXIDIZED_DIGEST>`, `<EXPORTER_DIGEST>`, `<ALPINE_DIGEST>`, `<BUSYBOX_DIGEST>` with the values from Task 0.3.
+
+`kubernetes/apps/observability/oxidized/app/helmrelease.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app oxidized
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      oxidized:
+        strategy: Recreate
+        initContainers:
+          ssh-setup:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37@sha256:<BUSYBOX_DIGEST>
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                install -m 0700 -d /ssh-out
+                printf '%s\n' "$GITHUB_DEPLOY_KEY" > /ssh-out/id_ed25519
+                chmod 0600 /ssh-out/id_ed25519
+                ssh-keygen -y -f /ssh-out/id_ed25519 > /ssh-out/id_ed25519.pub
+                printf '%s\n' "$GITHUB_KNOWN_HOSTS" > /ssh-out/known_hosts
+                chmod 0644 /ssh-out/id_ed25519.pub /ssh-out/known_hosts
+            env:
+              GITHUB_DEPLOY_KEY:
+                valueFrom:
+                  secretKeyRef: { name: oxidized-secret, key: GITHUB_DEPLOY_KEY }
+              GITHUB_KNOWN_HOSTS:
+                valueFrom:
+                  secretKeyRef: { name: oxidized-secret, key: GITHUB_KNOWN_HOSTS }
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: { drop: [ALL] }
+              seccompProfile: { type: RuntimeDefault }
+          router-db-render:
+            image:
+              repository: docker.io/library/alpine
+              tag: 3.21@sha256:<ALPINE_DIGEST>
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                apk add --no-cache gettext >/dev/null
+                envsubst < /etc/oxidized-tmpl/router.db > /router-out/router.db
+                chmod 0600 /router-out/router.db
+            env:
+              OPNSENSE_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: OPNSENSE_USERNAME } } }
+              OPNSENSE_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: OPNSENSE_PASSWORD } } }
+              ONYX_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: ONYX_USERNAME } } }
+              ONYX_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: ONYX_PASSWORD } } }
+              MIKROTIK_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_USERNAME } } }
+              MIKROTIK_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_PASSWORD } } }
+              RUCKUS_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: RUCKUS_USERNAME } } }
+              RUCKUS_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: RUCKUS_PASSWORD } } }
+              GLINET_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: GLINET_USERNAME } } }
+              GLINET_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: GLINET_PASSWORD } } }
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: { drop: [ALL] }
+              seccompProfile: { type: RuntimeDefault }
+        containers:
+          app:
+            image:
+              repository: docker.io/oxidized/oxidized
+              tag: 0.36.0@sha256:<OXIDIZED_DIGEST>
+            env:
+              PUSHOVER_TOKEN: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: PUSHOVER_TOKEN } } }
+              PUSHOVER_USER_KEY: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: PUSHOVER_USER_KEY } } }
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: { port: 8888 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /nodes.json, port: 8888 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+            resources:
+              requests: { cpu: 50m, memory: 128Mi }
+              limits: { memory: 256Mi }
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: { drop: [ALL] }
+              seccompProfile: { type: RuntimeDefault }
+          exporter:
+            image:
+              repository: ghcr.io/akquinet/oxidized-exporter
+              tag: v1.0.7@sha256:<EXPORTER_DIGEST>
+            args:
+              - --oxidized-url=http://localhost:8888
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: { port: 9001 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /metrics, port: 9001 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+            resources:
+              requests: { cpu: 10m, memory: 32Mi }
+              limits: { memory: 64Mi }
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: { drop: [ALL] }
+              seccompProfile: { type: RuntimeDefault }
+        pod:
+          securityContext:
+            fsGroup: 30000
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: oxidized
+        ports:
+          http: { port: 8888 }
+          metrics: { port: 9001 }
+
+    serviceMonitor:
+      app:
+        serviceName: oxidized
+        endpoints:
+          - port: metrics
+            interval: 30s
+            scrapeTimeout: 10s
+
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: ${VOLSYNC_CAPACITY}
+        advancedMounts:
+          oxidized:
+            app:
+              - path: /home/oxidized/.config/oxidized
+      ssh:
+        type: emptyDir
+        medium: Memory
+        advancedMounts:
+          oxidized:
+            ssh-setup:
+              - path: /ssh-out
+            app:
+              - path: /home/oxidized/.ssh
+                readOnly: true
+      router-db:
+        type: emptyDir
+        medium: Memory
+        advancedMounts:
+          oxidized:
+            router-db-render:
+              - path: /router-out
+            app:
+              - path: /etc/oxidized/router.db.d
+                readOnly: true
+      oxidized-config:
+        type: configMap
+        name: oxidized-config
+        advancedMounts:
+          oxidized:
+            app:
+              - subPath: config
+                path: /etc/oxidized/config
+            router-db-render:
+              - subPath: router.db
+                path: /etc/oxidized-tmpl/router.db
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          oxidized:
+            app:
+              - path: /tmp
+```
+
+- [ ] **Step 2: yamlfmt + commit**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+git add kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+git commit -m "feat(oxidized): add helmrelease"
+```
+
+### Task 1.8: Create `httproute.yaml`
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/httproute.yaml`
+
+- [ ] **Step 1: Write the file**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oxidized
+spec:
+  hostnames:
+    - oxidized.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: oxidized
+          port: 8888
+```
+
+- [ ] **Step 2: yamlfmt + commit**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/httproute.yaml
+git add kubernetes/apps/observability/oxidized/app/httproute.yaml
+git commit -m "feat(oxidized): add httproute"
+```
+
+### Task 1.9: Create `prometheusrule.yaml`
+
+Use the metric name from **Task 0.2**. Below template assumes `oxidized_node_last_success_timestamp_seconds`; substitute the actual name.
+
+**Files:**
+- Create: `kubernetes/apps/observability/oxidized/app/prometheusrule.yaml`
+
+- [ ] **Step 1: Write the file**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oxidized
+spec:
+  groups:
+    - name: oxidized
+      rules:
+        - alert: OxidizedDeviceStale
+          annotations:
+            summary: Oxidized has not polled {{ $labels.node }} successfully in over 48h.
+            description: The last successful Oxidized poll for {{ $labels.node }} was more than 48h ago. Check the device or the cluster's reachability to it.
+          expr: (time() - oxidized_node_last_success_timestamp_seconds) > 172800
+          for: 10m
+          labels:
+            severity: warning
+        - alert: OxidizedDown
+          annotations:
+            summary: Oxidized exporter is down.
+            description: Prometheus has been unable to scrape oxidized-exporter for 15m.
+          expr: up{job=~".*oxidized.*"} == 0
+          for: 15m
+          labels:
+            severity: warning
+```
+
+- [ ] **Step 2: yamlfmt + commit**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/prometheusrule.yaml
+git add kubernetes/apps/observability/oxidized/app/prometheusrule.yaml
+git commit -m "feat(oxidized): add prometheusrule"
+```
+
+### Task 1.10: Full flux-local build validation
+
+**Files:** None — validation only.
+
+- [ ] **Step 1: Build the entire kustomization**
+
+```bash
+cd ~/GIT/LukeEvansTech/talos-cluster
+flux-local build ks --path kubernetes/flux/cluster oxidized 2>&1 | tee /tmp/oxidized-build.txt
+```
+
+Expected: rendered YAML for HelmRelease, OCIRepository, ConfigMap, ExternalSecret, HTTPRoute, PrometheusRule (and the VolSync resources from the component) — no errors.
+
+- [ ] **Step 2: Visually verify the rendered HelmRelease**
+
+```bash
+grep -A2 "image:" /tmp/oxidized-build.txt | head -40
+```
+
+Expected: all four images (oxidized, exporter, alpine, busybox) carry `@sha256:` digests, no `<...>` placeholders.
+
+```bash
+grep -E "(SECRET_DOMAIN|VOLSYNC_CAPACITY)" /tmp/oxidized-build.txt
+```
+
+Expected: `${SECRET_DOMAIN}` is substituted to a real domain; `${VOLSYNC_CAPACITY}` is substituted to `1Gi`.
+
+- [ ] **Step 3: Run lefthook hooks once before opening PR**
+
+```bash
+lefthook run pre-commit
+```
+
+Expected: yamlfmt, prettier, actionlint, shellcheck all pass on changed files.
+
+- [ ] **Step 4: If anything failed, fix and commit. If clean, no commit needed.**
+
+---
+
+## Phase 2 — Pre-deploy verification
+
+Confirm the things that must be true outside the cluster before applying.
+
+### Task 2.1: Confirm in-cluster reachability to each device
+
+**Files:** None — runtime test.
+
+- [ ] **Step 1: Spin up an ephemeral debug pod in `observability`**
+
+```bash
+kubectl run -n observability -it --rm netshoot \
+  --image=ghcr.io/nicolaka/netshoot:latest \
+  --restart=Never -- bash
+```
+
+- [ ] **Step 2: From inside the pod, test each device**
+
+```bash
+for h in opnsense.lan onyx.lan mikrotik-poe.lan mikrotik-nonpoe.lan ruckus.lan glinet.lan; do
+  echo -n "$h:22 "
+  nc -z -w3 "$h" 22 && echo OK || echo FAIL
+done
+echo -n "opnsense.lan:443 "; nc -z -w3 opnsense.lan 443 && echo OK || echo FAIL
+echo -n "ruckus.lan:443 "; nc -z -w3 ruckus.lan 443 && echo OK || echo FAIL
+echo -n "github.com:22 "; nc -z -w3 github.com 22 && echo OK || echo FAIL
+echo -n "api.pushover.net:443 "; nc -z -w3 api.pushover.net 443 && echo OK || echo FAIL
+exit
+```
+
+Expected: every line ends `OK`. Any `FAIL` for an `.lan` host means a missing OPNsense rule between the cluster pod CIDR and the device VLAN — fix on OPNsense before deploying.
+
+- [ ] **Step 3: Confirm DNS resolution**
+
+```bash
+kubectl run -n observability -it --rm netshoot \
+  --image=ghcr.io/nicolaka/netshoot:latest \
+  --restart=Never -- bash -c 'for h in opnsense.lan onyx.lan ruckus.lan; do echo -n "$h: "; getent hosts $h; done'
+```
+
+Expected: each name resolves to an IP. If not, add the device IPs directly to `router.db` instead of hostnames (re-edit ConfigMap).
+
+### Task 2.2: Confirm credentials work (manual login from workstation)
+
+**Files:** None — runtime test.
+
+- [ ] **Step 1: Test SSH/API to each device using the credentials staged in 1Password**
+
+```bash
+ssh "$OPNSENSE_USERNAME@opnsense.lan" "exit"   # → 0 if creds OK
+ssh "$ONYX_USERNAME@onyx.lan" "exit"
+ssh "$MIKROTIK_USERNAME@mikrotik-poe.lan" "/system identity print"
+ssh "$MIKROTIK_USERNAME@mikrotik-nonpoe.lan" "/system identity print"
+ssh "$RUCKUS_USERNAME@ruckus.lan" "exit"        # method depends on Ruckus product; may use HTTPS API instead
+ssh "$GLINET_USERNAME@glinet.lan" "exit"
+```
+
+Expected: each succeeds. Any failure → fix the credential in 1Password before deploying.
+
+### Task 2.3: Confirm namespace NetworkPolicy permits required egress
+
+The `observability` namespace has a namespace-wide `netpol.yaml`. Verify it allows the egress paths Oxidized needs (device VLAN ports, GitHub SSH, Pushover HTTPS, Ceph, kube-dns); add a per-app `netpol.yaml` if not.
+
+**Files:** None initially — review only. Possibly create `kubernetes/apps/observability/oxidized/app/netpol.yaml`.
+
+- [ ] **Step 1: Read the existing namespace policy**
+
+```bash
+cat kubernetes/apps/observability/netpol.yaml
+```
+
+Determine its model:
+- **Default-allow-egress** (no egress restriction): nothing more to do.
+- **Default-deny-egress with explicit allow rules**: must extend.
+- **Selector-based** (per-app rules): add a per-app entry.
+
+- [ ] **Step 2: Test live egress now (with the cluster's current policies)**
+
+From inside the running pod (after Task 3.2 is done — temporarily move this verification later if you want to do it in order; otherwise skip until then):
+
+```bash
+kubectl -n observability exec deploy/oxidized -c app -- sh -c '
+  for h in opnsense.lan onyx.lan github.com api.pushover.net; do
+    echo -n "$h: "; nc -z -w3 "$h" $([ "$h" = github.com ] && echo 22 || ([ "$h" = api.pushover.net ] && echo 443 || echo 22))
+    echo $?
+  done'
+```
+
+Expected: every line ends `0`. If any returns non-zero with NetworkPolicy in deny-mode, add a per-app netpol.
+
+- [ ] **Step 3 (only if needed): create `kubernetes/apps/observability/oxidized/app/netpol.yaml`**
+
+```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: oxidized
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: oxidized
+  policyTypes: [Egress]
+  egress:
+    # kube-dns
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports: [{ protocol: UDP, port: 53 }, { protocol: TCP, port: 53 }]
+    # device VLAN — broad egress to LAN ranges (tighten to specific /32s if known)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8]
+      ports: [{ protocol: TCP, port: 22 }, { protocol: TCP, port: 443 }]
+    - to:
+        - ipBlock:
+            cidr: 192.168.0.0/16
+      ports: [{ protocol: TCP, port: 22 }, { protocol: TCP, port: 443 }]
+```
+
+(Adjust CIDRs to match your actual LAN. The above is illustrative.)
+
+If you create this file, also add `- ./netpol.yaml` to `kubernetes/apps/observability/oxidized/app/kustomization.yaml`.
+
+- [ ] **Step 4: Commit if a netpol was added**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/netpol.yaml \
+        kubernetes/apps/observability/oxidized/app/kustomization.yaml
+git add kubernetes/apps/observability/oxidized/app/netpol.yaml \
+        kubernetes/apps/observability/oxidized/app/kustomization.yaml
+git commit -m "feat(oxidized): add networkpolicy"
+```
+
+### Task 2.4: Push branch + rebase preflight
+
+**Files:** None — git only.
+
+- [ ] **Step 1: Confirm branch is up to date with main**
+
+```bash
+cd ~/GIT/LukeEvansTech/talos-cluster
+git fetch origin main
+git log --oneline feat/observability-oxidized..origin/main
+```
+
+If the second command shows commits on main that aren't on this branch:
+
+```bash
+git rebase origin/main
+```
+
+- [ ] **Step 2: Push branch (creates upstream)**
+
+```bash
+git push -u origin feat/observability-oxidized
+```
+
+---
+
+## Phase 3 — Validation deploy (short interval)
+
+We deploy with `interval: 60` (1-min poll) so iteration is fast, then restore to 86400 before merge.
+
+### Task 3.1: Temporarily reduce poll interval
+
+**Files:**
+- Modify: `kubernetes/apps/observability/oxidized/app/configmap.yaml`
+
+- [ ] **Step 1: Change `interval: 86400` → `interval: 60`**
+
+Edit the ConfigMap; only the one line in the embedded `config:` block:
+
+```yaml
+    interval: 60                  # TEMPORARY for validation; revert to 86400 before merge
+```
+
+- [ ] **Step 2: yamlfmt + commit (DO NOT push yet — validate locally first)**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/configmap.yaml
+git add kubernetes/apps/observability/oxidized/app/configmap.yaml
+git commit -m "test(oxidized): reduce poll interval to 60s for validation"
+```
+
+### Task 3.2: Apply the Kustomization to the live cluster
+
+`just kube apply-ks` renders locally (`flux-local build`) and applies directly via kubectl, bypassing the GitRepository → kustomize-controller path (which still points at `main`).
+
+**Files:** None — runtime apply.
+
+- [ ] **Step 1: Apply**
+
+```bash
+just kube apply-ks observability oxidized
+```
+
+Expected: outputs `<resource> created` for the HelmRelease, OCIRepository, ConfigMap, ExternalSecret, HTTPRoute, PrometheusRule, and any VolSync resources.
+
+- [ ] **Step 2: Watch the HelmRelease reconcile**
+
+```bash
+flux -n observability get helmrelease oxidized --watch
+```
+
+Expected within ~2 min: `Ready: True`, `Status: Helm install succeeded`. Ctrl-C when ready.
+
+- [ ] **Step 3: Watch pod come up**
+
+```bash
+kubectl -n observability get pods -l app.kubernetes.io/name=oxidized -w
+```
+
+Expected sequence:
+```
+oxidized-...  0/2   Init:0/2     0s
+oxidized-...  0/2   Init:1/2     5s
+oxidized-...  0/2   PodInitializing  10s
+oxidized-...  2/2   Running      30s
+```
+
+If init-1 fails: `kubectl -n observability logs <pod> -c ssh-setup` — usually a malformed deploy key.
+If init-2 fails: `kubectl -n observability logs <pod> -c router-db-render` — usually a missing env var = ExternalSecret not synced.
+
+- [ ] **Step 4: Confirm ExternalSecret is healthy**
+
+```bash
+kubectl -n observability get externalsecret oxidized
+```
+
+Expected: `STATUS: SecretSynced`. If `SecretSyncError`, the 1Password item is missing fields — fix in 1Password and re-sync: `just kube sync-es`.
+
+### Task 3.3: Verify all 6 devices poll successfully
+
+**Files:** None — runtime check.
+
+- [ ] **Step 1: Watch Oxidized's logs for the first poll cycle**
+
+```bash
+kubectl -n observability logs -f deploy/oxidized -c app
+```
+
+You should see (within 2-3 minutes of pod ready):
+```
+... INFO  [opnsense] -- Successfully fetched config
+... INFO  [onyx] -- Successfully fetched config
+... INFO  [mikrotik_poe] -- Successfully fetched config
+... INFO  [mikrotik_nonpoe] -- Successfully fetched config
+... INFO  [ruckus] -- Successfully fetched config
+... INFO  [glinet] -- Successfully fetched config
+```
+
+Ctrl-C after all six log a success.
+
+- [ ] **Step 2: Confirm via the REST API**
+
+```bash
+kubectl -n observability port-forward svc/oxidized 8888:8888 &
+PF=$!
+sleep 2
+curl -s http://localhost:8888/nodes.json | jq -r '.[] | "\(.name): \(.status) (last: \(.last.start))"'
+kill $PF
+```
+
+Expected: 6 nodes, each `status: success`. Any `none` or `no_connection` = device is unreachable or auth failed; check **Task 2.1** / **Task 2.2** for that device.
+
+- [ ] **Step 3: Confirm GitHub repo received initial commits**
+
+```bash
+gh repo view LukeEvansTech/network-configs -w
+# OR check via CLI:
+git ls-remote git@github.com:LukeEvansTech/network-configs.git
+```
+
+Expected: repo has 6 files (one per device) committed by `Oxidized <oxidized@...>`.
+
+### Task 3.4: Verify Pushover drift hook fires
+
+**Files:** None — runtime check.
+
+- [ ] **Step 1: Trigger drift on a low-risk device**
+
+On the MikroTik PoE switch, add a benign comment:
+
+```bash
+ssh "$MIKROTIK_USERNAME@mikrotik-poe.lan"
+[admin@MikroTik] > /system identity set comment="oxidized-test-$(date +%s)"
+[admin@MikroTik] > quit
+```
+
+- [ ] **Step 2: Force Oxidized to poll now**
+
+```bash
+kubectl -n observability port-forward svc/oxidized 8888:8888 &
+PF=$!
+sleep 2
+curl -X GET "http://localhost:8888/nodes/next/mikrotik_poe"   # forces this node next
+sleep 70   # wait for the next poll (interval=60s)
+kill $PF
+```
+
+- [ ] **Step 3: Confirm the diff was committed and pushed**
+
+```bash
+gh -R LukeEvansTech/network-configs api repos/LukeEvansTech/network-configs/commits | jq -r '.[0].commit.message' | head -3
+```
+
+Expected: most recent commit message contains `mikrotik_poe`.
+
+- [ ] **Step 4: Confirm Pushover notification arrived on your device**
+
+Expected: a Pushover notification titled "Oxidized: config drift" with body "mikrotik_poe (routeros) changed". If no notification:
+- Check pod logs for the exec hook output: `kubectl -n observability logs deploy/oxidized -c app | grep -i pushover`
+- Common causes: wrong `PUSHOVER_TOKEN` (app token vs user key swapped), Pushover app not enabled.
+
+- [ ] **Step 5: Revert the test change**
+
+```bash
+ssh "$MIKROTIK_USERNAME@mikrotik-poe.lan"
+[admin@MikroTik] > /system identity set comment=""
+[admin@MikroTik] > quit
+```
+
+(Next poll will commit the revert; that's expected and fine.)
+
+### Task 3.5: Verify exporter metrics scraped by Prometheus
+
+**Files:** None — runtime check.
+
+- [ ] **Step 1: Confirm the ServiceMonitor was discovered**
+
+```bash
+kubectl -n observability get servicemonitor oxidized -o yaml | head -20
+```
+
+Expected: ServiceMonitor exists with `port: metrics`.
+
+- [ ] **Step 2: Query Prometheus for an oxidized metric**
+
+```bash
+kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 9090:9090 &
+PF=$!
+sleep 2
+curl -s 'http://localhost:9090/api/v1/query?query=up{job=~".*oxidized.*"}' | jq '.data.result[] | {instance: .metric.instance, value: .value[1]}'
+kill $PF
+```
+
+Expected: at least one result with `value: "1"`. If empty, the ServiceMonitor isn't being discovered — check `serviceMonitorSelector` on the kube-prometheus-stack Prometheus CR.
+
+- [ ] **Step 3: Confirm device-level metric exists**
+
+Replace `<METRIC>` with the metric name confirmed in **Task 0.2**.
+
+```bash
+kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 9090:9090 &
+PF=$!
+sleep 2
+curl -s "http://localhost:9090/api/v1/query?query=<METRIC>" | jq '.data.result | length'
+kill $PF
+```
+
+Expected: a non-zero count (one per device that's been polled at least once).
+
+### Task 3.6: Audit committed configs for plaintext secrets (OPNsense focus)
+
+OPNsense's `config.xml` historically contains hashed passwords (still sensitive) and may contain plaintext API keys for sub-services. Spot-check the committed configs and add a `remove_secret` filter to the Oxidized config if needed.
+
+**Files:** Possibly modify `kubernetes/apps/observability/oxidized/app/configmap.yaml`.
+
+- [ ] **Step 1: Pull the committed configs locally**
+
+```bash
+mkdir -p ~/tmp/network-configs-audit && cd ~/tmp/network-configs-audit
+git clone git@github.com:LukeEvansTech/network-configs.git .
+ls -la
+```
+
+Expected: 6 files (or directories), one per device.
+
+- [ ] **Step 2: Scan opnsense for plaintext secret patterns**
+
+```bash
+grep -E '(<password>|<api_key>|<api_secret>|<bind_pw>|<radius_secret>|<token>|BEGIN [A-Z]+ PRIVATE KEY)' opnsense | head -20
+```
+
+Expected outcomes:
+- **Empty output**: no plaintext secrets — done.
+- **Hashed `<password>` entries (`$2b$10$...`)**: bcrypt — these are not plaintext but still sensitive. Acceptable but consider redacting.
+- **Plaintext `<api_secret>...</api_secret>`** or similar: must redact.
+
+- [ ] **Step 3: Scan other devices similarly**
+
+```bash
+for f in onyx mikrotik_poe mikrotik_nonpoe ruckus glinet; do
+  echo "=== $f ==="
+  grep -iE '(password|secret|api[-_]?key|token)' "$f" | grep -v '^\*\|^#\|hide-sensitive' | head -5
+done
+```
+
+Expected: `mikrotik_*` should produce nothing meaningful (RouterOS `/export hide-sensitive` already redacts). Others — review.
+
+- [ ] **Step 4 (only if redaction needed): add `remove_secret` block to Oxidized config**
+
+Edit `kubernetes/apps/observability/oxidized/app/configmap.yaml`. Inside the `data.config` block, add at the top level:
+
+```yaml
+    vars:
+      remove_secret: true
+```
+
+This activates Oxidized's per-model secret-stripping logic. For OPNsense specifically, also add a model-level override (still inside `data.config`):
+
+```yaml
+    models:
+      opnsense:
+        vars:
+          remove_secret: true
+        # additional regex if a specific tag isn't covered:
+        # cmd:
+        #   secret:
+        #     - generic: !ruby/regexp /<api_secret>.*?<\/api_secret>/
+```
+
+- [ ] **Step 5 (only if redaction edited): re-apply and re-verify**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/configmap.yaml
+just kube apply-ks observability oxidized
+# wait for poll cycle (60s with validation interval)
+sleep 90
+cd ~/tmp/network-configs-audit
+git pull
+grep -E '<password>|<api_secret>' opnsense | head -5
+```
+
+Expected: now empty.
+
+- [ ] **Step 6: Commit if changes were made**
+
+```bash
+cd ~/GIT/LukeEvansTech/talos-cluster
+git add kubernetes/apps/observability/oxidized/app/configmap.yaml
+git commit -m "fix(oxidized): strip secrets from device configs"
+```
+
+- [ ] **Step 7: Clean up local clone**
+
+```bash
+rm -rf ~/tmp/network-configs-audit
+```
+
+### Task 3.7: Verify alerts are routed correctly
+
+**Files:**
+- Modify (temporary): `kubernetes/apps/observability/oxidized/app/prometheusrule.yaml`
+
+- [ ] **Step 1: Lower the alert threshold for a fast test**
+
+Temporarily edit `prometheusrule.yaml` — change:
+```yaml
+expr: (time() - oxidized_node_last_success_timestamp_seconds) > 172800
+for: 10m
+```
+to:
+```yaml
+expr: (time() - oxidized_node_last_success_timestamp_seconds) > 60
+for: 1m
+```
+
+(This will fire shortly because at 60s thresholds the metric will commonly exceed it transiently.)
+
+- [ ] **Step 2: Apply the change**
+
+```bash
+just kube apply-ks observability oxidized
+```
+
+- [ ] **Step 3: Wait ~2 min and check Alertmanager**
+
+```bash
+kubectl -n observability port-forward svc/alertmanager-operated 9093:9093 &
+PF=$!
+sleep 2
+curl -s http://localhost:9093/api/v2/alerts | jq '.[] | select(.labels.alertname=="OxidizedDeviceStale") | {node: .labels.node, state: .status.state}'
+kill $PF
+```
+
+Expected: alert is `active` for one or more nodes. **You should also receive a Pushover alert** via Alertmanager's existing route.
+
+- [ ] **Step 4: Restore the original alert threshold**
+
+Revert the edit in step 1. Don't commit yet; combined cleanup commit happens in Task 4.1.
+
+---
+
+## Phase 4 — Cleanup, PR, merge
+
+### Task 4.1: Restore poll interval and alert thresholds
+
+**Files:**
+- Modify: `kubernetes/apps/observability/oxidized/app/configmap.yaml`
+- Modify: `kubernetes/apps/observability/oxidized/app/prometheusrule.yaml` (revert from Task 3.7 step 1, if not already reverted)
+
+- [ ] **Step 1: Restore `interval: 60` → `interval: 86400` in `configmap.yaml`**
+
+- [ ] **Step 2: Confirm `prometheusrule.yaml` thresholds are back to `> 172800` and `for: 10m`**
+
+- [ ] **Step 3: yamlfmt**
+
+```bash
+yamlfmt kubernetes/apps/observability/oxidized/app/configmap.yaml \
+        kubernetes/apps/observability/oxidized/app/prometheusrule.yaml
+```
+
+- [ ] **Step 4: Reset the validation commit and recommit cleanly**
+
+```bash
+git log --oneline -5
+# Should show "test(oxidized): reduce poll interval to 60s for validation" near the top
+git reset --soft HEAD~1
+git restore --staged kubernetes/apps/observability/oxidized/app/configmap.yaml
+git commit -m "feat(oxidized): production poll interval"  # or amend out of history entirely
+```
+
+Alternative (cleaner): drop the `test(...)` commit via interactive rebase, leaving no validation noise in history. Either is acceptable.
+
+- [ ] **Step 5: Re-apply the now-restored values to the live cluster**
+
+```bash
+just kube apply-ks observability oxidized
+```
+
+- [ ] **Step 6: Verify the running ConfigMap reflects `interval: 86400`**
+
+```bash
+kubectl -n observability get cm oxidized-config -o yaml | grep "interval:"
+```
+
+Expected: `interval: 86400`.
+
+### Task 4.2: Open the PR
+
+**Files:** None — git/GitHub only.
+
+- [ ] **Step 1: Push the cleaned-up branch**
+
+```bash
+git push -f origin feat/observability-oxidized
+```
+
+(The `-f` is needed because we may have rewritten the branch in Task 4.1 step 4.)
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat(oxidized): add network config backup app" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds Oxidized to the `observability` namespace, polling six homelab network devices daily and pushing config diffs to a private GitHub repo (`LukeEvansTech/network-configs`).
+- Two init containers stage the SSH deploy key and `envsubst`-render the `router.db` so device credentials never land on the Ceph PVC or in the ConfigMap.
+- Sidecar `oxidized-exporter` exposes per-device last-success metrics; `OxidizedDeviceStale` alerts via existing kube-prometheus-stack → Alertmanager → Pushover route. Drift events fire a direct Pushover hook.
+
+## Test plan
+- [x] `flux-local build ks --path kubernetes/flux/cluster oxidized` succeeds.
+- [x] All six devices polled successfully; initial configs committed to GitHub.
+- [x] Manual config change on `mikrotik_poe` produced a git diff and a Pushover drift notification.
+- [x] `OxidizedDeviceStale` alert verified via temporary threshold lowering.
+- [x] Poll interval and alert thresholds restored to production values.
+
+## Spec / Plan
+- Spec: [docs/superpowers/specs/2026-04-29-oxidized-design.md](docs/superpowers/specs/2026-04-29-oxidized-design.md)
+- Plan: [docs/superpowers/plans/2026-04-29-oxidized.md](docs/superpowers/plans/2026-04-29-oxidized.md)
+
+## Operational notes
+- 1Password item `oxidized` is required (14 fields).
+- Renovate will track new versions for `oxidized/oxidized` and `ghcr.io/akquinet/oxidized-exporter`.
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI to pass**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: yamlfmt, prettier, actionlint, shellcheck, and any flux-local PR validation pass.
+
+### Task 4.3: Merge
+
+- [ ] **Step 1: Merge via the repo's preferred mechanism**
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+- [ ] **Step 2: Confirm Flux on the cluster reconciles from main**
+
+```bash
+flux -n observability get kustomization oxidized
+flux -n observability get helmrelease oxidized
+```
+
+Expected: both `Ready: True`, `Source: GitRepository/flux-system`, `Revision:` matches the latest main commit.
+
+### Task 4.4: Smoke-test post-merge
+
+- [ ] **Step 1: Spot-check a recent commit lands**
+
+Wait one full poll cycle (24h is too long for impatience — pick any minor manual change and check next day, or trust the validation already done).
+
+```bash
+gh -R LukeEvansTech/network-configs api repos/LukeEvansTech/network-configs/commits | jq -r '.[0].commit.author.date'
+```
+
+Should be < 24h old after the first post-merge cycle.
+
+- [ ] **Step 2: Confirm Pushover notifications still functional**
+
+You'll either receive one within 24h (if any device drifted), or receive nothing (good — no drift). If you want explicit confirmation, repeat the **Task 3.4** drift test.
+
+---
+
+## Rollback procedure
+
+If at any point the deploy is misbehaving and needs to come down:
+
+```bash
+# Tear down the app
+just kube delete-ks observability oxidized
+
+# (Optional) delete the PVC if the issue is corrupted state
+kubectl -n observability delete pvc oxidized
+
+# Revert the PR if already merged
+gh pr revert <PR-number>
+```
+
+The GitHub repo `LukeEvansTech/network-configs` retains all history and can be re-attached when redeploying.

--- a/docs/superpowers/plans/2026-04-29-oxidized.md
+++ b/docs/superpowers/plans/2026-04-29-oxidized.md
@@ -92,7 +92,7 @@ get_digest() {
 }
 {
   echo "OXIDIZED_DIGEST=$(get_digest oxidized/oxidized:0.36.0)"
-  echo "EXPORTER_DIGEST=$(get_digest ghcr.io/akquinet/oxidized-exporter:v1.0.7)"
+  echo "EXPORTER_DIGEST=$(get_digest ghcr.io/akquinet/oxidized-exporter:v1.0.5)"
   echo "ALPINE_DIGEST=$(get_digest alpine:3.21)"
   echo "BUSYBOX_DIGEST=$(get_digest busybox:1.37)"
 } > ~/tmp/oxidized-resolved.env
@@ -179,19 +179,13 @@ ExternalSecret pulls 14 fields from a single 1Password item. Create it now.
 
 **Files:** None — out-of-cluster setup.
 
-- [ ] **Step 1: Identify the correct vault**
+- [ ] **Step 1: Confirm the target vault**
 
-The same vault used by other apps (e.g., `gitea`, `forgejo`). Inspect another app's externalsecret.yaml to confirm:
-
-```bash
-cat ~/GIT/LukeEvansTech/talos-cluster/kubernetes/apps/default/gitea/app/externalsecret.yaml
-```
-
-The `dataFrom.extract.key` value (e.g., `gitea`) corresponds to the 1Password item title in the connected vault.
+The cluster's `ClusterSecretStore onepassword-connect` reads only from the **`Talos`** 1Password vault (see `kubernetes/apps/external-secrets/onepassword-connect/app/clustersecretstore.yaml`). The new item must therefore live in `Talos`, not `Home Operations` — even though several source items (MikroTik, Ruckus) live in `Home Operations`. Use `op read "op://Home Operations/..."` to copy values across when creating the new item.
 
 - [ ] **Step 2: Create the `oxidized` item**
 
-In the 1Password UI (or via CLI), create a new **Secure Note** or **Login** item titled exactly `oxidized` in that vault, with these custom fields (text):
+In the 1Password UI (or via CLI), create a new **Secure Note** or **Login** item titled exactly `oxidized` in the `Talos` vault, with these custom fields (text):
 
 | Field name | Value |
 |---|---|
@@ -199,12 +193,12 @@ In the 1Password UI (or via CLI), create a new **Secure Note** or **Login** item
 | `OPNSENSE_PASSWORD` | Their password |
 | `ONYX_USERNAME` | Reuse from existing 1Password Onyx item |
 | `ONYX_PASSWORD` | Reuse from existing 1Password Onyx item |
-| `MIKROTIK_USERNAME` | Reuse from existing MikroTik item |
-| `MIKROTIK_PASSWORD` | Reuse from existing MikroTik item |
-| `RUCKUS_USERNAME` | Reuse from existing Ruckus item |
-| `RUCKUS_PASSWORD` | Reuse from existing Ruckus item |
-| `GLINET_USERNAME` | Reuse from existing GL.iNet item |
-| `GLINET_PASSWORD` | Reuse from existing GL.iNet item |
+| `MIKROTIK_POE_USERNAME` | From `op://Home Operations/Network-MikroTik-PoE/username` |
+| `MIKROTIK_POE_PASSWORD` | From `op://Home Operations/Network-MikroTik-PoE/password` |
+| `MIKROTIK_NONPOE_USERNAME` | From `op://Home Operations/Network-MikroTik-NonPoE/username` |
+| `MIKROTIK_NONPOE_PASSWORD` | From `op://Home Operations/Network-MikroTik-NonPoE/password` |
+| `RUCKUS_USERNAME` | From `op://Home Operations/Network-Ops - Ruckus/username` |
+| `RUCKUS_PASSWORD` | From `op://Home Operations/Network-Ops - Ruckus/password` |
 | `GITHUB_DEPLOY_KEY` | Multi-line — full content of `id_ed25519` from Task 0.4 step 5 |
 | `GITHUB_KNOWN_HOSTS` | The `ssh-keyscan` line from Task 0.4 step 4 |
 | `PUSHOVER_TOKEN` | Pushover **app token** (not user key) — create a new app at <https://pushover.net/apps/build> named "Oxidized" |
@@ -213,7 +207,7 @@ In the 1Password UI (or via CLI), create a new **Secure Note** or **Login** item
 - [ ] **Step 3: Smoke test that 1Password Connect can read the item**
 
 ```bash
-op item get oxidized --vault <vault-name> --format json | jq -r '.fields[] | "\(.label): \(if .value then "✓" else "✗ EMPTY" end)"'
+op item get oxidized --vault Talos --format json | jq -r '.fields[] | "\(.label): \(if .value then "✓" else "✗ EMPTY" end)"'
 ```
 
 Expected: 14 lines, all `✓`. Any `✗ EMPTY` means the field was not saved correctly.
@@ -501,10 +495,9 @@ data:
   router.db: |
     opnsense:opnsense.lan:opnsense:${OPNSENSE_USERNAME}:${OPNSENSE_PASSWORD}
     onyx:onyx.lan:onyx:${ONYX_USERNAME}:${ONYX_PASSWORD}
-    mikrotik_poe:mikrotik-poe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
-    mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
+    mikrotik_poe:mikrotik-poe.lan:routeros:${MIKROTIK_POE_USERNAME}:${MIKROTIK_POE_PASSWORD}
+    mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:${MIKROTIK_NONPOE_USERNAME}:${MIKROTIK_NONPOE_PASSWORD}
     ruckus:ruckus.lan:ruckusunleashed:${RUCKUS_USERNAME}:${RUCKUS_PASSWORD}
-    glinet:glinet.lan:openwrt:${GLINET_USERNAME}:${GLINET_PASSWORD}
 ```
 
 > **Note on Flux postBuild substitution scope**: Flux's postBuild substitutes `${VARNAME}` against the cluster-secrets ConfigMap. The `${OPNSENSE_USERNAME}` etc. placeholders in `router.db` would be substituted by Flux **only if they exist in cluster-secrets** — they don't, so Flux leaves them literal (good, that's what we want). The `envsubst` init container then substitutes them against env vars from the Secret.
@@ -550,12 +543,12 @@ spec:
         OPNSENSE_PASSWORD: "{{ .OPNSENSE_PASSWORD }}"
         ONYX_USERNAME: "{{ .ONYX_USERNAME }}"
         ONYX_PASSWORD: "{{ .ONYX_PASSWORD }}"
-        MIKROTIK_USERNAME: "{{ .MIKROTIK_USERNAME }}"
-        MIKROTIK_PASSWORD: "{{ .MIKROTIK_PASSWORD }}"
+        MIKROTIK_POE_USERNAME: "{{ .MIKROTIK_POE_USERNAME }}"
+        MIKROTIK_POE_PASSWORD: "{{ .MIKROTIK_POE_PASSWORD }}"
+        MIKROTIK_NONPOE_USERNAME: "{{ .MIKROTIK_NONPOE_USERNAME }}"
+        MIKROTIK_NONPOE_PASSWORD: "{{ .MIKROTIK_NONPOE_PASSWORD }}"
         RUCKUS_USERNAME: "{{ .RUCKUS_USERNAME }}"
         RUCKUS_PASSWORD: "{{ .RUCKUS_PASSWORD }}"
-        GLINET_USERNAME: "{{ .GLINET_USERNAME }}"
-        GLINET_PASSWORD: "{{ .GLINET_PASSWORD }}"
         GITHUB_DEPLOY_KEY: "{{ .GITHUB_DEPLOY_KEY }}"
         GITHUB_KNOWN_HOSTS: "{{ .GITHUB_KNOWN_HOSTS }}"
         PUSHOVER_TOKEN: "{{ .PUSHOVER_TOKEN }}"
@@ -650,12 +643,12 @@ spec:
               OPNSENSE_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: OPNSENSE_PASSWORD } } }
               ONYX_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: ONYX_USERNAME } } }
               ONYX_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: ONYX_PASSWORD } } }
-              MIKROTIK_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_USERNAME } } }
-              MIKROTIK_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_PASSWORD } } }
+              MIKROTIK_POE_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_POE_USERNAME } } }
+              MIKROTIK_POE_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_POE_PASSWORD } } }
+              MIKROTIK_NONPOE_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_NONPOE_USERNAME } } }
+              MIKROTIK_NONPOE_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_NONPOE_PASSWORD } } }
               RUCKUS_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: RUCKUS_USERNAME } } }
               RUCKUS_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: RUCKUS_PASSWORD } } }
-              GLINET_USERNAME: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: GLINET_USERNAME } } }
-              GLINET_PASSWORD: { valueFrom: { secretKeyRef: { name: oxidized-secret, key: GLINET_PASSWORD } } }
             securityContext:
               runAsNonRoot: true
               runAsUser: 30000
@@ -701,7 +694,7 @@ spec:
           exporter:
             image:
               repository: ghcr.io/akquinet/oxidized-exporter
-              tag: v1.0.7@sha256:<EXPORTER_DIGEST>
+              tag: v1.0.5@sha256:<EXPORTER_DIGEST>
             args:
               - -U
               - http://localhost:8888
@@ -946,7 +939,7 @@ kubectl run -n observability -it --rm netshoot \
 - [ ] **Step 2: From inside the pod, test each device**
 
 ```bash
-for h in opnsense.lan onyx.lan mikrotik-poe.lan mikrotik-nonpoe.lan ruckus.lan glinet.lan; do
+for h in opnsense.lan onyx.lan mikrotik-poe.lan mikrotik-nonpoe.lan ruckus.lan; do
   echo -n "$h:22 "
   nc -z -w3 "$h" 22 && echo OK || echo FAIL
 done
@@ -978,10 +971,9 @@ Expected: each name resolves to an IP. If not, add the device IPs directly to `r
 ```bash
 ssh "$OPNSENSE_USERNAME@opnsense.lan" "exit"   # → 0 if creds OK
 ssh "$ONYX_USERNAME@onyx.lan" "exit"
-ssh "$MIKROTIK_USERNAME@mikrotik-poe.lan" "/system identity print"
-ssh "$MIKROTIK_USERNAME@mikrotik-nonpoe.lan" "/system identity print"
+ssh "$MIKROTIK_POE_USERNAME@mikrotik-poe.lan" "/system identity print"
+ssh "$MIKROTIK_NONPOE_USERNAME@mikrotik-nonpoe.lan" "/system identity print"
 ssh "$RUCKUS_USERNAME@ruckus.lan" "exit"        # method depends on Ruckus product; may use HTTPS API instead
-ssh "$GLINET_USERNAME@glinet.lan" "exit"
 ```
 
 Expected: each succeeds. Any failure → fix the credential in 1Password before deploying.
@@ -1181,10 +1173,9 @@ You should see (within 2-3 minutes of pod ready):
 ... INFO  [mikrotik_poe] -- Successfully fetched config
 ... INFO  [mikrotik_nonpoe] -- Successfully fetched config
 ... INFO  [ruckus] -- Successfully fetched config
-... INFO  [glinet] -- Successfully fetched config
 ```
 
-Ctrl-C after all six log a success.
+Ctrl-C after all five log a success.
 
 - [ ] **Step 2: Confirm via the REST API**
 
@@ -1196,7 +1187,7 @@ curl -s http://localhost:8888/nodes.json | jq -r '.[] | "\(.name): \(.status) (l
 kill $PF
 ```
 
-Expected: 6 nodes, each `status: success`. Any `none` or `no_connection` = device is unreachable or auth failed; check **Task 2.1** / **Task 2.2** for that device.
+Expected: 5 nodes, each `status: success`. Any `none` or `no_connection` = device is unreachable or auth failed; check **Task 2.1** / **Task 2.2** for that device.
 
 - [ ] **Step 3: Confirm GitHub repo received initial commits**
 
@@ -1206,7 +1197,7 @@ gh repo view LukeEvansTech/network-configs -w
 git ls-remote git@github.com:LukeEvansTech/network-configs.git
 ```
 
-Expected: repo has 6 files (one per device) committed by `Oxidized <oxidized@...>`.
+Expected: repo has 5 files (one per device) committed by `Oxidized <oxidized@...>`.
 
 ### Task 3.4: Verify Pushover drift hook fires
 
@@ -1217,7 +1208,7 @@ Expected: repo has 6 files (one per device) committed by `Oxidized <oxidized@...
 On the MikroTik PoE switch, add a benign comment:
 
 ```bash
-ssh "$MIKROTIK_USERNAME@mikrotik-poe.lan"
+ssh "$MIKROTIK_POE_USERNAME@mikrotik-poe.lan"
 [admin@MikroTik] > /system identity set comment="oxidized-test-$(date +%s)"
 [admin@MikroTik] > quit
 ```
@@ -1250,7 +1241,7 @@ Expected: a Pushover notification titled "Oxidized: config drift" with body "mik
 - [ ] **Step 5: Revert the test change**
 
 ```bash
-ssh "$MIKROTIK_USERNAME@mikrotik-poe.lan"
+ssh "$MIKROTIK_POE_USERNAME@mikrotik-poe.lan"
 [admin@MikroTik] > /system identity set comment=""
 [admin@MikroTik] > quit
 ```
@@ -1292,7 +1283,7 @@ curl -s "http://localhost:9090/api/v1/query?query=oxidized_device_status" | jq '
 kill $PF
 ```
 
-Expected: count is `6` (one per device). Each `value` is `"2"` if all devices polled successfully.
+Expected: count is `5` (one per device). Each `value` is `"2"` if all devices polled successfully.
 
 ### Task 3.6: Audit committed configs for plaintext secrets (OPNsense focus)
 
@@ -1308,7 +1299,7 @@ git clone git@github.com:LukeEvansTech/network-configs.git .
 ls -la
 ```
 
-Expected: 6 files (or directories), one per device.
+Expected: 5 files (or directories), one per device.
 
 - [ ] **Step 2: Scan opnsense for plaintext secret patterns**
 
@@ -1324,7 +1315,7 @@ Expected outcomes:
 - [ ] **Step 3: Scan other devices similarly**
 
 ```bash
-for f in onyx mikrotik_poe mikrotik_nonpoe ruckus glinet; do
+for f in onyx mikrotik_poe mikrotik_nonpoe ruckus; do
   echo "=== $f ==="
   grep -iE '(password|secret|api[-_]?key|token)' "$f" | grep -v '^\*\|^#\|hide-sensitive' | head -5
 done

--- a/docs/superpowers/plans/2026-04-29-oxidized.md
+++ b/docs/superpowers/plans/2026-04-29-oxidized.md
@@ -54,25 +54,25 @@ If the chosen value is **not** `ruckusunleashed`, edit `docs/superpowers/specs/2
 - Update the example `router.db` line in the **`router.db` template** section.
 - Commit: `docs(oxidized): correct ruckus oxidized model`
 
-### Task 0.2: Confirm exporter metric name
+### Task 0.2: Note exporter metrics (already resolved during planning)
 
-The PrometheusRule `expr:` uses `oxidized_node_last_success_timestamp_seconds`. Verify the actual metric name from the exporter.
+The exporter source was inspected during plan-writing. Recording the resolved values here so the engineer doesn't repeat the lookup.
 
-**Files:** None — research only.
+**Files:** None.
 
-- [ ] **Step 1: Read the exporter README**
+**Resolved values** (from `akquinet/oxidized-exporter/oxidized/collector.go`):
 
-```bash
-gh repo view akquinet/oxidized-exporter -w
-# OR
-curl -s https://raw.githubusercontent.com/akquinet/oxidized-exporter/main/README.md
-```
+| Property | Value |
+|---|---|
+| Default listen port | `8080` |
+| Default metrics path | `/metrics` |
+| Oxidized URL flag | `--url` / `-U` (defaults to `http://localhost:8888`) |
+| Stale-device metric | `oxidized_device_status` |
+| Stale-device labels | `full_name`, `name`, `group`, `model` |
+| Stale-device values | `2`=success, `1`=never, `0`=no_connection |
+| Up metric | exposed by Prometheus at `up{job=~".*oxidized.*"}` (no exporter-specific metric needed) |
 
-Search for the metrics table. Note the exact metric that represents "last successful run timestamp per node" — common names are `oxidized_last_run_timestamp`, `oxidized_node_status`, etc.
-
-- [ ] **Step 2: Record the actual metric name**
-
-Save it as a note for **Task 1.7** (PrometheusRule). If it differs from `oxidized_node_last_success_timestamp_seconds`, the alert `expr` must be adjusted.
+These are baked into Tasks 1.7 and 1.9 below — no further action required for this task.
 
 ### Task 0.3: Resolve image digests + record open-item values
 
@@ -81,40 +81,42 @@ Both container images need a `@sha256:...` digest pinned per repo convention. Al
 **Files:**
 - Create (workstation, gitignored): `~/tmp/oxidized-resolved.env`
 
-- [ ] **Step 1: Pull digests**
+- [ ] **Step 1: Pull digests via `docker buildx imagetools inspect`**
+
+(`crane` and `skopeo` aren't in the project's mise toolchain — `docker` is.)
 
 ```bash
 mkdir -p ~/tmp
+get_digest() {
+  docker buildx imagetools inspect "$1" --format '{{println .Manifest.Digest}}' | tr -d '[:space:]'
+}
 {
-  echo "OXIDIZED_DIGEST=$(crane digest oxidized/oxidized:0.36.0)"
-  echo "EXPORTER_DIGEST=$(crane digest ghcr.io/akquinet/oxidized-exporter:v1.0.7)"
-  echo "ALPINE_DIGEST=$(crane digest alpine:3.21)"
-  echo "BUSYBOX_DIGEST=$(crane digest busybox:1.37)"
+  echo "OXIDIZED_DIGEST=$(get_digest oxidized/oxidized:0.36.0)"
+  echo "EXPORTER_DIGEST=$(get_digest ghcr.io/akquinet/oxidized-exporter:v1.0.7)"
+  echo "ALPINE_DIGEST=$(get_digest alpine:3.21)"
+  echo "BUSYBOX_DIGEST=$(get_digest busybox:1.37)"
 } > ~/tmp/oxidized-resolved.env
 cat ~/tmp/oxidized-resolved.env
 ```
 
-Expected: 4 lines, each `<NAME>=sha256:abc123...`.
+Expected: 4 lines, each `<NAME>=sha256:abc123...`. If `docker buildx` isn't available, fall back to `docker pull <image> && docker inspect <image> --format '{{index .RepoDigests 0}}'`.
 
-- [ ] **Step 2: Append the values from Tasks 0.1 and 0.2**
+- [ ] **Step 2: Append the Ruckus model from Task 0.1**
 
 ```bash
-cat <<EOF >> ~/tmp/oxidized-resolved.env
-RUCKUS_MODEL=<value-from-Task-0.1>
-EXPORTER_METRIC_NAME=<value-from-Task-0.2>
-EOF
+echo "RUCKUS_MODEL=<value-from-Task-0.1>" >> ~/tmp/oxidized-resolved.env
 cat ~/tmp/oxidized-resolved.env
 ```
 
-Hand-edit the two `<value-...>` placeholders to the actual values from those tasks. This single file is the source of truth for Tasks 1.5, 1.7, and 1.9.
+Hand-edit the `<value-from-Task-0.1>` placeholder. This single file is the source of truth for Tasks 1.5 and 1.7.
 
 - [ ] **Step 3: Verify the file contents**
 
 ```bash
-grep -c "^[A-Z_]*=sha256:\|^[A-Z_]*=[a-z_]" ~/tmp/oxidized-resolved.env
+grep -c "^[A-Z_]*=" ~/tmp/oxidized-resolved.env
 ```
 
-Expected: `6` (4 digests + RUCKUS_MODEL + EXPORTER_METRIC_NAME).
+Expected: `5` (4 digests + RUCKUS_MODEL).
 
 ### Task 0.4: Create GitHub repo + deploy key
 
@@ -701,20 +703,21 @@ spec:
               repository: ghcr.io/akquinet/oxidized-exporter
               tag: v1.0.7@sha256:<EXPORTER_DIGEST>
             args:
-              - --oxidized-url=http://localhost:8888
+              - -U
+              - http://localhost:8888
             probes:
               liveness:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket: { port: 9001 }
+                  tcpSocket: { port: 8080 }
                   initialDelaySeconds: 30
                   periodSeconds: 30
               readiness:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet: { path: /metrics, port: 9001 }
+                  httpGet: { path: /metrics, port: 8080 }
                   initialDelaySeconds: 30
                   periodSeconds: 30
             resources:
@@ -738,7 +741,7 @@ spec:
         controller: oxidized
         ports:
           http: { port: 8888 }
-          metrics: { port: 9001 }
+          metrics: { port: 8080 }
 
     serviceMonitor:
       app:
@@ -841,7 +844,7 @@ git commit -m "feat(oxidized): add httproute"
 
 ### Task 1.9: Create `prometheusrule.yaml`
 
-Use the metric name from **Task 0.2**. Below template assumes `oxidized_node_last_success_timestamp_seconds`; substitute the actual name.
+Uses `oxidized_device_status` (resolved in Task 0.2). The metric is a gauge with values `2`=success / `1`=never / `0`=no_connection. The alert fires when status is **not 2** continuously for 48h — with the daily 86400s poll interval, that's at least two consecutive failed cycles.
 
 **Files:**
 - Create: `kubernetes/apps/observability/oxidized/app/prometheusrule.yaml`
@@ -861,10 +864,10 @@ spec:
       rules:
         - alert: OxidizedDeviceStale
           annotations:
-            summary: Oxidized has not polled {{ $labels.node }} successfully in over 48h.
-            description: The last successful Oxidized poll for {{ $labels.node }} was more than 48h ago. Check the device or the cluster's reachability to it.
-          expr: (time() - oxidized_node_last_success_timestamp_seconds) > 172800
-          for: 10m
+            summary: Oxidized has not successfully polled {{ $labels.full_name }} in over 48h.
+            description: oxidized_device_status for {{ $labels.full_name }} ({{ $labels.model }}) has been != 2 (success) for 48h. Check device reachability or credentials.
+          expr: oxidized_device_status != 2
+          for: 48h
           labels:
             severity: warning
         - alert: OxidizedDown
@@ -1280,17 +1283,16 @@ Expected: at least one result with `value: "1"`. If empty, the ServiceMonitor is
 
 - [ ] **Step 3: Confirm device-level metric exists**
 
-Replace `<METRIC>` with the metric name confirmed in **Task 0.2**.
-
 ```bash
 kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 9090:9090 &
 PF=$!
 sleep 2
-curl -s "http://localhost:9090/api/v1/query?query=<METRIC>" | jq '.data.result | length'
+curl -s "http://localhost:9090/api/v1/query?query=oxidized_device_status" | jq '.data.result | length'
+curl -s "http://localhost:9090/api/v1/query?query=oxidized_device_status" | jq '.data.result[] | {full_name: .metric.full_name, value: .value[1]}'
 kill $PF
 ```
 
-Expected: a non-zero count (one per device that's been polled at least once).
+Expected: count is `6` (one per device). Each `value` is `"2"` if all devices polled successfully.
 
 ### Task 3.6: Audit committed configs for plaintext secrets (OPNsense focus)
 
@@ -1385,20 +1387,13 @@ rm -rf ~/tmp/network-configs-audit
 **Files:**
 - Modify (temporary): `kubernetes/apps/observability/oxidized/app/prometheusrule.yaml`
 
-- [ ] **Step 1: Lower the alert threshold for a fast test**
+- [ ] **Step 1: Lower the alert duration for a fast test**
 
-Temporarily edit `prometheusrule.yaml` — change:
-```yaml
-expr: (time() - oxidized_node_last_success_timestamp_seconds) > 172800
-for: 10m
-```
-to:
-```yaml
-expr: (time() - oxidized_node_last_success_timestamp_seconds) > 60
-for: 1m
-```
+Temporarily edit `prometheusrule.yaml`:
+- Change `for: 48h` → `for: 1m`. (Don't change the `expr` — the trick is to make the existing `!= 2` condition fire quickly.)
+- Then induce a failure: temporarily break one device's credentials in 1Password (e.g., flip the password to garbage), then `just kube sync-es` to refresh the Secret. Pod restart not needed — `router-db-render` already ran. Actually credentials are baked into router.db at init — to force a credential failure live, instead break network reachability: stop SSH on one device or block it in OPNsense for a few minutes.
 
-(This will fire shortly because at 60s thresholds the metric will commonly exceed it transiently.)
+Simpler alternative — just delete one device from `router.db` temporarily so Oxidized never tries it; `oxidized_device_status` will be missing for that device (`absent()` won't be triggered by `!= 2` though). The cleanest forced failure is to break the device's port temporarily, wait a poll cycle, see status drop to 0.
 
 - [ ] **Step 2: Apply the change**
 
@@ -1418,9 +1413,9 @@ kill $PF
 
 Expected: alert is `active` for one or more nodes. **You should also receive a Pushover alert** via Alertmanager's existing route.
 
-- [ ] **Step 4: Restore the original alert threshold**
+- [ ] **Step 4: Restore the device + the alert duration**
 
-Revert the edit in step 1. Don't commit yet; combined cleanup commit happens in Task 4.1.
+Restore network reachability to the device you broke. Revert `for: 1m` → `for: 48h` in `prometheusrule.yaml`. Don't commit yet; combined cleanup commit happens in Task 4.1.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-29-oxidized-design.md
+++ b/docs/superpowers/specs/2026-04-29-oxidized-design.md
@@ -17,7 +17,6 @@ Purpose: drift detection. The Terraform/Ansible IaC in the sibling `network-ops`
 | MikroTik CRS354 PoE | `mikrotik-poe.lan` | `routeros` |
 | MikroTik CRS354 non-PoE | `mikrotik-nonpoe.lan` | `routeros` |
 | Ruckus AP/controller | `ruckus.lan` | `ruckusunleashed` *(model TBC during pre-deploy)* |
-| GL.iNet router | `glinet.lan` | `openwrt` |
 
 **Out of scope:**
 - APC PDU — SNMP-only; no config-dump fit for Oxidized.
@@ -38,7 +37,7 @@ Single-pod deployment in `observability`, sitting next to `snmp-exporter`. Oxidi
 │                                            │                             │
 │  ┌─────────────────── oxidized pod ────────┴──────────────────┐          │
 │  │  oxidized:0.36.0  (port 8888)                              │          │
-│  │  oxidized-exporter:v1.0.7  (port 8080)                     │          │
+│  │  oxidized-exporter:v1.0.5  (port 8080)                     │          │
 │  │  initContainers:                                           │          │
 │  │   - ssh-setup       (writes deploy key to tmpfs)           │          │
 │  │   - router-db-render (envsubst → router.db on tmpfs)       │          │
@@ -66,7 +65,7 @@ Single-pod deployment in `observability`, sitting next to `snmp-exporter`. Oxidi
 └─────────────────────────┼────────────────────────────────────────────────┘
                           │ SSH / HTTPS polls (every 24h)
                           ▼
-   opnsense · onyx · mikrotik_poe · mikrotik_nonpoe · ruckus · glinet
+   opnsense · onyx · mikrotik_poe · mikrotik_nonpoe · ruckus
 ```
 
 ## File Layout
@@ -92,7 +91,7 @@ kubernetes/apps/observability/oxidized/
 | Image | Tag | Purpose |
 |---|---|---|
 | `docker.io/oxidized/oxidized` | `0.36.0@sha256:<digest>` | Main app (resolved at implementation) |
-| `ghcr.io/akquinet/oxidized-exporter` | `v1.0.7@sha256:<digest>` | Sidecar Prometheus exporter |
+| `ghcr.io/akquinet/oxidized-exporter` | `v1.0.5@sha256:<digest>` | Sidecar Prometheus exporter |
 
 Both tracked by Renovate.
 
@@ -145,12 +144,12 @@ controllers:
           OPNSENSE_PASSWORD: { secretKeyRef: { name: oxidized-secret, key: OPNSENSE_PASSWORD } }
           ONYX_USERNAME:     { secretKeyRef: { name: oxidized-secret, key: ONYX_USERNAME } }
           ONYX_PASSWORD:     { secretKeyRef: { name: oxidized-secret, key: ONYX_PASSWORD } }
-          MIKROTIK_USERNAME: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_USERNAME } }
-          MIKROTIK_PASSWORD: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_PASSWORD } }
-          RUCKUS_USERNAME:   { secretKeyRef: { name: oxidized-secret, key: RUCKUS_USERNAME } }
-          RUCKUS_PASSWORD:   { secretKeyRef: { name: oxidized-secret, key: RUCKUS_PASSWORD } }
-          GLINET_USERNAME:   { secretKeyRef: { name: oxidized-secret, key: GLINET_USERNAME } }
-          GLINET_PASSWORD:   { secretKeyRef: { name: oxidized-secret, key: GLINET_PASSWORD } }
+          MIKROTIK_POE_USERNAME:    { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_POE_USERNAME } }
+          MIKROTIK_POE_PASSWORD:    { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_POE_PASSWORD } }
+          MIKROTIK_NONPOE_USERNAME: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_NONPOE_USERNAME } }
+          MIKROTIK_NONPOE_PASSWORD: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_NONPOE_PASSWORD } }
+          RUCKUS_USERNAME:          { secretKeyRef: { name: oxidized-secret, key: RUCKUS_USERNAME } }
+          RUCKUS_PASSWORD:          { secretKeyRef: { name: oxidized-secret, key: RUCKUS_PASSWORD } }
     containers:
       app:
         image:
@@ -177,7 +176,7 @@ controllers:
       exporter:
         image:
           repository: ghcr.io/akquinet/oxidized-exporter
-          tag: v1.0.7@sha256:<digest>
+          tag: v1.0.5@sha256:<digest>
         args: ["-U", "http://localhost:8888"]   # exporter listens on :8080 by default
         resources:
           requests: { cpu: 10m, memory: 32Mi }
@@ -340,10 +339,9 @@ Template content:
 ```
 opnsense:opnsense.lan:opnsense:${OPNSENSE_USERNAME}:${OPNSENSE_PASSWORD}
 onyx:onyx.lan:onyx:${ONYX_USERNAME}:${ONYX_PASSWORD}
-mikrotik_poe:mikrotik-poe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
-mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
+mikrotik_poe:mikrotik-poe.lan:routeros:${MIKROTIK_POE_USERNAME}:${MIKROTIK_POE_PASSWORD}
+mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:${MIKROTIK_NONPOE_USERNAME}:${MIKROTIK_NONPOE_PASSWORD}
 ruckus:ruckus.lan:ruckusunleashed:${RUCKUS_USERNAME}:${RUCKUS_PASSWORD}
-glinet:glinet.lan:openwrt:${GLINET_USERNAME}:${GLINET_PASSWORD}
 ```
 
 ## ExternalSecret
@@ -364,12 +362,12 @@ spec:
         OPNSENSE_PASSWORD:    "{{ .OPNSENSE_PASSWORD }}"
         ONYX_USERNAME:        "{{ .ONYX_USERNAME }}"
         ONYX_PASSWORD:        "{{ .ONYX_PASSWORD }}"
-        MIKROTIK_USERNAME:    "{{ .MIKROTIK_USERNAME }}"
-        MIKROTIK_PASSWORD:    "{{ .MIKROTIK_PASSWORD }}"
+        MIKROTIK_POE_USERNAME:    "{{ .MIKROTIK_POE_USERNAME }}"
+        MIKROTIK_POE_PASSWORD:    "{{ .MIKROTIK_POE_PASSWORD }}"
+        MIKROTIK_NONPOE_USERNAME: "{{ .MIKROTIK_NONPOE_USERNAME }}"
+        MIKROTIK_NONPOE_PASSWORD: "{{ .MIKROTIK_NONPOE_PASSWORD }}"
         RUCKUS_USERNAME:      "{{ .RUCKUS_USERNAME }}"
         RUCKUS_PASSWORD:      "{{ .RUCKUS_PASSWORD }}"
-        GLINET_USERNAME:      "{{ .GLINET_USERNAME }}"
-        GLINET_PASSWORD:      "{{ .GLINET_PASSWORD }}"
         GITHUB_DEPLOY_KEY:    "{{ .GITHUB_DEPLOY_KEY }}"
         GITHUB_KNOWN_HOSTS:   "{{ .GITHUB_KNOWN_HOSTS }}"
         PUSHOVER_TOKEN:       "{{ .PUSHOVER_TOKEN }}"
@@ -378,7 +376,7 @@ spec:
     - extract: { key: oxidized }
 ```
 
-**1Password item to create**: `oxidized` in the same vault used by other apps, with the 14 fields above. The user is responsible for creating this item before deploy.
+**1Password item to create**: `oxidized` in the **`Talos`** vault (the only vault read by `ClusterSecretStore onepassword-connect`), with the 14 fields above. Source values for MikroTik / Ruckus / OPNsense live in `Home Operations` and must be copied across via `op read` when creating the item. The user is responsible for creating this item before deploy.
 
 ## PrometheusRule
 

--- a/docs/superpowers/specs/2026-04-29-oxidized-design.md
+++ b/docs/superpowers/specs/2026-04-29-oxidized-design.md
@@ -1,0 +1,492 @@
+# Oxidized Network Config Backup Design
+
+## Overview
+
+Deploy [Oxidized](https://github.com/ytti/oxidized) — a network device configuration backup tool — into the `observability` namespace, polling six homelab network devices daily and pushing config diffs to a private GitHub repo (`LukeEvansTech/network-configs`). Notifications go to Pushover (drift via Oxidized's `exec` hook; stale-device alerts via the existing kube-prometheus-stack → Alertmanager → Pushover route).
+
+Purpose: drift detection. The Terraform/Ansible IaC in the sibling `network-ops` repo describes *desired* state; Oxidized snapshots *actual* running state, catching out-of-band changes (manual GUI/SSH edits) that bypass IaC.
+
+## Scope
+
+**In scope (devices polled):**
+
+| Device | Hostname | Oxidized model |
+|---|---|---|
+| OPNsense firewall | `opnsense.lan` | `opnsense` |
+| Mellanox SN2700 core switch | `onyx.lan` | `onyx` |
+| MikroTik CRS354 PoE | `mikrotik-poe.lan` | `routeros` |
+| MikroTik CRS354 non-PoE | `mikrotik-nonpoe.lan` | `routeros` |
+| Ruckus AP/controller | `ruckus.lan` | `ruckusunleashed` *(model TBC during pre-deploy)* |
+| GL.iNet router | `glinet.lan` | `openwrt` |
+
+**Out of scope:**
+- APC PDU — SNMP-only; no config-dump fit for Oxidized.
+- Cloud services (NextDNS, Tailscale, Cloudflare) — already IaC-managed in Terraform Cloud.
+
+## Architecture
+
+Single-pod deployment in `observability`, sitting next to `snmp-exporter`. Oxidized polls devices on a 24h interval, writes to a local bare git repo on a Ceph PVC, and pushes commits to GitHub via a deploy key. A sidecar Prometheus exporter scrapes Oxidized's `/nodes.json` and exposes per-device last-success metrics.
+
+```
+                              ┌────────────────────────────────────────┐
+                              │  GitHub: LukeEvansTech/network-configs │
+                              │           (private)                    │
+                              └──────────────▲─────────────────────────┘
+                                             │ git push (SSH deploy key)
+┌────────────────────────────────────────────┼─────────────────────────────┐
+│ Talos cluster — namespace: observability   │                             │
+│                                            │                             │
+│  ┌─────────────────── oxidized pod ────────┴──────────────────┐          │
+│  │  oxidized:0.36.0  (port 8888)                              │          │
+│  │  oxidized-exporter:v1.0.7  (port 9001)                     │          │
+│  │  initContainers:                                           │          │
+│  │   - ssh-setup       (writes deploy key to tmpfs)           │          │
+│  │   - router-db-render (envsubst → router.db on tmpfs)       │          │
+│  │                                                            │          │
+│  │  PVC (ceph-block, 1Gi, VolSync-protected):                 │          │
+│  │    ~/.config/oxidized/  ← Oxidized state + bare git repo   │          │
+│  │  emptyDir tmpfs:                                           │          │
+│  │    ~/.ssh/                       ← deploy key (memory)     │          │
+│  │    /etc/oxidized/router.db.d/    ← rendered creds (memory) │          │
+│  │  ConfigMap (mounted on init only for router.db template):  │          │
+│  │    /etc/oxidized/config                                    │          │
+│  │  Secret (ExternalSecret → 1Password):                      │          │
+│  │    device creds, GH deploy key, Pushover token             │          │
+│  └────────┬─────────────┬───────────────┬─────────────────────┘          │
+│           │             │               │                                │
+│           ▼             ▼               ▼                                │
+│  HTTPRoute        ServiceMonitor   exec hook → Pushover API              │
+│  envoy-internal   → Prometheus      (drift + node_fail)                  │
+│                          │                                               │
+│                          ▼                                               │
+│              PrometheusRule: stale device > 48h                          │
+│                          │                                               │
+│                          ▼                                               │
+│              Alertmanager → Pushover (existing route)                    │
+└─────────────────────────┼────────────────────────────────────────────────┘
+                          │ SSH / HTTPS polls (every 24h)
+                          ▼
+   opnsense · onyx · mikrotik_poe · mikrotik_nonpoe · ruckus · glinet
+```
+
+## File Layout
+
+```
+kubernetes/apps/observability/oxidized/
+  ks.yaml                    # Flux Kustomization → ./app
+  app/
+    kustomization.yaml       # Resource list + components: ../../../../components/volsync
+    helmrelease.yaml         # bjw-s/app-template HelmRelease (oxidized + exporter sidecar)
+    ocirepository.yaml       # OCI chart source (bjw-s app-template)
+    externalsecret.yaml      # 1Password → Secret (creds, deploy key, Pushover)
+    configmap.yaml           # Oxidized config (YAML) + router.db (CSV)
+    httproute.yaml           # oxidized.${SECRET_DOMAIN} → envoy-internal
+    prometheusrule.yaml      # OxidizedDeviceStale + OxidizedDown alerts
+```
+
+**One change to existing files:**
+- `kubernetes/apps/observability/kustomization.yaml` — add `- ./oxidized` (alphabetical position between `nut-exporter` and `peanut`).
+
+## Container Images
+
+| Image | Tag | Purpose |
+|---|---|---|
+| `docker.io/oxidized/oxidized` | `0.36.0@sha256:<digest>` | Main app (resolved at implementation) |
+| `ghcr.io/akquinet/oxidized-exporter` | `v1.0.7@sha256:<digest>` | Sidecar Prometheus exporter |
+
+Both tracked by Renovate.
+
+## Chart Source
+
+`ocirepository.yaml`: `oci://ghcr.io/bjw-s-labs/helm/app-template` tag `4.6.2` (matches sibling apps).
+
+## Flux Kustomization (`ks.yaml`)
+
+- `dependsOn`: `rook-ceph-cluster` (for VolSync-backed PVC), `external-secrets-stores` (for `onepassword-connect` ClusterSecretStore).
+- Components: `../../../../components/volsync`.
+- `postBuild.substitute`:
+  - `APP: oxidized`
+  - `VOLSYNC_CAPACITY: 1Gi`
+  - `GATUS_SUBDOMAIN: oxidized` *(if you want a Gatus check — optional)*
+
+## HelmRelease Spec
+
+### Controllers / Containers
+
+```yaml
+controllers:
+  oxidized:
+    initContainers:
+      ssh-setup:
+        image: busybox:1.37
+        command: [/bin/sh, -c]
+        args:
+          - |
+            install -m 0700 -d /ssh-out
+            printf '%s\n' "$GITHUB_DEPLOY_KEY" > /ssh-out/id_ed25519
+            chmod 0600 /ssh-out/id_ed25519
+            ssh-keygen -y -f /ssh-out/id_ed25519 > /ssh-out/id_ed25519.pub
+            printf '%s\n' "$GITHUB_KNOWN_HOSTS" > /ssh-out/known_hosts
+            chmod 0644 /ssh-out/known_hosts /ssh-out/id_ed25519.pub
+        env:
+          GITHUB_DEPLOY_KEY: { secretKeyRef: { name: oxidized-secret, key: GITHUB_DEPLOY_KEY } }
+          GITHUB_KNOWN_HOSTS: { secretKeyRef: { name: oxidized-secret, key: GITHUB_KNOWN_HOSTS } }
+      router-db-render:
+        image: docker.io/alpine:3.21
+        command: [/bin/sh, -c]
+        args:
+          - |
+            apk add --no-cache gettext >/dev/null
+            envsubst < /etc/oxidized-tmpl/router.db > /router-out/router.db
+            chmod 0600 /router-out/router.db
+        env:
+          # all *_USERNAME / *_PASSWORD vars from oxidized-secret
+          OPNSENSE_USERNAME: { secretKeyRef: { name: oxidized-secret, key: OPNSENSE_USERNAME } }
+          OPNSENSE_PASSWORD: { secretKeyRef: { name: oxidized-secret, key: OPNSENSE_PASSWORD } }
+          ONYX_USERNAME:     { secretKeyRef: { name: oxidized-secret, key: ONYX_USERNAME } }
+          ONYX_PASSWORD:     { secretKeyRef: { name: oxidized-secret, key: ONYX_PASSWORD } }
+          MIKROTIK_USERNAME: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_USERNAME } }
+          MIKROTIK_PASSWORD: { secretKeyRef: { name: oxidized-secret, key: MIKROTIK_PASSWORD } }
+          RUCKUS_USERNAME:   { secretKeyRef: { name: oxidized-secret, key: RUCKUS_USERNAME } }
+          RUCKUS_PASSWORD:   { secretKeyRef: { name: oxidized-secret, key: RUCKUS_PASSWORD } }
+          GLINET_USERNAME:   { secretKeyRef: { name: oxidized-secret, key: GLINET_USERNAME } }
+          GLINET_PASSWORD:   { secretKeyRef: { name: oxidized-secret, key: GLINET_PASSWORD } }
+    containers:
+      app:
+        image:
+          repository: oxidized/oxidized
+          tag: 0.36.0@sha256:<digest>
+        env:
+          # only Pushover creds at runtime; device creds were baked into router.db by the init
+          PUSHOVER_TOKEN:    { secretKeyRef: { name: oxidized-secret, key: PUSHOVER_TOKEN } }
+          PUSHOVER_USER_KEY: { secretKeyRef: { name: oxidized-secret, key: PUSHOVER_USER_KEY } }
+        probes:
+          liveness:  { type: TCP, port: 8888 }
+          readiness: { type: HTTP, path: /nodes.json, port: 8888 }
+        resources:
+          requests: { cpu: 50m, memory: 128Mi }
+          limits:   { memory: 256Mi }
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 30000
+          runAsGroup: 30000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities: { drop: [ALL] }
+          seccompProfile: { type: RuntimeDefault }
+      exporter:
+        image:
+          repository: ghcr.io/akquinet/oxidized-exporter
+          tag: v1.0.7@sha256:<digest>
+        args: [--oxidized-url=http://localhost:8888]
+        resources:
+          requests: { cpu: 10m, memory: 32Mi }
+          limits:   { memory: 64Mi }
+        securityContext: { ...same hardening as app... }
+```
+
+### Service & Routing
+
+```yaml
+service:
+  app:
+    controller: oxidized
+    ports:
+      http:    { port: 8888 }
+      metrics: { port: 9001 }
+
+serviceMonitor:
+  app:
+    serviceName: oxidized
+    endpoints:
+      - port: metrics
+        interval: 30s
+        scrapeTimeout: 10s
+```
+
+`httproute.yaml`:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oxidized
+spec:
+  hostnames: [oxidized.${SECRET_DOMAIN}]
+  parentRefs: [{ name: envoy-internal, namespace: network }]
+  rules:
+    - backendRefs: [{ name: oxidized, port: 8888 }]
+```
+
+### Persistence
+
+```yaml
+persistence:
+  config:
+    type: persistentVolumeClaim
+    storageClass: ceph-block
+    accessMode: ReadWriteOnce
+    size: 1Gi
+    advancedMounts:
+      oxidized:
+        app:        [{ path: /home/oxidized/.config/oxidized }]
+  ssh:
+    type: emptyDir
+    medium: Memory
+    advancedMounts:
+      oxidized:
+        ssh-setup:  [{ path: /ssh-out }]
+        app:        [{ path: /home/oxidized/.ssh, readOnly: true }]
+  router-db:
+    type: emptyDir
+    medium: Memory
+    advancedMounts:
+      oxidized:
+        router-db-render: [{ path: /router-out }]
+        app:              [{ path: /etc/oxidized/router.db.d, readOnly: true }]
+  oxidized-config:
+    type: configMap
+    name: oxidized-config
+    advancedMounts:
+      oxidized:
+        app:
+          - { subPath: config, path: /etc/oxidized/config }
+        router-db-render:
+          - { subPath: router.db, path: /etc/oxidized-tmpl/router.db }
+  tmp:
+    type: emptyDir
+    advancedMounts:
+      oxidized:
+        app:        [{ path: /tmp }]
+```
+
+VolSync component handles snapshots of the `config` PVC.
+
+## ConfigMap
+
+### `config` (Oxidized YAML)
+
+```yaml
+username: placeholder            # router.db provides per-device user/pass
+password: placeholder
+model: routeros
+interval: 86400                  # 24h
+log: /home/oxidized/.config/oxidized/oxidized.log
+debug: false
+threads: 6
+timeout: 30
+retries: 2
+rest: 0.0.0.0:8888               # required for HTTPRoute, exporter, /nodes.json probe
+prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/
+
+input:
+  default: ssh
+  ssh:
+    secure: false
+
+output:
+  default: git
+  git:
+    user: Oxidized
+    email: oxidized@${SECRET_DOMAIN}
+    repo: /home/oxidized/.config/oxidized/devices.git
+
+source:
+  default: csv
+  csv:
+    file: /etc/oxidized/router.db.d/router.db
+    delimiter: !ruby/regexp /:/
+    map:
+      name:     0
+      ip:       1
+      model:    2
+      username: 3
+      password: 4
+
+hooks:
+  push_to_github:
+    type: githubrepo
+    events: [post_store]
+    remote_repo: git@github.com:LukeEvansTech/network-configs.git
+    publickey_file: /home/oxidized/.ssh/id_ed25519.pub
+    privatekey_file: /home/oxidized/.ssh/id_ed25519
+  pushover_drift:
+    type: exec
+    events: [post_store]
+    cmd: |
+      curl -s --form-string "token=$PUSHOVER_TOKEN" \
+              --form-string "user=$PUSHOVER_USER_KEY" \
+              --form-string "title=Oxidized: config drift" \
+              --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) changed" \
+              https://api.pushover.net/1/messages.json
+  pushover_fail:
+    type: exec
+    events: [node_fail]
+    cmd: |
+      curl -s --form-string "token=$PUSHOVER_TOKEN" \
+              --form-string "user=$PUSHOVER_USER_KEY" \
+              --form-string "title=Oxidized: poll failed" \
+              --form-string "priority=1" \
+              --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) — $OX_NODE_MSG" \
+              https://api.pushover.net/1/messages.json
+```
+
+### `router.db` template (CSV — `name:ip:model:username:password`)
+
+The ConfigMap holds a *template* with `${VAR}` placeholders. The `router-db-render` init container reads it from `/etc/oxidized-tmpl/router.db`, runs `envsubst` against env vars sourced from `oxidized-secret`, and writes the rendered file to a tmpfs `emptyDir` (`/router-out`). The main container mounts that tmpfs read-only at `/etc/oxidized/router.db.d/router.db`. Net result: device credentials never land on the Ceph PVC and never appear in the ConfigMap.
+
+Template content:
+
+```
+opnsense:opnsense.lan:opnsense:${OPNSENSE_USERNAME}:${OPNSENSE_PASSWORD}
+onyx:onyx.lan:onyx:${ONYX_USERNAME}:${ONYX_PASSWORD}
+mikrotik_poe:mikrotik-poe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
+mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:${MIKROTIK_USERNAME}:${MIKROTIK_PASSWORD}
+ruckus:ruckus.lan:ruckusunleashed:${RUCKUS_USERNAME}:${RUCKUS_PASSWORD}
+glinet:glinet.lan:openwrt:${GLINET_USERNAME}:${GLINET_PASSWORD}
+```
+
+## ExternalSecret
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oxidized
+spec:
+  secretStoreRef: { kind: ClusterSecretStore, name: onepassword-connect }
+  target:
+    name: oxidized-secret
+    template:
+      engineVersion: v2
+      data:
+        OPNSENSE_USERNAME:    "{{ .OPNSENSE_USERNAME }}"
+        OPNSENSE_PASSWORD:    "{{ .OPNSENSE_PASSWORD }}"
+        ONYX_USERNAME:        "{{ .ONYX_USERNAME }}"
+        ONYX_PASSWORD:        "{{ .ONYX_PASSWORD }}"
+        MIKROTIK_USERNAME:    "{{ .MIKROTIK_USERNAME }}"
+        MIKROTIK_PASSWORD:    "{{ .MIKROTIK_PASSWORD }}"
+        RUCKUS_USERNAME:      "{{ .RUCKUS_USERNAME }}"
+        RUCKUS_PASSWORD:      "{{ .RUCKUS_PASSWORD }}"
+        GLINET_USERNAME:      "{{ .GLINET_USERNAME }}"
+        GLINET_PASSWORD:      "{{ .GLINET_PASSWORD }}"
+        GITHUB_DEPLOY_KEY:    "{{ .GITHUB_DEPLOY_KEY }}"
+        GITHUB_KNOWN_HOSTS:   "{{ .GITHUB_KNOWN_HOSTS }}"
+        PUSHOVER_TOKEN:       "{{ .PUSHOVER_TOKEN }}"
+        PUSHOVER_USER_KEY:    "{{ .PUSHOVER_USER_KEY }}"
+  dataFrom:
+    - extract: { key: oxidized }
+```
+
+**1Password item to create**: `oxidized` in the same vault used by other apps, with the 14 fields above. The user is responsible for creating this item before deploy.
+
+## PrometheusRule
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oxidized
+spec:
+  groups:
+    - name: oxidized
+      rules:
+        - alert: OxidizedDeviceStale
+          expr: (time() - oxidized_node_last_success_timestamp_seconds) > 172800
+          for: 10m
+          labels: { severity: warning }
+          annotations:
+            summary: "Oxidized has not polled {{ $labels.node }} in >48h"
+        - alert: OxidizedDown
+          expr: up{job="oxidized"} == 0
+          for: 15m
+          labels: { severity: warning }
+          annotations:
+            summary: "Oxidized exporter is down"
+```
+
+Exact metric name will be confirmed against `akquinet/oxidized-exporter` README during implementation and adjusted if needed.
+
+## Preconditions
+
+Before deploy succeeds, the following must be true:
+
+| Precondition | How to verify |
+|---|---|
+| Pod can reach each device's hostname/port | `kubectl run -it --rm netshoot --image=nicolaka/netshoot -- nc -zv <device>.lan 22` |
+| OPNsense Unbound resolves `*.lan` for cluster | DNS query from a worker pod |
+| GitHub repo `LukeEvansTech/network-configs` exists, private | `gh repo view LukeEvansTech/network-configs` |
+| Deploy key with **write** access added to repo | `gh repo deploy-key list --repo LukeEvansTech/network-configs` |
+| 1Password item `oxidized` populated with all 14 fields | Manual check |
+| Each device's credentials work via direct SSH/API | Manual login test |
+| OPNsense firewall rule permitting cluster pod CIDR → device VLAN ports (SSH 22, HTTPS 443) | OPNsense rule check |
+
+If any precondition fails, the implementation plan defines specific recovery steps.
+
+## Failure Modes
+
+| Failure | Detection | Recovery |
+|---|---|---|
+| Single device unreachable | `node_fail` hook → Pushover; `OxidizedDeviceStale` alert after 48h | Self-heals when device returns |
+| GitHub push fails | Logs + `node_fail` event | Local commits accumulate; flush on next push |
+| PVC corrupted | Pod CrashLoopBackOff | Delete PVC → VolSync restore, **or** delete PVC and re-clone from GitHub |
+| 1Password Connect down | ExternalSecret stale | Already-mounted Secret keeps working; tolerable for hours |
+| Pushover outage | Hook curl exits non-zero | Drift commits still stored in git; only notification lost |
+| Wrong Ruckus model | That device's polls fail | Swap `model:` in router.db, redeploy ConfigMap |
+
+## Security Posture
+
+- All containers: `runAsNonRoot`, `runAsUser: 30000`, `readOnlyRootFilesystem`, `drop: [ALL]`, `seccompProfile: RuntimeDefault`.
+- SSH deploy key lives only on `tmpfs` (memory), never the Ceph PVC.
+- Deploy key scope: write to `LukeEvansTech/network-configs` only.
+- GitHub repo private. Configs may contain topology/IP info even after `remove_secret` filters.
+- NetworkPolicy: egress to device VLAN ports (22, 443), `github.com:22`, `api.pushover.net:443`, kube-dns; deny everything else.
+
+## Testing & Validation Plan
+
+**Pre-deploy:**
+1. Manually SSH/API each of 6 devices using the credentials staged in 1Password.
+2. Confirm GitHub repo + deploy key.
+3. `flux-local build ks --path kubernetes/flux/cluster oxidized` for CI parity.
+
+**Initial deploy (validation branch):**
+1. Set `interval: 60` (1-min) temporarily for fast feedback.
+2. `just kube apply-ks observability oxidized`.
+3. Watch pod logs: 6 successful logins + 6 initial commits.
+4. Browse Oxidized UI via HTTPRoute; all 6 devices green.
+5. Confirm GitHub repo shows 6 config files.
+6. Manually edit one device (e.g., add a comment in MikroTik) → wait for next poll → verify git diff + Pushover message.
+7. Stop SSH on one device temporarily; confirm `node_fail` hook fires (Pushover notification).
+8. Lower alert `for:` threshold and confirm `OxidizedDeviceStale` fires in Alertmanager.
+
+**Pre-merge cleanup:**
+1. Restore `interval: 86400`.
+2. Restore alert thresholds.
+3. Merge to main.
+
+## Rollback / Uninstall
+
+```bash
+just kube delete-ks observability oxidized
+kubectl delete pvc -n observability oxidized
+# 1Password item + GitHub repo remain — clean up manually if abandoning permanently
+```
+
+The git history on GitHub is durable evidence even after uninstall — redeploy picks up where left off.
+
+## Open Items (resolved during implementation plan)
+
+- **Ruckus model choice** — confirm Unleashed vs SmartZone vs ZoneDirector before populating `router.db`.
+- **OPNsense secret stripping** — exact `remove_secret` regex tuned to OPNsense `config.xml`.
+- **Exporter metric name** — confirm against `akquinet/oxidized-exporter` README.
+- **Container image digests** — pinned at implementation time.
+- **NetworkPolicy egress rules** — exact device IPs/CIDRs.
+
+## References
+
+- Oxidized: <https://github.com/ytti/oxidized>
+- Oxidized hooks docs: <https://github.com/ytti/oxidized/blob/master/docs/Hooks.md>
+- akquinet/oxidized-exporter: <https://github.com/akquinet/oxidized-exporter>
+- Pushover API: <https://pushover.net/api>
+- Reference blog post that prompted this work: <https://oneuptime.com/blog/post/2026-02-08-how-to-run-oxidized-in-docker-for-network-config-backup/view>
+- Sibling app pattern: `kubernetes/apps/observability/snmp-exporter/`

--- a/docs/superpowers/specs/2026-04-29-oxidized-design.md
+++ b/docs/superpowers/specs/2026-04-29-oxidized-design.md
@@ -38,7 +38,7 @@ Single-pod deployment in `observability`, sitting next to `snmp-exporter`. Oxidi
 │                                            │                             │
 │  ┌─────────────────── oxidized pod ────────┴──────────────────┐          │
 │  │  oxidized:0.36.0  (port 8888)                              │          │
-│  │  oxidized-exporter:v1.0.7  (port 9001)                     │          │
+│  │  oxidized-exporter:v1.0.7  (port 8080)                     │          │
 │  │  initContainers:                                           │          │
 │  │   - ssh-setup       (writes deploy key to tmpfs)           │          │
 │  │   - router-db-render (envsubst → router.db on tmpfs)       │          │
@@ -178,7 +178,7 @@ controllers:
         image:
           repository: ghcr.io/akquinet/oxidized-exporter
           tag: v1.0.7@sha256:<digest>
-        args: [--oxidized-url=http://localhost:8888]
+        args: ["-U", "http://localhost:8888"]   # exporter listens on :8080 by default
         resources:
           requests: { cpu: 10m, memory: 32Mi }
           limits:   { memory: 64Mi }
@@ -193,7 +193,7 @@ service:
     controller: oxidized
     ports:
       http:    { port: 8888 }
-      metrics: { port: 9001 }
+      metrics: { port: 8080 }
 
 serviceMonitor:
   app:
@@ -392,20 +392,21 @@ spec:
     - name: oxidized
       rules:
         - alert: OxidizedDeviceStale
-          expr: (time() - oxidized_node_last_success_timestamp_seconds) > 172800
-          for: 10m
+          # 2=success, 1=never, 0=no_connection per akquinet/oxidized-exporter
+          expr: oxidized_device_status != 2
+          for: 48h
           labels: { severity: warning }
           annotations:
-            summary: "Oxidized has not polled {{ $labels.node }} in >48h"
+            summary: "Oxidized has not successfully polled {{ $labels.full_name }} in >48h"
         - alert: OxidizedDown
-          expr: up{job="oxidized"} == 0
+          expr: up{job=~".*oxidized.*"} == 0
           for: 15m
           labels: { severity: warning }
           annotations:
             summary: "Oxidized exporter is down"
 ```
 
-Exact metric name will be confirmed against `akquinet/oxidized-exporter` README during implementation and adjusted if needed.
+Metric semantics confirmed against the akquinet/oxidized-exporter source: `oxidized_device_status` is a gauge labeled `full_name`, `name`, `group`, `model` with values `2=success / 1=never / 0=no_connection`. Alert fires only after 48h of continuously not-success (with daily polls, that's at least two consecutive failed cycles).
 
 ## Preconditions
 
@@ -477,8 +478,7 @@ The git history on GitHub is durable evidence even after uninstall — redeploy 
 ## Open Items (resolved during implementation plan)
 
 - **Ruckus model choice** — confirm Unleashed vs SmartZone vs ZoneDirector before populating `router.db`.
-- **OPNsense secret stripping** — exact `remove_secret` regex tuned to OPNsense `config.xml`.
-- **Exporter metric name** — confirm against `akquinet/oxidized-exporter` README.
+- **OPNsense secret stripping** — verify after first poll whether the committed `config.xml` contains plaintext secrets; add `remove_secret` filter and any custom regex if so.
 - **Container image digests** — pinned at implementation time.
 - **NetworkPolicy egress rules** — exact device IPs/CIDRs.
 

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - ./netdata/ks.yaml
   - ./network-ups-tools/ks.yaml
   - ./nut-exporter/ks.yaml
+  - ./oxidized/ks.yaml
   - ./peanut/ks.yaml
   - ./shelly-exporter/ks.yaml
   - ./silence-operator/ks.yaml

--- a/kubernetes/apps/observability/oxidized/app/configmap.yaml
+++ b/kubernetes/apps/observability/oxidized/app/configmap.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oxidized-config
+data:
+  config: |
+    ---
+    username: placeholder
+    password: placeholder
+    model: routeros
+    interval: 86400
+    log: /home/oxidized/.config/oxidized/oxidized.log
+    debug: false
+    threads: 6
+    timeout: 30
+    retries: 2
+    rest: 0.0.0.0:8888
+    prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/
+
+    input:
+      default: ssh
+      ssh:
+        secure: false
+
+    output:
+      default: git
+      git:
+        user: Oxidized
+        email: oxidized@${SECRET_DOMAIN}
+        repo: /home/oxidized/.config/oxidized/devices.git
+
+    source:
+      default: csv
+      csv:
+        file: /etc/oxidized/router.db.d/router.db
+        delimiter: !ruby/regexp /:/
+        map:
+          name: 0
+          ip: 1
+          model: 2
+          username: 3
+          password: 4
+
+    hooks:
+      push_to_github:
+        type: githubrepo
+        events: [post_store]
+        remote_repo: git@github.com:LukeEvansTech/network-configs.git
+        publickey_file: /home/oxidized/.ssh/id_ed25519.pub
+        privatekey_file: /home/oxidized/.ssh/id_ed25519
+      pushover_drift:
+        type: exec
+        events: [post_store]
+        cmd: |
+          curl -s --form-string "token=$PUSHOVER_TOKEN" \
+                  --form-string "user=$PUSHOVER_USER_KEY" \
+                  --form-string "title=Oxidized: config drift" \
+                  --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) changed" \
+                  https://api.pushover.net/1/messages.json
+      pushover_fail:
+        type: exec
+        events: [node_fail]
+        cmd: |
+          curl -s --form-string "token=$PUSHOVER_TOKEN" \
+                  --form-string "user=$PUSHOVER_USER_KEY" \
+                  --form-string "title=Oxidized: poll failed" \
+                  --form-string "priority=1" \
+                  --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) — $OX_NODE_MSG" \
+                  https://api.pushover.net/1/messages.json
+  router.db: |-
+    opnsense:opnsense.lan:opnsense:$${OPNSENSE_USERNAME}:$${OPNSENSE_PASSWORD}
+    onyx:onyx.lan:onyx:$${ONYX_USERNAME}:$${ONYX_PASSWORD}
+    mikrotik_poe:mikrotik-poe.lan:routeros:$${MIKROTIK_POE_USERNAME}:$${MIKROTIK_POE_PASSWORD}
+    mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:$${MIKROTIK_NONPOE_USERNAME}:$${MIKROTIK_NONPOE_PASSWORD}
+    ruckus:ruckus.lan:ruckusunleashed:$${RUCKUS_USERNAME}:$${RUCKUS_PASSWORD}

--- a/kubernetes/apps/observability/oxidized/app/configmap.yaml
+++ b/kubernetes/apps/observability/oxidized/app/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: oxidized-config
+  namespace: observability
 data:
   config: |-
     ---

--- a/kubernetes/apps/observability/oxidized/app/configmap.yaml
+++ b/kubernetes/apps/observability/oxidized/app/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: oxidized-config
 data:
-  config: |
+  config: |-
     ---
     username: placeholder
     password: placeholder
@@ -68,9 +68,3 @@ data:
                   --form-string "priority=1" \
                   --form-string "message=$OX_NODE_NAME ($OX_NODE_MODEL) — $OX_NODE_MSG" \
                   https://api.pushover.net/1/messages.json
-  router.db: |-
-    opnsense:opnsense.lan:opnsense:$${OPNSENSE_USERNAME}:$${OPNSENSE_PASSWORD}
-    onyx:onyx.lan:onyx:$${ONYX_USERNAME}:$${ONYX_PASSWORD}
-    mikrotik_poe:mikrotik-poe.lan:routeros:$${MIKROTIK_POE_USERNAME}:$${MIKROTIK_POE_PASSWORD}
-    mikrotik_nonpoe:mikrotik-nonpoe.lan:routeros:$${MIKROTIK_NONPOE_USERNAME}:$${MIKROTIK_NONPOE_PASSWORD}
-    ruckus:ruckus.lan:ruckusunleashed:$${RUCKUS_USERNAME}:$${RUCKUS_PASSWORD}

--- a/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oxidized
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: oxidized-secret
+    template:
+      engineVersion: v2
+      data:
+        OPNSENSE_USERNAME: "{{ .OPNSENSE_USERNAME }}"
+        OPNSENSE_PASSWORD: "{{ .OPNSENSE_PASSWORD }}"
+        ONYX_USERNAME: "{{ .ONYX_USERNAME }}"
+        ONYX_PASSWORD: "{{ .ONYX_PASSWORD }}"
+        MIKROTIK_POE_USERNAME: "{{ .MIKROTIK_POE_USERNAME }}"
+        MIKROTIK_POE_PASSWORD: "{{ .MIKROTIK_POE_PASSWORD }}"
+        MIKROTIK_NONPOE_USERNAME: "{{ .MIKROTIK_NONPOE_USERNAME }}"
+        MIKROTIK_NONPOE_PASSWORD: "{{ .MIKROTIK_NONPOE_PASSWORD }}"
+        RUCKUS_USERNAME: "{{ .RUCKUS_USERNAME }}"
+        RUCKUS_PASSWORD: "{{ .RUCKUS_PASSWORD }}"
+        GITHUB_DEPLOY_KEY: "{{ .GITHUB_DEPLOY_KEY }}"
+        GITHUB_KNOWN_HOSTS: "{{ .GITHUB_KNOWN_HOSTS }}"
+        PUSHOVER_TOKEN: "{{ .PUSHOVER_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+  dataFrom:
+    - extract:
+        key: oxidized

--- a/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
@@ -13,20 +13,16 @@ spec:
     template:
       engineVersion: v2
       data:
-        OPNSENSE_USERNAME: "{{ .OPNSENSE_USERNAME }}"
-        OPNSENSE_PASSWORD: "{{ .OPNSENSE_PASSWORD }}"
-        ONYX_USERNAME: "{{ .ONYX_USERNAME }}"
-        ONYX_PASSWORD: "{{ .ONYX_PASSWORD }}"
-        MIKROTIK_POE_USERNAME: "{{ .MIKROTIK_POE_USERNAME }}"
-        MIKROTIK_POE_PASSWORD: "{{ .MIKROTIK_POE_PASSWORD }}"
-        MIKROTIK_NONPOE_USERNAME: "{{ .MIKROTIK_NONPOE_USERNAME }}"
-        MIKROTIK_NONPOE_PASSWORD: "{{ .MIKROTIK_NONPOE_PASSWORD }}"
-        RUCKUS_USERNAME: "{{ .RUCKUS_USERNAME }}"
-        RUCKUS_PASSWORD: "{{ .RUCKUS_PASSWORD }}"
         GITHUB_DEPLOY_KEY: "{{ .GITHUB_DEPLOY_KEY }}"
         GITHUB_KNOWN_HOSTS: "{{ .GITHUB_KNOWN_HOSTS }}"
         PUSHOVER_TOKEN: "{{ .PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        router.db: |
+          opnsense:{{ .OPNSENSE_HOST }}:opnsense:{{ .OPNSENSE_USERNAME }}:{{ .OPNSENSE_PASSWORD }}
+          onyx:{{ .ONYX_HOST }}:onyx:{{ .ONYX_USERNAME }}:{{ .ONYX_PASSWORD }}
+          mikrotik_poe:{{ .MIKROTIK_POE_HOST }}:routeros:{{ .MIKROTIK_POE_USERNAME }}:{{ .MIKROTIK_POE_PASSWORD }}
+          mikrotik_nonpoe:{{ .MIKROTIK_NONPOE_HOST }}:routeros:{{ .MIKROTIK_NONPOE_USERNAME }}:{{ .MIKROTIK_NONPOE_PASSWORD }}
+          ruckus:{{ .RUCKUS_HOST }}:ruckusunleashed:{{ .RUCKUS_USERNAME }}:{{ .RUCKUS_PASSWORD }}
   dataFrom:
     - extract:
         key: oxidized

--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -1,0 +1,215 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app oxidized
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      oxidized:
+        strategy: Recreate
+        initContainers:
+          ssh-setup:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.37@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                install -m 0700 -d /ssh-out
+                printf '%s\n' "$GITHUB_DEPLOY_KEY" > /ssh-out/id_ed25519
+                chmod 0600 /ssh-out/id_ed25519
+                ssh-keygen -y -f /ssh-out/id_ed25519 > /ssh-out/id_ed25519.pub
+                printf '%s\n' "$GITHUB_KNOWN_HOSTS" > /ssh-out/known_hosts
+                chmod 0644 /ssh-out/id_ed25519.pub /ssh-out/known_hosts
+            env:
+              GITHUB_DEPLOY_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: oxidized-secret
+                    key: GITHUB_DEPLOY_KEY
+              GITHUB_KNOWN_HOSTS:
+                valueFrom:
+                  secretKeyRef:
+                    name: oxidized-secret
+                    key: GITHUB_KNOWN_HOSTS
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: {drop: [ALL]}
+              seccompProfile: {type: RuntimeDefault}
+          router-db-render:
+            image:
+              repository: docker.io/library/alpine
+              tag: 3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                apk add --no-cache gettext >/dev/null
+                envsubst < /etc/oxidized-tmpl/router.db > /router-out/router.db
+                chmod 0600 /router-out/router.db
+            env:
+              OPNSENSE_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: OPNSENSE_USERNAME}}}
+              OPNSENSE_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: OPNSENSE_PASSWORD}}}
+              ONYX_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: ONYX_USERNAME}}}
+              ONYX_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: ONYX_PASSWORD}}}
+              MIKROTIK_POE_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_POE_USERNAME}}}
+              MIKROTIK_POE_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_POE_PASSWORD}}}
+              MIKROTIK_NONPOE_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_NONPOE_USERNAME}}}
+              MIKROTIK_NONPOE_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_NONPOE_PASSWORD}}}
+              RUCKUS_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: RUCKUS_USERNAME}}}
+              RUCKUS_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: RUCKUS_PASSWORD}}}
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: {drop: [ALL]}
+              seccompProfile: {type: RuntimeDefault}
+        containers:
+          app:
+            image:
+              repository: docker.io/oxidized/oxidized
+              tag: 0.36.0@sha256:12c0155d7f7c827fd884cb9d33b8aac44fa6291a9e54499cca6e3122e90c47b9
+            env:
+              PUSHOVER_TOKEN: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: PUSHOVER_TOKEN}}}
+              PUSHOVER_USER_KEY: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: PUSHOVER_USER_KEY}}}
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: {port: 8888}
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: {path: /nodes.json, port: 8888}
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+            resources:
+              requests: {cpu: 50m, memory: 128Mi}
+              limits: {memory: 256Mi}
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: {drop: [ALL]}
+              seccompProfile: {type: RuntimeDefault}
+          exporter:
+            image:
+              repository: ghcr.io/akquinet/oxidized-exporter
+              tag: v1.0.5@sha256:93b5cc0eccd640f034d9dfa76aa3b5de1203252fcb4600650be67244262c0637
+            args:
+              - -U
+              - http://localhost:8888
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket: {port: 8080}
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: {path: /metrics, port: 8080}
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+            resources:
+              requests: {cpu: 10m, memory: 32Mi}
+              limits: {memory: 64Mi}
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 30000
+              runAsGroup: 30000
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: {drop: [ALL]}
+              seccompProfile: {type: RuntimeDefault}
+        pod:
+          securityContext:
+            fsGroup: 30000
+            fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: oxidized
+        ports:
+          http: {port: 8888}
+          metrics: {port: 8080}
+
+    serviceMonitor:
+      app:
+        serviceName: oxidized
+        endpoints:
+          - port: metrics
+            interval: 30s
+            scrapeTimeout: 10s
+
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: ceph-block
+        accessMode: ReadWriteOnce
+        size: ${VOLSYNC_CAPACITY}
+        advancedMounts:
+          oxidized:
+            app:
+              - path: /home/oxidized/.config/oxidized
+      ssh:
+        type: emptyDir
+        medium: Memory
+        advancedMounts:
+          oxidized:
+            ssh-setup:
+              - path: /ssh-out
+            app:
+              - path: /home/oxidized/.ssh
+                readOnly: true
+      router-db:
+        type: emptyDir
+        medium: Memory
+        advancedMounts:
+          oxidized:
+            router-db-render:
+              - path: /router-out
+            app:
+              - path: /etc/oxidized/router.db.d
+                readOnly: true
+      oxidized-config:
+        type: configMap
+        name: oxidized-config
+        advancedMounts:
+          oxidized:
+            app:
+              - subPath: config
+                path: /etc/oxidized/config
+            router-db-render:
+              - subPath: router.db
+                path: /etc/oxidized-tmpl/router.db
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          oxidized:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -48,37 +48,6 @@ spec:
               allowPrivilegeEscalation: false
               capabilities: {drop: [ALL]}
               seccompProfile: {type: RuntimeDefault}
-          router-db-render:
-            image:
-              repository: docker.io/library/alpine
-              tag: 3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
-            command:
-              - /bin/sh
-              - -c
-              - |
-                set -eu
-                apk add --no-cache gettext >/dev/null
-                envsubst < /etc/oxidized-tmpl/router.db > /router-out/router.db
-                chmod 0600 /router-out/router.db
-            env:
-              OPNSENSE_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: OPNSENSE_USERNAME}}}
-              OPNSENSE_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: OPNSENSE_PASSWORD}}}
-              ONYX_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: ONYX_USERNAME}}}
-              ONYX_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: ONYX_PASSWORD}}}
-              MIKROTIK_POE_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_POE_USERNAME}}}
-              MIKROTIK_POE_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_POE_PASSWORD}}}
-              MIKROTIK_NONPOE_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_NONPOE_USERNAME}}}
-              MIKROTIK_NONPOE_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: MIKROTIK_NONPOE_PASSWORD}}}
-              RUCKUS_USERNAME: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: RUCKUS_USERNAME}}}
-              RUCKUS_PASSWORD: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: RUCKUS_PASSWORD}}}
-            securityContext:
-              runAsNonRoot: true
-              runAsUser: 30000
-              runAsGroup: 30000
-              readOnlyRootFilesystem: true
-              allowPrivilegeEscalation: false
-              capabilities: {drop: [ALL]}
-              seccompProfile: {type: RuntimeDefault}
         containers:
           app:
             image:
@@ -187,14 +156,14 @@ spec:
               - path: /home/oxidized/.ssh
                 readOnly: true
       router-db:
-        type: emptyDir
-        medium: Memory
+        type: secret
+        name: oxidized-secret
+        defaultMode: 0400
         advancedMounts:
           oxidized:
-            router-db-render:
-              - path: /router-out
             app:
-              - path: /etc/oxidized/router.db.d
+              - subPath: router.db
+                path: /etc/oxidized/router.db.d/router.db
                 readOnly: true
       oxidized-config:
         type: configMap
@@ -204,9 +173,6 @@ spec:
             app:
               - subPath: config
                 path: /etc/oxidized/config
-            router-db-render:
-              - subPath: router.db
-                path: /etc/oxidized-tmpl/router.db
       tmp:
         type: emptyDir
         advancedMounts:

--- a/kubernetes/apps/observability/oxidized/app/httproute.yaml
+++ b/kubernetes/apps/observability/oxidized/app/httproute.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oxidized
+spec:
+  hostnames:
+    - oxidized.${SECRET_DOMAIN}
+    - oxidized.${SECRET_INTERNAL_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: oxidized
+          port: 8888

--- a/kubernetes/apps/observability/oxidized/app/kustomization.yaml
+++ b/kubernetes/apps/observability/oxidized/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/oxidized/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/oxidized/app/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 4.6.2

--- a/kubernetes/apps/observability/oxidized/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/oxidized/app/prometheusrule.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oxidized
+spec:
+  groups:
+    - name: oxidized
+      rules:
+        - alert: OxidizedDeviceStale
+          annotations:
+            summary: Oxidized has not successfully polled {{ $labels.full_name }} in over 48h.
+            description: oxidized_device_status for {{ $labels.full_name }} ({{ $labels.model }}) has been != 2 (success) for 48h. Check device reachability or credentials.
+          expr: oxidized_device_status != 2
+          for: 48h
+          labels:
+            severity: warning
+        - alert: OxidizedDown
+          annotations:
+            summary: Oxidized exporter is down.
+            description: Prometheus has been unable to scrape oxidized-exporter for 15m.
+          expr: up{job=~".*oxidized.*"} == 0
+          for: 15m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/oxidized/ks.yaml
+++ b/kubernetes/apps/observability/oxidized/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oxidized
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/observability/oxidized/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Adds [Oxidized](https://github.com/ytti/oxidized) to the `observability` namespace — polls 5 network devices (OPNsense, Mellanox Onyx, MikroTik PoE, MikroTik NonPoE, Ruckus Unleashed) on a 24h cadence, commits any config drift to a private GitHub repo (`LukeEvansTech/network-configs`), and exposes per-device success metrics via the `akquinet/oxidized-exporter` sidecar.

## How it works

- **Single pod, two containers**: `oxidized` polls devices and pushes to GitHub via SSH deploy key; `oxidized-exporter` (v1.0.5) scrapes `/nodes.json` and exposes `oxidized_device_status` for Prometheus.
- **`router.db` is rendered inside the ExternalSecret template** from per-device HOST/USERNAME/PASSWORD fields in the `Talos/oxidized` 1Password item — **no LAN IPs or internal hostnames in git** (this repo is public).
- **One init container** (`ssh-setup`) materialises the deploy key from secret to a tmpfs `~/.ssh`. The rendered `router.db` is mounted directly from the secret as a subPath.
- **Alerts**: `OxidizedDeviceStale` (status != 2 for 48h) and `OxidizedDown` (no scrape for 15m) → Alertmanager → Pushover, plus direct Pushover hooks for drift events from Oxidized itself.
- **State**: Ceph-block PVC (1Gi, VolSync-backed) at `~/.config/oxidized` for the bare git repo and Oxidized state.
- **HTTPRoute** on `envoy-internal` for `oxidized.${SECRET_DOMAIN}` + `oxidized.${SECRET_INTERNAL_DOMAIN}`.

Spec + plan: `docs/superpowers/specs/2026-04-29-oxidized-design.md`, `docs/superpowers/plans/2026-04-29-oxidized.md`.

## Test plan

- [x] `flux-local test --enable-helm` PASSED (kustomization + observability/oxidized)
- [x] In-cluster reachability from `observability` to all 5 devices on :22 (and OPNsense + Ruckus on :443) confirmed
- [x] github.com:22 + api.pushover.net:443 reachable from cluster pods
- [x] Existing `allow-all-egress` ClusterwideNetworkPolicy already permits required egress — no per-app netpol needed
- [ ] CI (`flux-local`, `security-scans`) green
- [ ] Post-merge: confirm Flux reconciles `oxidized` Kustomization and HelmRelease in `observability`
- [ ] Post-merge: verify each of the 5 devices logs `Successfully fetched config` in pod logs
- [ ] Post-merge: confirm `LukeEvansTech/network-configs` receives initial 5-file commit
- [ ] Post-merge: query Prometheus for `oxidized_device_status` — expect 5 series, all value `2`
- [ ] Post-merge: trigger drift on MikroTik PoE (benign comment) → verify Pushover notification fires + diff committed to GitHub