### PR TITLE
feat(litellm): deploy LiteLLM proxy in front of Ollama

### DIFF
--- a/docs/superpowers/plans/2026-05-15-litellm.md
+++ b/docs/superpowers/plans/2026-05-15-litellm.md
@@ -19,7 +19,7 @@
 - Every YAML file starts with `---` and a `yaml-language-server: $schema=...` comment matching the surrounding apps
 - YAML anchors `&app litellm`, `&namespace ai`, `*app` are used the way ollama does
 - Commits use the existing style (`feat(litellm): ...`, no Claude attribution)
-- Repo is **PUBLIC** — never put internal IPs, LAN hostnames, or `.lan` / `.internal` literals into git. `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}` are fine; Flux substitutes them at apply-time
+- Repository is **PUBLIC** — never put internal IPs, LAN hostnames, or `.lan` / `.internal` literals into Git. `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}` are fine; Flux substitutes them at apply-time
 - Linting: `just lint` runs the super-linter locally (same as CI). Configs in `.github/linters/`. Run before committing
 - Validation: `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` is the dry-run gate
 
@@ -29,7 +29,7 @@
 
 New files (all under `kubernetes/apps/ai/litellm/`):
 
-```
+```text
 ks.yaml                            # Flux Kustomization entrypoint
 app/
 ├── kustomization.yaml              # lists the resources below
@@ -74,7 +74,7 @@ Note the salt down — `LITELLM_SALT_KEY` cannot be rotated later without losing
 
 - [ ] **Step 2: Obtain the OpenRouter API key**
 
-Sign in at https://openrouter.ai/, create a new key, copy it (`sk-or-v1-...`). Set it locally:
+Sign in at <https://openrouter.ai/>, create a new key, copy it (`sk-or-v1-...`). Set it locally:
 
 ```bash
 OPENROUTER_API_KEY="sk-or-v1-..."   # paste the key
@@ -106,7 +106,7 @@ op item get litellm --vault Talos --format json | jq -r '.fields[].label' | sort
 
 Expected: prints `sk-...` and a sorted list containing exactly:
 
-```
+```text
 LITELLM_MASTER_KEY
 LITELLM_POSTGRES_PASS
 LITELLM_POSTGRES_USER
@@ -147,15 +147,15 @@ mkdir -p kubernetes/apps/ai/litellm/app
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: litellm
+    name: litellm
 spec:
-  interval: 1h
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 5.0.1
-  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+    interval: 1h
+    layerSelector:
+        mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+        operation: copy
+    ref:
+        tag: 5.0.1
+    url: oci://ghcr.io/bjw-s-labs/helm/app-template
 ```
 
 - [ ] **Step 3: Verify the YAML parses**
@@ -184,38 +184,38 @@ No commit yet — all manifests land in one commit at the end (Task 12).
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: litellm
+    name: litellm
 spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword-connect
-  target:
-    name: litellm-secret
-    template:
-      engineVersion: v2
-      data:
-        # Provider + auth
-        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
-        LITELLM_SALT_KEY: "{{ .LITELLM_SALT_KEY }}"
-        UI_USERNAME: "{{ .LITELLM_UI_USERNAME }}"
-        UI_PASSWORD: "{{ .LITELLM_UI_PASSWORD }}"
-        OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
+    secretStoreRef:
+        kind: ClusterSecretStore
+        name: onepassword-connect
+    target:
+        name: litellm-secret
+        template:
+            engineVersion: v2
+            data:
+                # Provider + auth
+                LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+                LITELLM_SALT_KEY: "{{ .LITELLM_SALT_KEY }}"
+                UI_USERNAME: "{{ .LITELLM_UI_USERNAME }}"
+                UI_PASSWORD: "{{ .LITELLM_UI_PASSWORD }}"
+                OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
 
-        # Database connection string consumed by LiteLLM at runtime
-        DATABASE_URL: "postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require"
+                # Database connection string consumed by LiteLLM at runtime
+                DATABASE_URL: "postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require"
 
-        # Inputs to the postgres-init initContainer (creates DB + role idempotently)
-        INIT_POSTGRES_DBNAME: litellm
-        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
-        INIT_POSTGRES_USER: "{{ .LITELLM_POSTGRES_USER }}"
-        INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASS }}"
-        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
-  dataFrom:
-    - extract:
-        key: litellm
-    - extract:
-        key: cloudnative-pg
+                # Inputs to the postgres-init initContainer (creates DB + role idempotently)
+                INIT_POSTGRES_DBNAME: litellm
+                INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+                INIT_POSTGRES_USER: "{{ .LITELLM_POSTGRES_USER }}"
+                INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASS }}"
+                INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+                INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+    dataFrom:
+        - extract:
+              key: litellm
+        - extract:
+              key: cloudnative-pg
 ```
 
 - [ ] **Step 2: Verify the YAML parses**
@@ -242,40 +242,40 @@ Expected: `OK`.
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: litellm-configmap
-  namespace: ai
+    name: litellm-configmap
+    namespace: ai
 data:
-  config.yaml: |
-    model_list:
-      - model_name: ollama/llama3
-        litellm_params:
-          model: ollama_chat/llama3
-          api_base: http://ollama.ai.svc.cluster.local:11434
+    config.yaml: |
+        model_list:
+          - model_name: ollama/llama3
+            litellm_params:
+              model: ollama_chat/llama3
+              api_base: http://ollama.ai.svc.cluster.local:11434
 
-      - model_name: openrouter/auto
-        litellm_params:
-          model: openrouter/openrouter/auto
-          api_key: os.environ/OPENROUTER_API_KEY
+          - model_name: openrouter/auto
+            litellm_params:
+              model: openrouter/openrouter/auto
+              api_key: os.environ/OPENROUTER_API_KEY
 
-    router_settings:
-      redis_host: os.environ/REDIS_HOST
-      redis_port: os.environ/REDIS_PORT
+        router_settings:
+          redis_host: os.environ/REDIS_HOST
+          redis_port: os.environ/REDIS_PORT
 
-    litellm_settings:
-      success_callback: ["prometheus"]
-      failure_callback: ["prometheus"]
-      cache: true
-      cache_params:
-        type: redis
-        host: os.environ/REDIS_HOST
-        port: os.environ/REDIS_PORT
-        ttl: 30
-      drop_params: true
-      num_retries: 2
-      request_timeout: 600
+        litellm_settings:
+          success_callback: ["prometheus"]
+          failure_callback: ["prometheus"]
+          cache: true
+          cache_params:
+            type: redis
+            host: os.environ/REDIS_HOST
+            port: os.environ/REDIS_PORT
+            ttl: 30
+          drop_params: true
+          num_retries: 2
+          request_timeout: 600
 
-    general_settings:
-      health_check_endpoint: /v1/health
+        general_settings:
+          health_check_endpoint: /v1/health
 ```
 
 Notes for the engineer:
@@ -308,102 +308,102 @@ Expected: both `outer OK` and `inner OK`.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app litellm
+    name: &app litellm
 spec:
-  interval: 1h
-  chartRef:
-    kind: OCIRepository
-    name: *app
-  install:
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-      strategy: rollback
-  values:
-    controllers:
-      litellm:
-        annotations:
-          reloader.stakater.com/auto: "true"
-        replicas: 1
-        strategy: Recreate
+    interval: 1h
+    chartRef:
+        kind: OCIRepository
+        name: *app
+    install:
+        remediation:
+            retries: 3
+    upgrade:
+        cleanupOnFail: true
+        remediation:
+            retries: 3
+            strategy: rollback
+    values:
+        controllers:
+            litellm:
+                annotations:
+                    reloader.stakater.com/auto: "true"
+                replicas: 1
+                strategy: Recreate
 
-        initContainers:
-          init-db:
-            image:
-              repository: ghcr.io/home-operations/postgres-init
-              tag: "18"
-            envFrom:
-              - secretRef:
-                  name: litellm-secret
+                initContainers:
+                    init-db:
+                        image:
+                            repository: ghcr.io/home-operations/postgres-init
+                            tag: "18"
+                        envFrom:
+                            - secretRef:
+                                  name: litellm-secret
 
-        containers:
-          app:
-            image:
-              repository: ghcr.io/berriai/litellm
-              tag: main-stable
-            args:
-              - --config=/app/config.yaml
-              - --port=4000
-            env:
-              LITELLM_LOG: INFO
-              LITELLM_MODE: PRODUCTION
-              STORE_MODEL_IN_DB: "True"
-              REDIS_HOST: dragonfly.database.svc.cluster.local
-              REDIS_PORT: "6379"
-            envFrom:
-              - secretRef:
-                  name: litellm-secret
-            probes:
-              liveness: &probe
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /health/liveliness
-                    port: 4000
-                  initialDelaySeconds: 30
-                  periodSeconds: 10
-                  failureThreshold: 6
-              readiness: *probe
-            resources:
-              requests:
-                cpu: 100m
-                memory: 512Mi
-              limits:
-                memory: 2Gi
+                containers:
+                    app:
+                        image:
+                            repository: ghcr.io/berriai/litellm
+                            tag: main-stable
+                        args:
+                            - --config=/app/config.yaml
+                            - --port=4000
+                        env:
+                            LITELLM_LOG: INFO
+                            LITELLM_MODE: PRODUCTION
+                            STORE_MODEL_IN_DB: "True"
+                            REDIS_HOST: dragonfly.database.svc.cluster.local
+                            REDIS_PORT: "6379"
+                        envFrom:
+                            - secretRef:
+                                  name: litellm-secret
+                        probes:
+                            liveness: &probe
+                                enabled: true
+                                custom: true
+                                spec:
+                                    httpGet:
+                                        path: /health/liveliness
+                                        port: 4000
+                                    initialDelaySeconds: 30
+                                    periodSeconds: 10
+                                    failureThreshold: 6
+                            readiness: *probe
+                        resources:
+                            requests:
+                                cpu: 100m
+                                memory: 512Mi
+                            limits:
+                                memory: 2Gi
 
