### PR TITLE
feat(metabase): deploy Metabase backed by postgres18

### DIFF
--- a/docs/superpowers/plans/2026-05-15-metabase.md
+++ b/docs/superpowers/plans/2026-05-15-metabase.md
@@ -1,0 +1,886 @@
+# Metabase Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy Metabase to the `database` namespace, backed by the existing `postgres18` CNPG cluster, internal-only via envoy-internal, instrumented with its native Prometheus exporter and a Grafana dashboard.
+
+**Architecture:** Single bjw-s `app-template` HelmRelease with a `postgres-init` initContainer that bootstraps a dedicated `metabase` database and role on first run. App state lives in Postgres (no PVC). Metrics served on port 9191 via `MB_PROMETHEUS_SERVER_PORT`, scraped by a PodMonitor; Grafana dashboard imported via a `GrafanaDashboard` CR.
+
+**Tech Stack:** Flux CD, Kustomize, bjw-s `app-template` Helm chart (OCI), CloudNativePG, External-Secrets Operator (1Password Connect), Envoy Gateway API, kube-prometheus-stack, Grafana Operator.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-metabase-design.md`
+
+---
+
+## Pre-flight: gather current image references
+
+These two image tags/digests are needed in multiple later tasks. Resolve them once up front and substitute the literal strings in every place the plan says `<METABASE_TAG_DIGEST>` and `<POSTGRES_INIT_TAG_DIGEST>`.
+
+### Task 0: Resolve current image digests
+
+**Files:** none (lookup only — record the values in your scratch buffer)
+
+- [ ] **Step 1: Resolve the current Metabase OSS stable tag**
+
+Run:
+
+```bash
+curl -fsSL 'https://hub.docker.com/v2/repositories/metabase/metabase/tags/?page_size=50&name=v0' \
+  | jq -r '.results[] | select(.name | test("^v0\\.[0-9]+\\.[0-9]+$")) | .name' \
+  | sort -V | tail -1
+```
+
+Expected: a single line like `v0.55.4` (whatever is current). Record as `METABASE_TAG`.
+
+- [ ] **Step 2: Resolve the matching digest**
+
+Run (replace `<TAG>` with the value from Step 1):
+
+```bash
+docker buildx imagetools inspect docker.io/metabase/metabase:<TAG> \
+  --format '{{ .Manifest.Digest }}'
+```
+
+Expected: `sha256:…`. Combine as `<METABASE_TAG_DIGEST>` → `<TAG>@sha256:…`.
+
+- [ ] **Step 3: Resolve the current `home-operations/postgres-init` tag for Postgres 18**
+
+Run:
+
+```bash
+gh api -H "Accept: application/vnd.github+json" \
+  /orgs/home-operations/packages/container/postgres-init/versions \
+  | jq -r '.[] | .metadata.container.tags[]' \
+  | grep -E '^18(\.|$)' | sort -V | tail -1
+```
+
+Expected: a line like `18` or `18.0.0`. Record as `POSTGRES_INIT_TAG`.
+
+- [ ] **Step 4: Resolve the matching digest**
+
+Run (replace `<TAG>`):
+
+```bash
+docker buildx imagetools inspect ghcr.io/home-operations/postgres-init:<TAG> \
+  --format '{{ .Manifest.Digest }}'
+```
+
+Expected: `sha256:…`. Combine as `<POSTGRES_INIT_TAG_DIGEST>` → `<TAG>@sha256:…`.
+
+- [ ] **Step 5: Sanity-check the values are non-empty**
+
+Confirm both strings are populated and shaped `<tag>@sha256:<64hex>`. Do not proceed without them.
+
+---
+
+## Task 1: Provision the 1Password item
+
+**Files:** none (1Password vault mutation only)
+
+Per project memory (`feedback_op_cli_for_secrets.md`): never have the user paste credentials into the 1Password UI; generate locally with `op` and create the item via CLI.
+
+- [ ] **Step 1: Generate the Metabase encryption-secret key**
+
+Run:
+
+```bash
+openssl rand -base64 32
+```
+
+Expected: a 44-character base64 string (no whitespace, ends in `=`). Record as `MB_ENC_KEY`.
+
+- [ ] **Step 2: Verify the `Talos` vault is the signed-in default and no existing `metabase` item collides**
+
+Run:
+
+```bash
+op item get metabase --vault Talos 2>&1 | head -3
+```
+
+Expected: `"metabase" isn't an item.` (i.e. not found). If it exists, abort and decide how to handle the collision (rotate vs reuse) before continuing.
+
+- [ ] **Step 3: Create the 1Password item**
+
+Run (substitute `MB_ENC_KEY` from Step 1):
+
+```bash
+op item create \
+  --vault Talos \
+  --category=Login \
+  --title=metabase \
+  --generate-password='letters,digits,32' \
+  username=metabase \
+  'MB_DBUSER[text]=metabase' \
+  "MB_DBPASS[concealed]=$(op item get metabase --vault Talos --fields password 2>/dev/null || echo CHANGEME)" \
+  "MB_ENCRYPTION_SECRET_KEY[concealed]=<MB_ENC_KEY>"
+```
+
+That bootstrap form has a chicken/egg issue (the password isn't readable until after create). Use this two-step form instead:
+
+```bash
+# 3a — create with a generated password, capture it via the create output
+op item create \
+  --vault Talos \
+  --category=Login \
+  --title=metabase \
+  --generate-password='letters,digits,32' \
+  username=metabase \
+  'MB_DBUSER[text]=metabase' \
+  "MB_ENCRYPTION_SECRET_KEY[concealed]=<MB_ENC_KEY>"
+
+# 3b — copy the generated `password` field into MB_DBPASS so the ExternalSecret can read it
+GENERATED=$(op item get metabase --vault Talos --fields password --reveal)
+op item edit metabase --vault Talos "MB_DBPASS[concealed]=${GENERATED}"
+```
+
+Expected: both commands succeed with no errors.
+
+- [ ] **Step 4: Verify all three required fields read back**
+
+Run:
+
+```bash
+for f in MB_DBUSER MB_DBPASS MB_ENCRYPTION_SECRET_KEY; do
+  echo -n "${f}: "; op item get metabase --vault Talos --fields "${f}" --reveal | wc -c
+done
+```
+
+Expected: `MB_DBUSER: 9` (8 chars + newline), `MB_DBPASS: 33`, `MB_ENCRYPTION_SECRET_KEY: 45` (44 + newline). Values are non-empty.
+
+- [ ] **Step 5: Confirm `cloudnative-pg` 1Password item exposes the keys we'll combine with**
+
+Run:
+
+```bash
+op item get cloudnative-pg --vault Talos --fields POSTGRES_SUPER_USER,POSTGRES_SUPER_PASS --reveal | sed 's/./*/g'
+```
+
+Expected: two non-empty lines (printed as asterisks). The ExternalSecret will combine these with the `metabase` item.
+
+---
+
+## Task 2: Create the app directory and OCIRepository
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/app/ocirepository.yaml`
+
+- [ ] **Step 1: Create the directory tree**
+
+Run:
+
+```bash
+mkdir -p kubernetes/apps/database/metabase/app
+```
+
+Expected: no output; `ls kubernetes/apps/database/metabase/app` returns empty.
+
+- [ ] **Step 2: Write the OCIRepository pointing at the bjw-s app-template chart**
+
+Create `kubernetes/apps/database/metabase/app/ocirepository.yaml`:
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: metabase
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+```
+
+- [ ] **Step 3: Verify YAML parses**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/app/ocirepository.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 3: ExternalSecret
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/app/externalsecret.yaml`
+
+- [ ] **Step 1: Write the ExternalSecret**
+
+Create `kubernetes/apps/database/metabase/app/externalsecret.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: metabase
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: metabase-secret
+    template:
+      engineVersion: v2
+      data:
+        # ---- Metabase application connection ---------------------------------
+        MB_DB_TYPE: postgres
+        MB_DB_HOST: postgres18-rw.database.svc.cluster.local
+        MB_DB_PORT: "5432"
+        MB_DB_DBNAME: metabase
+        MB_DB_USER: "{{ .MB_DBUSER }}"
+        MB_DB_PASS: "{{ .MB_DBPASS }}"
+        # Encrypts source-database credentials stored inside Metabase's app DB.
+        # Lost key = unable to decrypt saved DB connections. Rotation requires
+        # Metabase's `rotate-encryption-key` admin command.
+        MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
+        # ---- init-db (postgres-init initContainer) ---------------------------
+        INIT_POSTGRES_DBNAME: metabase
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
+        INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: metabase
+```
+
+- [ ] **Step 2: Verify YAML parses**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/app/externalsecret.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 4: HelmRelease
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/app/helmrelease.yaml`
+
+- [ ] **Step 1: Write the HelmRelease**
+
+Create `kubernetes/apps/database/metabase/app/helmrelease.yaml` (substitute `<METABASE_TAG_DIGEST>` and `<POSTGRES_INIT_TAG_DIGEST>` from Task 0):
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app metabase
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: metabase
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      metabase:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: <POSTGRES_INIT_TAG_DIGEST>
+            envFrom:
+              - secretRef:
+                  name: metabase-secret
+
+        containers:
+          app:
+            image:
+              repository: docker.io/metabase/metabase
+              tag: <METABASE_TAG_DIGEST>
+            env:
+              TZ: ${TIMEZONE}
+              MB_JETTY_PORT: "3000"
+              MB_PROMETHEUS_SERVER_PORT: "9191"
+              # JDK 17+ requires --add-opens for the Prometheus collector's
+              # native NIO access. Documented at
+              # https://www.metabase.com/docs/latest/installation-and-operation/observability-with-prometheus
+              JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"
+            envFrom:
+              - secretRef:
+                  name: metabase-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: &port 3000
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1536Mi
+              limits:
+                memory: 3Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    service:
+      app:
+        controller: metabase
+        ports:
+          http:
+            port: 3000
+          metrics:
+            port: 9191
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      plugins:
+        type: emptyDir
+        globalMounts:
+          - path: /plugins
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+```
+
+- [ ] **Step 2: Confirm both `<…_TAG_DIGEST>` placeholders are substituted**
+
+Run:
+
+```bash
+grep -n '<.*TAG_DIGEST>' kubernetes/apps/database/metabase/app/helmrelease.yaml || echo "no placeholders remain"
+```
+
+Expected: `no placeholders remain`.
+
+- [ ] **Step 3: Verify YAML parses**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/app/helmrelease.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 5: PodMonitor
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/app/podmonitor.yaml`
+
+- [ ] **Step 1: Write the PodMonitor**
+
+Create `kubernetes/apps/database/metabase/app/podmonitor.yaml`:
+
+```yaml
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metabase
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metabase
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics
+```
+
+- [ ] **Step 2: Verify YAML parses**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/app/podmonitor.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 6: GrafanaDashboard
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/app/grafanadashboard.yaml`
+
+The native Metabase exporter emits mostly JVM/Jetty metrics. We pull a maintained community JVM-flavoured dashboard (Grafana ID 17668 is the canonical "Metabase" dashboard at the time of writing; verify it still exists before merging).
+
+- [ ] **Step 1: Verify dashboard 17668 still exists on grafana.com**
+
+Run:
+
+```bash
+curl -fsSL https://grafana.com/api/dashboards/17668 | jq -r '.name, .revision'
+```
+
+Expected: a name containing "Metabase" and a non-empty revision number. Record the latest revision as `MB_DASH_REV`.
+
+If the dashboard is gone or unmaintained, abort this task and instead author a minimal embedded JSON dashboard (configMap-backed, following `kubernetes/apps/flux-system/flux-instance/app/grafanadashboard.yaml`). The fallback covers JVM heap, GC, thread count, Jetty request rate/error rate, and DB pool — but this branch is only reached if 17668 is unavailable. Stop and flag for human decision.
+
+- [ ] **Step 2: Write the GrafanaDashboard CR**
+
+Create `kubernetes/apps/database/metabase/app/grafanadashboard.yaml` (substitute `<MB_DASH_REV>` from Step 1):
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: metabase
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/17668/revisions/<MB_DASH_REV>/download
+```
+
+- [ ] **Step 3: Verify YAML parses and contains no placeholders**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/app/grafanadashboard.yaml > /dev/null \
+  && grep -n '<.*>' kubernetes/apps/database/metabase/app/grafanadashboard.yaml \
+  || echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 7: app/kustomization.yaml
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/app/kustomization.yaml`
+
+- [ ] **Step 1: Write the kustomization**
+
+Create `kubernetes/apps/database/metabase/app/kustomization.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./podmonitor.yaml
+```
+
+- [ ] **Step 2: Verify YAML parses and that `kustomize build` succeeds**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/app/kustomization.yaml > /dev/null && echo YAML_OK
+kustomize build kubernetes/apps/database/metabase/app > /tmp/metabase-app.yaml && echo BUILD_OK
+wc -l /tmp/metabase-app.yaml
+```
+
+Expected: `YAML_OK`, `BUILD_OK`, and a line count > 50 (HelmRelease + ExternalSecret + OCIRepository + PodMonitor + GrafanaDashboard rendered).
+
+---
+
+## Task 8: Flux Kustomization (ks.yaml)
+
+**Files:**
+- Create: `kubernetes/apps/database/metabase/ks.yaml`
+
+- [ ] **Step 1: Write the Flux Kustomization**
+
+Create `kubernetes/apps/database/metabase/ks.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app metabase
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/database/metabase/app
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: metabase
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+```
+
+- [ ] **Step 2: Verify YAML parses**
+
+Run:
+
+```bash
+yq -e . kubernetes/apps/database/metabase/ks.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 9: Register metabase in the namespace kustomization
+
+**Files:**
+- Modify: `kubernetes/apps/database/kustomization.yaml`
+
+- [ ] **Step 1: Add `./metabase/ks.yaml` to the resources list (alphabetical: between `dragonfly` and `pgadmin`)**
+
+Edit `kubernetes/apps/database/kustomization.yaml` so the `resources:` block reads:
+
+```yaml
+resources:
+  - ./namespace.yaml
+  - ./netpol.yaml
+  - ./cloudnative-pg/ks.yaml
+  - ./dragonfly/ks.yaml
+  - ./metabase/ks.yaml
+  - ./pgadmin/ks.yaml
+  - ./whodb/ks.yaml
+```
+
+If the file already contains `./dozerdb/ks.yaml` (added on a parallel branch), preserve alphabetical order — slot `metabase` between `dragonfly`/`dozerdb` and `pgadmin` accordingly.
+
+- [ ] **Step 2: Verify `kustomize build` of the namespace succeeds**
+
+Run:
+
+```bash
+kustomize build kubernetes/apps/database > /tmp/database-ns.yaml && echo OK
+grep -c 'name: metabase' /tmp/database-ns.yaml
+```
+
+Expected: `OK` and a non-zero count (the Flux Kustomization for metabase rendered).
+
+---
+
+## Task 10: flux-local validation
+
+**Files:** none
+
+- [ ] **Step 1: Run flux-local against the whole cluster path**
+
+Run:
+
+```bash
+flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose 2>&1 | tail -40
+```
+
+Expected: no failures. The output should mention `metabase` as one of the tested HelmReleases (typically as `database/metabase`). If errors mention `cluster-secrets` substitution variables, that's pre-existing and unrelated to this change.
+
+- [ ] **Step 2: Run a diff (no live cluster needed) to inspect what would be applied**
+
+Run:
+
+```bash
+flux-local diff ks --path kubernetes/flux/cluster --all-namespaces 2>&1 | grep -A 5 -B 2 metabase | head -80
+```
+
+Expected: a diff block showing the new metabase Kustomization, HelmRelease, ExternalSecret, OCIRepository, PodMonitor, GrafanaDashboard — and only those.
+
+---
+
+## Task 11: Local lint
+
+**Files:** none
+
+- [ ] **Step 1: Run the repo's lint task**
+
+Run:
+
+```bash
+just lint 2>&1 | tail -40
+```
+
+Expected: no failures from `yamlfmt`, `super-linter`, or `actionlint`. If `yamlfmt` reports formatting diffs, accept them with `just lint --fix` (if defined) or re-run `yamlfmt` directly on the new files, then re-stage.
+
+---
+
+## Task 12: Commit
+
+**Files:** all changes staged
+
+- [ ] **Step 1: Stage only the new/modified files for this feature**
+
+Run:
+
+```bash
+git add \
+  kubernetes/apps/database/metabase/ \
+  kubernetes/apps/database/kustomization.yaml
+git status
+```
+
+Expected: six new files under `kubernetes/apps/database/metabase/` and one modification to `kubernetes/apps/database/kustomization.yaml`. Nothing else staged.
+
+- [ ] **Step 2: Commit**
+
+Run:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(metabase): deploy Metabase backed by postgres18
+
+Adds a Metabase instance to the database namespace using the bjw-s
+app-template chart. App metadata lives in a dedicated database on the
+existing postgres18 CNPG cluster (bootstrapped by a postgres-init
+initContainer). Internal-only HTTPRoute on envoy-internal.
+
+Observability: Metabase's native Prometheus exporter on port 9191
+(MB_PROMETHEUS_SERVER_PORT) is scraped by a PodMonitor and surfaced
+through a community Grafana dashboard.
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, fix the underlying issue, re-stage, and create a new commit (do not `--amend`).
+
+---
+
+## Task 13: Push and open the PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the worktree branch**
+
+Run:
+
+```bash
+git push -u origin HEAD
+```
+
+Expected: the remote branch is created.
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+
+```bash
+gh pr create --title "feat(metabase): deploy Metabase backed by postgres18" \
+  --body "$(cat <<'EOF'
+## Summary
+- Deploy Metabase OSS to the \`database\` namespace via the bjw-s app-template chart
+- App metadata in a dedicated DB on the existing \`postgres18\` CNPG cluster (bootstrapped by a postgres-init initContainer)
+- Internal-only HTTPRoute on \`envoy-internal\` for \`metabase.\${SECRET_DOMAIN}\` and \`metabase.\${SECRET_INTERNAL_DOMAIN}\`
+- Native Prometheus exporter (MB_PROMETHEUS_SERVER_PORT=9191) scraped via PodMonitor; Grafana dashboard imported
+
+Spec: \`docs/superpowers/specs/2026-05-15-metabase-design.md\`
+
+## Test plan
+- [ ] flux-local test passes on the branch
+- [ ] After merge + Flux reconcile, \`HelmRelease metabase -n database\` reaches Ready
+- [ ] init-db container exits 0 and \`\\l\` on postgres18 lists the \`metabase\` database
+- [ ] \`https://metabase.\${SECRET_INTERNAL_DOMAIN}\` serves the setup wizard from LAN
+- [ ] \`curl localhost:9191/metrics\` (via port-forward) returns Prometheus output
+- [ ] Prometheus targets page shows the \`metabase\` PodMonitor as Up
+- [ ] Grafana shows the imported \`metabase\` dashboard with non-empty JVM panels
+EOF
+)"
+```
+
+Expected: PR URL returned. Watch CI: `flux-local`, `Checkov`, both `Trivy` checks should all pass.
+
+---
+
+## Task 14: Post-apply verification (runs after PR is merged + Flux has reconciled)
+
+**Files:** none (verification only)
+
+These steps require the PR to be merged and Flux to have reconciled. Use the in-repo kubeconfig (set automatically by `.mise.toml`; CLAUDE.md spells out the explicit path).
+
+- [ ] **Step 1: HelmRelease is Ready**
+
+Run:
+
+```bash
+kubectl -n database get helmrelease metabase
+```
+
+Expected: a row with `READY=True` and `STATUS` containing `Release reconciliation succeeded`.
+
+- [ ] **Step 2: Pod is Ready with both containers having run**
+
+Run:
+
+```bash
+kubectl -n database get pod -l app.kubernetes.io/name=metabase -o wide
+kubectl -n database get pod -l app.kubernetes.io/name=metabase \
+  -o jsonpath='{.items[0].status.initContainerStatuses[0].state}'; echo
+```
+
+Expected: `1/1 Running`; init container state shows `terminated` with `reason: Completed, exitCode: 0`.
+
+- [ ] **Step 3: `metabase` database exists on postgres18**
+
+Run:
+
+```bash
+kubectl -n database exec sts/postgres18 -c postgres -- psql -U postgres -l \
+  | grep -E '^\s*metabase\b'
+```
+
+Expected: a row showing the `metabase` database owned by the `metabase` role.
+
+- [ ] **Step 4: HTTP health endpoint responds**
+
+Run:
+
+```bash
+kubectl -n database port-forward svc/metabase 3000:3000 >/dev/null 2>&1 &
+PF=$!; sleep 3
+curl -fsS http://localhost:3000/api/health
+kill $PF
+```
+
+Expected: JSON body `{"status":"ok"}`.
+
+- [ ] **Step 5: Prometheus metrics endpoint responds**
+
+Run:
+
+```bash
+kubectl -n database port-forward svc/metabase 9191:9191 >/dev/null 2>&1 &
+PF=$!; sleep 3
+curl -fsS http://localhost:9191/metrics | grep -E '^jvm_memory_used_bytes' | head -3
+kill $PF
+```
+
+Expected: at least one `jvm_memory_used_bytes{…} <number>` line.
+
+- [ ] **Step 6: Prometheus is scraping the PodMonitor**
+
+Run:
+
+```bash
+kubectl -n observability port-forward svc/kube-prometheus-stack-prometheus 9090:9090 >/dev/null 2>&1 &
+PF=$!; sleep 3
+curl -fsS 'http://localhost:9090/api/v1/targets' \
+  | jq -r '.data.activeTargets[] | select(.labels.namespace=="database" and .labels.pod | startswith("metabase-")) | .health'
+kill $PF
+```
+
+Expected: one or more lines reading `up`.
+
+- [ ] **Step 7: Grafana dashboard imported**
+
+Run:
+
+```bash
+kubectl -n observability get grafanadashboards.grafana.integreatly.org metabase \
+  -o jsonpath='{.status.conditions[?(@.type=="DashboardSynced")].status}'; echo
+```
+
+Expected: `True`.
+
+- [ ] **Step 8: Browse the UI from LAN (manual)**
+
+Open `https://metabase.${SECRET_INTERNAL_DOMAIN}` in a browser on the home network. Expected: the Metabase first-run setup wizard renders. Do **not** complete the wizard via the agent — leave that to the user, who will choose admin credentials and seed source DB connections.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Walked through each spec section.
+
+- File layout (`ks.yaml`, `app/{kustomization,ocirepository,externalsecret,helmrelease,podmonitor,grafanadashboard}.yaml` + database/kustomization edit) → Tasks 2-9.
+- Flux Kustomization with `dependsOn: cloudnative-pg-cluster`, `gatus/guarded` component → Task 8.
+- OCIRepository pinned to bjw-s app-template 5.0.1 → Task 2.
+- ExternalSecret combining `metabase` + `cloudnative-pg` 1Password items, materialising all `MB_*` and `INIT_POSTGRES_*` keys → Tasks 1, 3.
+- HelmRelease with `home-operations/postgres-init` initContainer; UID/GID 2000; `MB_PROMETHEUS_SERVER_PORT=9191` + the `--add-opens` JAVA_OPTS; emptyDir for `/plugins` and `/tmp`; service ports 3000 + 9191; HTTPRoute on `envoy-internal` → Task 4.
+- PodMonitor scraping port `metrics` → Task 5.
+- GrafanaDashboard via integreatly CR → Task 6.
+- Testing & success criteria → Tasks 10-14.
+
+**Placeholder scan:** Three explicit placeholders are documented as Task-0 lookups (`<METABASE_TAG_DIGEST>`, `<POSTGRES_INIT_TAG_DIGEST>`, `<MB_DASH_REV>`). Each has a concrete resolution command earlier in the plan and a verification step that the placeholder has been substituted. No "TBD"/"TODO" left.
+
+**Type consistency:** Secret keys are consistent — `MB_DBUSER`/`MB_DBPASS` in 1Password, mapped to `MB_DB_USER`/`MB_DB_PASS` env vars (Metabase's expected names). `INIT_POSTGRES_*` keys match the variable names `ghcr.io/home-operations/postgres-init` reads. Service port names (`http`, `metrics`) match the HelmRelease, the PodMonitor (`port: metrics`), and the route (`http` implicit). Labels — `app.kubernetes.io/name: metabase` is applied by `commonMetadata` in `ks.yaml` and used as the PodMonitor selector.

--- a/docs/superpowers/plans/2026-05-15-metabase.md
+++ b/docs/superpowers/plans/2026-05-15-metabase.md
@@ -162,6 +162,7 @@ Expected: two non-empty lines (printed as asterisks). The ExternalSecret will co
 ## Task 2: Create the app directory and OCIRepository
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/app/ocirepository.yaml`
 
 - [ ] **Step 1: Create the directory tree**
@@ -183,15 +184,15 @@ Create `kubernetes/apps/database/metabase/app/ocirepository.yaml`:
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: metabase
+    name: metabase
 spec:
-  interval: 1h
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.0.1
-  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+    interval: 1h
+    layerSelector:
+        mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+        operation: copy
+    ref:
+        tag: 5.0.1
+    url: oci://ghcr.io/bjw-s-labs/helm/app-template
 ```
 
 - [ ] **Step 3: Verify YAML parses**
@@ -209,6 +210,7 @@ Expected: `OK`.
 ## Task 3: ExternalSecret
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/app/externalsecret.yaml`
 
 - [ ] **Step 1: Write the ExternalSecret**
@@ -221,39 +223,39 @@ Create `kubernetes/apps/database/metabase/app/externalsecret.yaml`:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: metabase
+    name: metabase
 spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword-connect
-  target:
-    name: metabase-secret
-    template:
-      engineVersion: v2
-      data:
-        # ---- Metabase application connection ---------------------------------
-        MB_DB_TYPE: postgres
-        MB_DB_HOST: postgres18-rw.database.svc.cluster.local
-        MB_DB_PORT: "5432"
-        MB_DB_DBNAME: metabase
-        MB_DB_USER: "{{ .MB_DBUSER }}"
-        MB_DB_PASS: "{{ .MB_DBPASS }}"
-        # Encrypts source-database credentials stored inside Metabase's app DB.
-        # Lost key = unable to decrypt saved DB connections. Rotation requires
-        # Metabase's `rotate-encryption-key` admin command.
-        MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
-        # ---- init-db (postgres-init initContainer) ---------------------------
-        INIT_POSTGRES_DBNAME: metabase
-        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
-        INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
-        INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
-        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
-  dataFrom:
-    - extract:
-        key: cloudnative-pg
-    - extract:
-        key: metabase
+    secretStoreRef:
+        kind: ClusterSecretStore
+        name: onepassword-connect
+    target:
+        name: metabase-secret
+        template:
+            engineVersion: v2
+            data:
+                # ---- Metabase application connection ---------------------------------
+                MB_DB_TYPE: postgres
+                MB_DB_HOST: postgres18-rw.database.svc.cluster.local
+                MB_DB_PORT: "5432"
+                MB_DB_DBNAME: metabase
+                MB_DB_USER: "{{ .MB_DBUSER }}"
+                MB_DB_PASS: "{{ .MB_DBPASS }}"
+                # Encrypts source-database credentials stored inside Metabase's app DB.
+                # Lost key = unable to decrypt saved DB connections. Rotation requires
+                # Metabase's `rotate-encryption-key` admin command.
+                MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
+                # ---- init-db (postgres-init initContainer) ---------------------------
+                INIT_POSTGRES_DBNAME: metabase
+                INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+                INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
+                INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
+                INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+                INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+    dataFrom:
+        - extract:
+              key: cloudnative-pg
+        - extract:
+              key: metabase
 ```
 
 - [ ] **Step 2: Verify YAML parses**
@@ -271,6 +273,7 @@ Expected: `OK`.
 ## Task 4: HelmRelease
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/app/helmrelease.yaml`
 
 - [ ] **Step 1: Write the HelmRelease**
@@ -283,124 +286,124 @@ Create `kubernetes/apps/database/metabase/app/helmrelease.yaml` (substitute `<ME
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app metabase
+    name: &app metabase
 spec:
-  interval: 1h
-  chartRef:
-    kind: OCIRepository
-    name: metabase
-  install:
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-      strategy: rollback
-  values:
-    controllers:
-      metabase:
-        annotations:
-          reloader.stakater.com/auto: "true"
+    interval: 1h
+    chartRef:
+        kind: OCIRepository
+        name: metabase
+    install:
+        remediation:
+            retries: 3
+    upgrade:
+        cleanupOnFail: true
+        remediation:
+            retries: 3
+            strategy: rollback
+    values:
+        controllers:
+            metabase:
+                annotations:
+                    reloader.stakater.com/auto: "true"
 
-        initContainers:
-          init-db:
-            image:
-              repository: ghcr.io/home-operations/postgres-init
-              tag: <POSTGRES_INIT_TAG_DIGEST>
-            envFrom:
-              - secretRef:
-                  name: metabase-secret
+                initContainers:
+                    init-db:
+                        image:
+                            repository: ghcr.io/home-operations/postgres-init
+                            tag: <POSTGRES_INIT_TAG_DIGEST>
+                        envFrom:
+                            - secretRef:
+                                  name: metabase-secret
 
-        containers:
-          app:
-            image:
-              repository: docker.io/metabase/metabase
-              tag: <METABASE_TAG_DIGEST>
-            env:
-              TZ: ${TIMEZONE}
-              MB_JETTY_PORT: "3000"
-              MB_PROMETHEUS_SERVER_PORT: "9191"
-              # JDK 17+ requires --add-opens for the Prometheus collector's
-              # native NIO access. Documented at
-              # https://www.metabase.com/docs/latest/installation-and-operation/observability-with-prometheus
-              JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"
-            envFrom:
-              - secretRef:
-                  name: metabase-secret
-            probes:
-              liveness: &probes
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /api/health
-                    port: &port 3000
-                  initialDelaySeconds: 0
-                  periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 3
-              readiness: *probes
-              startup:
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /api/health
-                    port: *port
-                  initialDelaySeconds: 0
-                  periodSeconds: 5
-                  timeoutSeconds: 5
-                  failureThreshold: 60
+                containers:
+                    app:
+                        image:
+                            repository: docker.io/metabase/metabase
+                            tag: <METABASE_TAG_DIGEST>
+                        env:
+                            TZ: ${TIMEZONE}
+                            MB_JETTY_PORT: "3000"
+                            MB_PROMETHEUS_SERVER_PORT: "9191"
+                            # JDK 17+ requires --add-opens for the Prometheus collector's
+                            # native NIO access. Documented at
+                            # https://www.metabase.com/docs/latest/installation-and-operation/observability-with-prometheus
+                            JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"
+                        envFrom:
+                            - secretRef:
+                                  name: metabase-secret
+                        probes:
+                            liveness: &probes
+                                enabled: true
+                                custom: true
+                                spec:
+                                    httpGet:
+                                        path: /api/health
+                                        port: &port 3000
+                                    initialDelaySeconds: 0
+                                    periodSeconds: 30
+                                    timeoutSeconds: 5
+                                    failureThreshold: 3
+                            readiness: *probes
+                            startup:
+                                enabled: true
+                                custom: true
+                                spec:
+                                    httpGet:
+                                        path: /api/health
+                                        port: *port
+                                    initialDelaySeconds: 0
+                                    periodSeconds: 5
+                                    timeoutSeconds: 5
+                                    failureThreshold: 60
+                        securityContext:
+                            allowPrivilegeEscalation: false
+                            readOnlyRootFilesystem: true
+                            capabilities:
+                                drop:
+                                    - ALL
+                        resources:
+                            requests:
+                                cpu: 100m
+                                memory: 1536Mi
+                            limits:
+                                memory: 3Gi
+
+        defaultPodOptions:
             securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities:
-                drop:
-                  - ALL
-            resources:
-              requests:
-                cpu: 100m
-                memory: 1536Mi
-              limits:
-                memory: 3Gi
+                runAsNonRoot: true
+                runAsUser: 2000
+                runAsGroup: 2000
+                fsGroup: 2000
+                fsGroupChangePolicy: OnRootMismatch
+                seccompProfile: { type: RuntimeDefault }
 
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 2000
-        runAsGroup: 2000
-        fsGroup: 2000
-        fsGroupChangePolicy: OnRootMismatch
-        seccompProfile: { type: RuntimeDefault }
+        service:
+            app:
+                controller: metabase
+                ports:
+                    http:
+                        port: 3000
+                    metrics:
+                        port: 9191
 
-    service:
-      app:
-        controller: metabase
-        ports:
-          http:
-            port: 3000
-          metrics:
-            port: 9191
+        route:
+            app:
+                hostnames:
+                    - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+                    - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+                parentRefs:
+                    - name: envoy-internal
+                      namespace: network
 
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-
-    persistence:
-      plugins:
-        type: emptyDir
-        globalMounts:
-          - path: /plugins
-      tmp:
-        type: emptyDir
-        globalMounts:
-          - path: /tmp
+        persistence:
+            plugins:
+                type: emptyDir
+                globalMounts:
+                    - path: /plugins
+            tmp:
+                type: emptyDir
+                globalMounts:
+                    - path: /tmp
 ```
 
 - [ ] **Step 2: Confirm both `<…_TAG_DIGEST>` placeholders are substituted**
@@ -428,6 +431,7 @@ Expected: `OK`.
 ## Task 5: PodMonitor
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/app/podmonitor.yaml`
 
 - [ ] **Step 1: Write the PodMonitor**
@@ -439,15 +443,15 @@ Create `kubernetes/apps/database/metabase/app/podmonitor.yaml`:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: metabase
+    name: metabase
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: metabase
-  podMetricsEndpoints:
-    - port: metrics
-      interval: 30s
-      path: /metrics
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: metabase
+    podMetricsEndpoints:
+        - port: metrics
+          interval: 30s
+          path: /metrics
 ```
 
 - [ ] **Step 2: Verify YAML parses**
@@ -465,6 +469,7 @@ Expected: `OK`.
 ## Task 6: GrafanaDashboard
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/app/grafanadashboard.yaml`
 
 The native Metabase exporter emits mostly JVM/Jetty metrics. We pull a maintained community JVM-flavoured dashboard (Grafana ID 17668 is the canonical "Metabase" dashboard at the time of writing; verify it still exists before merging).
@@ -491,16 +496,16 @@ Create `kubernetes/apps/database/metabase/app/grafanadashboard.yaml` (substitute
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: metabase
+    name: metabase
 spec:
-  allowCrossNamespaceImport: true
-  instanceSelector:
-    matchLabels:
-      grafana.internal/instance: grafana
-  datasources:
-    - datasourceName: prometheus
-      inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/17668/revisions/<MB_DASH_REV>/download
+    allowCrossNamespaceImport: true
+    instanceSelector:
+        matchLabels:
+            grafana.internal/instance: grafana
+    datasources:
+        - datasourceName: prometheus
+          inputName: DS_PROMETHEUS
+    url: https://grafana.com/api/dashboards/17668/revisions/<MB_DASH_REV>/download
 ```
 
 - [ ] **Step 3: Verify YAML parses and contains no placeholders**
@@ -520,6 +525,7 @@ Expected: `OK`.
 ## Task 7: app/kustomization.yaml
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/app/kustomization.yaml`
 
 - [ ] **Step 1: Write the kustomization**
@@ -533,11 +539,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: database
 resources:
-  - ./externalsecret.yaml
-  - ./grafanadashboard.yaml
-  - ./helmrelease.yaml
-  - ./ocirepository.yaml
-  - ./podmonitor.yaml
+    - ./externalsecret.yaml
+    - ./grafanadashboard.yaml
+    - ./helmrelease.yaml
+    - ./ocirepository.yaml
+    - ./podmonitor.yaml
 ```
 
 - [ ] **Step 2: Verify YAML parses and that `kustomize build` succeeds**
@@ -557,6 +563,7 @@ Expected: `YAML_OK`, `BUILD_OK`, and a line count > 50 (HelmRelease + ExternalSe
 ## Task 8: Flux Kustomization (ks.yaml)
 
 **Files:**
+
 - Create: `kubernetes/apps/database/metabase/ks.yaml`
 
 - [ ] **Step 1: Write the Flux Kustomization**
@@ -569,32 +576,32 @@ Create `kubernetes/apps/database/metabase/ks.yaml`:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app metabase
-  namespace: &namespace database
+    name: &app metabase
+    namespace: &namespace database
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  components:
-    - ../../../../components/gatus/guarded
-  dependsOn:
-    - name: cloudnative-pg-cluster
-      namespace: database
-  interval: 1h
-  path: ./kubernetes/apps/database/metabase/app
-  postBuild:
-    substitute:
-      APP: *app
-      GATUS_SUBDOMAIN: metabase
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: *namespace
-  timeout: 5m
-  wait: false
+    commonMetadata:
+        labels:
+            app.kubernetes.io/name: *app
+    components:
+        - ../../../../components/gatus/guarded
+    dependsOn:
+        - name: cloudnative-pg-cluster
+          namespace: database
+    interval: 1h
+    path: ./kubernetes/apps/database/metabase/app
+    postBuild:
+        substitute:
+            APP: *app
+            GATUS_SUBDOMAIN: metabase
+    prune: true
+    retryInterval: 2m
+    sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+    targetNamespace: *namespace
+    timeout: 5m
+    wait: false
 ```
 
 - [ ] **Step 2: Verify YAML parses**
@@ -612,6 +619,7 @@ Expected: `OK`.
 ## Task 9: Register metabase in the namespace kustomization
 
 **Files:**
+
 - Modify: `kubernetes/apps/database/kustomization.yaml`
 
 - [ ] **Step 1: Add `./metabase/ks.yaml` to the resources list (alphabetical: between `dragonfly` and `pgadmin`)**
@@ -620,13 +628,13 @@ Edit `kubernetes/apps/database/kustomization.yaml` so the `resources:` block rea
 
 ```yaml
 resources:
-  - ./namespace.yaml
-  - ./netpol.yaml
-  - ./cloudnative-pg/ks.yaml
-  - ./dragonfly/ks.yaml
-  - ./metabase/ks.yaml
-  - ./pgadmin/ks.yaml
-  - ./whodb/ks.yaml
+    - ./namespace.yaml
+    - ./netpol.yaml
+    - ./cloudnative-pg/ks.yaml
+    - ./dragonfly/ks.yaml
+    - ./metabase/ks.yaml
+    - ./pgadmin/ks.yaml
+    - ./whodb/ks.yaml
 ```
 
 If the file already contains `./dozerdb/ks.yaml` (added on a parallel branch), preserve alphabetical order — slot `metabase` between `dragonfly`/`dozerdb` and `pgadmin` accordingly.
@@ -674,7 +682,7 @@ Expected: a diff block showing the new metabase Kustomization, HelmRelease, Exte
 
 **Files:** none
 
-- [ ] **Step 1: Run the repo's lint task**
+- [ ] **Step 1: Run the repository's lint task**
 
 Run:
 
@@ -776,7 +784,7 @@ Expected: PR URL returned. Watch CI: `flux-local`, `Checkov`, both `Trivy` check
 
 **Files:** none (verification only)
 
-These steps require the PR to be merged and Flux to have reconciled. Use the in-repo kubeconfig (set automatically by `.mise.toml`; CLAUDE.md spells out the explicit path).
+These steps require the PR to be merged and Flux to have reconciled. Use the in-repository kubeconfig (set automatically by `.mise.toml`; CLAUDE.md spells out the explicit path).
 
 - [ ] **Step 1: HelmRelease is Ready**
 

--- a/docs/superpowers/specs/2026-05-15-metabase-design.md
+++ b/docs/superpowers/specs/2026-05-15-metabase-design.md
@@ -101,18 +101,18 @@ Mirrors `pgadmin/ks.yaml`:
 ```yaml
 url: oci://ghcr.io/bjw-s-labs/helm/app-template
 ref:
-  tag: 5.0.1   # match other apps; Renovate will keep current
+    tag: 5.0.1 # match other apps; Renovate will keep current
 ```
 
 ### ExternalSecret
 
 1Password item `metabase` in the `Talos` vault. Fields:
 
-| Field                          | Purpose                                                        |
-| ------------------------------ | -------------------------------------------------------------- |
-| `MB_DBUSER`                    | Literal `metabase`                                             |
-| `MB_DBPASS`                    | Random 32-char password for the app role                       |
-| `MB_ENCRYPTION_SECRET_KEY`     | 32-byte base64 — encrypts source-DB creds stored in app DB     |
+| Field                      | Purpose                                                    |
+| -------------------------- | ---------------------------------------------------------- |
+| `MB_DBUSER`                | Literal `metabase`                                         |
+| `MB_DBPASS`                | Random 32-char password for the app role                   |
+| `MB_ENCRYPTION_SECRET_KEY` | 32-byte base64 — encrypts source-DB creds stored in app DB |
 
 Created via `op item create --vault Talos --category=Login --title=metabase ...` (per project memory: never paste credentials into the 1Password UI; generate locally with `op`).
 
@@ -120,30 +120,30 @@ The ExternalSecret pulls from two 1Password items, materialising the keys consum
 
 ```yaml
 target:
-  name: metabase-secret
-  template:
-    engineVersion: v2
-    data:
-      # Metabase application
-      MB_DB_TYPE: postgres
-      MB_DB_HOST: postgres18-rw.database.svc.cluster.local
-      MB_DB_PORT: "5432"
-      MB_DB_DBNAME: metabase
-      MB_DB_USER: "{{ .MB_DBUSER }}"
-      MB_DB_PASS: "{{ .MB_DBPASS }}"
-      MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
-      # postgres-init initContainer
-      INIT_POSTGRES_DBNAME: metabase
-      INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
-      INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
-      INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
-      INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
-      INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+    name: metabase-secret
+    template:
+        engineVersion: v2
+        data:
+            # Metabase application
+            MB_DB_TYPE: postgres
+            MB_DB_HOST: postgres18-rw.database.svc.cluster.local
+            MB_DB_PORT: "5432"
+            MB_DB_DBNAME: metabase
+            MB_DB_USER: "{{ .MB_DBUSER }}"
+            MB_DB_PASS: "{{ .MB_DBPASS }}"
+            MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
+            # postgres-init initContainer
+            INIT_POSTGRES_DBNAME: metabase
+            INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+            INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
+            INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
+            INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+            INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
 dataFrom:
-  - extract:
-      key: cloudnative-pg
-  - extract:
-      key: metabase
+    - extract:
+          key: cloudnative-pg
+    - extract:
+          key: metabase
 ```
 
 ### HelmRelease
@@ -153,12 +153,12 @@ dataFrom:
 - **Image**: `docker.io/metabase/metabase` pinned to the current stable tag with `@sha256:…` digest. Tag resolved at implementation time via the registry; Renovate keeps it fresh.
 - **initContainers.init-db**: `ghcr.io/onedr0p/postgres-init` with `envFrom: metabase-secret`.
 - **containers.app**:
-  - `envFrom: metabase-secret`.
-  - `env.MB_PROMETHEUS_SERVER_PORT: "9191"`.
-  - `env.JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"` (required by Metabase's metrics collector on JDK 17+).
-  - `env.TZ: ${TIMEZONE}`.
-  - Probes: HTTP `GET /api/health` on `http` (3000). Startup probe `failureThreshold: 60`, `periodSeconds: 5` (Metabase cold start is ~60-90s on first run when it migrates the app DB).
-  - Resources: `requests.cpu: 100m`, `requests.memory: 1.5Gi`, `limits.memory: 3Gi`.
+    - `envFrom: metabase-secret`.
+    - `env.MB_PROMETHEUS_SERVER_PORT: "9191"`.
+    - `env.JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"` (required by Metabase's metrics collector on JDK 17+).
+    - `env.TZ: ${TIMEZONE}`.
+    - Probes: HTTP `GET /api/health` on `http` (3000). Startup probe `failureThreshold: 60`, `periodSeconds: 5` (Metabase cold start is ~60-90s on first run when it migrates the app DB).
+    - Resources: `requests.cpu: 100m`, `requests.memory: 1.5Gi`, `limits.memory: 3Gi`.
 - **defaultPodOptions.securityContext**: `runAsNonRoot: true`, `runAsUser: 2000`, `runAsGroup: 2000`, `fsGroup: 2000`, `seccompProfile: { type: RuntimeDefault }`. (UID 2000 matches the upstream Metabase image's default user.)
 - **service.app**: ports `http: 3000`, `metrics: 9191`.
 - **route.app**: parentRef `envoy-internal/network`, hostnames `{{ .Release.Name }}.${SECRET_DOMAIN}` and `{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}`.
@@ -170,14 +170,14 @@ dataFrom:
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
-  name: metabase
+    name: metabase
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: metabase
-  podMetricsEndpoints:
-    - port: metrics
-      interval: 30s
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: metabase
+    podMetricsEndpoints:
+        - port: metrics
+          interval: 30s
 ```
 
 ### GrafanaDashboard
@@ -197,7 +197,7 @@ spec:
 4. Metabase container starts, runs its internal Liquibase migrations on the empty app DB (first run only), and listens on `:3000` and `:9191`.
 5. Envoy-internal HTTPRoute routes `metabase.${SECRET_DOMAIN}` / `metabase.${SECRET_INTERNAL_DOMAIN}` to the Service.
 6. Operator visits the URL, completes the setup wizard, adds source databases through the UI.
-7. Prometheus scrapes port 9191 every 30s via the PodMonitor; Grafana auto-imports the dashboard CR.
+7. Prometheus scrapes port 9191 every 30s via the PodMonitor; Grafana autoimports the dashboard CR.
 
 ## Failure modes & handling
 
@@ -227,7 +227,7 @@ Post-apply:
 ## Decisions & rationale
 
 - **CNPG over embedded H2** — Metabase's own docs explicitly warn against H2 in production (corruption risk, no concurrent access). The cluster already runs a hardened, replicated, backed-up Postgres; reusing it costs one extra database.
-- **bjw-s app-template, not Metabase's own Helm chart** — every other app in this repo uses app-template; consistency wins, and the Metabase requirements (one Deployment + Service + HTTPRoute + initContainer) fit it cleanly. The official Metabase Helm chart adds little for this footprint.
+- **bjw-s app-template, not Metabase's own Helm chart** — every other app in this repository uses app-template; consistency wins, and the Metabase requirements (one Deployment + Service + HTTPRoute + initContainer) fit it cleanly. The official Metabase Helm chart adds little for this footprint.
 - **Internal-only ingress** — matches the user's stated intent and the namespace's existing posture (pgAdmin, WhoDB, DozerDB are all internal-only). Cloudflare-fronting can be added later by switching the `parentRef` and adding an external hostname.
 - **Native Prometheus, not JMX-exporter** — Metabase 0.49+ ships a built-in `/metrics` endpoint; no sidecar or javaagent needed. Fewer moving parts.
 - **No `/plugins` PVC** — third-party JDBC drivers are out of scope for the initial deploy. If/when one is needed, switching `plugins` from `emptyDir` to a small PVC is a one-line change.

--- a/docs/superpowers/specs/2026-05-15-metabase-design.md
+++ b/docs/superpowers/specs/2026-05-15-metabase-design.md
@@ -1,0 +1,240 @@
+# Metabase Deployment Design
+
+## Overview
+
+Deploy [Metabase](https://github.com/metabase/metabase) — an open-source business intelligence / dashboarding platform — into the `database` namespace. Backed by the existing `postgres18` CloudNativePG cluster (no embedded H2), exposed on the internal Envoy Gateway only (both `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}` hostnames), and instrumented via Metabase's native Prometheus exporter (`MB_PROMETHEUS_SERVER_PORT`, available since 0.49). No PVC: the pod is stateless because all application state lives in Postgres.
+
+Purpose: provide self-service analytics over the cluster's various Postgres datasets (Prowler findings, pgAdmin-managed databases, app DBs) without requiring SQL knowledge for every consumer.
+
+## Scope
+
+**In scope:**
+
+- `metabase` HelmRelease using the bjw-s `app-template` chart (matches every other app in the namespace).
+- Dedicated `metabase` Postgres database and role on the existing `postgres18` cluster, bootstrapped by a `postgres-init` initContainer (idempotent, same pattern as Prowler).
+- 1Password item `metabase` in the `Talos` vault (created via `op item create`) holding the app role password and the Metabase encryption-secret key. `ExternalSecret` materialises `metabase-secret` with all required `MB_*` and `INIT_POSTGRES_*` keys.
+- `HTTPRoute` on `envoy-internal` for `metabase.${SECRET_DOMAIN}` and `metabase.${SECRET_INTERNAL_DOMAIN}`.
+- Gatus health monitoring via the `gatus/guarded` component (same as pgAdmin/Prowler).
+- `PodMonitor` scraping Metabase's native Prometheus endpoint on port 9191.
+- `GrafanaDashboard` (preferred: a maintained community dashboard pulled from grafana.com; fallback: a minimal hand-built JSON covering JVM heap, request rate/latency, DB pool, query counters).
+
+**Out of scope:**
+
+- External (Cloudflare-fronted) exposure. Internal LAN only for now.
+- Volsync / PVC. Metabase is stateless when its app DB is external; `/plugins` and `/tmp` use `emptyDir`.
+- SSO / LDAP / OIDC integration. First-run wizard creates a local admin; SSO can be layered later (Metabase requires a paid edition for SAML/JWT/LDAP — local users only on OSS).
+- Pre-seeded source databases or dashboards. Initial setup is manual through the Metabase UI.
+- Email/SMTP configuration. Deferred until alerting is wanted.
+
+## Architecture
+
+```text
+                           HTTPRoute (Gateway API)
+                  metabase.${SECRET_DOMAIN}
+                  metabase.${SECRET_INTERNAL_DOMAIN}
+                                │
+                                ▼
+                  ┌─────────────────────────────┐
+                  │ envoy-internal (network ns) │
+                  └─────────────┬───────────────┘
+                                │  HTTP :3000
+                                ▼
+   ┌──────────────────────── metabase Pod (database ns) ────────────────────────┐
+   │                                                                            │
+   │   initContainer: ghcr.io/onedr0p/postgres-init                             │
+   │     ── uses INIT_POSTGRES_SUPER_* to CREATE DATABASE metabase /            │
+   │        CREATE ROLE metabase (idempotent)                                   │
+   │                                                                            │
+   │   container: metabase/metabase                                             │
+   │     ── envFrom: metabase-secret                                            │
+   │     ── port 3000 (http) · port 9191 (metrics)                              │
+   │     ── /plugins and /tmp as emptyDir                                       │
+   │                                                                            │
+   └─────────────────────┬──────────────────────────────────────────┬───────────┘
+                         │ postgres                                 │ /metrics
+                         ▼                                          ▼
+              ┌────────────────────────┐               ┌─────────────────────────┐
+              │ postgres18-rw          │               │ PodMonitor → Prometheus │
+              │ (CNPG cluster)         │               │  (observability ns)     │
+              │  db: metabase          │               └─────────────────────────┘
+              │  role: metabase        │                            │
+              └────────────────────────┘                            ▼
+                         ▲                                ┌─────────────────────┐
+                         │ Barman / Kopia                 │ GrafanaDashboard CR │
+                         ▼                                └─────────────────────┘
+              ┌────────────────────────┐
+              │ MinIO / R2 backups     │
+              └────────────────────────┘
+```
+
+Backups: app data is captured automatically by the existing CNPG backup pipeline (Barman → MinIO + scheduled R2). No app-side backup is required.
+
+## File layout
+
+```text
+kubernetes/apps/database/metabase/
+├── ks.yaml                          # Flux Kustomization (entry point)
+└── app/
+    ├── kustomization.yaml           # lists the resources below
+    ├── ocirepository.yaml           # bjw-s app-template (OCI)
+    ├── externalsecret.yaml          # → metabase-secret (Talos vault)
+    ├── helmrelease.yaml             # app-template values
+    ├── podmonitor.yaml              # scrape port 9191
+    └── grafanadashboard.yaml        # community dashboard import
+```
+
+Plus one resources entry added to `kubernetes/apps/database/kustomization.yaml` (alphabetical order, slotted between `dragonfly` and `pgadmin`).
+
+## Components
+
+### Flux Kustomization (`ks.yaml`)
+
+Mirrors `pgadmin/ks.yaml`:
+
+- `dependsOn: cloudnative-pg-cluster` (and implicitly `onepassword` via the global dependency chain).
+- `components: [gatus/guarded]`. No `volsync` because there is no PVC.
+- `postBuild.substitute.APP: metabase`, `GATUS_SUBDOMAIN: metabase`.
+- `wait: false`, `timeout: 5m`, `interval: 1h`, `retryInterval: 2m`.
+
+### OCIRepository
+
+```yaml
+url: oci://ghcr.io/bjw-s-labs/helm/app-template
+ref:
+  tag: 5.0.1   # match other apps; Renovate will keep current
+```
+
+### ExternalSecret
+
+1Password item `metabase` in the `Talos` vault. Fields:
+
+| Field                          | Purpose                                                        |
+| ------------------------------ | -------------------------------------------------------------- |
+| `MB_DBUSER`                    | Literal `metabase`                                             |
+| `MB_DBPASS`                    | Random 32-char password for the app role                       |
+| `MB_ENCRYPTION_SECRET_KEY`     | 32-byte base64 — encrypts source-DB creds stored in app DB     |
+
+Created via `op item create --vault Talos --category=Login --title=metabase ...` (per project memory: never paste credentials into the 1Password UI; generate locally with `op`).
+
+The ExternalSecret pulls from two 1Password items, materialising the keys consumed by the container (`MB_*`) and the init container (`INIT_POSTGRES_*`):
+
+```yaml
+target:
+  name: metabase-secret
+  template:
+    engineVersion: v2
+    data:
+      # Metabase application
+      MB_DB_TYPE: postgres
+      MB_DB_HOST: postgres18-rw.database.svc.cluster.local
+      MB_DB_PORT: "5432"
+      MB_DB_DBNAME: metabase
+      MB_DB_USER: "{{ .MB_DBUSER }}"
+      MB_DB_PASS: "{{ .MB_DBPASS }}"
+      MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
+      # postgres-init initContainer
+      INIT_POSTGRES_DBNAME: metabase
+      INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+      INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
+      INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
+      INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+      INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+dataFrom:
+  - extract:
+      key: cloudnative-pg
+  - extract:
+      key: metabase
+```
+
+### HelmRelease
+
+`app-template` values (truncated; final file documents every field):
+
+- **Image**: `docker.io/metabase/metabase` pinned to the current stable tag with `@sha256:…` digest. Tag resolved at implementation time via the registry; Renovate keeps it fresh.
+- **initContainers.init-db**: `ghcr.io/onedr0p/postgres-init` with `envFrom: metabase-secret`.
+- **containers.app**:
+  - `envFrom: metabase-secret`.
+  - `env.MB_PROMETHEUS_SERVER_PORT: "9191"`.
+  - `env.JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"` (required by Metabase's metrics collector on JDK 17+).
+  - `env.TZ: ${TIMEZONE}`.
+  - Probes: HTTP `GET /api/health` on `http` (3000). Startup probe `failureThreshold: 60`, `periodSeconds: 5` (Metabase cold start is ~60-90s on first run when it migrates the app DB).
+  - Resources: `requests.cpu: 100m`, `requests.memory: 1.5Gi`, `limits.memory: 3Gi`.
+- **defaultPodOptions.securityContext**: `runAsNonRoot: true`, `runAsUser: 2000`, `runAsGroup: 2000`, `fsGroup: 2000`, `seccompProfile: { type: RuntimeDefault }`. (UID 2000 matches the upstream Metabase image's default user.)
+- **service.app**: ports `http: 3000`, `metrics: 9191`.
+- **route.app**: parentRef `envoy-internal/network`, hostnames `{{ .Release.Name }}.${SECRET_DOMAIN}` and `{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}`.
+- **persistence**: `plugins` and `tmp` declared as `emptyDir`, mounted at `/plugins` and `/tmp`.
+
+### PodMonitor
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metabase
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metabase
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s
+```
+
+### GrafanaDashboard
+
+`grafana.integreatly.org/v1beta1 GrafanaDashboard`, `instanceSelector` matching the cluster's Grafana instance, importing a community Metabase dashboard from grafana.com. Implementation step: pick the most-recently-revised community dashboard that targets the native `MB_PROMETHEUS_SERVER_PORT` exporter (not legacy JMX-exporter ones). If no maintained option exists, ship a minimal embedded JSON dashboard (configMap-backed, like `flux-instance/app/grafanadashboard.yaml`) covering:
+
+- JVM heap and GC
+- HTTP request rate, error rate, latency p50/p95
+- Metabase query execution rate and duration
+- DB connection pool utilisation
+
+## Data flow
+
+1. Flux reconciles `metabase` Kustomization once `cloudnative-pg-cluster` is Ready.
+2. ExternalSecret materialises `metabase-secret` from 1Password.
+3. Pod starts; `postgres-init` initContainer creates the `metabase` DB and role using superuser credentials (idempotent — short-circuits on subsequent rollouts).
+4. Metabase container starts, runs its internal Liquibase migrations on the empty app DB (first run only), and listens on `:3000` and `:9191`.
+5. Envoy-internal HTTPRoute routes `metabase.${SECRET_DOMAIN}` / `metabase.${SECRET_INTERNAL_DOMAIN}` to the Service.
+6. Operator visits the URL, completes the setup wizard, adds source databases through the UI.
+7. Prometheus scrapes port 9191 every 30s via the PodMonitor; Grafana auto-imports the dashboard CR.
+
+## Failure modes & handling
+
+- **`postgres18` unavailable at startup**: init container exits non-zero, Kubernetes restarts the pod with backoff. Once Postgres returns, the next attempt succeeds. No manual intervention.
+- **`MB_ENCRYPTION_SECRET_KEY` lost/rotated**: Metabase cannot decrypt source-DB credentials in its app DB. Mitigation: the key lives in 1Password (the canonical store); never rotate it without first running Metabase's `rotate-encryption-key` admin command.
+- **Metabase OOM at startup**: First-run Liquibase migration can spike memory. Mitigation: 3Gi memory limit (well above Metabase's documented 1Gi floor) and a generous startup probe.
+- **Schema migration failure mid-version-upgrade**: Metabase rolls back on failure but leaves the pod CrashLooping. Mitigation: CNPG's continuous Barman backups and scheduled R2 backups allow a point-in-time recovery of the `metabase` DB if needed.
+
+## Testing & success criteria
+
+Pre-merge:
+
+- `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` passes on the branch.
+- `just lint` passes (yamlfmt, super-linter mirror).
+- Both `Trivy` checks green on the PR.
+
+Post-apply:
+
+- `kubectl -n database get helmrelease metabase` → Ready=True.
+- `kubectl -n database get pod -l app.kubernetes.io/name=metabase` → Running, both init and app containers complete/ready.
+- `kubectl -n database exec sts/postgres18 -- psql -U postgres -l` lists the `metabase` database; `\du` lists the `metabase` role.
+- `https://metabase.${SECRET_INTERNAL_DOMAIN}` resolves on internal DNS and serves the Metabase setup wizard; `/api/health` returns `{"status":"ok"}`.
+- `kubectl -n database port-forward svc/metabase 9191:9191` followed by `curl localhost:9191/metrics` returns Prometheus metrics including `jvm_memory_used_bytes` and `metabase_*` series.
+- Prometheus targets page shows the `metabase` PodMonitor as Up.
+- Grafana shows the imported dashboard, with non-empty panels for JVM heap.
+
+## Decisions & rationale
+
+- **CNPG over embedded H2** — Metabase's own docs explicitly warn against H2 in production (corruption risk, no concurrent access). The cluster already runs a hardened, replicated, backed-up Postgres; reusing it costs one extra database.
+- **bjw-s app-template, not Metabase's own Helm chart** — every other app in this repo uses app-template; consistency wins, and the Metabase requirements (one Deployment + Service + HTTPRoute + initContainer) fit it cleanly. The official Metabase Helm chart adds little for this footprint.
+- **Internal-only ingress** — matches the user's stated intent and the namespace's existing posture (pgAdmin, WhoDB, DozerDB are all internal-only). Cloudflare-fronting can be added later by switching the `parentRef` and adding an external hostname.
+- **Native Prometheus, not JMX-exporter** — Metabase 0.49+ ships a built-in `/metrics` endpoint; no sidecar or javaagent needed. Fewer moving parts.
+- **No `/plugins` PVC** — third-party JDBC drivers are out of scope for the initial deploy. If/when one is needed, switching `plugins` from `emptyDir` to a small PVC is a one-line change.
+- **No SMTP / SSO / pre-seeded data** — YAGNI; all of those are configurable after the fact through the UI without redeploying.
+
+## Risks
+
+- **First-run cold start** is slow (Liquibase migrations against an empty DB). The startup probe is sized for it, but if the pod misses the failure threshold, the workaround is to bump `failureThreshold` or `initialDelaySeconds` and re-roll.
+- **JVM flag drift**: future Metabase versions may require additional `--add-opens` flags. Easy to spot — pod logs the JVM error on start. Append to `JAVA_OPTS`.
+- **Community Grafana dashboard staleness**: if no maintained dashboard exists for the native exporter, the fallback hand-built JSON is small and easy to extend.

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -10,7 +10,8 @@ resources:
   - ./namespace.yaml
   - ./netpol.yaml
   - ./cloudnative-pg/ks.yaml
-  - ./dragonfly/ks.yaml
   - ./dozerdb/ks.yaml
+  - ./dragonfly/ks.yaml
+  - ./metabase/ks.yaml
   - ./pgadmin/ks.yaml
   - ./whodb/ks.yaml

--- a/kubernetes/apps/database/metabase/app/externalsecret.yaml
+++ b/kubernetes/apps/database/metabase/app/externalsecret.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: metabase
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: metabase-secret
+    template:
+      engineVersion: v2
+      data:
+        # ---- Metabase application connection ---------------------------------
+        MB_DB_TYPE: postgres
+        MB_DB_HOST: postgres18-rw.database.svc.cluster.local
+        MB_DB_PORT: "5432"
+        MB_DB_DBNAME: metabase
+        MB_DB_USER: "{{ .MB_DBUSER }}"
+        MB_DB_PASS: "{{ .MB_DBPASS }}"
+        # Encrypts source-database credentials stored inside Metabase's app DB.
+        # Lost key = unable to decrypt saved DB connections. Rotation requires
+        # Metabase's `rotate-encryption-key` admin command.
+        MB_ENCRYPTION_SECRET_KEY: "{{ .MB_ENCRYPTION_SECRET_KEY }}"
+        # ---- init-db (postgres-init initContainer) ---------------------------
+        INIT_POSTGRES_DBNAME: metabase
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .MB_DBUSER }}"
+        INIT_POSTGRES_PASS: "{{ .MB_DBPASS }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: metabase

--- a/kubernetes/apps/database/metabase/app/grafanadashboard.yaml
+++ b/kubernetes/apps/database/metabase/app/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: metabase
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/24133/revisions/1/download

--- a/kubernetes/apps/database/metabase/app/helmrelease.yaml
+++ b/kubernetes/apps/database/metabase/app/helmrelease.yaml
@@ -1,0 +1,123 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app metabase
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: metabase
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      metabase:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18.3.0@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+            envFrom:
+              - secretRef:
+                  name: metabase-secret
+
+        containers:
+          app:
+            image:
+              repository: docker.io/metabase/metabase
+              tag: v0.61.1@sha256:95228c25b23f014c0fbc4f86d69a66ad5f14ff74fd8e6b8223bf82e58ee416ea
+            env:
+              TZ: ${TIMEZONE}
+              MB_JETTY_PORT: "3000"
+              MB_PROMETHEUS_SERVER_PORT: "9191"
+              # JDK 17+ requires --add-opens for the Prometheus collector's
+              # native NIO access. Documented at
+              # https://www.metabase.com/docs/latest/installation-and-operation/observability-with-prometheus
+              JAVA_OPTS: "--add-opens java.base/java.nio=ALL-UNNAMED"
+            envFrom:
+              - secretRef:
+                  name: metabase-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: &port 3000
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 5
+                  failureThreshold: 60
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1536Mi
+              limits:
+                memory: 3Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+
+    service:
+      app:
+        controller: metabase
+        ports:
+          http:
+            port: 3000
+          metrics:
+            port: 9191
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      plugins:
+        type: emptyDir
+        globalMounts:
+          - path: /plugins
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/database/metabase/app/kustomization.yaml
+++ b/kubernetes/apps/database/metabase/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/database/metabase/app/ocirepository.yaml
+++ b/kubernetes/apps/database/metabase/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: metabase
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/database/metabase/app/podmonitor.yaml
+++ b/kubernetes/apps/database/metabase/app/podmonitor.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metabase
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metabase
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 30s
+      path: /metrics

--- a/kubernetes/apps/database/metabase/ks.yaml
+++ b/kubernetes/apps/database/metabase/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app metabase
+  namespace: &namespace database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/database/metabase/app
+  postBuild:
+    substitute:
+      APP: *app
+      GATUS_SUBDOMAIN: metabase
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary
- Deploy Metabase OSS to the `database` namespace via the bjw-s `app-template` chart
- App metadata in a dedicated DB on the existing `postgres18` CNPG cluster, bootstrapped by a `postgres-init` initContainer
- Internal-only HTTPRoute on `envoy-internal` for `metabase.${SECRET_DOMAIN}` and `metabase.${SECRET_INTERNAL_DOMAIN}`
- Native Prometheus exporter (`MB_PROMETHEUS_SERVER_PORT=9191`) scraped via PodMonitor; Grafana dashboard 24133 imported
- Pod is stateless (no PVC); all state lives in Postgres and is captured by the existing CNPG/Barman backup pipeline

Design spec: [`docs/superpowers/specs/2026-05-15-metabase-design.md`](docs/superpowers/specs/2026-05-15-metabase-design.md) (commit 6bdb641)
Implementation plan: [`docs/superpowers/plans/2026-05-15-metabase.md`](docs/superpowers/plans/2026-05-15-metabase.md) (commit 82c3b08)

## Test plan
- [x] `flux-local test --all-namespaces --enable-helm` — 384 passed, including `database/metabase`
- [x] `yamlfmt` + `prettier` clean on all new files
- [x] 1Password item `metabase` created in `Talos` vault (MB_DBUSER, MB_DBPASS, MB_ENCRYPTION_SECRET_KEY)
- [ ] After merge + Flux reconcile, `kubectl -n database get helmrelease metabase` reaches `Ready=True`
- [ ] init-db container exits 0; `psql -l` on `postgres18` lists the `metabase` database and role
- [ ] `https://metabase.${SECRET_INTERNAL_DOMAIN}` from LAN serves the first-run setup wizard; `/api/health` returns `{"status":"ok"}`
- [ ] `curl localhost:9191/metrics` (via port-forward) returns Prometheus output with `jvm_memory_used_bytes`
- [ ] Prometheus targets page shows the `metabase` PodMonitor as Up
- [ ] Grafana shows the imported `metabase` dashboard with non-empty JVM panels

## Notes
- bjw-s `app-template` 5.0.1 (matches namespace convention)
- Metabase image `v0.61.1` (current OSS stable, digest-pinned)
- `postgres-init` image `18.3.0` (matches CNPG Postgres 18 major)
- `JAVA_OPTS: --add-opens java.base/java.nio=ALL-UNNAMED` required for the Prometheus collector on JDK 17+
- One thing to verify post-apply: PodMonitor scrapes the pod's `metrics` port (synthesised by bjw-s from the service port). If `up{namespace="database",pod=~"metabase.*"} == 0` after deploy, switch `port: metrics` to a literal `targetPort: 9191` in `podmonitor.yaml`.