### PR TITLE
chore(bootstrap): use kubectl wait --for=create for CRD readiness

### DIFF
--- a/bootstrap/helmfile.d/01-apps.yaml
+++ b/bootstrap/helmfile.d/01-apps.yaml
@@ -15,10 +15,15 @@ releases:
       - ./templates/values.yaml.gotmpl
     hooks:
       - # Wait for Cilium CRDs to be available
-        command: bash
+        command: kubectl
         args:
-          - -c
-          - until kubectl get crd ciliumloadbalancerippools.cilium.io ciliumbgpadvertisements.cilium.io ciliumbgppeerconfigs.cilium.io ciliumbgpclusterconfigs.cilium.io &>/dev/null; do sleep 5; done
+          - wait
+          - --for=create
+          - crd/ciliumbgpadvertisements.cilium.io
+          - crd/ciliumbgpclusterconfigs.cilium.io
+          - crd/ciliumbgppeerconfigs.cilium.io
+          - crd/ciliumloadbalancerippools.cilium.io
+          - --timeout=2m
         events:
           - postsync
         showlogs: true
@@ -26,10 +31,10 @@ releases:
         command: kubectl
         args:
           - apply
-          - --namespace=kube-system
+          - --namespace={{ .Release.Namespace }}
           - --server-side
           - --field-manager=kustomize-controller
-          - --filename=../../kubernetes/apps/kube-system/cilium/app/networking.yaml
+          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/app/networking.yaml
         events:
           - postsync
         showlogs: true
@@ -78,10 +83,12 @@ releases:
       - ./templates/values.yaml.gotmpl
     hooks:
       - # Wait for ExternalSecrets CRDs to be available
-        command: bash
+        command: kubectl
         args:
-          - -c
-          - until kubectl get crd clustersecretstores.external-secrets.io &>/dev/null; do sleep 5; done
+          - wait
+          - --for=create
+          - crd/clustersecretstores.external-secrets.io
+          - --timeout=2m
         events:
           - postsync
         showlogs: true
@@ -91,7 +98,7 @@ releases:
           - apply
           - --server-side
           - --field-manager=kustomize-controller
-          - --filename=../../kubernetes/apps/external-secrets/onepassword-connect/app/clustersecretstore.yaml
+          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/app/clustersecretstore.yaml
         events:
           - postsync
         showlogs: true


### PR DESCRIPTION
## Summary
- Replace `until kubectl get crd ... ; sleep 5; done` busy-loops in cilium / onepassword-connect post-sync hooks with `kubectl wait --for=create crd/... --timeout=2m`
- Templatize hook `--filename` paths via `{{ .Release.Namespace }} / {{ .Release.Name }}`
- Picked up from onedr0p/home-ops (housekeeping commits 2026-05-09)

## Test plan
- [ ] `helmfile -f bootstrap/helmfile.d/01-apps.yaml list` parses cleanly
- [ ] Bootstrap path remains a no-op for an already-running cluster (only relevant on next bare-metal bootstrap)