### PR TITLE
chore(renovate): standardize and group busybox image references

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -15,6 +15,16 @@
       minimumGroupSize: 2,
     },
     {
+      description: "Busybox Group (matches any docker.io/(library/)?busybox variant)",
+      groupName: "Busybox",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/^docker\\.io\\/(library\\/)?busybox$/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 1,
+    },
+    {
       description: "Cert-Manager Group",
       groupName: "Cert-Manager",
       matchDatasources: ["docker"],

--- a/kubernetes/apps/infrastructure/nextdns/app/cronjob.yaml
+++ b/kubernetes/apps/infrastructure/nextdns/app/cronjob.yaml
@@ -22,7 +22,7 @@ spec:
           automountServiceAccountToken: false
           containers:
             - name: wget
-              image: docker.io/busybox:1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+              image: docker.io/library/busybox:1.37.0@sha256:0d3f1e630be52ade0c06107515937607be2cab11a2ad2122099fc79e19bcc18b
               command:
                 - "/bin/sh"
                 - "-c"

--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           ssh-setup:
             image:
               repository: docker.io/library/busybox
-              tag: 1.37@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
+              tag: 1.37.0@sha256:0d3f1e630be52ade0c06107515937607be2cab11a2ad2122099fc79e19bcc18b
             command:
               - /bin/sh
               - -c
@@ -55,48 +55,34 @@ spec:
               runAsGroup: 30000
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
-              capabilities: { drop: [ALL] }
-              seccompProfile: { type: RuntimeDefault }
+              capabilities: {drop: [ALL]}
+              seccompProfile: {type: RuntimeDefault}
         containers:
           app:
             image:
               repository: docker.io/oxidized/oxidized
               tag: 0.37.0@sha256:07d8d7d669bb210b1100d121bbe214a3d64d621b1768f8f2179a1508a772541e
             env:
-              PUSHOVER_TOKEN:
-                {
-                  valueFrom:
-                    {
-                      secretKeyRef:
-                        { name: oxidized-secret, key: PUSHOVER_TOKEN },
-                    },
-                }
-              PUSHOVER_USER_KEY:
-                {
-                  valueFrom:
-                    {
-                      secretKeyRef:
-                        { name: oxidized-secret, key: PUSHOVER_USER_KEY },
-                    },
-                }
+              PUSHOVER_TOKEN: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: PUSHOVER_TOKEN}}}
+              PUSHOVER_USER_KEY: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: PUSHOVER_USER_KEY}}}
             probes:
               liveness:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket: { port: 8888 }
+                  tcpSocket: {port: 8888}
                   initialDelaySeconds: 30
                   periodSeconds: 30
               readiness:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet: { path: /nodes.json, port: 8888 }
+                  httpGet: {path: /nodes.json, port: 8888}
                   initialDelaySeconds: 30
                   periodSeconds: 30
             resources:
-              requests: { cpu: 50m, memory: 128Mi }
-              limits: { memory: 256Mi }
+              requests: {cpu: 50m, memory: 128Mi}
+              limits: {memory: 256Mi}
             securityContext:
               # The oxidized image bootstraps as root (uid 0): runsvdir
               # initialises supervise dirs under /etc/service/*, runit's
@@ -117,7 +103,7 @@ spec:
                   - CHOWN
                   - SETUID
                   - SETGID
-              seccompProfile: { type: RuntimeDefault }
+              seccompProfile: {type: RuntimeDefault}
           exporter:
             image:
               repository: ghcr.io/akquinet/oxidized-exporter
@@ -130,27 +116,27 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket: { port: 8080 }
+                  tcpSocket: {port: 8080}
                   initialDelaySeconds: 30
                   periodSeconds: 30
               readiness:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet: { path: /metrics, port: 8080 }
+                  httpGet: {path: /metrics, port: 8080}
                   initialDelaySeconds: 30
                   periodSeconds: 30
             resources:
-              requests: { cpu: 10m, memory: 32Mi }
-              limits: { memory: 64Mi }
+              requests: {cpu: 10m, memory: 32Mi}
+              limits: {memory: 64Mi}
             securityContext:
               runAsNonRoot: true
               runAsUser: 30000
               runAsGroup: 30000
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
-              capabilities: { drop: [ALL] }
-              seccompProfile: { type: RuntimeDefault }
+              capabilities: {drop: [ALL]}
+              seccompProfile: {type: RuntimeDefault}
         pod:
           securityContext:
             fsGroup: 30000
@@ -160,8 +146,8 @@ spec:
       app:
         controller: oxidized
         ports:
-          http: { port: 8888 }
-          metrics: { port: 8080 }
+          http: {port: 8888}
+          metrics: {port: 8080}
 
     route:
       app:

--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -55,34 +55,48 @@ spec:
               runAsGroup: 30000
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
-              capabilities: {drop: [ALL]}
-              seccompProfile: {type: RuntimeDefault}
+              capabilities: { drop: [ALL] }
+              seccompProfile: { type: RuntimeDefault }
         containers:
           app:
             image:
               repository: docker.io/oxidized/oxidized
               tag: 0.37.0@sha256:07d8d7d669bb210b1100d121bbe214a3d64d621b1768f8f2179a1508a772541e
             env:
-              PUSHOVER_TOKEN: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: PUSHOVER_TOKEN}}}
-              PUSHOVER_USER_KEY: {valueFrom: {secretKeyRef: {name: oxidized-secret, key: PUSHOVER_USER_KEY}}}
+              PUSHOVER_TOKEN:
+                {
+                  valueFrom:
+                    {
+                      secretKeyRef:
+                        { name: oxidized-secret, key: PUSHOVER_TOKEN },
+                    },
+                }
+              PUSHOVER_USER_KEY:
+                {
+                  valueFrom:
+                    {
+                      secretKeyRef:
+                        { name: oxidized-secret, key: PUSHOVER_USER_KEY },
+                    },
+                }
             probes:
               liveness:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket: {port: 8888}
+                  tcpSocket: { port: 8888 }
                   initialDelaySeconds: 30
                   periodSeconds: 30
               readiness:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet: {path: /nodes.json, port: 8888}
+                  httpGet: { path: /nodes.json, port: 8888 }
                   initialDelaySeconds: 30
                   periodSeconds: 30
             resources:
-              requests: {cpu: 50m, memory: 128Mi}
-              limits: {memory: 256Mi}
+              requests: { cpu: 50m, memory: 128Mi }
+              limits: { memory: 256Mi }
             securityContext:
               # The oxidized image bootstraps as root (uid 0): runsvdir
               # initialises supervise dirs under /etc/service/*, runit's
@@ -103,7 +117,7 @@ spec:
                   - CHOWN
                   - SETUID
                   - SETGID
-              seccompProfile: {type: RuntimeDefault}
+              seccompProfile: { type: RuntimeDefault }
           exporter:
             image:
               repository: ghcr.io/akquinet/oxidized-exporter
@@ -116,27 +130,27 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  tcpSocket: {port: 8080}
+                  tcpSocket: { port: 8080 }
                   initialDelaySeconds: 30
                   periodSeconds: 30
               readiness:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet: {path: /metrics, port: 8080}
+                  httpGet: { path: /metrics, port: 8080 }
                   initialDelaySeconds: 30
                   periodSeconds: 30
             resources:
-              requests: {cpu: 10m, memory: 32Mi}
-              limits: {memory: 64Mi}
+              requests: { cpu: 10m, memory: 32Mi }
+              limits: { memory: 64Mi }
             securityContext:
               runAsNonRoot: true
               runAsUser: 30000
               runAsGroup: 30000
               readOnlyRootFilesystem: true
               allowPrivilegeEscalation: false
-              capabilities: {drop: [ALL]}
-              seccompProfile: {type: RuntimeDefault}
+              capabilities: { drop: [ALL] }
+              seccompProfile: { type: RuntimeDefault }
         pod:
           securityContext:
             fsGroup: 30000
@@ -146,8 +160,8 @@ spec:
       app:
         controller: oxidized
         ports:
-          http: {port: 8888}
-          metrics: {port: 8080}
+          http: { port: 8888 }
+          metrics: { port: 8080 }
 
     route:
       app:

--- a/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/app/mutatingadmissionpolicy.yaml
@@ -47,7 +47,7 @@ spec:
               op: "add", path: "/spec/template/spec/initContainers/-",
               value: Object.spec.template.spec.initContainers{
                 name: "jitter",
-                image: "docker.io/library/busybox:1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e",
+                image: "docker.io/library/busybox:1.37.0@sha256:0d3f1e630be52ade0c06107515937607be2cab11a2ad2122099fc79e19bcc18b",
                 imagePullPolicy: "IfNotPresent",
                 command: ["sh", "-c", "sleep $(shuf -i 0-900 -n 1)"]
               }


### PR DESCRIPTION
## Summary

- Align all three busybox usages on `docker.io/library/busybox:1.37.0@sha256:0d3f1e6...` (was a mix of `docker.io/busybox`, `docker.io/library/busybox`, tag `1.37` vs `1.37.0`)
- Add a `Busybox` group to `.renovate/groups.json5` so future digest/minor bumps fan-in to one PR instead of producing 3-5 duplicates per Renovate run

Closes the busybox PR fan-out (#2645, #2646, #2647, #2650, #2651) — Renovate will re-issue any pending updates as a single grouped PR on its next run.

## Test plan

- [x] yamlfmt clean
- [ ] CI passes (super-linter + flux-local)
- [ ] Spot-check rendered manifests use the new digest