### PR TITLE
fix(prowler): override entrypoint on worker + beat (port collision + OOM)

### DIFF
--- a/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
@@ -80,6 +80,13 @@ spec:
                 memory: 1Gi
           worker:
             image: *image
+            # Override the image's hardcoded ENTRYPOINT
+            # `["../docker-entrypoint.sh", "prod"]`. Without `command`,
+            # `args: [worker]` is APPENDED ("prod worker") and the script
+            # still runs in `prod` mode (migrate + gunicorn), causing
+            # port 8080 collision with the api container.
+            command:
+              - "../docker-entrypoint.sh"
             args:
               - "worker"
             env: *commonEnv

--- a/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
@@ -30,6 +30,13 @@ spec:
             image:
               repository: prowlercloud/prowler-api
               tag: 5.26.1@sha256:6c373234ad95150c761f1ab1b1be56adcaea981f272f55b6490d50fc56245a0f
+            # Override the image's hardcoded ENTRYPOINT
+            # `["../docker-entrypoint.sh", "prod"]`. Without `command`,
+            # `args: [beat]` is APPENDED ("prod beat") and the script
+            # still runs in `prod` mode (migrate + gunicorn), which OOMs
+            # on the small beat resource budget.
+            command:
+              - "../docker-entrypoint.sh"
             args:
               - "beat"
             env:


### PR DESCRIPTION
## Summary

Root cause of both remaining post-deploy failures from PRs #2542 / #2549.

The upstream `prowlercloud/prowler-api` image has:

```
ENTRYPOINT ["../docker-entrypoint.sh", "prod"]
```

Kubernetes `args:` is appended to ENTRYPOINT, not substituted. So `args: ["worker"]` became `docker-entrypoint.sh prod worker` — the script reads only the first arg ("prod"), runs the prod path (migrate → gunicorn).

Symptoms:
- **prowler-api pod**: both `api` and `worker` containers ran in prod mode → second one fails with `[Errno 98] Address already in use` on port 8080.
- **prowler-beat pod**: also ran prod mode → OOMKilled during `migrate` even after raising the limit to 256Mi.

Fix: set `command: ["../docker-entrypoint.sh"]` on both worker and beat. With `command` overriding the entrypoint, `args: [worker|beat]` becomes the actual first (and only) argument the script sees.

## Test plan
- [ ] flux-local test passes
- [ ] After merge, `kubectl get hr -n security` shows all three Prowler HRs Ready
- [ ] Worker container logs show `celery@... ready` (not "Starting gunicorn")
- [ ] Beat container logs show `beat: Starting...` (not migration output)
- [ ] No more `Address already in use` errors on the api pod