### PR TITLE
ci(lint): disable kubeconform + graduate to blocking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,13 @@ permissions:
 jobs:
   lint:
     uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@2410829c6d03158086d6cab16e15153942c5d4b8 # v1
+    with:
+      # Kubeconform validates raw YAML source. On this Flux GitOps repo the
+      # source is meaningless until kustomize substitutes vars
+      # (${SECRET_DOMAIN}, ${SVC_*_ADDR}, ...) and merges components — so it
+      # false-positives on every CRD-shaped file regardless of schema config.
+      # Real K8s validation lives in flux-local (kustomize build pipeline).
+      validate-kubernetes-kubeconform: false
+      # Graduate to blocking: with kubeconform off, the remaining super-linter
+      # checks (yamllint, prettier, actionlint, shellcheck, ...) are clean.
+      soft-launch: false


### PR DESCRIPTION
## Summary
- Bumps shared-workflows pin to `2410829c6d03158086d6cab16e15153942c5d4b8` (v1) — picks up [shared-workflows#5](https://github.com/LukeEvansTech/shared-workflows/pull/5) which exposes `validate-kubernetes-kubeconform`.
- Disables kubeconform on this caller (`with: validate-kubernetes-kubeconform: false`).
- Graduates super-linter to blocking again (`with: soft-launch: false`).

## Why kubeconform off here

Kubeconform validates raw YAML source files. On this Flux GitOps repo the source is meaningless until kustomize has:

- substituted vars (`${SECRET_DOMAIN}`, `${SVC_*_ADDR}`, `${TIMEZONE}`, …) — injected by the root Flux Kustomization patch in `kubernetes/flux/cluster/ks.yaml` from `cluster-secrets`, not present in source files
- merged shared `components/` (alerts, gatus, global-vars, volsync, …)
- applied per-app patches

Result: kubeconform false-positives on every CRD-shaped file (HelmRelease, OCIRepository, ExternalSecret, Flux Kustomization, Kustomize Kustomization) regardless of how good the CRD schema catalog is. We've been masking those errors via `soft-launch: true` since the shared-workflows consolidation; this PR removes the mask the right way — by stopping the meaningless validation rather than ignoring its output.

Real K8s validation already lives in `flux-local` (`.github/workflows/flux-local.yaml`): it renders Kustomizations and HelmReleases against the actual Flux state, then diffs them against `main` — much closer to what the cluster will actually see.

## What super-linter still does
yamllint · prettier · actionlint · shellcheck · jscpd (at 10% threshold) · checkov/trivy/gitleaks (handled by the separate `security-scans.yaml` shared caller). Those should already be clean — `soft-launch: false` will surface anything that isn't.

## Test plan
- [ ] Lint check passes on this PR (no kubeconform errors, no other regressions)
- [ ] After merge, the next push to main lints green and is genuinely blocking (not soft-launched)
- [ ] Spot-check next Renovate PR that touches a HelmRelease — no spurious kubeconform errors