### PR TITLE
fix(downloads/imgur-proxy): widen SNI allowlist to apex + *.imgur.com

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -178,12 +178,14 @@ spec:
               log_format basic '$$remote_addr [$$time_local] sni=$$ssl_preread_server_name upstream=$$upstream sent=$$bytes_sent recv=$$bytes_received session=$$session_time';
               access_log /dev/stdout basic;
 
-              # SNI allowlist: only forward known Imgur hostnames.
-              # Empty default means any other SNI is dropped (open-relay protection).
+              # SNI allowlist: apex imgur.com + any *.imgur.com subdomain.
+              # Empty default drops other SNI (open-relay protection — only
+              # Imgur-owned hosts are relayed).
               map $$ssl_preread_server_name $$upstream {
                 hostnames;
-                i.imgur.com   $$ssl_preread_server_name;
-                default       "";
+                imgur.com    $$ssl_preread_server_name;
+                .imgur.com   $$ssl_preread_server_name;
+                default      "";
               }
 
               server {


### PR DESCRIPTION
## Summary

- Browser hits to `https://imgur.com/gallery/...` were failing — the proxy only forwarded `i.imgur.com` SNI, dropping the apex and other subdomains. Map widened to apex + `.imgur.com` (matches apex *and* any subdomain via nginx `hostnames;` syntax).
- Open-relay scope unchanged: only Imgur-owned hostnames are relayed; everything else still drops via the empty `default ""`.
- Pairs with network-ops PR #34, which widens the matching Unbound zone redirect from `i.imgur.com.` → `imgur.com.` and aligns the pinned IP to the live LB (`10.32.8.106`).

Diagnosis details (the PR #2435 deploy is healthy — gluetun connected via Amsterdam, LB reachable, end-to-end `curl` against `i.imgur.com` returns 200 from a NL Fastly cache). Failure was purely allowlist scope.

## Test plan

- [ ] Flux reconciles HelmRelease and the configMap is updated
- [ ] `kubectl -n downloads get cm -l app.kubernetes.io/name=imgur-proxy -o yaml` shows both `imgur.com` and `.imgur.com` lines in the SNI map
- [ ] Pod restarts (reloader picks up the configmap change) — `kubectl -n downloads rollout status deploy/imgur-proxy`
- [ ] `curl --resolve imgur.com:443:10.32.8.106 -o /dev/null -w "%{http_code}\n" https://imgur.com/gallery/SVu9DY5` returns 200 (only meaningful after network-ops PR #34 is applied so DNS routes apex through the proxy)
- [ ] Browser: `https://imgur.com/gallery/SVu9DY5` loads end-to-end on a LAN client
- [ ] nginx logs show `sni=imgur.com upstream=imgur.com session=...` entries succeeding alongside the existing `i.imgur.com` traffic
- [ ] Open-relay sanity check: `curl --resolve example.com:443:10.32.8.106 -k --max-time 5 https://example.com/` still hangs / drops (allowlist still rejects unknown SNI)