-    service:
-      app:
-        controller: *app
-        ports:
-          http:
-            port: 4000
+        service:
+            app:
+                controller: *app
+                ports:
+                    http:
+                        port: 4000
 
-    route:
-      app:
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
+        route:
+            app:
+                hostnames:
+                    - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+                parentRefs:
+                    - name: envoy-internal
+                      namespace: network
 
-    persistence:
-      config:
-        type: configMap
-        name: litellm-configmap
-        globalMounts:
-          - path: /app/config.yaml
-            subPath: config.yaml
-            readOnly: true
+        persistence:
+            config:
+                type: configMap
+                name: litellm-configmap
+                globalMounts:
+                    - path: /app/config.yaml
+                      subPath: config.yaml
+                      readOnly: true
 ```
 
 Notes:
 
 - Image tags are `main-stable` for LiteLLM and `18` for postgres-init. **Renovate will append `@sha256:...` digest pinning on first PR scan.** Don't hand-pin a digest now; Renovate's PR will do it and tests will catch a mismatch.
-- The probe path is `/health/liveliness` (LiteLLM upstream spelling, *not* a typo). `/v1/health` requires auth and runs full backend probes — too heavy for kubelet.
+- The probe path is `/health/liveliness` (LiteLLM upstream spelling, _not_ a typo). `/v1/health` requires auth and runs full backend probes — too heavy for kubelet.
 - `STORE_MODEL_IN_DB: "True"` lets you add more models from the UI later without code changes; the two seed models from the ConfigMap remain authoritative.
 - The route uses only `${SECRET_INTERNAL_DOMAIN}`. Per `feedback_hostname_intent.md`, do not add `${SECRET_DOMAIN}` here — this app is intended internal-only for now.
 
@@ -431,21 +431,21 @@ Expected: `OK`.
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: &app litellm
-  labels:
-    app.kubernetes.io/name: *app
+    name: &app litellm
+    labels:
+        app.kubernetes.io/name: *app
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: *app
-  namespaceSelector:
-    matchNames:
-      - ai
-  endpoints:
-    - port: http
-      path: /metrics
-      interval: 30s
-      scrapeTimeout: 10s
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: *app
+    namespaceSelector:
+        matchNames:
+            - ai
+    endpoints:
+        - port: http
+          path: /metrics
+          interval: 30s
+          scrapeTimeout: 10s
 ```
 
 The `app.kubernetes.io/name: litellm` selector matches the label that `commonMetadata.labels` in `ks.yaml` (Task 9) will stamp on every workload of this Kustomization, including the Service the HelmRelease produces.
@@ -484,16 +484,16 @@ Expected: a number ≥ 2. If higher than 2, substitute it into the URL below bef
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
-  name: litellm
+    name: litellm
 spec:
-  allowCrossNamespaceImport: true
-  instanceSelector:
-    matchLabels:
-      grafana.internal/instance: grafana
-  datasources:
-    - datasourceName: prometheus
-      inputName: DS_PROMETHEUS
-  url: https://grafana.com/api/dashboards/24965/revisions/2/download
+    allowCrossNamespaceImport: true
+    instanceSelector:
+        matchLabels:
+            grafana.internal/instance: grafana
+    datasources:
+        - datasourceName: prometheus
+          inputName: DS_PROMETHEUS
+    url: https://grafana.com/api/dashboards/24965/revisions/2/download
 ```
 
 - [ ] **Step 3: Verify the YAML parses**
@@ -520,12 +520,12 @@ Expected: `OK`.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./configmap.yaml
-  - ./externalsecret.yaml
-  - ./grafanadashboard.yaml
-  - ./helmrelease.yaml
-  - ./ocirepository.yaml
-  - ./servicemonitor.yaml
+    - ./configmap.yaml
+    - ./externalsecret.yaml
+    - ./grafanadashboard.yaml
+    - ./helmrelease.yaml
+    - ./ocirepository.yaml
+    - ./servicemonitor.yaml
 ```
 
 Resources are listed alphabetically — Renovate/super-linter prefer that.
@@ -544,7 +544,7 @@ grep -E '^kind:' /tmp/litellm-rendered.yaml | sort -u
 
 Expected:
 
-```
+```text
 kind: ConfigMap
 kind: ExternalSecret
 kind: GrafanaDashboard
@@ -569,41 +569,41 @@ kind: ServiceMonitor
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app litellm
-  namespace: &namespace ai
+    name: &app litellm
+    namespace: &namespace ai
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  components:
-    - ../../../../components/gatus/guarded
-  dependsOn:
-    - name: cloudnative-pg-cluster
-      namespace: database
-    - name: dragonfly-cluster
-      namespace: flux-system
-    - name: onepassword-connect
-      namespace: external-secrets
-  interval: 1h
-  path: ./kubernetes/apps/ai/litellm/app
-  postBuild:
-    substitute:
-      APP: *app
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: *namespace
-  timeout: 5m
-  wait: false
+    commonMetadata:
+        labels:
+            app.kubernetes.io/name: *app
+    components:
+        - ../../../../components/gatus/guarded
+    dependsOn:
+        - name: cloudnative-pg-cluster
+          namespace: database
+        - name: dragonfly-cluster
+          namespace: flux-system
+        - name: onepassword-connect
+          namespace: external-secrets
+    interval: 1h
+    path: ./kubernetes/apps/ai/litellm/app
+    postBuild:
+        substitute:
+            APP: *app
+    prune: true
+    retryInterval: 2m
+    sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+    targetNamespace: *namespace
+    timeout: 5m
+    wait: false
 ```
 
 Notes:
 
 - `dependsOn[].namespace` defaults to the Kustomization's own namespace (`ai` here), so every entry must be specified explicitly — `cloudnative-pg-cluster` lives in `database`, `dragonfly-cluster` lives in `flux-system`, `onepassword-connect` lives in `external-secrets`.
-- **No** `components/volsync` — there is no PVC for this app (state in Postgres, config in git).
+- **No** `components/volsync` — there is no PVC for this app (state in Postgres, config in Git).
 - `APP: *app` is consumed by the `gatus/guarded` component to generate the health-check endpoint.
 
 - [ ] **Step 2: Verify the YAML parses**
@@ -637,15 +637,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai
 components:
-  - ../../components/global-vars
-  - ../../components/alerts
+    - ../../components/global-vars
+    - ../../components/alerts
 resources:
-  - ./namespace.yaml
-  - ./netpol.yaml
-  - ./ollama/ks.yaml
-  - ./open-webui/ks.yaml
-  - ./openaiwhisper/ks.yaml
-  - ./whisper/ks.yaml
+    - ./namespace.yaml
+    - ./netpol.yaml
+    - ./ollama/ks.yaml
+    - ./open-webui/ks.yaml
+    - ./openaiwhisper/ks.yaml
+    - ./whisper/ks.yaml
 ```
 
 - [ ] **Step 2: Add `./litellm/ks.yaml` to the `resources` list, alphabetically before `./ollama/ks.yaml`**
@@ -659,16 +659,16 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: ai
 components:
-  - ../../components/global-vars
-  - ../../components/alerts
+    - ../../components/global-vars
+    - ../../components/alerts
 resources:
