### PR TITLE
chore(justfile): apply niceties (lazy/group/script/confirm)

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,12 +1,21 @@
 #!/usr/bin/env -S just --justfile
 
+set lazy
 set positional-arguments := true
 set quiet := true
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
+# Bootstrap Recipes
+[group: 'Bootstrap']
 mod bootstrap "bootstrap"
+
+# Kube Recipes
+[group: 'Kube']
 mod kube "kubernetes"
+
+# Talos Recipes
+[group: 'Talos']
 mod talos "talos"
 
 [private]

--- a/bootstrap/mod.just
+++ b/bootstrap/mod.just
@@ -1,84 +1,94 @@
+set lazy
 set positional-arguments := true
 set quiet := true
+set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
-bootstrap_dir := justfile_dir() + '/bootstrap'
 kubernetes_dir := justfile_dir() + '/kubernetes'
 controller := `talosctl config info -o yaml | yq -e '.endpoints[0]'`
 nodes := `talosctl config info -o yaml | yq -e '.nodes | join (" ")'`
 
+[confirm('Bootstrap cluster? [y|N]')]
 [private]
 default: talos kube (kubeconfig "node") wait namespaces resources crds apps kubeconfig
 
 [doc('Install Talos')]
+[script]
 talos:
     just log info "Running stage..." "stage" "$0"
-    for n in {{ nodes }}; do \
-        if ! op=$(just talos apply-node "$n" --insecure 2>&1); then \
-            if [[ "$op" == *"certificate required"* ]]; then \
-                just log info "Talos already configured, skipping apply of config" "stage" "$0" "node" "$n"; \
-                continue; \
-            fi; \
-            just log fatal "Failed to apply Talos configuration" "stage" "$0" "node" "$n" "output" "$op"; \
-        fi; \
+    for n in {{ nodes }}; do
+        if ! op=$(just talos apply-node "$n" --insecure 2>&1); then
+            if [[ "$op" == *"certificate required"* ]]; then
+                just log info "Talos already configured, skipping apply of config" "stage" "$0" "node" "$n"
+                continue
+            fi
+            just log fatal "Failed to apply Talos configuration" "stage" "$0" "node" "$n" "output" "$op"
+        fi
     done
 
 [doc('Install Kubernetes')]
+[script]
 kube:
     just log info "Running stage..." "stage" "$0"
-    until op=$(talosctl -n "{{ controller }}" bootstrap 2>&1 || true) && [[ "$op" == *"AlreadyExists"* ]]; do \
-        just log info "Kubernetes bootstrap in progress. Retrying in 5 seconds..." "stage" "$0"; \
-        sleep 5; \
+    until op=$(talosctl -n "{{ controller }}" bootstrap 2>&1 || true) && [[ "$op" == *"AlreadyExists"* ]]; do
+        just log info "Kubernetes bootstrap in progress. Retrying in 5 seconds..." "stage" "$0"
+        sleep 5
     done
 
 [doc('Fetch kubeconfig')]
+[script]
 kubeconfig lb="cilium":
     just log info "Running stage..." "stage" "$0"
-    if ! talosctl kubeconfig -n "{{ controller }}" -f --force-context-name main {{ justfile_dir() }}; then \
-        just log fatal "Failed to fetch kubeconfig" "stage" "$0"; \
+    if ! talosctl kubeconfig -n "{{ controller }}" -f --force-context-name main {{ justfile_dir() }}; then
+        just log fatal "Failed to fetch kubeconfig" "stage" "$0"
     fi
-    if [[ "{{ lb }}" != "cilium" ]]; then \
-        if ! kubectl config set-cluster main --server "https://{{ controller }}:6443"; then \
-            just log fatal "Failed to set kubectl cluster server address" "stage" "$0"; \
-        fi; \
+    if [[ "{{ lb }}" != "cilium" ]]; then
+        if ! kubectl config set-cluster main --server "https://{{ controller }}:6443"; then
+            just log fatal "Failed to set kubectl cluster server address" "stage" "$0"
+        fi
     fi
 
 [doc('Wait for nodes to be not-ready')]
+[script]
 wait:
     just log info "Running stage..." "stage" "$0"
