### PR TITLE
fix(ci): move lint workflow permissions to job level

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,13 @@ on:
 
 permissions:
   contents: read
-  statuses: write
-  pull-requests: write
 
 jobs:
   lint:
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: write
     uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@2410829c6d03158086d6cab16e15153942c5d4b8 # v1
     with:
       # Kubeconform validates raw YAML source. On this Flux GitOps repo the


### PR DESCRIPTION
## Summary

- Drop the workflow-level `statuses: write` + `pull-requests: write` down to the `lint` job, leaving only `contents: read` at the top.

## Why

Mitigates zizmor `excessive-permissions` and Checkov `CKV2_GHA_1` — matches the caller-pattern convention in our [`CLAUDE.md`](../blob/main/CLAUDE.md) ("Permissions at job level, not workflow level"). The other workflows in the repo already follow this; `lint.yml` was the holdout.

## Test plan

- [ ] super-linter run on this PR passes (still produces statuses + PR comments)
- [ ] zizmor no longer flags `lint.yml` for excessive permissions