### PR TITLE
fix(metabase): connect to app-DB with sslmode=disable

### DIFF
--- a/kubernetes/apps/database/metabase/app/externalsecret.yaml
+++ b/kubernetes/apps/database/metabase/app/externalsecret.yaml
@@ -14,10 +14,12 @@ spec:
       engineVersion: v2
       data:
         # ---- Metabase application connection ---------------------------------
-        MB_DB_TYPE: postgres
-        MB_DB_HOST: postgres18-rw.database.svc.cluster.local
-        MB_DB_PORT: "5432"
-        MB_DB_DBNAME: metabase
+        # JDBC URI with sslmode=disable. CNPG's server cert has an empty issuer
+        # DN that Java's X509Factory rejects (CertificateParsingException),
+        # which kills Metabase's startup before fallback. Intra-cluster traffic
+        # on a private CNI mesh, so plaintext is fine here. MB_DB_USER/PASS are
+        # still supplied separately and applied as connection properties.
+        MB_DB_CONNECTION_URI: jdbc:postgresql://postgres18-rw.database.svc.cluster.local:5432/metabase?sslmode=disable
         MB_DB_USER: "{{ .MB_DBUSER }}"
         MB_DB_PASS: "{{ .MB_DBPASS }}"
         # Encrypts source-database credentials stored inside Metabase's app DB.

--- a/kubernetes/apps/database/metabase/app/helmrelease.yaml
+++ b/kubernetes/apps/database/metabase/app/helmrelease.yaml
@@ -37,6 +37,14 @@ spec:
             image:
               repository: docker.io/metabase/metabase
               tag: v0.61.1@sha256:95228c25b23f014c0fbc4f86d69a66ad5f14ff74fd8e6b8223bf82e58ee416ea
+            # Explicit named container ports are required for the PodMonitor
+            # to match `port: metrics` — bjw-s app-template does not synthesise
+            # container ports from the service spec.
+            ports:
+              - name: http
+                containerPort: 3000
+              - name: metrics
+                containerPort: 9191
             env:
               TZ: ${TIMEZONE}
               MB_JETTY_PORT: "3000"


### PR DESCRIPTION
## Summary
Metabase HelmRelease #2547 failed to install: the JDBC driver's TLS handshake against the CNPG-issued cert throws \`CertificateParsingException: Empty issuer DN not allowed in X509Certificates\`. The driver tries SSL by default when the server offers it, and cert-parsing fails before any fallback can run.

Switching the app-DB connection to \`MB_DB_CONNECTION_URI\` with \`sslmode=disable\` sidesteps it. Intra-cluster traffic on a private CNI is safe in plaintext. \`MB_DB_USER\`/\`MB_DB_PASS\` continue to feed in as connection properties.

## Test plan
- [x] \`flux-local test\` (390 passed)
- [ ] After merge: pod becomes Ready, \`/api/health\` returns \`{"status":"ok"}\`
- [ ] Metabase setup wizard reachable at \`https://metabase.\${SECRET_INTERNAL_DOMAIN}\`

Follow-up to #2547.