-  - ./namespace.yaml
-  - ./netpol.yaml
-  - ./litellm/ks.yaml
-  - ./ollama/ks.yaml
-  - ./open-webui/ks.yaml
-  - ./openaiwhisper/ks.yaml
-  - ./whisper/ks.yaml
+    - ./namespace.yaml
+    - ./netpol.yaml
+    - ./litellm/ks.yaml
+    - ./ollama/ks.yaml
+    - ./open-webui/ks.yaml
+    - ./openaiwhisper/ks.yaml
+    - ./whisper/ks.yaml
 ```
 
 - [ ] **Step 3: Verify ai namespace kustomize builds**
@@ -881,7 +881,7 @@ Expected: both calls return a string containing `OK`.
 
 - [ ] **Step 6: Verify metrics + dashboard**
 
-Browse to Grafana → Dashboards → "LiteLLM". Panels for request rate, p50/p95 latency, and tokens/sec should be populated within ~1 minute of the curl tests above.
+Browse to Grafana → Dashboards → "LiteLLM". Panels for request rate, p50/p95 latency, and tokens/sec should be populated within ~1 minute of the cURL tests above.
 
 Optional CLI sanity check:
 

--- a/docs/superpowers/plans/2026-05-15-litellm.md
+++ b/docs/superpowers/plans/2026-05-15-litellm.md
@@ -1,0 +1,910 @@
+# LiteLLM Proxy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy LiteLLM proxy at `kubernetes/apps/ai/litellm/` in front of the existing Ollama instance, with OpenRouter as a second backend. State in shared `postgres18` CNPG; cache in shared dragonfly. Internal-only HTTPRoute. Prometheus + Grafana wired.
+
+**Architecture:** Single bjw-s app-template HelmRelease (1 replica, `Recreate`), `postgres-init` initContainer creates the `litellm` DB + role on the shared `postgres18` CNPG cluster, ConfigMap-driven `config.yaml` seeds Ollama + OpenRouter models, ExternalSecret pulls a new `litellm` 1Password item from the `Talos` vault. ServiceMonitor scrapes `/metrics`; GrafanaDashboard CR imports upstream Berri dashboard.
+
+**Tech Stack:** Flux v2, bjw-s app-template 5.0.1, External Secrets Operator + 1Password Connect, CloudNativePG (existing `postgres18`), Dragonfly (existing), Envoy Gateway (Gateway API), Prometheus + Grafana operator, LiteLLM `main-stable`.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-litellm-design.md`
+
+---
+
+## Conventions reminder
+
+- Branch: work happens on `feat/litellm` (already created, contains only the spec commit on top of `main`)
+- All `kubectl` and `flux` commands must be prefixed with `KUBECONFIG=/Users/luke.evans/GIT/LukeEvansTech/talos-cluster/kubeconfig` (or simply run after `mise install` exports it via `.mise.toml`)
+- Every YAML file starts with `---` and a `yaml-language-server: $schema=...` comment matching the surrounding apps
+- YAML anchors `&app litellm`, `&namespace ai`, `*app` are used the way ollama does
+- Commits use the existing style (`feat(litellm): ...`, no Claude attribution)
+- Repo is **PUBLIC** — never put internal IPs, LAN hostnames, or `.lan` / `.internal` literals into git. `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}` are fine; Flux substitutes them at apply-time
+- Linting: `just lint` runs the super-linter locally (same as CI). Configs in `.github/linters/`. Run before committing
+- Validation: `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose` is the dry-run gate
+
+---
+
+## File structure
+
+New files (all under `kubernetes/apps/ai/litellm/`):
+
+```
+ks.yaml                            # Flux Kustomization entrypoint
+app/
+├── kustomization.yaml              # lists the resources below
+├── ocirepository.yaml              # bjw-s app-template 5.0.1
+├── externalsecret.yaml             # 1Password "litellm" + "cloudnative-pg" → litellm-secret
+├── configmap.yaml                  # litellm-configmap holding config.yaml
+├── helmrelease.yaml                # main HR (postgres-init initContainer + app container)
+├── servicemonitor.yaml             # Prometheus /metrics scrape
+└── grafanadashboard.yaml           # GrafanaDashboard CR pointing at grafana.com dashboard 24965
+```
+
+Modified files:
+
+- `kubernetes/apps/ai/kustomization.yaml` — add `./litellm/ks.yaml` (alphabetical placement before `./ollama/ks.yaml`)
+
+Out-of-repo:
+
+- 1Password vault `Talos`, new item `litellm` (Task 1)
+
+---
+
+## Task 1: Create the 1Password item for LiteLLM
+
+**Why first:** without this, the ExternalSecret will fail to resolve and Flux will stall on the HelmRelease forever. Create it before any manifest hits the cluster.
+
+**Files:** none (out-of-band, runs locally via `op` CLI)
+
+- [ ] **Step 1: Generate the four random secrets locally**
+
+```bash
+LITELLM_MASTER_KEY="sk-$(openssl rand -hex 32)"
+LITELLM_SALT_KEY="$(openssl rand -hex 32)"
+LITELLM_UI_PASSWORD="$(openssl rand -base64 24 | tr -d '/+=' | head -c 24)"
+LITELLM_POSTGRES_PASS="$(openssl rand -base64 24 | tr -d '/+=' | head -c 24)"
+echo "MASTER:   $LITELLM_MASTER_KEY"
+echo "SALT:     $LITELLM_SALT_KEY"
+echo "UIPASS:   $LITELLM_UI_PASSWORD"
+echo "PGPASS:   $LITELLM_POSTGRES_PASS"
+```
+
+Note the salt down — `LITELLM_SALT_KEY` cannot be rotated later without losing decryption of any provider keys added via the UI. Stash it in 1Password and the item notes.
+
+- [ ] **Step 2: Obtain the OpenRouter API key**
+
+Sign in at https://openrouter.ai/, create a new key, copy it (`sk-or-v1-...`). Set it locally:
+
+```bash
+OPENROUTER_API_KEY="sk-or-v1-..."   # paste the key
+```
+
+- [ ] **Step 3: Create the 1Password item**
+
+```bash
+op item create \
+  --category="API Credential" \
+  --vault=Talos \
+  --title=litellm \
+  LITELLM_MASTER_KEY="$LITELLM_MASTER_KEY" \
+  LITELLM_SALT_KEY="$LITELLM_SALT_KEY" \
+  LITELLM_UI_USERNAME=admin \
+  LITELLM_UI_PASSWORD="$LITELLM_UI_PASSWORD" \
+  LITELLM_POSTGRES_USER=litellm \
+  LITELLM_POSTGRES_PASS="$LITELLM_POSTGRES_PASS" \
+  OPENROUTER_API_KEY="$OPENROUTER_API_KEY" \
+  notesPlain="LITELLM_SALT_KEY must never be rotated — UI-added provider keys become undecipherable if it changes. The Postgres role 'litellm' is created automatically by the postgres-init initContainer on first pod start."
+```
+
+- [ ] **Step 4: Verify the item is readable**
+
+```bash
+op item get litellm --vault Talos --fields label=LITELLM_MASTER_KEY --reveal | head -c 10 && echo "..."
+op item get litellm --vault Talos --format json | jq -r '.fields[].label' | sort
+```
+
+Expected: prints `sk-...` and a sorted list containing exactly:
+
+```
+LITELLM_MASTER_KEY
+LITELLM_POSTGRES_PASS
+LITELLM_POSTGRES_USER
+LITELLM_SALT_KEY
+LITELLM_UI_PASSWORD
+LITELLM_UI_USERNAME
+OPENROUTER_API_KEY
+notesPlain
+```
+
+- [ ] **Step 5: Clear the local shell variables**
+
+```bash
+unset LITELLM_MASTER_KEY LITELLM_SALT_KEY LITELLM_UI_PASSWORD LITELLM_POSTGRES_PASS OPENROUTER_API_KEY
+```
+
+No commit — this task touches no files.
+
+---
+
+## Task 2: Create the OCIRepository for the app-template chart
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/ocirepository.yaml`
+
+- [ ] **Step 1: Create the directory tree**
+
+```bash
+mkdir -p kubernetes/apps/ai/litellm/app
+```
+
+- [ ] **Step 2: Write `kubernetes/apps/ai/litellm/app/ocirepository.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+```
+
+- [ ] **Step 3: Verify the YAML parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/app/ocirepository.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+No commit yet — all manifests land in one commit at the end (Task 12).
+
+---
+
+## Task 3: Create the ExternalSecret
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/externalsecret.yaml`
+
+- [ ] **Step 1: Write `kubernetes/apps/ai/litellm/app/externalsecret.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: litellm-secret
+    template:
+      engineVersion: v2
+      data:
+        # Provider + auth
+        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        LITELLM_SALT_KEY: "{{ .LITELLM_SALT_KEY }}"
+        UI_USERNAME: "{{ .LITELLM_UI_USERNAME }}"
+        UI_PASSWORD: "{{ .LITELLM_UI_PASSWORD }}"
+        OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
+
+        # Database connection string consumed by LiteLLM at runtime
+        DATABASE_URL: "postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require"
+
+        # Inputs to the postgres-init initContainer (creates DB + role idempotently)
+        INIT_POSTGRES_DBNAME: litellm
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .LITELLM_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: cloudnative-pg
+```
+
+- [ ] **Step 2: Verify the YAML parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/app/externalsecret.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 4: Create the LiteLLM configmap (the config.yaml)
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/configmap.yaml`
+
+- [ ] **Step 1: Write `kubernetes/apps/ai/litellm/app/configmap.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/configmap.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-configmap
+  namespace: ai
+data:
+  config.yaml: |
+    model_list:
+      - model_name: ollama/llama3
+        litellm_params:
+          model: ollama_chat/llama3
+          api_base: http://ollama.ai.svc.cluster.local:11434
+
+      - model_name: openrouter/auto
+        litellm_params:
+          model: openrouter/openrouter/auto
+          api_key: os.environ/OPENROUTER_API_KEY
+
+    router_settings:
+      redis_host: os.environ/REDIS_HOST
+      redis_port: os.environ/REDIS_PORT
+
+    litellm_settings:
+      success_callback: ["prometheus"]
+      failure_callback: ["prometheus"]
+      cache: true
+      cache_params:
+        type: redis
+        host: os.environ/REDIS_HOST
+        port: os.environ/REDIS_PORT
+        ttl: 30
+      drop_params: true
+      num_retries: 2
+      request_timeout: 600
+
+    general_settings:
+      health_check_endpoint: /v1/health
+```
+
+Notes for the engineer:
+
+- `metadata.namespace: ai` is mandatory — Checkov (CKV_K8S_21) fails any ConfigMap without an explicit namespace
+- The `config.yaml` block is a YAML scalar literal (`|`) embedding YAML — `yamlfmt`/`prettier` should leave the inner content alone because it's a string. If lint complains, double-check the indent is exactly 4 spaces relative to `config.yaml:`
+
+- [ ] **Step 2: Verify the YAML parses AND that the embedded `config.yaml` parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/app/configmap.yaml > /dev/null && echo "outer OK"
+yq '.data."config.yaml"' kubernetes/apps/ai/litellm/app/configmap.yaml | yq '.' > /dev/null && echo "inner OK"
+```
+
+Expected: both `outer OK` and `inner OK`.
+
+---
+
+## Task 5: Create the HelmRelease
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/helmrelease.yaml`
+
+- [ ] **Step 1: Write `kubernetes/apps/ai/litellm/app/helmrelease.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app litellm
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      litellm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18"
+            envFrom:
+              - secretRef:
+                  name: litellm-secret
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: main-stable
+            args:
+              - --config=/app/config.yaml
+              - --port=4000
+            env:
+              LITELLM_LOG: INFO
+              LITELLM_MODE: PRODUCTION
+              STORE_MODEL_IN_DB: "True"
+              REDIS_HOST: dragonfly.database.svc.cluster.local
+              REDIS_PORT: "6379"
+            envFrom:
+              - secretRef:
+                  name: litellm-secret
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/liveliness
+                    port: 4000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 6
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 4000
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      config:
+        type: configMap
+        name: litellm-configmap
+        globalMounts:
+          - path: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true
+```
+
+Notes:
+
+- Image tags are `main-stable` for LiteLLM and `18` for postgres-init. **Renovate will append `@sha256:...` digest pinning on first PR scan.** Don't hand-pin a digest now; Renovate's PR will do it and tests will catch a mismatch.
+- The probe path is `/health/liveliness` (LiteLLM upstream spelling, *not* a typo). `/v1/health` requires auth and runs full backend probes — too heavy for kubelet.
+- `STORE_MODEL_IN_DB: "True"` lets you add more models from the UI later without code changes; the two seed models from the ConfigMap remain authoritative.
+- The route uses only `${SECRET_INTERNAL_DOMAIN}`. Per `feedback_hostname_intent.md`, do not add `${SECRET_DOMAIN}` here — this app is intended internal-only for now.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/app/helmrelease.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 6: Create the ServiceMonitor
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/servicemonitor.yaml`
+
+- [ ] **Step 1: Write `kubernetes/apps/ai/litellm/app/servicemonitor.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app litellm
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *app
+  namespaceSelector:
+    matchNames:
+      - ai
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+```
+
+The `app.kubernetes.io/name: litellm` selector matches the label that `commonMetadata.labels` in `ks.yaml` (Task 9) will stamp on every workload of this Kustomization, including the Service the HelmRelease produces.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/app/servicemonitor.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 7: Create the GrafanaDashboard
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/grafanadashboard.yaml`
+
+LiteLLM's official dashboard is published at grafana.com as ID **24965** (revision 2 as of 2026-05-15). Use the `url:` pattern like `cloudflare-tunnel` does — no JSON to vendor.
+
+- [ ] **Step 1: Confirm the current latest revision**
+
+```bash
+curl -s https://grafana.com/api/dashboards/24965 | jq -r '.revision'
+```
+
+Expected: a number ≥ 2. If higher than 2, substitute it into the URL below before writing the file.
+
+- [ ] **Step 2: Write `kubernetes/apps/ai/litellm/app/grafanadashboard.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: litellm
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/24965/revisions/2/download
+```
+
+- [ ] **Step 3: Verify the YAML parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/app/grafanadashboard.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 8: Wire all resources into `app/kustomization.yaml`
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/app/kustomization.yaml`
+
+- [ ] **Step 1: Write `kubernetes/apps/ai/litellm/app/kustomization.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./servicemonitor.yaml
+```
+
+Resources are listed alphabetically — Renovate/super-linter prefer that.
+
+- [ ] **Step 2: Verify with kustomize build (no cluster needed)**
+
+```bash
+kubectl kustomize kubernetes/apps/ai/litellm/app/ > /tmp/litellm-rendered.yaml && wc -l /tmp/litellm-rendered.yaml
+```
+
+Expected: a positive line count and no error. Skim `/tmp/litellm-rendered.yaml` to confirm all six kinds are present:
+
+```bash
+grep -E '^kind:' /tmp/litellm-rendered.yaml | sort -u
+```
+
+Expected:
+
+```
+kind: ConfigMap
+kind: ExternalSecret
+kind: GrafanaDashboard
+kind: HelmRelease
+kind: OCIRepository
+kind: ServiceMonitor
+```
+
+---
+
+## Task 9: Create the Flux Kustomization (`ks.yaml`)
+
+**Files:**
+
+- Create: `kubernetes/apps/ai/litellm/ks.yaml`
+
+- [ ] **Step 1: Write `kubernetes/apps/ai/litellm/ks.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: dragonfly-cluster
+      namespace: flux-system
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/ai/litellm/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+```
+
+Notes:
+
+- `dependsOn[].namespace` defaults to the Kustomization's own namespace (`ai` here), so every entry must be specified explicitly — `cloudnative-pg-cluster` lives in `database`, `dragonfly-cluster` lives in `flux-system`, `onepassword-connect` lives in `external-secrets`.
+- **No** `components/volsync` — there is no PVC for this app (state in Postgres, config in git).
+- `APP: *app` is consumed by the `gatus/guarded` component to generate the health-check endpoint.
+
+- [ ] **Step 2: Verify the YAML parses**
+
+```bash
+yq '.' kubernetes/apps/ai/litellm/ks.yaml > /dev/null && echo OK
+```
+
+Expected: `OK`.
+
+---
+
+## Task 10: Register the new app in `kubernetes/apps/ai/kustomization.yaml`
+
+**Files:**
+
+- Modify: `kubernetes/apps/ai/kustomization.yaml`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat kubernetes/apps/ai/kustomization.yaml
+```
+
+Expected current content:
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+components:
+  - ../../components/global-vars
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./netpol.yaml
+  - ./ollama/ks.yaml
+  - ./open-webui/ks.yaml
+  - ./openaiwhisper/ks.yaml
+  - ./whisper/ks.yaml
+```
+
+- [ ] **Step 2: Add `./litellm/ks.yaml` to the `resources` list, alphabetically before `./ollama/ks.yaml`**
+
+Resulting file:
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ai
+components:
+  - ../../components/global-vars
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./netpol.yaml
+  - ./litellm/ks.yaml
+  - ./ollama/ks.yaml
+  - ./open-webui/ks.yaml
+  - ./openaiwhisper/ks.yaml
+  - ./whisper/ks.yaml
+```
+
+- [ ] **Step 3: Verify ai namespace kustomize builds**
+
+```bash
+kubectl kustomize kubernetes/apps/ai/ > /tmp/ai-rendered.yaml && grep -c 'kind: Kustomization' /tmp/ai-rendered.yaml
+```
+
+Expected: a number > 0 (the namespace bundle aggregates child Kustomization CRs).
+
+---
+
+## Task 11: Lint everything locally
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Run super-linter via just**
+
+```bash
+just lint
+```
+
+Expected: exits 0. Per `project_super_linter_local.md`, super-linter v8 uses HEAD commit data, so make sure files are at least `git add`ed (no need to commit) before running if you hit "no files for inspection".
+
+If yamlfmt/prettier complain about indentation in the embedded `config.yaml` literal block, run `yamlfmt` directly on the configmap.yaml first to see what it wants, then update. Don't reorder the inner YAML keys — that's a linter mistake, not your problem.
+
+- [ ] **Step 2: Stage all new files so super-linter sees them**
+
+```bash
+git add kubernetes/apps/ai/litellm/ kubernetes/apps/ai/kustomization.yaml
+just lint
+```
+
+Expected: still exits 0.
+
+---
+
+## Task 12: Run `flux-local test` (full validation gate)
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Ensure the app-template OCIRepository chart is fetchable**
+
+```bash
+docker run --rm -v "$PWD":/repo --workdir /repo ghcr.io/allenporter/flux-local:latest \
+  test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose 2>&1 | tail -60
+```
+
+Alternatively if `mise` is configured for flux-local:
+
+```bash
+flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose 2>&1 | tail -60
+```
+
+Expected: ends with `PASSED`. Look for the line `kustomization 'litellm' (ai)` in the output — it must appear under tests-run.
+
+- [ ] **Step 2: Inspect the diff (sanity check)**
+
+```bash
+flux-local diff --all-namespaces --enable-helm --path kubernetes/flux/cluster 2>&1 | grep -A 200 'ai/litellm' | head -100
+```
+
+Expected: the diff shows the six new resources being created (HelmRelease, OCIRepository, ExternalSecret, ConfigMap, ServiceMonitor, GrafanaDashboard) plus the rendered chart Deployment + Service + HTTPRoute.
+
+If any resource fails to render, fix it now — `flux-local` failures here will fail in CI.
+
+---
+
+## Task 13: Commit, push, and open the PR
+
+**Files:** all staged from prior tasks
+
+- [ ] **Step 1: Stage and review**
+
+```bash
+git status --short
+git diff --cached --stat
+```
+
+Expected: 8 new files under `kubernetes/apps/ai/litellm/` and 1 modified `kubernetes/apps/ai/kustomization.yaml`. No other changes.
+
+If unrelated files appear (e.g. the in-flight certwarden edits), DO NOT include them in this commit — `git restore --staged` them, leave their working-tree changes alone:
+
+```bash
+git restore --staged kubernetes/apps/infrastructure/certwarden/cert-deployment/kustomization.yaml || true
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(litellm): deploy LiteLLM proxy in front of Ollama
+
+Adds a new bjw-s app-template HelmRelease at kubernetes/apps/ai/litellm/.
+Single replica + Recreate strategy, postgres-init initContainer bootstraps
+the litellm database on the shared postgres18 CNPG cluster, Dragonfly
+provides the response cache. Two seed models in the ConfigMap (Ollama +
+OpenRouter); STORE_MODEL_IN_DB=True lets more be added through the UI.
+Internal-only HTTPRoute on envoy-internal. Prometheus ServiceMonitor +
+GrafanaDashboard CR pulling the upstream Berri dashboard (id 24965).
+
+Spec: docs/superpowers/specs/2026-05-15-litellm-design.md
+EOF
+)"
+```
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+git push -u origin feat/litellm
+gh pr create --title "feat(litellm): deploy LiteLLM proxy in front of Ollama" --body "$(cat <<'EOF'
+## Summary
+
+- New `litellm` app in the `ai` namespace, sitting alongside `ollama` and `open-webui`
+- Backed by a new database on the shared `postgres18` CNPG cluster (created on first start via `postgres-init`)
+- Uses the shared dragonfly for response caching
+- Internal-only HTTPRoute on `envoy-internal`; Admin UI auth via built-in `UI_USERNAME`/`UI_PASSWORD`
+- Prometheus ServiceMonitor + GrafanaDashboard CR (Berri dashboard id 24965)
+
+Open-WebUI and n8n are **not** migrated in this PR — they continue to talk directly to Ollama / their own providers. Existing consumers are untouched.
+
+## Test plan
+
+- [ ] `flux-local test` passes in CI
+- [ ] After merge: HelmRelease becomes Ready
+- [ ] `kubectl -n ai logs deploy/litellm -c init-db` shows the role + DB being created idempotently
+- [ ] `kubectl -n ai logs deploy/litellm -c app` shows Prisma migrations applied and server listening on `:4000`
+- [ ] Browse to `https://litellm.${SECRET_INTERNAL_DOMAIN}/ui`, log in with the credentials from the 1Password `litellm` item
+- [ ] `curl` test against `/v1/chat/completions` for both `ollama/llama3` and `openrouter/auto` round-trips successfully (with `Authorization: Bearer $LITELLM_MASTER_KEY`)
+- [ ] Grafana dashboard "LiteLLM" populated with request rate/latency panels
+- [ ] Gatus shows `litellm` green
+
+Design spec: [docs/superpowers/specs/2026-05-15-litellm-design.md](../blob/feat/litellm/docs/superpowers/specs/2026-05-15-litellm-design.md)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for CI**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: both `flux-local` and `security-scans` PASS. Fix any failures inline (commit additional changes to the same branch).
+
+---
+
+## Task 14: Post-merge verification
+
+After the PR merges, Flux reconciles automatically. Walk through the verification plan from the spec.
+
+- [ ] **Step 1: Force the reconcile chain**
+
+```bash
+flux reconcile source git flux-system
+flux reconcile kustomization external-secrets -n external-secrets
+flux reconcile kustomization onepassword -n external-secrets
+flux reconcile kustomization litellm -n ai
+flux reconcile helmrelease litellm -n ai
+```
+
+- [ ] **Step 2: Check HelmRelease state**
+
+```bash
+kubectl -n ai get hr litellm
+```
+
+Expected: `READY=True`, `STATUS` says install succeeded.
+
+- [ ] **Step 3: Check the init container ran**
+
+```bash
+kubectl -n ai logs deploy/litellm -c init-db
+```
+
+Expected: logs show creating role `litellm` and database `litellm`, exits 0. (On subsequent restarts: "already exists", which is fine — postgres-init is idempotent.)
+
+- [ ] **Step 4: Check the app container is healthy**
+
+```bash
+kubectl -n ai logs deploy/litellm -c app | tail -40
+kubectl -n ai get pods -l app.kubernetes.io/name=litellm
+```
+
+Expected: Prisma migrations apply, server listens on `0.0.0.0:4000`, pod `Running` and `READY 1/1`.
+
+- [ ] **Step 5: Verify the API actually works**
+
+Grab the master key from 1Password (so it never enters shell history):
+
+```bash
+MASTER_KEY=$(op item get litellm --vault Talos --fields label=LITELLM_MASTER_KEY --reveal)
+
+# Ollama backend
+curl -sS -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"ollama/llama3","messages":[{"role":"user","content":"reply with the single word OK"}]}' \
+  https://litellm.${SECRET_INTERNAL_DOMAIN}/v1/chat/completions | jq '.choices[0].message.content'
+
+# OpenRouter backend
+curl -sS -H "Authorization: Bearer $MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"openrouter/auto","messages":[{"role":"user","content":"reply with the single word OK"}]}' \
+  https://litellm.${SECRET_INTERNAL_DOMAIN}/v1/chat/completions | jq '.choices[0].message.content'
+
+unset MASTER_KEY
+```
+
+Expected: both calls return a string containing `OK`.
+
+- [ ] **Step 6: Verify metrics + dashboard**
+
+Browse to Grafana → Dashboards → "LiteLLM". Panels for request rate, p50/p95 latency, and tokens/sec should be populated within ~1 minute of the curl tests above.
+
+Optional CLI sanity check:
+
+```bash
+kubectl -n observability exec -it deploy/kube-prometheus-stack-prometheus -c prometheus -- \
+  wget -qO- 'http://localhost:9090/api/v1/query?query=litellm_request_total' | jq '.data.result | length'
+```
+
+Expected: a number ≥ 1.
+
+- [ ] **Step 7: Verify Gatus**
+
+Browse to the Gatus internal endpoint → `litellm` group → green.
+
+---
+
+## Out of scope (deferred follow-ups)
+
+These were ruled out in the spec and stay out of this plan. Track them as separate work if/when needed:
+
+- Langfuse / Phoenix / Helicone for request tracing
+- OIDC SSO in front of the Admin UI
+- Public exposure via `envoy-external` / Cloudflare tunnel
+- Migrating Open-WebUI / n8n onto LiteLLM
+- Multi-replica + separate migration Job (only relevant if we scale)
+- Per-consumer virtual keys with budgets (runtime configuration in the UI, not a manifest change)

