### PR TITLE
fix(prowler): cap gunicorn workers + raise memory limits

### DIFF
--- a/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
@@ -46,6 +46,9 @@ spec:
               DJANGO_LOGGING_FORMATTER: ndjson
               DJANGO_LOGGING_LEVEL: INFO
               DJANGO_MANAGE_DB_PARTITIONS: "True"
+              # Cap gunicorn workers — defaults to (CPU*2+1) which on a
+              # 24-core node was 49 workers * ~80MB each = 4GB just for api.
+              DJANGO_WORKERS: "4"
             envFrom: *envFrom
             probes:
               # Django enforces ALLOWED_HOSTS on every request. The kubelet
@@ -75,9 +78,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 768Mi
               limits:
-                memory: 1Gi
+                memory: 2Gi
           worker:
             image: *image
             # Override the image's hardcoded ENTRYPOINT
@@ -100,9 +103,9 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                memory: 768Mi
               limits:
-                memory: 2Gi
+                memory: 4Gi
 
     defaultPodOptions:
       securityContext:

--- a/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
@@ -56,9 +56,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 128Mi
-              limits:
                 memory: 256Mi
+              limits:
+                memory: 512Mi
 
     defaultPodOptions:
       securityContext:


### PR DESCRIPTION
## Summary

Follow-up to PR #2551 (entrypoint override). Now that all three containers run their intended modes, they all OOMKill at the original budgets:

- **api**: gunicorn's default `workers = 2 * CPU + 1` produced **49 workers** on a 24-core node, each holding ~80MB of Django app = ~4GB before any traffic. Setting `DJANGO_WORKERS=4` makes resource sizing predictable. Limit 1Gi → 2Gi for headroom.
- **worker**: celery loading the full Django app needs more than 2Gi for spiky scans. Limit 2Gi → 4Gi.
- **beat**: celery beat + Django needs more than 256Mi at boot. Limit 256Mi → 512Mi.

## Test plan
- [ ] flux-local test passes
- [ ] After merge, all three Prowler HRs Ready
- [ ] `kubectl top pod -n security` shows api ~600MB / worker ~700MB / beat ~250MB after stabilization
- [ ] No OOMKills