### PR TITLE
feat(talos): enable HPAScaleToZero feature gate

### DIFF
--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -15,6 +15,7 @@ cluster:
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
+      feature-gates: HPAScaleToZero=true
   coreDNS:
     disabled: true
   etcd:


### PR DESCRIPTION
## Summary
- Enable the \`HPAScaleToZero\` feature gate on \`kube-controller-manager\` so HPAs (notably KEDA-managed workloads using \`keda-nfs-scaler\`) can scale replicas to zero.

Mirrors [onedr0p/home-ops@a804209](https://github.com/onedr0p/home-ops/commit/a804209).

## Apply (manual after merge)
\`\`\`bash
just talos gen-config
just talos apply-node 10.32.8.80
just talos apply-node 10.32.8.81
just talos apply-node 10.32.8.82
\`\`\`
Apply rolling, one node at a time, verifying \`kubectl get nodes\` between each.

## Test plan
- [ ] \`kubectl -n kube-system get pod -l component=kube-controller-manager -o yaml | grep feature-gates\` shows \`HPAScaleToZero=true\` after apply
- [ ] Existing HPAs continue to reconcile
- [ ] Confirm a KEDA scaler can drive replicas to 0