### PR TITLE
chore(silence-operator): silence PrometheusRuleFailures during rook-ceph mgr rollout

### DIFF
--- a/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./ceph-network-packet-drops.yaml
   - ./etcd-alerts.yaml
   - ./keda-nfs-scaler.yaml
+  - ./prometheus-rule-failures-rook-ceph.yaml
   - ./zfs-storage-memory.yaml

--- a/kubernetes/apps/observability/silence-operator/silences/prometheus-rule-failures-rook-ceph.yaml
+++ b/kubernetes/apps/observability/silence-operator/silences/prometheus-rule-failures-rook-ceph.yaml
@@ -1,0 +1,21 @@
+---
+# Temporary band-aid: silence PrometheusRuleFailures while the rook-ceph
+# CephPoolGrowthWarning rule self-recovers after the v1.19.5 -> v1.19.6 mgr
+# rollout (PR #2700). The rule uses predict_linear(...[2d]), so a fresh
+# mgr-b pod aliasing the old pod on (cluster, pool_id, instance) produces a
+# many-to-many join error until the pre-upgrade pod's samples age out of
+# the 2-day lookback window (~48h from 2026-05-27 21:30 UTC).
+#
+# DELETE THIS FILE on or after 2026-05-30 unless the same alert is still
+# firing (in which case a permanent fix belongs upstream in rook-ceph or
+# in a chart values override, not here).
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: prometheus-rule-failures-rook-ceph
+spec:
+  matchers:
+    - name: alertname
+      value: PrometheusRuleFailures
+      isRegex: false
+      isEqual: true


### PR DESCRIPTION
## Summary

Add a temporary `Silence` CR for `alertname=PrometheusRuleFailures` to quiet the noise from the rook-ceph mgr rollout transition.

## Background

After merging #2700 (rook-ceph v1.19.5 → v1.19.6), both ceph mgr pods restarted. The upstream rook-ceph rule `CephPoolGrowthWarning` uses:

```
(predict_linear(ceph_pool_percent_used[2d], 432000) * on(cluster, pool_id, instance) group_right() ceph_pool_metadata) >= 95
```

The 2-day lookback means the pre-upgrade `mgr-b` pod's samples coexist with the new pod's samples for the same `(cluster, pool_id, instance)` — producing a `many-to-many matching not allowed` error, which trips `PrometheusRuleFailures` (severity=critical).

Confirmed in cluster:
```
found duplicate series for the match group {instance="10.32.8.82:9283", pool_id="1"} on the left hand-side:
  pod=rook-ceph-mgr-b-77865c67d4-x7tf6 (current)
  pod=rook-ceph-mgr-b-744cf558f7-z4qpw (pre-upgrade, terminated)
```

## Lifetime

The `Silence` CRD has no TTL — file header says **delete on or after 2026-05-30** when the stale series age out of the 2d window. A permanent fix belongs upstream in rook-ceph (or via a chart-values override of `CephPoolGrowthWarning`), not here.

## Test plan

- [ ] Flux reconciles `silence-operator-silences` Kustomization
- [ ] Silence CR `prometheus-rule-failures-rook-ceph` appears: `kubectl get silence prometheus-rule-failures-rook-ceph`
- [ ] `PrometheusRuleFailures` clears from Alertmanager UI