### PR TITLE
fix(prowler): probes + beat memory after first cluster deploy

### DIFF
--- a/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
@@ -48,6 +48,9 @@ spec:
               DJANGO_MANAGE_DB_PARTITIONS: "True"
             envFrom: *envFrom
             probes:
+              # Django enforces ALLOWED_HOSTS on every request. The kubelet
+              # probes by pod IP, which Django rejects with HTTP 400. Override
+              # the Host header so the probe passes ALLOWED_HOSTS validation.
               liveness: &apiProbe
                 enabled: true
                 custom: true
@@ -55,6 +58,9 @@ spec:
                   httpGet:
                     path: /api/v1/
                     port: &port 8080
+                    httpHeaders:
+                      - name: Host
+                        value: prowler-api
                   initialDelaySeconds: 60
                   periodSeconds: 30
                   timeoutSeconds: 5

--- a/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
@@ -49,9 +49,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
-              limits:
                 memory: 128Mi
+              limits:
+                memory: 256Mi
 
     defaultPodOptions:
       securityContext:

--- a/kubernetes/apps/security/prowler/app/helmrelease-ui.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-ui.yaml
@@ -39,12 +39,14 @@ spec:
               - secretRef:
                   name: prowler-ui-secret
             probes:
+              # Probe `/` (returns 307 redirect to /sign-in — accepted as 2xx-3xx
+              # by kubelet). Prowler-UI's `/api/health` returns 404 in 5.26.1.
               liveness: &uiProbe
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /api/health
+                    path: /
                     port: &port 3000
                   initialDelaySeconds: 30
                   periodSeconds: 30


### PR DESCRIPTION
## Summary

Three follow-ups from first deploy of Prowler on the cluster (PR #2542):

- **prowler-api** readiness/liveness probes were failing with HTTP 400 (`Invalid HTTP_HOST header: '10.42.1.35:8080'`). The kubelet probes by pod IP, and Django's ALLOWED_HOSTS list rejects it. Setting `httpHeaders.Host: prowler-api` makes the probe present an allowed host. Migrations and gunicorn boot fine; only the probe was unhappy.
- **prowler-ui** probe at `/api/health` returns 404 in `prowlercloud/prowler-ui:5.26.1`. Switched to `/` which returns a 307 redirect (accepted as 2xx-3xx by the kubelet). Confirmed by curl from inside the cluster.
- **prowler-beat** was OOMKilled in a tight restart loop at 128Mi. Raised request to 128Mi and limit to 256Mi.

## Test plan
- [ ] flux-local test passes
- [ ] After merge, `kubectl rollout status deploy/prowler-api -n security --timeout=5m` succeeds
- [ ] `kubectl get hr -n security` shows all three Prowler HRs Ready
- [ ] UI reachable at the internal hostname (307 redirect to /sign-in)