### PR TITLE
feat(container): update image mirror.gcr.io/envoyproxy/gateway-helm ( v1.7.3 → v1.8.0 )

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -18,7 +18,7 @@ releases:
   - name: envoy-gateway
     namespace: network
     chart: oci://mirror.gcr.io/envoyproxy/gateway-helm
-    version: v1.7.3
+    version: v1.8.0
 
   - name: grafana-operator
     namespace: observability

--- a/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 15m
   url: oci://mirror.gcr.io/envoyproxy/gateway-helm
   ref:
-    tag: v1.7.3
+    tag: v1.8.0
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy


### PR DESCRIPTION
Re-creation of #2506, which was inadvertently auto-closed by a `close #2506` reference in the body of #2520. The branch was deleted on close, so reopen wasn't possible — pushed the same change (clean tag, no `@sha256:` suffix this time) and opened a fresh PR.

## Summary

- Bumps `envoy-gateway` helm chart: `v1.7.3` → `v1.8.0`
- Updates both the Flux `OCIRepository` (`kubernetes/apps/network/envoy-gateway/app/ocirepository.yaml`) and the bootstrap helmfile (`bootstrap/helmfile.d/00-crds.yaml`)

## Test plan

- [ ] flux-local CI passes