### PR TITLE
chore(renovate): block erroneous pulsarr 1.1.6 release

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -40,5 +40,12 @@
       matchManagers: ["flux"],
       pinDigests: false,
     },
+    {
+      // pulsarr 1.1.6 was a bad upstream release; block it but allow later versions.
+      description: "Block pulsarr 1.1.6 (erroneous upstream release)",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["docker.io/lakker/pulsarr"],
+      allowedVersions: "!/^1\\.1\\.6$/",
+    },
   ],
 }


### PR DESCRIPTION
## Summary
- Upstream `docker.io/lakker/pulsarr` 1.1.6 is a bad release. Renovate keeps re-proposing it (see #2537).
- Add `allowedVersions: "!/^1\\.1\\.6$/"` rule so that exact version is filtered out while future bumps still flow through.

## Test plan
- [ ] flux-local CI passes
- [ ] Close #2537 after this lands; verify Renovate does not recreate a PR for 1.1.6
- [ ] Confirm a later upstream release (e.g. 1.1.7+) still opens a PR