--- a/docs/superpowers/specs/2026-05-15-litellm-design.md
+++ b/docs/superpowers/specs/2026-05-15-litellm-design.md
@@ -1,0 +1,315 @@
+# LiteLLM Proxy Design
+
+## Overview
+
+Deploy [LiteLLM](https://github.com/BerriAI/litellm) proxy in front of the existing Ollama instance, alongside an OpenRouter passthrough. Run the **full proxy** with a Postgres backend so we exercise virtual keys, per-key budgets, request logging, and the Admin UI — the features that make LiteLLM more than a thin wrapper.
+
+Purpose: learn the LLM-gateway pattern on a low-stakes deployment before considering it for real consumers (n8n, Open-WebUI, future MCP/agent work). Existing apps are not migrated in this change.
+
+## Scope
+
+**In scope:**
+
+- New app at `kubernetes/apps/ai/litellm/` using bjw-s `app-template`
+- New database `litellm` and role `litellm` on the existing `postgres18` CNPG cluster (created on first start by the `postgres-init` initContainer pattern, same as `tandoor`)
+- Reuses the existing `dragonfly.database.svc.cluster.local` for response caching
+- ConfigMap-driven `config.yaml` with two seed models (Ollama + OpenRouter) and `STORE_MODEL_IN_DB: True` so more models can be added through the UI
+- ExternalSecret pulling a new `litellm` item from 1Password (vault `Talos`) plus the existing `cloudnative-pg` item for superuser credentials
+- Internal-only HTTPRoute on `envoy-internal` at `litellm.${SECRET_INTERNAL_DOMAIN}`
+- Prometheus ServiceMonitor on `/metrics` + GrafanaDashboard CR importing LiteLLM's published dashboard JSON
+- Gatus `guarded` health check via the existing component
+
+**Out of scope (deferred):**
+
+- Langfuse / Phoenix / Helicone — external request tracing. Prometheus + Grafana cover the metrics surface; Langfuse adds a second app + Postgres DB that doubles scope.
+- OIDC SSO in front of the Admin UI. Built-in `UI_USERNAME` / `UI_PASSWORD` is sufficient on the internal network.
+- Public exposure via `envoy-external` / Cloudflare tunnel.
+- Migrating Open-WebUI or n8n to call LiteLLM. They keep their existing direct connections to Ollama / their own providers.
+- HA / multi-replica. Single replica with `Recreate` strategy is appropriate for a learning deployment and avoids rolling-update races against Prisma DB migrations.
+- VolSync backup. The proxy keeps no state on disk (PVC-less); state lives in Postgres (already covered by Barman/R2) and config lives in git.
+- Per-consumer virtual keys with budgets. Provisioning those is a runtime exercise via the UI after deployment, not a manifest change.
+- CiliumNetworkPolicy specific to LiteLLM. The namespace-level `allow-cross-namespace-ingress` policy in `ai/netpol.yaml` already covers ingress from the gateway.
+
+## Architecture
+
+```text
+┌─ namespace: ai ────────────────────────────────────────────────────────┐
+│                                                                        │
+│   ollama        existing       :11434                                  │
+│   open-webui    existing       → talks directly to ollama (unchanged)  │
+│                                                                        │
+│   litellm       NEW Deployment, 1 replica                              │
+│   ┌─ Pod ──────────────────────────────────────────────────────────┐  │
+│   │  initContainer: init-db (postgres-init:18) creates DB + role   │  │
+│   │  container: app  ghcr.io/berriai/litellm  :4000                │  │
+│   │    args: --config=/app/config.yaml --port=4000                 │  │
+│   │    config.yaml mounted from configMap "litellm-configmap"      │  │
+│   └─────────────────────────────────────────────────────────────────┘  │
+│                                                                        │
+└────────────────────────────────────────────────────────────────────────┘
+       │                              │                            │
+       ▼                              ▼                            ▼
+┌─ namespace: database ───────────────────────────┐    ┌─ egress ──────────┐
+│   postgres18-rw  CNPG :5432                     │    │  openrouter.ai    │
+│      db: litellm, role: litellm                 │    │  (provider calls) │
+│   dragonfly     :6379                            │    └───────────────────┘
+│      cache, success/failure callback queues     │
+└─────────────────────────────────────────────────┘
+
+ingress: envoy-internal
+  HTTPRoute litellm.${SECRET_INTERNAL_DOMAIN}
+    /        → litellm:4000   (proxy API + Admin UI on same port)
+```
+
+The Admin UI and the OpenAI-compatible API share port 4000. The UI lives at `/ui`, the API at `/v1/*`. Both are reachable through the same HTTPRoute on the internal listener.
+
+## Repo layout
+
+```text
+kubernetes/apps/ai/litellm/
+├── ks.yaml                          # Flux Kustomization; depends on cnpg-cluster, dragonfly-cluster, onepassword
+└── app/
+    ├── kustomization.yaml
+    ├── ocirepository.yaml           # bjw-s app-template chart
+    ├── helmrelease.yaml             # 1 replica, Recreate, postgres-init initContainer, envoy-internal route
+    ├── configmap.yaml               # litellm-configmap, holds config.yaml
+    ├── externalsecret.yaml          # litellm-secret from 1Password "litellm" + "cloudnative-pg"
+    ├── servicemonitor.yaml          # scrape :4000/metrics, 30s interval
+    └── grafanadashboard.yaml        # GrafanaDashboard CR referencing LiteLLM's published JSON
+```
+
+Plus one line added to `kubernetes/apps/ai/kustomization.yaml` to register `./litellm/ks.yaml`. Alphabetical order places it before `ollama`.
+
+## Components & dependencies
+
+The `ks.yaml` uses:
+
+- `components/gatus/guarded` — internal-only health check, matches `ollama`
+- **No** `components/volsync` — there is no PVC
+- `dependsOn` (all Kustomizations live in the `flux-system` namespace per repo convention):
+  - `cloudnative-pg-cluster` — so `postgres18-rw` is healthy
+  - `dragonfly-cluster` — so the cache backend is up
+  - `onepassword-connect` — for the ExternalSecret
+
+## Secret & data flow
+
+### 1Password item
+
+Vault: `Talos`. Item: `litellm`. Created via `op item create --vault Talos`, never the UI. Fields:
+
+| Field | Purpose |
+|---|---|
+| `LITELLM_MASTER_KEY` | `sk-`-prefixed long random string. Root API key; also the bootstrap admin identity in the UI. |
+| `LITELLM_SALT_KEY` | 32-byte random. Encrypts provider keys stored in Postgres. **Cannot be rotated without losing UI-added provider keys** — record this in 1Password notes. |
+| `LITELLM_UI_USERNAME` | Admin UI login |
+| `LITELLM_UI_PASSWORD` | Admin UI password |
+| `LITELLM_POSTGRES_USER` | Per-app role name, e.g. `litellm` |
+| `LITELLM_POSTGRES_PASS` | Random |
+| `OPENROUTER_API_KEY` | From openrouter.ai, prefixed `sk-or-...` |
+
+The existing 1Password item `cloudnative-pg` already provides `POSTGRES_SUPER_USER` / `POSTGRES_SUPER_PASS` for the init container.
+
+### ExternalSecret
+
+Pulls both 1Password items and templates a single `litellm-secret`. Same shape as `tandoor`'s ExternalSecret:
+
+```yaml
+target:
+  name: litellm-secret
+  template:
+    engineVersion: v2
+    data:
+      DATABASE_URL: postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require
+      LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+      LITELLM_SALT_KEY:   "{{ .LITELLM_SALT_KEY }}"
+      UI_USERNAME:        "{{ .LITELLM_UI_USERNAME }}"
+      UI_PASSWORD:        "{{ .LITELLM_UI_PASSWORD }}"
+      OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
+      INIT_POSTGRES_DBNAME:     litellm
+      INIT_POSTGRES_HOST:       postgres18-rw.database.svc.cluster.local
+      INIT_POSTGRES_USER:       "{{ .LITELLM_POSTGRES_USER }}"
+      INIT_POSTGRES_PASS:       "{{ .LITELLM_POSTGRES_PASS }}"
+      INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+      INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+dataFrom:
+  - extract: { key: litellm }
+  - extract: { key: cloudnative-pg }
+```
+
+### First-start flow
+
+1. Flux reconciles → ExternalSecret materialises `litellm-secret`
+2. Pod scheduled. `init-db` initContainer (`ghcr.io/home-operations/postgres-init:18`) runs against `postgres18-rw` using the super credentials, idempotently creates role `litellm` and database `litellm`
+3. Main container starts. LiteLLM runs Prisma migrations against `DATABASE_URL`, comes up on port 4000
+4. ServiceMonitor begins scraping `/metrics` on the next interval (30s)
+5. GrafanaDashboard CR is picked up by the Grafana operator and appears in Grafana
+
+## config.yaml
+
+ConfigMap `litellm-configmap` carries the proxy config. Seeded with two models, `STORE_MODEL_IN_DB: True` set in env so additional models added via the UI persist to Postgres and merge with the file list.
+
+```yaml
+model_list:
+  - model_name: ollama/llama3              # alias clients see
+    litellm_params:
+      model: ollama_chat/llama3            # actual ollama call
+      api_base: http://ollama.ai.svc.cluster.local:11434
+  - model_name: openrouter/auto
+    litellm_params:
+      model: openrouter/openrouter/auto
+      api_key: os.environ/OPENROUTER_API_KEY
+
+router_settings:
+  redis_host: os.environ/REDIS_HOST
+  redis_port: os.environ/REDIS_PORT
+
+litellm_settings:
+  success_callback: ["prometheus"]
+  failure_callback: ["prometheus"]
+  cache: true
+  cache_params:
+    type: redis
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+    ttl: 30
+  drop_params: true
+  num_retries: 2
+  request_timeout: 600
+
+general_settings:
+  health_check_endpoint: /v1/health
+```
+
+Notes:
+
+- `os.environ/<NAME>` is LiteLLM syntax for "read this env var at request time" — keeps the OpenRouter key out of git and out of the rendered ConfigMap.
+- `prometheus` callbacks emit per-request counters/histograms scraped by the ServiceMonitor.
+- `drop_params: true` silently drops parameters a backend doesn't support (e.g. some Ollama models don't accept `tool_choice`).
+- `cache.ttl: 30` is short on purpose — long TTLs make per-request usage tracking misleading; LiteLLM caches identical requests for 30s which is enough to deduplicate burst traffic from things like agent loops.
+
+## HelmRelease shape
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata: { name: &app litellm }
+spec:
+  interval: 1h
+  chartRef: { kind: OCIRepository, name: app-template }
+  install:  { remediation: { retries: 3 } }
+  upgrade:  { cleanupOnFail: true, remediation: { retries: 3, strategy: rollback } }
+  values:
+    controllers:
+      litellm:
+        annotations: { reloader.stakater.com/auto: "true" }
+        replicas: 1
+        strategy: Recreate
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18@sha256:<pinned>"
+            envFrom: [{ secretRef: { name: litellm-secret } }]
+        containers:
+          app:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: main-stable@sha256:<pinned>
+            args: ["--config=/app/config.yaml", "--port=4000"]
+            env:
+              LITELLM_LOG: INFO
+              LITELLM_MODE: PRODUCTION
+              STORE_MODEL_IN_DB: "True"
+              REDIS_HOST: dragonfly.database.svc.cluster.local
+              REDIS_PORT: "6379"
+            envFrom: [{ secretRef: { name: litellm-secret } }]
+            probes:
+              liveness:  &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /health/liveliness, port: 4000 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+              readiness: *probe
+            resources:
+              requests: { cpu: 100m, memory: 512Mi }
+              limits:   { memory: 2Gi }
+    service:
+      app:
+        controller: litellm
+        ports: { http: { port: 4000 } }
+    route:
+      app:
+        hostnames: ["{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"]
+        parentRefs: [{ name: envoy-internal, namespace: network }]
+    persistence:
+      config:
+        type: configMap
+        name: litellm-configmap
+        globalMounts:
+          - { path: /app/config.yaml, subPath: config.yaml, readOnly: true }
+```
+
+Notable choices:
+
+- **`strategy: Recreate`** — with one replica running Prisma migrations on startup, avoids the brief window where an old pod talks to a freshly-migrated schema. Easy to revert to RollingUpdate once we run multiple replicas.
+- **Hostname on `envoy-internal` only** — no public exposure. The Admin UI ships with a username/password login, but the broader security surface (UI vulns, leaked master key) is not worth Cloudflare-exposing for a learning deployment.
+- **Single hostname** — `litellm.${SECRET_INTERNAL_DOMAIN}` only. We don't dual-stack with `${SECRET_DOMAIN}` because LiteLLM is not intended for external clients in this iteration.
+- **Liveness/readiness path `/health/liveliness`** — LiteLLM's actual liveness endpoint. (Yes, `liveliness` not `liveness`; that's the upstream spelling.) `/v1/health` requires authentication and runs a real backend probe — too heavy for kubelet.
+
+## Observability
+
+### ServiceMonitor
+
+Standard pattern. Selects on the `app.kubernetes.io/name: litellm` label that `commonMetadata` applies via the Flux Kustomization.
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: litellm
+  labels: { app.kubernetes.io/name: litellm }
+spec:
+  selector:
+    matchLabels: { app.kubernetes.io/name: litellm }
+  namespaceSelector: { matchNames: [ai] }
+  endpoints:
+    - { port: http, path: /metrics, interval: 30s, scrapeTimeout: 10s }
+```
+
+### GrafanaDashboard
+
+Reference LiteLLM's published dashboard JSON. Follows the same pattern as the `flux-system` / `gpu-operator` dashboards — a `GrafanaDashboard` CR pointing at a sibling ConfigMap holding the JSON body, with `allowCrossNamespaceImport: true` so the operator picks it up.
+
+Any Grafana template variables in the JSON (`${datasource}`, `${interval}`, etc.) must be escaped to `$${...}` so Flux `postBuild` doesn't strip them. Set `"datasource": null` rather than a hardcoded UID so the default Prometheus datasource resolves correctly.
+
+### Gatus
+
+`components/gatus/guarded` adds an internal Gatus endpoint that probes `https://litellm.${SECRET_INTERNAL_DOMAIN}` and alerts via the existing AlertManager wiring.
+
+## Verification plan
+
+After Flux reconciles:
+
+1. `kubectl -n ai get hr litellm` → `Ready: True`
+2. `kubectl -n ai logs deploy/litellm -c init-db` → exits 0; role + DB created
+3. `kubectl -n ai logs deploy/litellm -c app` → Prisma "Migration applied"; server listening on `0.0.0.0:4000`
+4. Browse to `https://litellm.${SECRET_INTERNAL_DOMAIN}/ui`, log in with `UI_USERNAME` / `UI_PASSWORD`
+5. Call the API directly:
+   ```
+   curl -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+        -d '{"model":"ollama/llama3","messages":[{"role":"user","content":"hi"}]}' \
+        https://litellm.${SECRET_INTERNAL_DOMAIN}/v1/chat/completions
+   ```
+   Should round-trip to Ollama.
+6. Repeat with `model: openrouter/auto` — should round-trip to OpenRouter and consume tokens there.
+7. Grafana → LiteLLM dashboard shows the two requests above.
+8. Gatus shows `litellm` green within the next interval.
+
+## Risks & mitigations
+
+- **OpenRouter spend.** Once a virtual key is created and handed to a consumer, runaway agent loops can burn credit fast. Mitigated by (a) keeping consumers off LiteLLM initially and (b) using the UI's per-key `max_budget` once a real consumer is introduced. Out of scope for the deployment itself.
+- **Salt key loss.** Rotating `LITELLM_SALT_KEY` makes UI-added provider keys undecipherable. Mitigated by storing it in 1Password and noting in the item that it must never change. The config-file-defined OpenRouter key in `config.yaml` is unaffected (not stored in DB).
+- **Postgres tenant noise.** LiteLLM joins five other apps on `postgres18`. Mitigated by `postgres18`'s 300-connection ceiling and the proxy's small connection pool. Re-evaluate if logging volume balloons.
+- **Stale-schema on rolling update.** Avoided by `strategy: Recreate` + 1 replica. If we later scale replicas, LiteLLM's docs call out running migrations as a separate Job; revisit then.

