### PR TITLE
chore(renovate): widen pulsarr block to 1.x

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -41,11 +41,13 @@
       pinDigests: false,
     },
     {
-      // pulsarr 1.1.6 was a bad upstream release; block it but allow later versions.
-      description: "Block pulsarr 1.1.6 (erroneous upstream release)",
+      // pulsarr upstream (github.com/jamcalli/Pulsarr) is still on 0.15.x.
+      // Stray 1.x tags appeared on Docker Hub (1.1.5, 1.1.6) and were pulled.
+      // Block the whole 1.x major until upstream legitimately ships a 1.0 release.
+      description: "Block pulsarr 1.x — no matching upstream release",
       matchDatasources: ["docker"],
       matchPackageNames: ["docker.io/lakker/pulsarr"],
-      allowedVersions: "!/^1\\.1\\.6$/",
+      allowedVersions: "<1.0.0",
     },
   ],
 }


### PR DESCRIPTION
## Summary
- Renovate proposed pulsarr 1.1.5 (#2539) right after the 1.1.6 block landed in #2538.
- Upstream [`jamcalli/Pulsarr`](https://github.com/jamcalli/Pulsarr) is still on **0.15.5** — there are no 1.x releases. The 1.x tags appeared briefly on Docker Hub and were withdrawn.
- Replace the single-version regex with `allowedVersions: "<1.0.0"` so the whole 1.x major is filtered until upstream legitimately ships a 1.0.

## Test plan
- [ ] flux-local CI passes
- [ ] Close #2539 once this lands; verify Renovate doesn't recreate
- [ ] Future 0.15.6 / 0.16.x PRs still get opened