### PR TITLE
fix(oxidized): push to main not master

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/configmap.yaml
+++ b/kubernetes/apps/observability/oxidized/app/configmap.yaml
@@ -57,7 +57,7 @@ data:
           cd /home/oxidized/.config/oxidized/devices.git
           git remote get-url origin >/dev/null 2>&1 \
             || git remote add origin git@github.com:LukeEvansTech/network-configs.git
-          git push -u origin master 2>&1
+          git push -u origin main 2>&1
       pushover_drift:
         type: exec
         events: [post_store]


### PR DESCRIPTION
GitHub auto-creates the default branch as `main`. Oxidized was committing to `master` because the bare git repo's HEAD defaulted there. Switched the exec hook to push `main`. The bare repo's local branch + GitHub state have already been renamed (master force-updated onto main + master deleted on GitHub).