### PR TITLE
fix(renovate): don't pin digests on Flux OCIRepository chart tags

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -32,5 +32,13 @@
       matchPackageNames: ["homebridge/homebridge"],
       enabled: false,
     },
+    {
+      // Flux OCIRepository has separate `tag:` and `digest:` fields; appending
+      // `@sha256:...` to `tag:` makes helm reject the chart ref with
+      // `improper constraint` (or `unable to locate any tags` on ghcr).
+      description: "Don't pin digests on Flux OCIRepository chart tags",
+      matchManagers: ["flux"],
+      pinDigests: false,
+    },
   ],
 }


### PR DESCRIPTION
## Summary

- `docker:pinDigests` (added in 41bc7c5f6) is appending `@sha256:<digest>` to `OCIRepository.spec.ref.tag` for Helm charts
- Helm rejects this — `Error: improper constraint: <version>@sha256:...` on quay/gcr, `Error: unable to locate any tags` on ghcr
- All four currently-open renovate chart-bump PRs are red on flux-local because of this (#2514 rook-ceph, #2512 actions-runner-controller, #2508 cilium, #2506 envoy-gateway)
- Flux exposes `tag:` and `digest:` as separate fields on `OCIRepository`, so digest pinning has to be skipped for the `flux` manager

Once merged, the 4 broken PRs should be closed so renovate reopens them clean. Container-image PRs (helmfile, helm-values, kubernetes managers) are unaffected and keep digest pinning.

## Test plan

- [ ] flux-local passes on this PR
- [ ] After merge, close #2506, #2508, #2512, #2514 and confirm renovate recreates them without `@sha256:` in the chart tag