### PR TITLE
feat(silence-operator): silence noisy etcd alerts

### DIFF
--- a/kubernetes/apps/observability/silence-operator/silences/etcd-alerts.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/etcd-alerts.yaml
@@ -1,0 +1,25 @@
+---
+# etcd on consumer SSDs intermittently exceeds the strict commit-duration
+# thresholds during fsync-heavy load. These have not correlated with real
+# cluster issues, so silence to cut paging noise.
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: etcd-high-commit-durations
+spec:
+  matchers:
+    - name: alertname
+      value: etcdHighCommitDurations
+      isRegex: false
+      isEqual: true
+---
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: etcd-member-communication-slow
+spec:
+  matchers:
+    - name: alertname
+      value: etcdMemberCommunicationSlow
+      isRegex: false
+      isEqual: true

--- a/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
@@ -4,5 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ceph-network-packet-drops.yaml
+  - ./etcd-alerts.yaml
   - ./keda-nfs-scaler.yaml
   - ./zfs-storage-memory.yaml


### PR DESCRIPTION
## Summary
- Add two `Silence` resources covering `etcdHighCommitDurations` and `etcdMemberCommunicationSlow`. Both fire on transient fsync spikes without indicating real cluster trouble.
- Uses the project's existing `monitoring.giantswarm.io/v1alpha1` schema (matches `keda-nfs-scaler.yaml` / `ceph-network-packet-drops.yaml`).

Inspired by [onedr0p/home-ops@2db89f7](https://github.com/onedr0p/home-ops/commit/2db89f7).

## Test plan
- [ ] silence-operator reconciles the new CRs
- [ ] Both alerts no longer page after next firing window