### PR TITLE
fix(litellm): disable auth on /metrics so ServiceMonitor can scrape

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -25,6 +25,7 @@ data:
     litellm_settings:
       success_callback: ["prometheus"]
       failure_callback: ["prometheus"]
+      require_auth_for_metrics_endpoint: false
       cache: true
       cache_params:
         type: redis


### PR DESCRIPTION
## Summary

Follow-up to #2560 and #2566. The `/metrics` endpoint returns 401 to unauthenticated requests by default in current LiteLLM (`require_auth_for_metrics_endpoint: true`). The in-cluster Prometheus ServiceMonitor has no credentials, so the Grafana dashboard would stay empty.

Setting `require_auth_for_metrics_endpoint: false` in `litellm_settings` opens up the metrics endpoint to in-cluster scraping. The endpoint is only reachable via the Service (port 4000) — the HTTPRoute only routes to `/v1/*` and `/ui/*`-style paths, not `/metrics` directly — so blast radius is in-cluster only.

## Test plan

- [ ] After merge: curl http://litellm.ai.svc.cluster.local:4000/metrics from in-cluster returns Prometheus text format
- [ ] Grafana "LiteLLM" dashboard panels populate after a request flows through