### PR TITLE
fix(oxidized): writable rootfs on app container (runit needs lock dirs)

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -87,7 +87,12 @@ spec:
               runAsNonRoot: true
               runAsUser: 30000
               runAsGroup: 30000
-              readOnlyRootFilesystem: true
+              # The oxidized image uses runit (runsv) as its process
+              # supervisor and writes lock files to /etc/sv/*/supervise.
+              # readOnlyRootFilesystem breaks runsv with "unable to open
+              # supervise/lock". Init + exporter keep the locked-down
+              # default; only the app container needs writable rootfs.
+              readOnlyRootFilesystem: false
               allowPrivilegeEscalation: false
               capabilities: {drop: [ALL]}
               seccompProfile: {type: RuntimeDefault}


### PR DESCRIPTION
## Summary

Diagnosed via live container logs:

```
runsv oxidized: fatal: unable to open supervise/lock: file does not exist
runsv auto-reload-config: fatal: unable to open supervise/lock: file does not exist
runsv update-ca-certificates: fatal: unable to open supervise/lock: file does not exist
```

The oxidized 0.36.0 image uses runit (runsv) as its process supervisor and writes lock files into `/etc/sv/<service>/supervise/`. `readOnlyRootFilesystem: true` breaks that.

Drop `readOnlyRootFilesystem` on the **app container only**. The `ssh-setup` init container and the `exporter` sidecar keep the locked-down default.

## Test plan

- [x] flux-local would pass (no schema changes)
- [ ] Post-merge: pod transitions to Ready, both containers Ready
- [ ] Post-merge: oxidized logs show all 5 devices polled successfully
- [ ] Post-merge: initial commit lands in `LukeEvansTech/network-configs`