### PR TITLE
chore(renovate): enable docker:pinDigests for container images

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -4,6 +4,7 @@
   extends: [
     "config:recommended",
     "docker:enableMajor",
+    "docker:pinDigests",
     "helpers:pinGitHubActionDigests",
     "github>LukeEvansTech/talos-cluster//.renovate/autoMerge.json5",
     "github>LukeEvansTech/talos-cluster//.renovate/changelogs.json5",


### PR DESCRIPTION
## Summary

- Enables the `docker:pinDigests` Renovate preset alongside the existing `helpers:pinGitHubActionDigests`, so container image tags get pinned to immutable SHA digests.
- Brings container handling in line with the repo convention (`repository:tag@sha256:...`) and how we already manage GitHub Actions.

## Why

PR #2510 shipped a Renovate bump that left `imgur-proxy` on `tag: 1.31-alpine` with no digest. Audit shows five HelmReleases currently unpinned:

- `kubernetes/apps/default/contracthound`
- `kubernetes/apps/default/subspy`
- `kubernetes/apps/observability/acinfinity-exporter`
- `kubernetes/apps/custom/loupe`
- `kubernetes/apps/downloads/imgur-proxy`

After this merges, Renovate is expected to open backfill PRs adding digests to those five (one-time PR storm, then steady-state).

## Test plan

- [ ] Merge and confirm Renovate's next dashboard run picks up the preset (no validation error).
- [ ] Confirm backfill PRs appear for the five unpinned HelmReleases above.
- [ ] Confirm the next routine image bump (e.g. another nginx minor) includes the `@sha256:` suffix.