### PR TITLE
fix(oxidized): drop install -m on /ssh-out init step

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -23,7 +23,10 @@ spec:
               - -c
               - |
                 set -eu
-                install -m 0700 -d /ssh-out
+                # /ssh-out is an emptyDir mount; perms are managed by fsGroup,
+                # we can't chmod the dir itself from a non-root UID. SSH only
+                # strictly enforces FILE perms on the private key, so rely on
+                # those.
                 printf '%s\n' "$GITHUB_DEPLOY_KEY" > /ssh-out/id_ed25519
                 chmod 0600 /ssh-out/id_ed25519
                 ssh-keygen -y -f /ssh-out/id_ed25519 > /ssh-out/id_ed25519.pub


### PR DESCRIPTION
## Summary

Init container `ssh-setup` was crashlooping with `install: can't change permissions of /ssh-out: Operation not permitted`. The container runs as uid 30000 and the `/ssh-out` emptyDir mount point is owned by root with fsGroup 30000 applied — chmod on the dir is denied. SSH's StrictModes only strictly checks FILE perms on a private key, so we keep `chmod 0600` on `id_ed25519` and drop the directory chmod.

## Test plan

- [x] flux-local would pass (no schema changes)
- [ ] Post-merge: pod transitions Pending → Running, both containers Ready
- [ ] Post-merge: oxidized logs show all 5 devices polled successfully
- [ ] Post-merge: initial commit lands in `LukeEvansTech/network-configs`