### PR TITLE
feat(prowler): bump api+ui to 5.28.0 and group in Renovate

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -55,6 +55,16 @@
       minimumGroupSize: 2,
     },
     {
+      description: "Prowler Group (api + ui move in lockstep)",
+      groupName: "Prowler",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/^prowlercloud\\//"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 1,
+    },
+    {
       description: "Rook-Ceph Group",
       groupName: "Rook-Ceph",
       matchDatasources: ["docker"],

--- a/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
@@ -36,7 +36,7 @@ spec:
           api:
             image: &image
               repository: prowlercloud/prowler-api
-              tag: 5.27.0@sha256:59a124905155767cda713226ddf784713d3ff614599ae90f2e1b64611eacb30d
+              tag: 5.28.0@sha256:a67db11208885c22768bb4b8d89b1b8529ed4c6a44454e7b09b35b47d63aa747
             env: &commonEnv
               TZ: ${TIMEZONE}
               DJANGO_SETTINGS_MODULE: config.django.production

--- a/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-beat.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: prowlercloud/prowler-api
-              tag: 5.27.0@sha256:59a124905155767cda713226ddf784713d3ff614599ae90f2e1b64611eacb30d
+              tag: 5.28.0@sha256:a67db11208885c22768bb4b8d89b1b8529ed4c6a44454e7b09b35b47d63aa747
             # Override the image's hardcoded ENTRYPOINT
             # `["../docker-entrypoint.sh", "prod"]`. Without `command`,
             # `args: [beat]` is APPENDED ("prod beat") and the script

--- a/kubernetes/apps/security/prowler/app/helmrelease-ui.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-ui.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: prowlercloud/prowler-ui
-              tag: 5.27.0@sha256:eb561bd0825f951823aed71a2b48e5f8c1e283d04b1f189f8cb0f493f5ad8345
+              tag: 5.28.0@sha256:e41c40a08d17942eabe62a48db6f8a2d92dd1fc4c6708cab4c22c3e9029fadde
             env:
               TZ: ${TIMEZONE}
               UI_PORT: "3000"


### PR DESCRIPTION
## Summary

- Bumps `prowlercloud/prowler-api` (and the beat HelmRelease which shares the image) and `prowlercloud/prowler-ui` from `5.27.0` → `5.28.0`
- Adds a `Prowler` group to `.renovate/groups.json5` keyed on `prowlercloud/*` so api + ui (which must move in lockstep) arrive as a single grouped PR going forward

Closes the fan-out of #2628 (api) and #2630 (ui).

## Test plan

- [x] yamlfmt clean (no churn)
- [ ] CI passes (super-linter + flux-local)
- [ ] After merge, confirm Renovate reconciles both deployments cleanly