### PR TITLE
feat(blackbox-exporter): add grafana dashboard

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: blackbox-exporter
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  grafanaCom:
+    # renovate: depName="Prometheus Blackbox Exporter"
+    id: 7587
+    revision: 3

--- a/kubernetes/apps/observability/blackbox-exporter/lan/kustomization.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./probes.yaml


### PR DESCRIPTION
## Summary
- Add a \`GrafanaDashboard\` CR pulling [grafana.com/dashboards/7587](https://grafana.com/grafana/dashboards/7587) (Prometheus Blackbox Exporter), revision 3.
- Uses the project's existing \`grafanaCom: { id, revision }\` pattern with renovate \`depName\` annotation (matches \`snmp-exporter\`, \`nut-exporter\`, etc.).
- Targets the project's standard \`grafana.internal/instance: grafana\` instance selector.

Inspired by [onedr0p/home-ops@75b2f07](https://github.com/onedr0p/home-ops/commit/75b2f07).

## Test plan
- [ ] Flux reconciles the GrafanaDashboard CR
- [ ] Dashboard appears in Grafana UI under the blackbox folder
- [ ] Dashboard panels render data from the existing probes