### PR TITLE
fix(imgur-proxy): break DNS loop + unblackhole LB traffic

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -152,7 +152,13 @@ spec:
           # Pin the LB IP from the Cilium pool. Add SVC_IMGUR_PROXY_ADDR
           # to cluster-secrets in 1Password before applying.
           lbipam.cilium.io/ips: ${SVC_IMGUR_PROXY_ADDR}
-        externalTrafficPolicy: Local
+        # externalTrafficPolicy: Cluster (default) — Cilium L2 picks any
+        # node as announcer; with Local the announcer must coincide with
+        # the pod's node, which Cilium L2 doesn't currently guarantee
+        # (announcer is hash-selected from the policy's nodeSelector).
+        # Source IP visibility isn't useful here — the proxy is
+        # SNI-allowlisted and doesn't do per-client policy.
+        externalTrafficPolicy: Cluster
         ports:
           https:
             port: 443
@@ -171,8 +177,15 @@ spec:
             }
 
             stream {
-              # gluetun runs an in-pod DNS resolver on 127.0.0.1:53 (DOT proxy).
-              resolver 127.0.0.1 valid=10s ipv6=off;
+              # Cloudflare public resolver. We deliberately do NOT use
+              # cluster DNS (kube-dns) here: CoreDNS forwards external
+              # names to OPNsense Unbound, which has a local-zone
+              # redirect for i.imgur.com → this proxy's own IP — that
+              # would create an infinite loop.
+              # Querying 1.1.1.1 directly egresses via the WireGuard
+              # tunnel (gluetun's default route), so the response comes
+              # from real Cloudflare and resolves to real Imgur IPs.
+              resolver 1.1.1.1 valid=10s ipv6=off;
               resolver_timeout 5s;
 
               log_format basic '$$remote_addr [$$time_local] sni=$$ssl_preread_server_name upstream=$$upstream sent=$$bytes_sent recv=$$bytes_received session=$$session_time';


### PR DESCRIPTION
## Summary

Two bugs surfaced after #2435 deployed. Both fixed in this PR; verified end-to-end on cluster (LAN curl returns 200/302 from real Imgur, cert subject `CN=*.imgur.com`).

### 1. DNS loop (`resolver 127.0.0.1` → `1.1.1.1`)
- nginx's `resolver 127.0.0.1` assumed gluetun (`DOT: on`) binds a local listener. It doesn't — DOT only inserts iptables NAT rules. Nothing was bound on `:53` so nginx logged `recv() failed (111: Connection refused) while resolving`.
- Falling back to kube-dns is worse: CoreDNS → OPNsense Unbound → returns the proxy's own LB IP (because of the `local-zone redirect` for `i.imgur.com.`) → infinite loop.
- Fix: `resolver 1.1.1.1`. Cloudflare is reachable through gluetun's WireGuard tunnel (pod default route), so we get real Imgur IPs from a non-UK exit.

### 2. LB blackhole (`externalTrafficPolicy: Local` → `Cluster`)
- Cilium L2 announcer is hash-selected from `CiliumL2AnnouncementPolicy.nodeSelector` (all linux nodes), not constrained to endpoint-hosting nodes.
- For `10.32.8.106` the announcer is `cr-talos-02` but the pod is on `cr-talos-03`. With `Local`, traffic to the announcer's node has no local endpoint and gets dropped.
- Fix: `Cluster`. The SNI allowlist + gluetun firewall do access control, so source-IP visibility isn't load-bearing here.

## Test plan

- [x] `flux-local test`: 382/382 passed
- [x] LAN: `curl --resolve i.imgur.com:443:10.32.8.106 …` returns HTTP 200/302 with cert `CN=*.imgur.com` (Sectigo, Imgur's CA)
- [x] HTTPS RR (TYPE65) at OPNsense: NODATA (no leak path)
- [x] Non-Imgur SNI to the LB IP: RST'd by the nginx map allowlist
- [x] gluetun publicip: `185.65.134.200` Amsterdam NL (non-UK ✓)