--- a/docs/superpowers/specs/2026-05-15-litellm-design.md
+++ b/docs/superpowers/specs/2026-05-15-litellm-design.md
@@ -26,7 +26,7 @@ Purpose: learn the LLM-gateway pattern on a low-stakes deployment before conside
 - Public exposure via `envoy-external` / Cloudflare tunnel.
 - Migrating Open-WebUI or n8n to call LiteLLM. They keep their existing direct connections to Ollama / their own providers.
 - HA / multi-replica. Single replica with `Recreate` strategy is appropriate for a learning deployment and avoids rolling-update races against Prisma DB migrations.
-- VolSync backup. The proxy keeps no state on disk (PVC-less); state lives in Postgres (already covered by Barman/R2) and config lives in git.
+- VolSync backup. The proxy keeps no state on disk (PVC-less); state lives in Postgres (already covered by Barman/R2) and config lives in Git.
 - Per-consumer virtual keys with budgets. Provisioning those is a runtime exercise via the UI after deployment, not a manifest change.
 - CiliumNetworkPolicy specific to LiteLLM. The namespace-level `allow-cross-namespace-ingress` policy in `ai/netpol.yaml` already covers ingress from the gateway.
 
@@ -63,7 +63,7 @@ ingress: envoy-internal
 
 The Admin UI and the OpenAI-compatible API share port 4000. The UI lives at `/ui`, the API at `/v1/*`. Both are reachable through the same HTTPRoute on the internal listener.
 
