### PR TITLE
chore(alerts): silence flux source-controller unreachable noise

### DIFF
--- a/kubernetes/components/alerts/alertmanager/alert.yaml
+++ b/kubernetes/components/alerts/alertmanager/alert.yaml
@@ -25,6 +25,7 @@ spec:
     - "error.*lookup github\\.com"
     - "error.*lookup raw\\.githubusercontent\\.com"
     - "dial.*tcp.*timeout"
+    - "dial.*tcp.*unreachable"
     - "waiting.*socket"
     # NGC's CDN flaps with transient 502s on index.yaml fetches; cluster keeps
     # serving from cached chart artifact, and FluxHelmReleaseNotReady (15m for:)


### PR DESCRIPTION
## Summary
- Add `dial.*tcp.*unreachable` to the alertmanager Alert exclusionList so transient ICMP-unreachable errors from the Flux source-controller don't trigger pages.

Mirrors [onedr0p/home-ops@259d91c](https://github.com/onedr0p/home-ops/commit/259d91c).

## Test plan
- [ ] Flux reconciles the alert resource
- [ ] No new pages from `*unreachable*` source-controller events