### PR TITLE
fix(oxidized): start app as root for runit/gosu handover

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -84,17 +84,25 @@ spec:
               requests: {cpu: 50m, memory: 128Mi}
               limits: {memory: 256Mi}
             securityContext:
-              runAsNonRoot: true
-              runAsUser: 30000
-              runAsGroup: 30000
-              # The oxidized image uses runit (runsv) as its process
-              # supervisor and writes lock files to /etc/sv/*/supervise.
-              # readOnlyRootFilesystem breaks runsv with "unable to open
-              # supervise/lock". Init + exporter keep the locked-down
-              # default; only the app container needs writable rootfs.
+              # The oxidized image bootstraps as root (uid 0): runsvdir
+              # initialises supervise dirs under /etc/service/*, runit's
+              # run script then 'chown -R oxidized:oxidized
+              # /home/oxidized/.config/oxidized' and 'gosu oxidized
+              # oxidized' to drop privileges. We must therefore start as
+              # root and grant the minimal caps needed for that handover.
+              # The actual oxidized process ends up running as uid 30000.
+              runAsNonRoot: false
+              runAsUser: 0
+              runAsGroup: 0
               readOnlyRootFilesystem: false
               allowPrivilegeEscalation: false
-              capabilities: {drop: [ALL]}
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - SETUID
+                  - SETGID
               seccompProfile: {type: RuntimeDefault}
           exporter:
             image:


### PR DESCRIPTION
## Summary

Diagnosed via live container logs + image inspection. The oxidized 0.36.0 image's runit run script does:

```bash
chown -R oxidized:oxidized /home/oxidized/.config/oxidized
exec gosu oxidized oxidized
```

This requires the container to start as root so:
1. `runsvdir` can populate `/etc/service/*/supervise/` (root-owned 0755 dirs)
2. `chown` works (CAP_CHOWN)
3. `gosu` can drop privileges to uid 30000 (CAP_SETUID/CAP_SETGID)

The actual `oxidized` process ends up running as uid 30000 once gosu has handed over, so the runtime security posture is identical to before for the actual workload — we just give the entrypoint chain the privileges it needs to do that handover.

Init container + exporter sidecar keep their fully locked-down 30000 defaults.

## Test plan

- [x] flux-local build passes
- [ ] Post-merge: pod transitions Pending → Running, both containers Ready
- [ ] Post-merge: oxidized logs show all 5 devices polled
- [ ] Post-merge: initial commit lands in `LukeEvansTech/network-configs`