### PR TITLE
feat(kopia): set web UI refresh-interval to 5m

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -27,6 +27,7 @@ spec:
               - secretRef:
                   name: kopia-secret
             args:
+              - --refresh-interval=5m
               - --without-password
             probes:
               liveness: &probes


### PR DESCRIPTION
## Summary
- Add `--refresh-interval=5m` to Kopia container args so the web UI reflects backup state quicker than the 4h default.

Mirrors [onedr0p/home-ops@a73467d](https://github.com/onedr0p/home-ops/commit/a73467d).

## Test plan
- [ ] Flux reconciles the HelmRelease cleanly
- [ ] `kopia.<domain>` UI shows snapshots updated within 5m of new backups