### PR TITLE
fix(dozerdb): allow default capabilities so chown works at startup

### DIFF
--- a/kubernetes/apps/database/dozerdb/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dozerdb/app/helmrelease.yaml
@@ -45,11 +45,12 @@ spec:
             envFrom:
               - secretRef:
                   name: dozerdb-secret
+            # NOTE: capabilities.drop is intentionally omitted — DozerDB's
+            # entrypoint chowns /var/lib/neo4j at startup and needs CAP_CHOWN.
+            # Dropping all caps causes "Operation not permitted" on chown
+            # and the container CrashLoops.
             securityContext:
               allowPrivilegeEscalation: false
-              capabilities:
-                drop:
-                  - ALL
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
## Summary

DozerDB crashed in a chown loop right after the prowler PR (#2542) merged. Logs show:

```
chown: changing ownership of '/var/lib/neo4j/lib/...': Operation not permitted
```

I added `capabilities.drop: [ALL]` in a follow-up commit to match the hardening pattern used elsewhere. Neo4j's entrypoint chowns the entire `/var/lib/neo4j` tree on every start — without `CAP_CHOWN` it fails and the container CrashLoops.

Reverting just `capabilities.drop: [ALL]`. Keeping `allowPrivilegeEscalation: false` and the `fsGroup: 7474` / `seccompProfile: RuntimeDefault` settings.

## Test plan
- [ ] flux-local test passes
- [ ] After merge, `kubectl rollout status sts/dozerdb -n database --timeout=5m` returns success
- [ ] `nc -zv dozerdb.database.svc 7687` from inside the cluster
- [ ] Prowler HelmReleases (which were also stuck behind this) reach Ready