### PR TITLE
fix(downloads/imgur-proxy): restore in-pod DOT resolver, drop DNS_KEEP_NAMESERVER

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -77,7 +77,6 @@ spec:
               DOT: "on"
               DOT_CACHING: "on"
               DOT_IPV6: off
-              DNS_KEEP_NAMESERVER: "on"
               FIREWALL: true
               FIREWALL_DEBUG: on
               # nginx (8443) + gluetun health server (9999)
@@ -177,15 +176,13 @@ spec:
             }
 
             stream {
-              # Cloudflare public resolver. We deliberately do NOT use
-              # cluster DNS (kube-dns) here: CoreDNS forwards external
-              # names to OPNsense Unbound, which has a local-zone
-              # redirect for i.imgur.com → this proxy's own IP — that
-              # would create an infinite loop.
-              # Querying 1.1.1.1 directly egresses via the WireGuard
-              # tunnel (gluetun's default route), so the response comes
-              # from real Cloudflare and resolves to real Imgur IPs.
-              resolver 1.1.1.1 valid=10s ipv6=off;
+              # gluetun runs an in-pod DOT proxy on 127.0.0.1:53 (default
+              # behaviour with DOT=on). It forwards encrypted DNS over the
+              # WireGuard tunnel to gluetun's configured DOT upstreams, so
+              # lookups are authenticated end-to-end (DOT cert verified)
+              # and never traverse cluster DNS (which would loop back to
+              # this proxy's own IP via the OPNsense local-zone redirect).
+              resolver 127.0.0.1 valid=10s ipv6=off;
               resolver_timeout 5s;
 
               log_format basic '$$remote_addr [$$time_local] sni=$$ssl_preread_server_name upstream=$$upstream sent=$$bytes_sent recv=$$bytes_received session=$$session_time';


### PR DESCRIPTION
## Summary

Re-enables gluetun's DOT proxy inside the pod and points nginx back at it.

PR #2441 set `resolver 1.1.1.1` and kept `DNS_KEEP_NAMESERVER: "on"` to dodge a cluster-DNS loopback (kube-dns → OPNsense → `imgur.com → 10.32.8.106` → infinite loop). That works but uses **plain UDP DNS to a public resolver**, not DOT — losing upstream cert verification, defeating `DOT_CACHING=on`, and leaving the pod's `/etc/resolv.conf` pointed at kube-dns (any non-nginx component would still hit the loop).

This change:
- Removes `DNS_KEEP_NAMESERVER: "on"` so gluetun starts its DOT proxy on `127.0.0.1:53` and replaces resolv.conf with `nameserver 127.0.0.1`.
- Reverts nginx `resolver` to `127.0.0.1`.

Net effect: nginx's upstream lookups are authenticated DOT, encrypted in transit over WireGuard, NL-exited, and the loop concern is gone (no path to kube-dns at all).

## Test plan

- [ ] Pod 2/2 Running, no nginx `[emerg]` errors
- [ ] `kubectl exec ... -c gluetun -- ss -lntu` shows `127.0.0.1:53` listening (or equivalent)
- [ ] `kubectl exec ... -c gluetun -- cat /etc/resolv.conf` shows `nameserver 127.0.0.1` (no kube-dns)
- [ ] gluetun logs show DOT proxy started, no "keeping default container nameservers" leak warning
- [ ] `curl --resolve imgur.com:443:10.32.8.106 https://imgur.com/gallery/SVu9DY5` still 200 from a NL Fastly POP
- [ ] `curl --resolve i.imgur.com:443:10.32.8.106 https://i.imgur.com/` still 302 from a NL Fastly POP