### PR TITLE
fix(litellm): dragonfly-cluster lives in database, not flux-system

### DIFF
--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -15,7 +15,7 @@ spec:
     - name: cloudnative-pg-cluster
       namespace: database
     - name: dragonfly-cluster
-      namespace: flux-system
+      namespace: database
     - name: onepassword-connect
       namespace: external-secrets
   interval: 1h


### PR DESCRIPTION
## Summary

One-line fix for #2560. The litellm Kustomization was stalling with `DependencyNotReady: 'flux-system/dragonfly-cluster' not found`.

`dragonfly-cluster` Kustomization CR actually lives in the `database` namespace, not `flux-system`. The file `kubernetes/apps/database/dragonfly/ks.yaml` declares `metadata.namespace: flux-system`, but the parent `kubernetes/apps/database/kustomization.yaml` has `namespace: database` which Kustomize applies to every resource it processes — including embedded Kustomization CRs.

Same applies to all other ks.yaml files in this repo: they declare `flux-system` but end up wherever their parent directory's namespace is.

## Test plan

- [ ] After merge: `kubectl get kustomization litellm -n ai` shows Ready=True
- [ ] HelmRelease litellm reconciles successfully