### PR TITLE
fix(oxidized): system-git push hook + drop unsupported Onyx/Ruckus

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/configmap.yaml
+++ b/kubernetes/apps/observability/oxidized/app/configmap.yaml
@@ -45,11 +45,19 @@ data:
 
     hooks:
       push_to_github:
-        type: githubrepo
+        # System git over SSH instead of the githubrepo hook (rugged/libgit2),
+        # which fails against current GitHub with
+        # 'Rugged::SshError: remote rejected authentication'. The system
+        # git+ssh client uses ~/.ssh/{id_ed25519,known_hosts} prepared by
+        # the ssh-setup init container.
+        type: exec
         events: [post_store]
-        remote_repo: git@github.com:LukeEvansTech/network-configs.git
-        publickey_file: /home/oxidized/.ssh/id_ed25519.pub
-        privatekey_file: /home/oxidized/.ssh/id_ed25519
+        cmd: |
+          set -e
+          cd /home/oxidized/.config/oxidized/devices.git
+          git remote get-url origin >/dev/null 2>&1 \
+            || git remote add origin git@github.com:LukeEvansTech/network-configs.git
+          git push -u origin master 2>&1
       pushover_drift:
         type: exec
         events: [post_store]

--- a/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
@@ -18,12 +18,13 @@ spec:
         GITHUB_KNOWN_HOSTS: "{{ .GITHUB_KNOWN_HOSTS }}"
         PUSHOVER_TOKEN: "{{ .PUSHOVER_TOKEN }}"
         PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        # Onyx (Mellanox SN2700) and Ruckus Unleashed not included:
+        # oxidized 0.36.0 has no built-in models for either. Re-add when
+        # custom models land or those devices are replaced.
         router.db: |
           opnsense:{{ .OPNSENSE_HOST }}:opnsense:{{ .OPNSENSE_USERNAME }}:{{ .OPNSENSE_PASSWORD }}
-          onyx:{{ .ONYX_HOST }}:onyx:{{ .ONYX_USERNAME }}:{{ .ONYX_PASSWORD }}
           mikrotik_poe:{{ .MIKROTIK_POE_HOST }}:routeros:{{ .MIKROTIK_POE_USERNAME }}:{{ .MIKROTIK_POE_PASSWORD }}
           mikrotik_nonpoe:{{ .MIKROTIK_NONPOE_HOST }}:routeros:{{ .MIKROTIK_NONPOE_USERNAME }}:{{ .MIKROTIK_NONPOE_PASSWORD }}
-          ruckus:{{ .RUCKUS_HOST }}:ruckusunleashed:{{ .RUCKUS_USERNAME }}:{{ .RUCKUS_PASSWORD }}
   dataFrom:
     - extract:
         key: oxidized


### PR DESCRIPTION
## Summary

Two runtime issues caught after the pod finally came healthy on PR #2360:

### 1. GitHub push failed with rugged
```
E [hook.rb:110] Oxidized::HookManager -- Hook push_to_github failed
  (#<Rugged::SshError: remote rejected authentication: Failed getting response>)
```
The bundled `githubrepo` hook uses rugged/libgit2 + libssh2, which fails against current GitHub. The system `git push` over SSH succeeds with the same deploy key. Switch the `post_store` push to an `exec` hook that shells out to system git.

Verified manually inside the pod — `git push -v origin master` produced `* [new branch] master -> master`.

### 2. Unsupported device models
```
E [nodes.rb:27] Oxidized::Nodes -- node {:name=>"onyx" ...} raised
  Oxidized::ModelNotFound with message 'onyx not found'
E [nodes.rb:27] Oxidized::Nodes -- node {:name=>"ruckus" ...} raised
  Oxidized::ModelNotFound with message 'ruckusunleashed not found'
```
oxidized 0.36.0 ships no model for **Mellanox Onyx** (SN2700) or **Ruckus Unleashed**. Drop both from `router.db` for now. The 1Password host/username/password fields stay so the lines can be re-added when custom models land or those devices are replaced.

## Outcome after merge

3 backed-up devices (OPNsense + MikroTik PoE + MikroTik NonPoE) polling on the 24h interval and pushing every config drift to `LukeEvansTech/network-configs` via system git.

## Test plan

- [x] flux-local build passes
- [x] System git push verified manually inside the pod
- [ ] Post-merge: oxidized log shows `push_to_github` hook succeeding (no `Rugged::SshError`)
- [ ] Post-merge: `LukeEvansTech/network-configs` has 3 device-config files committed