-## Repo layout
+## Repository layout
 
 ```text
 kubernetes/apps/ai/litellm/
@@ -86,10 +86,10 @@ The `ks.yaml` uses:
 
 - `components/gatus/guarded` — internal-only health check, matches `ollama`
 - **No** `components/volsync` — there is no PVC
-- `dependsOn` (all Kustomizations live in the `flux-system` namespace per repo convention):
-  - `cloudnative-pg-cluster` — so `postgres18-rw` is healthy
-  - `dragonfly-cluster` — so the cache backend is up
-  - `onepassword-connect` — for the ExternalSecret
+- `dependsOn` (all Kustomizations live in the `flux-system` namespace per repository convention):
+    - `cloudnative-pg-cluster` — so `postgres18-rw` is healthy
+    - `dragonfly-cluster` — so the cache backend is up
+    - `onepassword-connect` — for the ExternalSecret
 
 ## Secret & data flow
 
@@ -97,15 +97,15 @@ The `ks.yaml` uses:
 
 Vault: `Talos`. Item: `litellm`. Created via `op item create --vault Talos`, never the UI. Fields:
 
-| Field | Purpose |
-|---|---|
-| `LITELLM_MASTER_KEY` | `sk-`-prefixed long random string. Root API key; also the bootstrap admin identity in the UI. |
-| `LITELLM_SALT_KEY` | 32-byte random. Encrypts provider keys stored in Postgres. **Cannot be rotated without losing UI-added provider keys** — record this in 1Password notes. |
-| `LITELLM_UI_USERNAME` | Admin UI login |
-| `LITELLM_UI_PASSWORD` | Admin UI password |
-| `LITELLM_POSTGRES_USER` | Per-app role name, e.g. `litellm` |
-| `LITELLM_POSTGRES_PASS` | Random |
-| `OPENROUTER_API_KEY` | From openrouter.ai, prefixed `sk-or-...` |
+| Field                   | Purpose                                                                                                                                                  |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LITELLM_MASTER_KEY`    | `sk-`-prefixed long random string. Root API key; also the bootstrap admin identity in the UI.                                                            |
+| `LITELLM_SALT_KEY`      | 32-byte random. Encrypts provider keys stored in Postgres. **Cannot be rotated without losing UI-added provider keys** — record this in 1Password notes. |
+| `LITELLM_UI_USERNAME`   | Admin UI login                                                                                                                                           |
+| `LITELLM_UI_PASSWORD`   | Admin UI password                                                                                                                                        |
+| `LITELLM_POSTGRES_USER` | Per-app role name, e.g. `litellm`                                                                                                                        |
+| `LITELLM_POSTGRES_PASS` | Random                                                                                                                                                   |
+| `OPENROUTER_API_KEY`    | From openrouter.ai, prefixed `sk-or-...`                                                                                                                 |
 
 The existing 1Password item `cloudnative-pg` already provides `POSTGRES_SUPER_USER` / `POSTGRES_SUPER_PASS` for the init container.
 