-    if ! kubectl wait nodes --for=condition=Ready=True --all --timeout=10s &>/dev/null; then \
-        until kubectl wait nodes --for=condition=Ready=False --all --timeout=10s &>/dev/null; do \
-            just log info "Nodes not available, waiting for nodes to be available. Retrying in 5 seconds..." "stage" "$0"; \
-            sleep 5; \
-        done \
+    if ! kubectl wait nodes --for=condition=Ready=True --all --timeout=10s &>/dev/null; then
+        until kubectl wait nodes --for=condition=Ready=False --all --timeout=10s &>/dev/null; do
+            just log info "Nodes not available, waiting for nodes to be available. Retrying in 5 seconds..." "stage" "$0"
+            sleep 5
+        done
     fi
 
 [doc('Apply Kubernetes namespaces')]
+[script]
 namespaces:
     just log info "Running stage..." "stage" "$0"
-    find "{{ kubernetes_dir }}/apps" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do \
-        if ! kustomize build "$dir" | yq ea -e 'select(.kind == "Namespace")' | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then \
-            just log fatal "Failed to apply namespace" "stage" "$0" "namespace" "$(basename "$dir")"; \
-        fi; \
+    find "{{ kubernetes_dir }}/apps" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do
+        if ! kustomize build "$dir" | yq ea -e 'select(.kind == "Namespace")' | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
+            just log fatal "Failed to apply namespace" "stage" "$0" "namespace" "$(basename "$dir")"
+        fi
     done
 
 [doc('Apply Kubernetes resources')]
+[script]
 resources:
     just log info "Running stage..." "stage" "$0"
-    if ! just template "{{ bootstrap_dir }}/resources.yaml.j2" | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then \
-        just log fatal "Failed to apply resources" "stage" "$0"; \
-    fi;
+    if ! just template "{{ source_directory() }}/resources.yaml.j2" | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
+        just log fatal "Failed to apply resources" "stage" "$0"
+    fi
 
 [doc('Apply Helmfile CRDs')]
+[script]
 crds:
     just log info "Running stage..." "stage" "$0"
-    if ! helmfile -f "{{ bootstrap_dir }}/helmfile.d/00-crds.yaml" template -q | yq ea -e 'select(.kind == "CustomResourceDefinition")' | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then \
-        just log fatal "Failed to apply crds" "stage" "$0"; \
-    fi;
+    if ! helmfile -f "{{ source_directory() }}/helmfile.d/00-crds.yaml" template -q | yq ea -e 'select(.kind == "CustomResourceDefinition")' | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
+        just log fatal "Failed to apply crds" "stage" "$0"
+    fi
 
 [doc('Apply Helmfile Apps')]
+[script]
 apps:
     just log info "Running stage..." "stage" "$0"
-    if ! helmfile -f "{{ bootstrap_dir }}/helmfile.d/01-apps.yaml" sync --hide-notes; then \
-        just log fatal "Failed to sync helmfile" "stage" "$0"; \
+    if ! helmfile -f "{{ source_directory() }}/helmfile.d/01-apps.yaml" sync --hide-notes; then
+        just log fatal "Failed to sync helmfile" "stage" "$0"
     fi

--- a/kubernetes/mod.just
+++ b/kubernetes/mod.just
@@ -1,9 +1,8 @@
+set lazy
 set positional-arguments := true
 set quiet := true
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
-
-kubernetes_dir := justfile_dir() + '/kubernetes'
 
 [private]
 default:
@@ -22,62 +21,72 @@ delete-ks ns ks:
     just kube render-local-ks "{{ ns }}" "{{ ks }}" | kubectl delete -f -
 
 [doc('Open a shell on a node')]
+[script]
 node-shell node:
     kubectl debug node/{{ node }} -n default -it --image="mirror.gcr.io/alpine:latest" --profile sysadmin
     kubectl delete pod -n default -l app.kubernetes.io/managed-by=kubectl-debug
 
 [doc('Prune pods in Failed, Pending, or Succeeded state')]
+[script]
 prune-pods:
