### PR TITLE
fix(oxidized): write deploy pubkey directly (busybox lacks ssh-keygen)

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       engineVersion: v2
       data:
         GITHUB_DEPLOY_KEY: "{{ .GITHUB_DEPLOY_KEY }}"
+        GITHUB_DEPLOY_KEY_PUB: "{{ .GITHUB_DEPLOY_KEY_PUB }}"
         GITHUB_KNOWN_HOSTS: "{{ .GITHUB_KNOWN_HOSTS }}"
         PUSHOVER_TOKEN: "{{ .PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"

--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -25,11 +25,12 @@ spec:
                 set -eu
                 # /ssh-out is an emptyDir mount; perms are managed by fsGroup,
                 # we can't chmod the dir itself from a non-root UID. SSH only
-                # strictly enforces FILE perms on the private key, so rely on
-                # those.
+                # strictly enforces FILE perms on the private key.
+                # busybox does not bundle ssh-keygen, so the public key half
+                # is written directly from the secret instead of derived.
                 printf '%s\n' "$GITHUB_DEPLOY_KEY" > /ssh-out/id_ed25519
                 chmod 0600 /ssh-out/id_ed25519
-                ssh-keygen -y -f /ssh-out/id_ed25519 > /ssh-out/id_ed25519.pub
+                printf '%s\n' "$GITHUB_DEPLOY_KEY_PUB" > /ssh-out/id_ed25519.pub
                 printf '%s\n' "$GITHUB_KNOWN_HOSTS" > /ssh-out/known_hosts
                 chmod 0644 /ssh-out/id_ed25519.pub /ssh-out/known_hosts
             env:
@@ -38,6 +39,11 @@ spec:
                   secretKeyRef:
                     name: oxidized-secret
                     key: GITHUB_DEPLOY_KEY
+              GITHUB_DEPLOY_KEY_PUB:
+                valueFrom:
+                  secretKeyRef:
+                    name: oxidized-secret
+                    key: GITHUB_DEPLOY_KEY_PUB
               GITHUB_KNOWN_HOSTS:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
## Summary

Init container `ssh-setup` was crashlooping with `ssh-keygen: not found` because busybox 1.37 doesn't bundle `ssh-keygen`. Instead of switching to a heavier image (alpine + apk add openssh-keygen) at every pod start, store the deploy key's public half (which isn't sensitive) in the same `Talos/oxidized` 1Password item alongside the private key, expose it via the ExternalSecret as `GITHUB_DEPLOY_KEY_PUB`, and write it directly to disk.

## Test plan

- [x] flux-local build passes
- [ ] Post-merge: pod transitions Pending → Running, both containers Ready
- [ ] Post-merge: oxidized logs show all 5 devices polled successfully
- [ ] Post-merge: initial commit lands in `LukeEvansTech/network-configs`