### PR TITLE
feat(litellm): swap seed model from llama3 to gemma4:26b

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -8,9 +8,9 @@ metadata:
 data:
   config.yaml: |-
     model_list:
-      - model_name: ollama/llama3
+      - model_name: ollama/gemma4
         litellm_params:
-          model: ollama_chat/llama3
+          model: ollama_chat/gemma4:26b
           api_base: http://ollama.ai.svc.cluster.local:11434
 
       - model_name: openrouter/auto


### PR DESCRIPTION
## Summary

Follow-up to #2560. Ollama on this cluster has `gemma4:26b` pulled but never had `llama3`, so the original seed model was non-functional. Swapping `ollama/llama3` → `ollama/gemma4` (Ollama-side `gemma4:26b`) makes the in-house route work out of the box.

## Test plan

- [ ] After merge: `kubectl rollout restart deploy/litellm -n ai` (reloader picks up the configmap change automatically thanks to `reloader.stakater.com/auto`, so this may be redundant)
- [ ] `curl -H "Authorization: Bearer $LITELLM_MASTER_KEY" -d '{"model":"ollama/gemma4",...}' http://litellm.ai.svc.cluster.local:4000/v1/chat/completions` returns a real completion