-    for phase in Failed Pending Succeeded; do \
-        kubectl delete pods -A --field-selector status.phase="$phase" --ignore-not-found=true; \
+    for phase in Failed Pending Succeeded; do
+        kubectl delete pods -A --field-selector status.phase="$phase" --ignore-not-found=true
     done
 
 [doc('Snapshot VolSync PVCs')]
+[script]
 snapshot:
-    kubectl get replicationsources --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" patch replicationsources "$name" --type merge -p '{"spec":{"trigger":{"manual":"$(date +%s)"}}}'; \
+    kubectl get replicationsources --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" patch replicationsources "$name" --type merge -p '{"spec":{"trigger":{"manual":"$(date +%s)"}}}'
     done
 
 [doc('Suspend or resume Keda ScaledObjects')]
+[script]
 keda state:
-    kubectl get scaledobjects --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite so "$name" autoscaling.keda.sh/paused{{ if state != "suspend" { "-" } else { "=true" } }}; \
+    kubectl get scaledobjects --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite so "$name" autoscaling.keda.sh/paused{{ if state != "suspend" { "-" } else { "=true" } }}
     done
 
 [doc('Suspend or resume VolSync')]
+[script]
 volsync state:
     flux -n volsync-system {{ state }} kustomization volsync
     flux -n volsync-system {{ state }} helmrelease volsync
     kubectl -n volsync-system scale deployment volsync --replicas {{ if state != "suspend" { "1" } else { "0" } }}
 
 [doc('Sync ExternalSecrets')]
+[script]
 sync-es:
-    kubectl get es --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite es "$name" force-sync="$(date +%s)"; \
+    kubectl get es --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite es "$name" force-sync="$(date +%s)"
     done
 
 [doc('Sync GitRepositories')]
+[script]
 sync-git:
-    kubectl get gitrepo --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite gitrepo "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"; \
+    kubectl get gitrepo --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite gitrepo "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"
     done
 
 [doc('Sync HelmReleases')]
+[script]
 sync-hr:
-    kubectl get hr --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite hr "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)" reconcile.fluxcd.io/forceAt="$(date +%s)"; \
+    kubectl get hr --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite hr "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)" reconcile.fluxcd.io/forceAt="$(date +%s)"
     done
 
 [doc('Sync Kustomizations')]
+[script]
 sync-ks:
-    kubectl get ks --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite ks "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"; \
+    kubectl get ks --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite ks "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"
     done
 
 [doc('Sync OCIRepositories')]
+[script]
 sync-oci:
-    kubectl get ocirepo --no-headers -A | while read -r ns name _; do \
-        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite ocirepo "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"; \
+    kubectl get ocirepo --no-headers -A | while read -r ns name _; do
+        kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite ocirepo "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"
     done
 
 [doc('View a secret')]
@@ -86,4 +95,4 @@ view-secret namespace secret:
 
 [private]
 render-local-ks ns ks:
-    flux-local build ks --namespace "{{ ns }}" --path "{{ kubernetes_dir }}/flux/cluster" "{{ ks }}"
+    flux-local build ks --namespace "{{ ns }}" --path "{{ source_directory() }}/flux/cluster" "{{ ks }}"

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -1,52 +1,55 @@
+set lazy
 set positional-arguments := true
 set quiet := true
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
-
-talos_dir := justfile_dir() + '/talos'
 
 [private]
 default:
     just -l talos
 
 [doc('Generate Talos configuration with talhelper')]
+[script]
 gen-config:
     just log info "Generating Talos configuration..." "stage" "$0"
-    talhelper genconfig --config-file "{{ talos_dir }}/talconfig.yaml" --secret-file "{{ talos_dir }}/talsecret.sops.yaml" --out-dir "{{ talos_dir }}/clusterconfig"
+    talhelper genconfig --config-file "{{ source_directory() }}/talconfig.yaml" --secret-file "{{ source_directory() }}/talsecret.sops.yaml" --out-dir "{{ source_directory() }}/clusterconfig"
 
 [doc('Generate secret if missing')]
 [script]
 gen-secret:
-    if [ ! -f "{{ talos_dir }}/talsecret.sops.yaml" ]; then
+    if [ ! -f "{{ source_directory() }}/talsecret.sops.yaml" ]; then
         just log info "Generating Talos secret..." "stage" "$0"
