### PR TITLE
chore(tooling): adopt onedr0p justfile patterns + flux-local caBundle ignore

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -87,7 +87,7 @@ jobs:
             --unified 6
             --path /github/workspace/pull/kubernetes/flux/cluster
             --path-orig /github/workspace/default/kubernetes/flux/cluster
-            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart"
+            --strip-attrs "helm.sh/chart,checksum/config,app.kubernetes.io/version,chart,caBundle"
             --limit-bytes 10000
             --all-namespaces
             --sources "flux-system"

--- a/.justfile
+++ b/.justfile
@@ -1,6 +1,8 @@
 #!/usr/bin/env -S just --justfile
 
+set positional-arguments := true
 set quiet := true
+set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
 mod bootstrap "bootstrap"

--- a/kubernetes/mod.just
+++ b/kubernetes/mod.just
@@ -1,4 +1,6 @@
+set positional-arguments := true
 set quiet := true
+set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
 kubernetes_dir := justfile_dir() + '/kubernetes'
@@ -9,7 +11,7 @@ default:
 
 [doc('Apply local Flux Kustomization')]
 apply-ks ns ks:
-    just kube render-local-ks "{{ ns }}" "{{ ks }}" | kubectl apply --server-side --field-manager=kustomize-controller --force-conflicts -f /dev/stdin
+    just kube render-local-ks "{{ ns }}" "{{ ks }}" | kubectl apply --server-side --field-manager=kustomize-controller --force-conflicts -f -
 
 [doc('Browse a PVC')]
 browse-pvc namespace claim:
@@ -17,7 +19,7 @@ browse-pvc namespace claim:
 
 [doc('Delete local Flux Kustomization')]
 delete-ks ns ks:
-    just kube render-local-ks "{{ ns }}" "{{ ks }}" | kubectl delete -f /dev/stdin
+    just kube render-local-ks "{{ ns }}" "{{ ks }}" | kubectl delete -f -
 
 [doc('Open a shell on a node')]
 node-shell node:

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -1,4 +1,6 @@
+set positional-arguments := true
 set quiet := true
+set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
 talos_dir := justfile_dir() + '/talos'
@@ -13,14 +15,13 @@ gen-config:
     talhelper genconfig --config-file "{{ talos_dir }}/talconfig.yaml" --secret-file "{{ talos_dir }}/talsecret.sops.yaml" --out-dir "{{ talos_dir }}/clusterconfig"
 
 [doc('Generate secret if missing')]
+[script]
 gen-secret:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    if [ ! -f "{{ talos_dir }}/talsecret.sops.yaml" ]; then \
-        just log info "Generating Talos secret..." "stage" "$0"; \
-        talhelper gensecret | sops --filename-override talos/talsecret.sops.yaml --encrypt /dev/stdin > "{{ talos_dir }}/talsecret.sops.yaml"; \
-    else \
-        just log info "Talos secret already exists" "stage" "$0"; \
+    if [ ! -f "{{ talos_dir }}/talsecret.sops.yaml" ]; then
+        just log info "Generating Talos secret..." "stage" "$0"
+        talhelper gensecret | sops --filename-override talos/talsecret.sops.yaml --encrypt - > "{{ talos_dir }}/talsecret.sops.yaml"
+    else
+        just log info "Talos secret already exists" "stage" "$0"
     fi
 
 [doc('Apply Talos config to a specific node')]
@@ -29,26 +30,23 @@ apply-node node *args:
     talhelper gencommand apply --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --node {{ node }} --extra-flags "{{ args }}" | bash
 
 [doc('Upgrade Talos on a specific node')]
+[script]
 upgrade-node node:
-    #!/usr/bin/env bash
-    set -euo pipefail
     just log info "Upgrading Talos on node..." "stage" "$0" "node" "{{ node }}"
     TALOS_IMAGE=$(yq '.nodes[] | select(.ipAddress == "{{ node }}") | .talosImageURL' "{{ talos_dir }}/talconfig.yaml")
     TALOS_VERSION=$(yq '.talosVersion' "{{ talos_dir }}/talenv.yaml")
     talhelper gencommand upgrade --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --node {{ node }} --extra-flags "--image=${TALOS_IMAGE}:${TALOS_VERSION} --timeout=10m" | bash
 
 [doc('Upgrade Kubernetes version')]
+[script]
 upgrade-k8s:
-    #!/usr/bin/env bash
-    set -euo pipefail
     just log info "Upgrading Kubernetes..." "stage" "$0"
     K8S_VERSION=$(yq '.kubernetesVersion' "{{ talos_dir }}/talenv.yaml")
     talhelper gencommand upgrade-k8s --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --extra-flags "--to ${K8S_VERSION}" | bash
 
 [doc('Reset cluster nodes to maintenance mode')]
+[script]
 reset:
-    #!/usr/bin/env bash
-    set -euo pipefail
     gum confirm "This will destroy your cluster and reset the nodes back to maintenance mode. Continue?" --default=false || exit 0
     just log warn "Resetting cluster..." "stage" "$0"
     talhelper gencommand reset --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --extra-flags "--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash


### PR DESCRIPTION
## Summary

Three small, low-risk patterns lifted from onedr0p/home-ops's last 7 days. No cluster impact.

- **justfile (`acead07`, `4772fa2`):** Add `set positional-arguments := true` and `set script-interpreter := ['bash','-euo','pipefail']` to `.justfile`, `kubernetes/mod.just`, `talos/mod.just`. Convert the four shebang-style recipes in `talos/mod.just` (`gen-secret`, `upgrade-node`, `upgrade-k8s`, `reset`) to `[script]` decoration so the bodies are plain bash with no trailing `\` continuations. Strict `-euo pipefail` is now applied uniformly.
- **`/dev/stdin` → `-` (`400a4a4`):** kubectl/sops accept `-` as the idiomatic stdin token. Functionally identical.
- **flux-local caBundle ignore (`42b9a69`):** Add `caBundle` to `--strip-attrs` so cert-manager-injected webhook `caBundle` churn stops generating PR diff noise.

`barman-cloud` is already correctly migrated to app-template v5 (has `defaultPodOptions.automountServiceAccountToken: true` + top-level `serviceAccount: barman-cloud: {}`), so no app changes here.

## Test plan

- [x] `just --fmt --check --unstable` passes locally
- [x] `just -l`, `just -l kube`, `just -l talos` list all recipes correctly
- [ ] flux-local diff in CI exits clean
- [ ] super-linter / security-scans green