### PR TITLE
fix(downloads/imgur-proxy): drop apex from SNI map (conflicts with .imgur.com)

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -191,12 +191,12 @@ spec:
               log_format basic '$$remote_addr [$$time_local] sni=$$ssl_preread_server_name upstream=$$upstream sent=$$bytes_sent recv=$$bytes_received session=$$session_time';
               access_log /dev/stdout basic;
 
-              # SNI allowlist: apex imgur.com + any *.imgur.com subdomain.
+              # SNI allowlist: leading-dot `.imgur.com` matches the apex
+              # AND any subdomain in nginx's `hostnames;` map syntax.
               # Empty default drops other SNI (open-relay protection — only
               # Imgur-owned hosts are relayed).
               map $$ssl_preread_server_name $$upstream {
                 hostnames;
-                imgur.com    $$ssl_preread_server_name;
                 .imgur.com   $$ssl_preread_server_name;
                 default      "";
               }


### PR DESCRIPTION
## Hotfix

PR #2441 widened the SNI map from `i.imgur.com` only to:

```nginx
imgur.com    $ssl_preread_server_name;
.imgur.com   $ssl_preread_server_name;
```

nginx rejected this at startup:

```
[emerg] 1#1: conflicting parameter ".imgur.com" in /etc/nginx/nginx.conf:30
```

In nginx `map ... { hostnames; ... }`, a leading-dot wildcard (`.imgur.com`) already matches both the apex AND any subdomain — so listing `imgur.com` separately is a duplicate, and nginx errors. After Flux reconciled #2441 the new pod went straight to CrashLoopBackOff, taking the whole proxy offline (incl. the previously-working `i.imgur.com` flow).

This drops the explicit apex line. `.imgur.com` alone covers `imgur.com`, `i.imgur.com`, `s.imgur.com`, etc. — same intent as #2441, valid nginx config.

## Test plan

- [ ] CI green
- [ ] Pod rolls out 2/2 Running, no `[emerg]` in nginx logs
- [ ] `curl --resolve imgur.com:443:10.32.8.106 -o /dev/null -w "%{http_code}\n" https://imgur.com/gallery/SVu9DY5` returns 2xx/3xx (not 000)
- [ ] `curl --resolve i.imgur.com:443:10.32.8.106 -o /dev/null -w "%{http_code}\n" https://i.imgur.com/` still returns 302 from an Amsterdam Fastly POP (regression check)
- [ ] nginx access log shows both `sni=imgur.com` and `sni=i.imgur.com` sessions succeeding