### PR TITLE
feat(volsync): add cache settings to nfs replicationsource

### DIFF
--- a/kubernetes/components/volsync/nfs/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs/replicationsource.yaml
@@ -11,6 +11,10 @@ spec:
   kopia:
     accessModes:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}
+    cacheAccessModes:
+      - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=10Gi}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
     compression: zstd-fastest
     copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:


### PR DESCRIPTION
## Summary
- Mirrors what the \`remote\` (R2) replicationsource already does: explicit \`cacheAccessModes\`, \`cacheCapacity\`, \`cacheStorageClassName\` with substitutable defaults.
- Defaults (\`ReadWriteOnce\` / \`10Gi\` / \`openebs-hostpath\`) match prior implicit behaviour, so no immediate change for existing apps.
- Lets individual apps override for CephFS RWX backups (e.g. \`VOLSYNC_CACHE_ACCESSMODES=ReadOnlyMany\`).

Inspired by [onedr0p/home-ops@7353665](https://github.com/onedr0p/home-ops/commit/7353665).

## Test plan
- [ ] Flux reconciles every component-using app cleanly
- [ ] Next NFS replication snapshot completes successfully
- [ ] Cache PVCs report the expected storage class