-        talhelper gensecret | sops --filename-override talos/talsecret.sops.yaml --encrypt - > "{{ talos_dir }}/talsecret.sops.yaml"
+        talhelper gensecret | sops --filename-override talos/talsecret.sops.yaml --encrypt - > "{{ source_directory() }}/talsecret.sops.yaml"
     else
         just log info "Talos secret already exists" "stage" "$0"
     fi
 
 [doc('Apply Talos config to a specific node')]
+[script]
 apply-node node *args:
     just log info "Applying Talos config to node..." "stage" "$0" "node" "{{ node }}"
-    talhelper gencommand apply --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --node {{ node }} --extra-flags "{{ args }}" | bash
+    talhelper gencommand apply --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --node {{ node }} --extra-flags "{{ args }}" | bash
 
+[confirm('Upgrade Talos on node? [y|N]')]
 [doc('Upgrade Talos on a specific node')]
 [script]
 upgrade-node node:
     just log info "Upgrading Talos on node..." "stage" "$0" "node" "{{ node }}"
-    TALOS_IMAGE=$(yq '.nodes[] | select(.ipAddress == "{{ node }}") | .talosImageURL' "{{ talos_dir }}/talconfig.yaml")
-    TALOS_VERSION=$(yq '.talosVersion' "{{ talos_dir }}/talenv.yaml")
-    talhelper gencommand upgrade --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --node {{ node }} --extra-flags "--image=${TALOS_IMAGE}:${TALOS_VERSION} --timeout=10m" | bash
+    TALOS_IMAGE=$(yq '.nodes[] | select(.ipAddress == "{{ node }}") | .talosImageURL' "{{ source_directory() }}/talconfig.yaml")
+    TALOS_VERSION=$(yq '.talosVersion' "{{ source_directory() }}/talenv.yaml")
+    talhelper gencommand upgrade --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --node {{ node }} --extra-flags "--image=${TALOS_IMAGE}:${TALOS_VERSION} --timeout=10m" | bash
 
+[confirm('Upgrade Kubernetes on the cluster? [y|N]')]
 [doc('Upgrade Kubernetes version')]
 [script]
 upgrade-k8s:
     just log info "Upgrading Kubernetes..." "stage" "$0"
-    K8S_VERSION=$(yq '.kubernetesVersion' "{{ talos_dir }}/talenv.yaml")
-    talhelper gencommand upgrade-k8s --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --extra-flags "--to ${K8S_VERSION}" | bash
+    K8S_VERSION=$(yq '.kubernetesVersion' "{{ source_directory() }}/talenv.yaml")
+    talhelper gencommand upgrade-k8s --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --extra-flags "--to ${K8S_VERSION}" | bash
 
 [doc('Reset cluster nodes to maintenance mode')]
 [script]
 reset:
     gum confirm "This will destroy your cluster and reset the nodes back to maintenance mode. Continue?" --default=false || exit 0
     just log warn "Resetting cluster..." "stage" "$0"
-    talhelper gencommand reset --config-file "{{ talos_dir }}/talconfig.yaml" --out-dir "{{ talos_dir }}/clusterconfig" --extra-flags "--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash
+    talhelper gencommand reset --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --extra-flags "--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash


### PR DESCRIPTION
## Summary
- `set lazy` across all modules
- `[group:]` annotations on top-level mod imports for grouped `just -l` output
- `[script]` decorators on multi-line recipes; drop `\` continuations
- `[confirm()]` prompts on `bootstrap default`, `talos upgrade-node`, `talos upgrade-k8s`
- Swap module-local `justfile_dir()` concats for `source_directory()`
- Picked up from onedr0p/home-ops (justfile housekeeping commits 2026-05-06..2026-05-09)

`just 1.47.1` doesn't yet support variable interpolation in `[confirm()]` so prompts use literal strings.

## Test plan
- [ ] `just bootstrap` lists recipes (or, for default, prompts the confirm)
- [ ] `just kube` lists recipes
- [ ] `just talos` lists recipes
- [ ] `just kube sync-hr` (and similar one-shots) still execute correctly