### PR TITLE
fix(litellm): scrape /metrics/ — LiteLLM 307s the no-slash form

### DIFF
--- a/kubernetes/apps/ai/litellm/app/servicemonitor.yaml
+++ b/kubernetes/apps/ai/litellm/app/servicemonitor.yaml
@@ -15,6 +15,6 @@ spec:
       - ai
   endpoints:
     - port: http
-      path: /metrics
+      path: /metrics/
       interval: 30s
       scrapeTimeout: 10s


### PR DESCRIPTION
## Summary

Follow-up to #2567. LiteLLM serves Prometheus metrics at `/metrics/` (with trailing slash) and 307-redirects `/metrics` (no slash) to the canonical path. Prometheus scrapers don't follow redirects, so the ServiceMonitor's `path: /metrics` gave up at the redirect and produced no samples.

Verified with an in-cluster curl: `GET /metrics/` returns HTTP 200 with the expected `python_*` / `litellm_*` Prometheus text format.

## Test plan

- [ ] After merge: in Prometheus UI, `up{service="litellm"}` is 1
- [ ] Grafana "LiteLLM" dashboard populates