@@ -115,25 +115,25 @@ Pulls both 1Password items and templates a single `litellm-secret`. Same shape a
 
 ```yaml
 target:
-  name: litellm-secret
-  template:
-    engineVersion: v2
-    data:
-      DATABASE_URL: postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require
-      LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
-      LITELLM_SALT_KEY:   "{{ .LITELLM_SALT_KEY }}"
-      UI_USERNAME:        "{{ .LITELLM_UI_USERNAME }}"
-      UI_PASSWORD:        "{{ .LITELLM_UI_PASSWORD }}"
-      OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
-      INIT_POSTGRES_DBNAME:     litellm
-      INIT_POSTGRES_HOST:       postgres18-rw.database.svc.cluster.local
-      INIT_POSTGRES_USER:       "{{ .LITELLM_POSTGRES_USER }}"
-      INIT_POSTGRES_PASS:       "{{ .LITELLM_POSTGRES_PASS }}"
-      INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
-      INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+    name: litellm-secret
+    template:
+        engineVersion: v2
+        data:
+            DATABASE_URL: postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require
+            LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+            LITELLM_SALT_KEY: "{{ .LITELLM_SALT_KEY }}"
+            UI_USERNAME: "{{ .LITELLM_UI_USERNAME }}"
+            UI_PASSWORD: "{{ .LITELLM_UI_PASSWORD }}"
+            OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
+            INIT_POSTGRES_DBNAME: litellm
+            INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+            INIT_POSTGRES_USER: "{{ .LITELLM_POSTGRES_USER }}"
+            INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASS }}"
+            INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+            INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
 dataFrom:
-  - extract: { key: litellm }
-  - extract: { key: cloudnative-pg }
+    - extract: { key: litellm }
+    - extract: { key: cloudnative-pg }
 ```
 
 ### First-start flow
@@ -150,39 +150,39 @@ ConfigMap `litellm-configmap` carries the proxy config. Seeded with two models, 
 
 ```yaml
 model_list:
-  - model_name: ollama/llama3              # alias clients see
-    litellm_params:
-      model: ollama_chat/llama3            # actual ollama call
-      api_base: http://ollama.ai.svc.cluster.local:11434
-  - model_name: openrouter/auto
-    litellm_params:
-      model: openrouter/openrouter/auto
-      api_key: os.environ/OPENROUTER_API_KEY
+    - model_name: ollama/llama3 # alias clients see
+      litellm_params:
+          model: ollama_chat/llama3 # actual ollama call
+          api_base: http://ollama.ai.svc.cluster.local:11434
+    - model_name: openrouter/auto
+      litellm_params:
+          model: openrouter/openrouter/auto
+          api_key: os.environ/OPENROUTER_API_KEY
 
 router_settings:
-  redis_host: os.environ/REDIS_HOST
-  redis_port: os.environ/REDIS_PORT
+    redis_host: os.environ/REDIS_HOST
+    redis_port: os.environ/REDIS_PORT
 
 litellm_settings:
-  success_callback: ["prometheus"]
-  failure_callback: ["prometheus"]
-  cache: true
-  cache_params:
-    type: redis
-    host: os.environ/REDIS_HOST
-    port: os.environ/REDIS_PORT
-    ttl: 30
-  drop_params: true
-  num_retries: 2
-  request_timeout: 600
+    success_callback: ["prometheus"]
+    failure_callback: ["prometheus"]
+    cache: true
+    cache_params:
+        type: redis
+        host: os.environ/REDIS_HOST
+        port: os.environ/REDIS_PORT
+        ttl: 30
+    drop_params: true
+    num_retries: 2
+    request_timeout: 600
 
 general_settings:
-  health_check_endpoint: /v1/health
+    health_check_endpoint: /v1/health
 ```
 
 Notes:
 
-- `os.environ/<NAME>` is LiteLLM syntax for "read this env var at request time" — keeps the OpenRouter key out of git and out of the rendered ConfigMap.
+- `os.environ/<NAME>` is LiteLLM syntax for "read this env var at request time" — keeps the OpenRouter key out of Git and out of the rendered ConfigMap.
 - `prometheus` callbacks emit per-request counters/histograms scraped by the ServiceMonitor.
 - `drop_params: true` silently drops parameters a backend doesn't support (e.g. some Ollama models don't accept `tool_choice`).
 - `cache.ttl: 30` is short on purpose — long TTLs make per-request usage tracking misleading; LiteLLM caches identical requests for 30s which is enough to deduplicate burst traffic from things like agent loops.
@@ -194,61 +194,67 @@ apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata: { name: &app litellm }
 spec:
-  interval: 1h
-  chartRef: { kind: OCIRepository, name: app-template }
-  install:  { remediation: { retries: 3 } }
-  upgrade:  { cleanupOnFail: true, remediation: { retries: 3, strategy: rollback } }
-  values:
-    controllers:
-      litellm:
-        annotations: { reloader.stakater.com/auto: "true" }
-        replicas: 1
-        strategy: Recreate
-        initContainers:
-          init-db:
-            image:
-              repository: ghcr.io/home-operations/postgres-init
-              tag: "18@sha256:<pinned>"
-            envFrom: [{ secretRef: { name: litellm-secret } }]
-        containers:
-          app:
-            image:
-              repository: ghcr.io/berriai/litellm
-              tag: main-stable@sha256:<pinned>
-            args: ["--config=/app/config.yaml", "--port=4000"]
-            env:
-              LITELLM_LOG: INFO
-              LITELLM_MODE: PRODUCTION
-              STORE_MODEL_IN_DB: "True"
-              REDIS_HOST: dragonfly.database.svc.cluster.local
-              REDIS_PORT: "6379"
-            envFrom: [{ secretRef: { name: litellm-secret } }]
-            probes:
-              liveness:  &probe
-                enabled: true
-                custom: true
-                spec:
-                  httpGet: { path: /health/liveliness, port: 4000 }
-                  initialDelaySeconds: 30
-                  periodSeconds: 10
-              readiness: *probe
-            resources:
-              requests: { cpu: 100m, memory: 512Mi }
-              limits:   { memory: 2Gi }
-    service:
-      app:
-        controller: litellm
-        ports: { http: { port: 4000 } }
-    route:
-      app:
-        hostnames: ["{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"]
-        parentRefs: [{ name: envoy-internal, namespace: network }]
-    persistence:
-      config:
-        type: configMap
-        name: litellm-configmap
-        globalMounts:
-          - { path: /app/config.yaml, subPath: config.yaml, readOnly: true }
+    interval: 1h
+    chartRef: { kind: OCIRepository, name: app-template }
+    install: { remediation: { retries: 3 } }
+    upgrade:
+        { cleanupOnFail: true, remediation: { retries: 3, strategy: rollback } }
+    values:
+        controllers:
+            litellm:
+                annotations: { reloader.stakater.com/auto: "true" }
+                replicas: 1
+                strategy: Recreate
+                initContainers:
+                    init-db:
+                        image:
+                            repository: ghcr.io/home-operations/postgres-init
+                            tag: "18@sha256:<pinned>"
+                        envFrom: [{ secretRef: { name: litellm-secret } }]
+                containers:
+                    app:
+                        image:
+                            repository: ghcr.io/berriai/litellm
+                            tag: main-stable@sha256:<pinned>
+                        args: ["--config=/app/config.yaml", "--port=4000"]
+                        env:
+                            LITELLM_LOG: INFO
+                            LITELLM_MODE: PRODUCTION
+                            STORE_MODEL_IN_DB: "True"
+                            REDIS_HOST: dragonfly.database.svc.cluster.local
+                            REDIS_PORT: "6379"
+                        envFrom: [{ secretRef: { name: litellm-secret } }]
+                        probes:
+                            liveness: &probe
+                                enabled: true
+                                custom: true
+                                spec:
+                                    httpGet:
+                                        { path: /health/liveliness, port: 4000 }
+                                    initialDelaySeconds: 30
+                                    periodSeconds: 10
+                            readiness: *probe
+                        resources:
+                            requests: { cpu: 100m, memory: 512Mi }
+                            limits: { memory: 2Gi }
+        service:
+            app:
+                controller: litellm
+                ports: { http: { port: 4000 } }
+        route:
+            app:
+                hostnames: ["{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"]
+                parentRefs: [{ name: envoy-internal, namespace: network }]
+        persistence:
+            config:
+                type: configMap
+                name: litellm-configmap
+                globalMounts:
+                    - {
+                          path: /app/config.yaml,
+                          subPath: config.yaml,
+                          readOnly: true,
+                      }
 ```
 
 Notable choices:
@@ -268,14 +274,14 @@ Standard pattern. Selects on the `app.kubernetes.io/name: litellm` label that `c
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: litellm
-  labels: { app.kubernetes.io/name: litellm }
+    name: litellm
+    labels: { app.kubernetes.io/name: litellm }
 spec:
-  selector:
-    matchLabels: { app.kubernetes.io/name: litellm }
-  namespaceSelector: { matchNames: [ai] }
-  endpoints:
-    - { port: http, path: /metrics, interval: 30s, scrapeTimeout: 10s }
+    selector:
+        matchLabels: { app.kubernetes.io/name: litellm }
+    namespaceSelector: { matchNames: [ai] }
+    endpoints:
+        - { port: http, path: /metrics, interval: 30s, scrapeTimeout: 10s }
 ```
 
 ### GrafanaDashboard
@@ -297,12 +303,15 @@ After Flux reconciles:
 3. `kubectl -n ai logs deploy/litellm -c app` → Prisma "Migration applied"; server listening on `0.0.0.0:4000`
 4. Browse to `https://litellm.${SECRET_INTERNAL_DOMAIN}/ui`, log in with `UI_USERNAME` / `UI_PASSWORD`
 5. Call the API directly:
-   ```
-   curl -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
-        -d '{"model":"ollama/llama3","messages":[{"role":"user","content":"hi"}]}' \
-        https://litellm.${SECRET_INTERNAL_DOMAIN}/v1/chat/completions
-   ```
-   Should round-trip to Ollama.
+
+    ```bash
+    curl -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+         -d '{"model":"ollama/llama3","messages":[{"role":"user","content":"hi"}]}' \
+         https://litellm.${SECRET_INTERNAL_DOMAIN}/v1/chat/completions
+    ```
+
+    Should round-trip to Ollama.
+
 6. Repeat with `model: openrouter/auto` — should round-trip to OpenRouter and consume tokens there.
 7. Grafana → LiteLLM dashboard shows the two requests above.
 8. Gatus shows `litellm` green within the next interval.

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./netpol.yaml
+  - ./litellm/ks.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml
   - ./openaiwhisper/ks.yaml

--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/configmap.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: litellm-configmap
+  namespace: ai
+data:
+  config.yaml: |-
+    model_list:
+      - model_name: ollama/llama3
+        litellm_params:
+          model: ollama_chat/llama3
+          api_base: http://ollama.ai.svc.cluster.local:11434
+
+      - model_name: openrouter/auto
+        litellm_params:
+          model: openrouter/openrouter/auto
+          api_key: os.environ/OPENROUTER_API_KEY
+
+    router_settings:
+      redis_host: os.environ/REDIS_HOST
+      redis_port: os.environ/REDIS_PORT
+
+    litellm_settings:
+      success_callback: ["prometheus"]
+      failure_callback: ["prometheus"]
+      cache: true
+      cache_params:
+        type: redis
+        host: os.environ/REDIS_HOST
+        port: os.environ/REDIS_PORT
+        ttl: 30
+      drop_params: true
+      num_retries: 2
+      request_timeout: 600
+
+    general_settings:
+      health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: litellm-secret
+    template:
+      engineVersion: v2
+      data:
+        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        LITELLM_SALT_KEY: "{{ .LITELLM_SALT_KEY }}"
+        UI_USERNAME: "{{ .LITELLM_UI_USERNAME }}"
+        UI_PASSWORD: "{{ .LITELLM_UI_PASSWORD }}"
+        OPENROUTER_API_KEY: "{{ .OPENROUTER_API_KEY }}"
+        DATABASE_URL: "postgresql://{{ .LITELLM_POSTGRES_USER }}:{{ .LITELLM_POSTGRES_PASS }}@postgres18-rw.database.svc.cluster.local:5432/litellm?sslmode=require"
+        INIT_POSTGRES_DBNAME: litellm
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .LITELLM_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASS }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/ai/litellm/app/grafanadashboard.yaml
+++ b/kubernetes/apps/ai/litellm/app/grafanadashboard.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: litellm
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  url: https://grafana.com/api/dashboards/24965/revisions/2/download

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app litellm
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      litellm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        replicas: 1
+        strategy: Recreate
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18"
+            envFrom:
+              - secretRef:
+                  name: litellm-secret
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: main-stable
+            args:
+              - --config=/app/config.yaml
+              - --port=4000
+            env:
+              LITELLM_LOG: INFO
+              LITELLM_MODE: PRODUCTION
+              STORE_MODEL_IN_DB: "True"
+              REDIS_HOST: dragonfly.database.svc.cluster.local
+              REDIS_PORT: "6379"
+            envFrom:
+              - secretRef:
+                  name: litellm-secret
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health/liveliness
+                    port: 4000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 6
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 4000
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      config:
+        type: configMap
+        name: litellm-configmap
+        globalMounts:
+          - path: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/litellm/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/litellm/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/litellm/app/servicemonitor.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app litellm
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *app
+  namespaceSelector:
+    matchNames:
+      - ai
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: dragonfly-cluster
+      namespace: flux-system
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/ai/litellm/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

- New `litellm` app in the `ai` namespace, sitting alongside `ollama` and `open-webui`
- Backed by a new database on the shared `postgres18` CNPG cluster (created on first start via the `postgres-init` initContainer pattern)
- Uses the shared dragonfly for response caching
- Internal-only HTTPRoute on `envoy-internal`; Admin UI auth via built-in `UI_USERNAME`/`UI_PASSWORD`
- Prometheus ServiceMonitor + GrafanaDashboard CR (Berri dashboard id 24965)

Open-WebUI and n8n are **not** migrated in this PR — they continue to talk directly to Ollama / their own providers. Existing consumers are untouched.

`OPENROUTER_API_KEY` is currently a placeholder in 1Password (`disabled-placeholder`) — the proxy works for Ollama-routed calls; OpenRouter calls will 401 until a real key is dropped in via ` op item edit litellm OPENROUTER_API_KEY=sk-or-v1-... `  and the pod is reloaded.

## Test plan

- [ ] flux-local test passes in CI
- [ ] After merge: HelmRelease becomes Ready
- [ ] kubectl -n ai logs deploy/litellm -c init-db shows the role + DB being created idempotently
- [ ] kubectl -n ai logs deploy/litellm -c app shows Prisma migrations applied and server listening on :4000
- [ ] Browse to https://litellm.${SECRET_INTERNAL_DOMAIN}/ui, log in with the credentials from the 1Password \`litellm\` item
- [ ] curl test against /v1/chat/completions for ollama/llama3 round-trips successfully (with Authorization: Bearer master-key)
- [ ] Grafana dashboard "LiteLLM" populated with request rate/latency panels
- [ ] Gatus shows litellm green

Design spec: docs/superpowers/specs/2026-05-15-litellm-design.md
Plan: docs/superpowers/plans/2026-05-15-litellm.md