### PR TITLE
chore(bootstrap): use kustomize for resources

### DIFF
--- a/bootstrap/kustomize/apps/external-secrets/kustomization.yaml
+++ b/bootstrap/kustomize/apps/external-secrets/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: external-secrets
+
+components:
+  - ../../components/namespace
+
+resources:
+  - ./secret.yaml

--- a/bootstrap/kustomize/apps/external-secrets/secret.yaml
+++ b/bootstrap/kustomize/apps/external-secrets/secret.yaml
@@ -3,12 +3,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: onepassword-connect-credentials-secret
+  namespace: external-secrets
 stringData:
-  1password-credentials.json: 'op://Talos/1password/OP_CONNECT_JSON'
+  1password-credentials.json: "op://Talos/1password/OP_CONNECT_JSON"
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: onepassword-connect-vault-secret
+  namespace: external-secrets
 stringData:
-  token: op://Talos/1password/OP_CONNECT_TOKEN
+  token: "op://Talos/1password/OP_CONNECT_TOKEN"

--- a/bootstrap/kustomize/apps/external-secrets/secret.yaml
+++ b/bootstrap/kustomize/apps/external-secrets/secret.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: onepassword-connect-credentials-secret
-  namespace: external-secrets
 stringData:
   1password-credentials.json: 'op://Talos/1password/OP_CONNECT_JSON'
 ---
@@ -11,14 +10,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: onepassword-connect-vault-secret
-  namespace: external-secrets
 stringData:
   token: op://Talos/1password/OP_CONNECT_TOKEN
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cloudflare-tunnel-id-secret
-  namespace: network
-stringData:
-  CLOUDFLARE_TUNNEL_ID: op://Talos/cloudflare/CLOUDFLARE_TUNNEL_ID

--- a/bootstrap/kustomize/apps/kustomization.yaml
+++ b/bootstrap/kustomize/apps/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./external-secrets
+  - ./network

--- a/bootstrap/kustomize/apps/network/kustomization.yaml
+++ b/bootstrap/kustomize/apps/network/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: network
+
+components:
+  - ../../components/namespace
+
+resources:
+  - ./secret.yaml

--- a/bootstrap/kustomize/apps/network/secret.yaml
+++ b/bootstrap/kustomize/apps/network/secret.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-tunnel-id-secret
+stringData:
+  CLOUDFLARE_TUNNEL_ID: op://Talos/cloudflare/CLOUDFLARE_TUNNEL_ID

--- a/bootstrap/kustomize/apps/network/secret.yaml
+++ b/bootstrap/kustomize/apps/network/secret.yaml
@@ -3,5 +3,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: cloudflare-tunnel-id-secret
+  namespace: network
 stringData:
-  CLOUDFLARE_TUNNEL_ID: op://Talos/cloudflare/CLOUDFLARE_TUNNEL_ID
+  CLOUDFLARE_TUNNEL_ID: "op://Talos/cloudflare/CLOUDFLARE_TUNNEL_ID"

--- a/bootstrap/kustomize/components/namespace/kustomization.yaml
+++ b/bootstrap/kustomize/components/namespace/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ./namespace.yaml

--- a/bootstrap/kustomize/components/namespace/namespace.yaml
+++ b/bootstrap/kustomize/components/namespace/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/bootstrap/mod.just
+++ b/bootstrap/mod.just
@@ -73,7 +73,7 @@ namespaces:
 [script]
 resources:
     just log info "Running stage..." "stage" "$0"
-    if ! just template "{{ source_directory() }}/resources.yaml.j2" | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
+    if ! kustomize build "{{ source_directory() }}/kustomize/apps" | just template - | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
         just log fatal "Failed to apply resources" "stage" "$0"
     fi
 


### PR DESCRIPTION
## Summary
- Replace the single `bootstrap/resources.yaml.j2` Jinja file with a kustomize tree under `bootstrap/kustomize/`, mirroring the per-namespace layout used upstream
- Each app dir uses a shared namespace component to declare its target namespace alongside its `op://` secrets
- The resources stage now runs `kustomize build kustomize/apps | just template - | kubectl apply ...`
- Picked up from onedr0p/home-ops#10850

## Notes
- Namespace pre-creation step (`just bootstrap namespaces`) is preserved — this PR only restructures the secret manifests fed to the `resources` stage; per-namespace pre-creation still walks `kubernetes/apps/<ns>/namespace.yaml`
- Op references unchanged: `op://Talos/1password/...` and `op://Talos/cloudflare/...`
- Bases on `bootstrap_dir` not `source_directory()` so this PR is independent of the justfile-niceties PR — whichever merges second will rebase trivially

## Test plan
- [ ] `kustomize build bootstrap/kustomize/apps` outputs the same 3 secrets + 2 namespaces
- [ ] flux-local CI passes
- [ ] Bootstrap path remains a no-op for an already-running cluster (only relevant on next bare-metal bootstrap)