### PR TITLE
ci(super-linter): scope Checkov to one-shot k8s/helm scan

### DIFF
--- a/.github/linters/.checkov.yaml
+++ b/.github/linters/.checkov.yaml
@@ -1,0 +1,14 @@
+---
+# Super-Linter picks this up from .github/linters/.checkov.yaml
+# (default LINTER_RULES_PATH).
+#
+# The presence of `directory:` flips Super-Linter into single-invocation mode
+# (see super-linter/super-linter `worker.sh:198`), avoiding the per-file fork
+# storm that took ~6h on this repo. Scoping `framework:` to kubernetes+helm
+# matches the standalone Checkov in security-scans.yaml.
+quiet: true
+directory:
+  - .
+framework:
+  - kubernetes
+  - helm


### PR DESCRIPTION
## Summary
- Super-linter's default Checkov path is per-file (pipes every file to `parallel` → `checkov --directory <path>`, with all frameworks loaded). On this repo (1,237 yaml files) every Lint run was hitting the 6-hour GitHub job timeout.
- Per [`super-linter/super-linter` `worker.sh:198`](https://github.com/super-linter/super-linter/blob/main/lib/functions/worker.sh#L198), the presence of a `directory:` key in `.github/linters/.checkov.yaml` flips Super-Linter to a single Checkov invocation that lets Checkov walk the tree itself.
- Scoping `framework: kubernetes,helm` matches the standalone Checkov in `security-scans.yaml` and skips loading frameworks irrelevant to this repo.

## Test plan
- [x] Verified locally with `ghcr.io/super-linter/super-linter:v8.6.0` (Rosetta amd64): full run completed in **84 seconds** (down from 6h timeout).
- [ ] After merge: `gh workflow enable lint.yml` to re-arm the workflow on the default branch.
- [ ] Confirm next PR's `Lint` check completes in minutes.

Note: the `Lint` workflow is currently disabled on `main` (`gh workflow disable lint.yml` ran while we diagnosed) — this PR will not trigger it. Re-enable after merge.