### PR TITLE
feat(cloudnative-pg): set failoverDelay=60s

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -10,6 +10,11 @@ spec:
 
   primaryUpdateStrategy: unsupervised
 
+  # Wait 60s before triggering failover after primary unhealthy. Prevents
+  # spurious failovers during control-plane restarts (Talos node apply,
+  # kube-controller-manager leader churn) which typically resolve in ~10-25s.
+  failoverDelay: 60
+
   storage:
     size: 200Gi
     storageClass: openebs-hostpath


### PR DESCRIPTION
## Summary
Add \`failoverDelay: 60\` to the postgres18 cluster spec. Default is \`0\` (immediate failover on detected primary unhealth), which caused multiple spurious primary failovers during today's Talos rolling apply for the HPAScaleToZero feature gate (PR #2383). Each kube-controller-manager restart triggered a brief leader-election window which CNPG misread as primary death.

Net effect of those failovers: \`postgres18-1\` ended up with diverged WAL on timeline 34 (past the new primary's branch point) and could not be recovered via streaming. It required full pg_basebackup re-clone (became \`postgres18-5\`).

## Tradeoff
- **Cost**: up to 60s of write unavailability if the primary actually dies hard before any failover begins.
- **Benefit**: rides out normal control-plane restarts (typically 10-25s) without a primary churn.

For a home cluster where rolling Talos applies are routine, this is a clear win.

## Test plan
- [ ] Flux reconciles the Cluster CR (CNPG operator updates spec, no pod restart needed)
- [ ] Verify with: \`kubectl -n database get cluster postgres18 -o jsonpath='{.spec.failoverDelay}'\`
- [ ] Next Talos rolling apply: confirm primary stays \`postgres18-4\` (or wherever current primary is) without churn