### PR TITLE
feat(netbox): deploy NetBox (DCIM/IPAM)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-netbox.md
+++ b/docs/superpowers/plans/2026-05-29-netbox.md
@@ -1,0 +1,499 @@
+# NetBox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deploy NetBox (DCIM/IPAM) to the `default` namespace via Flux, using the shared CNPG `postgres18` cluster, Dragonfly for Redis, a VolSync-backed `ceph-block` media PVC, and an internal-only HTTPRoute.
+
+**Architecture:** Standard 4-file Flux app modelled on `paperless`. The `netbox-chart` (OCI Helm chart) runs web + RQ worker + housekeeping CronJob. A `postgres-init` initContainer creates the `netbox` role/DB on `postgres18-rw`. One `ExternalSecret` (`netbox-secret`) satisfies every chart secret reference. The VolSync component owns the `netbox` PVC; the chart consumes it via `persistence.existingClaim`.
+
+**Tech Stack:** Flux Kustomization + HelmRelease/OCIRepository, External Secrets (1Password), CloudNativePG, Dragonfly, VolSync, Envoy Gateway (Gateway API), Rook-Ceph block storage.
+
+---
+
+## Pre-resolved facts (verified against chart 8.3.3 / appVersion v4.6.1 and this repo)
+
+- Chart: `oci://ghcr.io/netbox-community/netbox-chart/netbox`, tag **8.3.3**.
+- `postgres-init` image (repo standard): `ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7`.
+- CNPG: `postgres18-rw.database.svc.cluster.local:5432`; superuser creds in 1Password item `cloudnative-pg` (`POSTGRES_SUPER_USER` / `POSTGRES_SUPER_PASS`).
+- Dragonfly: `dragonfly.database.svc.cluster.local:6379`; password in 1Password item `dragonfly` (`DRAGONFLY_PASSWORD`); auth user `default`.
+- VolSync component creates PVC named `${APP}` (`netbox`) on `ceph-block`, size `VOLSYNC_CAPACITY`. Chart must use `persistence.existingClaim: netbox`.
+- `worker.enabled` and `housekeeping.enabled` default to `true` in the chart.
+- Chart secret-key contract (the projected `secrets` volume, all items **required** unless noted):
+  - global `existingSecret` → keys `secret_key`, `email-password` (required), `api_token_peppers` (optional)
+  - `superuser.existingSecret` → keys `password`, `api_token`
+  - `externalDatabase.existingSecretName` → key set by `externalDatabase.existingSecretKey`
+  - `tasksDatabase` / `cachingDatabase` `existingSecretName` → keys set by their `existingSecretKey`
+  - All five references will point at the single secret `netbox-secret`.
+- `${TIMEZONE}` and `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` are cluster-secrets substitute vars.
+
+---
+
+## File Structure
+
+```
+kubernetes/apps/default/netbox/
+├── ks.yaml                      # Flux Kustomization (&app netbox); components volsync + gatus/guarded
+└── app/
+    ├── ocirepository.yaml       # OCI Helm chart source
+    ├── helmrelease.yaml         # NetBox HelmRelease (all values)
+    ├── externalsecret.yaml      # 1Password → netbox-secret (every key the chart needs)
+    ├── httproute.yaml           # envoy-internal route, both domains
+    └── kustomization.yaml       # lists the 4 resources above
+kubernetes/apps/default/kustomization.yaml   # MODIFY: add ./netbox/ks.yaml (alphabetical, after ./n8n)
+```
+
+---
+
+## Task 1: Create the `netbox` 1Password item
+
+**Files:** none (out-of-band secret creation; required before the ExternalSecret can resolve).
+
+- [ ] **Step 1: Generate values and create the item in the `Talos` vault**
+
+`op` is on PATH via mise. Generate values locally (never paste into the UI):
+
+```bash
+op item create --vault Talos --category login --title netbox \
+  "NETBOX_SUPERUSER_PASSWORD[password]=$(openssl rand -base64 24)" \
+  "NETBOX_SUPERUSER_API_TOKEN[text]=$(openssl rand -hex 20)" \
+  "NETBOX_SECRET_KEY[password]=$(openssl rand -base64 60 | tr -d '\n')" \
+  "NETBOX_POSTGRES_PASSWORD[password]=$(openssl rand -base64 24)"
+```
+
+- [ ] **Step 2: Verify the item exists with all four fields**
+
+Run:
+```bash
+op item get netbox --vault Talos --fields label=NETBOX_SECRET_KEY,label=NETBOX_SUPERUSER_PASSWORD,label=NETBOX_SUPERUSER_API_TOKEN,label=NETBOX_POSTGRES_PASSWORD
+```
+Expected: four non-empty values printed. (NetBox SECRET_KEY must be 50+ chars — `rand -base64 60` yields ~80.)
+
+No commit (no repo change).
+
+---
+
+## Task 2: Scaffold the Flux Kustomization and register it
+
+**Files:**
+- Create: `kubernetes/apps/default/netbox/ks.yaml`
+- Create: `kubernetes/apps/default/netbox/app/kustomization.yaml`
+- Modify: `kubernetes/apps/default/kustomization.yaml` (add `./netbox/ks.yaml` after `./n8n/ks.yaml`)
+
+- [ ] **Step 1: Write `ks.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app netbox
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: dragonfly-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/default/netbox/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+```
+
+- [ ] **Step 2: Write `app/kustomization.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+```
+
+- [ ] **Step 3: Register in the namespace kustomization**
+
+In `kubernetes/apps/default/kustomization.yaml`, add the line `  - ./netbox/ks.yaml` immediately after `  - ./n8n/ks.yaml` (keeps alphabetical order: n8n < netbox < netronome).
+
+- [ ] **Step 4: Validate YAML parses**
+
+Run:
+```bash
+yq -e '.' kubernetes/apps/default/netbox/ks.yaml >/dev/null && \
+yq -e '.' kubernetes/apps/default/netbox/app/kustomization.yaml >/dev/null && \
+echo OK
+```
+Expected: `OK`. (Full Flux validation runs in Task 6 once all resources exist — the app/kustomization references files not yet created, so a kustomize build is deferred.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add kubernetes/apps/default/netbox/ks.yaml \
+        kubernetes/apps/default/netbox/app/kustomization.yaml \
+        kubernetes/apps/default/kustomization.yaml
+git commit -m "feat(netbox): scaffold flux kustomization"
+```
+
+---
+
+## Task 3: ExternalSecret (`netbox-secret`)
+
+**Files:**
+- Create: `kubernetes/apps/default/netbox/app/externalsecret.yaml`
+
+- [ ] **Step 1: Write `externalsecret.yaml`**
+
+Every key consumed by the chart is templated here. `email-password` is set empty (the chart's projected volume requires the key to exist even when email is unused). The `INIT_POSTGRES_*` keys feed the `postgres-init` initContainer via `envFrom`.
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: netbox
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: netbox-secret
+    template:
+      engineVersion: v2
+      data:
+        # --- chart: global existingSecret (config) ---
+        secret_key: "{{ .NETBOX_SECRET_KEY }}"
+        email-password: ""
+        # --- chart: superuser.existingSecret ---
+        password: "{{ .NETBOX_SUPERUSER_PASSWORD }}"
+        api_token: "{{ .NETBOX_SUPERUSER_API_TOKEN }}"
+        # --- chart: externalDatabase.existingSecretKey: db_password ---
+        db_password: "{{ .NETBOX_POSTGRES_PASSWORD }}"
+        # --- chart: tasks/caching DB (Dragonfly), existingSecretKey: tasks_password / cache_password ---
+        tasks_password: "{{ .DRAGONFLY_PASSWORD }}"
+        cache_password: "{{ .DRAGONFLY_PASSWORD }}"
+        # --- postgres-init initContainer (envFrom) ---
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_DBNAME: netbox
+        INIT_POSTGRES_USER: netbox
+        INIT_POSTGRES_PASS: "{{ .NETBOX_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: netbox
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: dragonfly
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `yq -e '.' kubernetes/apps/default/netbox/app/externalsecret.yaml >/dev/null && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/apps/default/netbox/app/externalsecret.yaml
+git commit -m "feat(netbox): add externalsecret"
+```
+
+---
+
+## Task 4: OCIRepository + HelmRelease
+
+**Files:**
+- Create: `kubernetes/apps/default/netbox/app/ocirepository.yaml`
+- Create: `kubernetes/apps/default/netbox/app/helmrelease.yaml`
+
+- [ ] **Step 1: Write `ocirepository.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: netbox
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 8.3.3
+  url: oci://ghcr.io/netbox-community/netbox-chart/netbox
+```
+
+- [ ] **Step 2: Write `helmrelease.yaml`**
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: netbox
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: netbox
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    commonAnnotations:
+      reloader.stakater.com/auto: "true"
+    replicaCount: 1
+    timeZone: "${TIMEZONE}"
+    loginRequired: true
+    superuser:
+      name: admin
+      email: "admin@${SECRET_DOMAIN}"
+      existingSecret: netbox-secret
+    existingSecret: netbox-secret
+    allowedHosts:
+      - "netbox.${SECRET_DOMAIN}"
+      - "netbox.${SECRET_INTERNAL_DOMAIN}"
+    allowedHostsIncludesPodIP: true
+    csrf:
+      trustedOrigins:
+        - "https://netbox.${SECRET_DOMAIN}"
+        - "https://netbox.${SECRET_INTERNAL_DOMAIN}"
+    plugins: []
+    persistence:
+      enabled: true
+      existingClaim: netbox
+    resourcesPreset: none
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    initContainers:
+      - name: init-db
+        image: ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+        envFrom:
+          - secretRef:
+              name: netbox-secret
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    postgresql:
+      enabled: false
+    externalDatabase:
+      host: postgres18-rw.database.svc.cluster.local
+      port: 5432
+      database: netbox
+      username: netbox
+      existingSecretName: netbox-secret
+      existingSecretKey: db_password
+      options:
+        sslmode: require
+        target_session_attrs: read-write
+    valkey:
+      enabled: false
+    tasksDatabase:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+      database: 0
+      username: default
+      existingSecretName: netbox-secret
+      existingSecretKey: tasks_password
+    cachingDatabase:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+      database: 1
+      username: default
+      existingSecretName: netbox-secret
+      existingSecretKey: cache_password
+    worker:
+      enabled: true
+    housekeeping:
+      enabled: true
+```
+
+- [ ] **Step 3: Validate YAML parses**
+
+Run:
+```bash
+yq -e '.' kubernetes/apps/default/netbox/app/ocirepository.yaml >/dev/null && \
+yq -e '.' kubernetes/apps/default/netbox/app/helmrelease.yaml >/dev/null && echo OK
+```
+Expected: `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add kubernetes/apps/default/netbox/app/ocirepository.yaml \
+        kubernetes/apps/default/netbox/app/helmrelease.yaml
+git commit -m "feat(netbox): add ocirepository and helmrelease"
+```
+
+---
+
+## Task 5: HTTPRoute (internal)
+
+**Files:**
+- Create: `kubernetes/apps/default/netbox/app/httproute.yaml`
+
+- [ ] **Step 1: Write `httproute.yaml`**
+
+Both hostnames on `envoy-internal` — per repo convention, listing the `${SECRET_DOMAIN}` host on the internal listener keeps it internal-only (no public exposure). Backend is the chart's `netbox` Service on port 80.
+
+```yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: netbox
+spec:
+  hostnames:
+    - "netbox.${SECRET_DOMAIN}"
+    - "netbox.${SECRET_INTERNAL_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: netbox
+          port: 80
+```
+
+- [ ] **Step 2: Validate YAML parses**
+
+Run: `yq -e '.' kubernetes/apps/default/netbox/app/httproute.yaml >/dev/null && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add kubernetes/apps/default/netbox/app/httproute.yaml
+git commit -m "feat(netbox): add internal httproute"
+```
+
+---
+
+## Task 6: Full validation (flux-local + lint)
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Run flux-local against the cluster path**
+
+Run:
+```bash
+flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose 2>&1 | tail -30
+```
+Expected: completes without error; the `netbox` Kustomization and HelmRelease are built/templated successfully. Common failure to watch for: a `${VAR}` that should have been escaped, or a chart value rejected by the schema.
+
+- [ ] **Step 2: Confirm the rendered HelmRelease wiring (spot check)**
+
+Run:
+```bash
+flux-local build hr netbox -n default --enable-helm --path kubernetes/flux/cluster 2>/dev/null \
+  | yq 'select(.kind=="Deployment") | .spec.template.spec.initContainers[].name' | head
+```
+Expected: includes `init-db`. (If `flux-local build hr` syntax differs in the installed version, fall back to inspecting the Task 6 Step 1 output.)
+
+- [ ] **Step 3: Run super-linter locally**
+
+Run: `just lint`
+Expected: no findings on the new YAML (yamllint/prettier/actionlint/shellcheck clean).
+
+- [ ] **Step 4: Commit any lint-driven formatting fixes (if any)**
+
+```bash
+git add -A && git commit -m "style(netbox): lint fixes" || echo "nothing to commit"
+```
+
+---
+
+## Task 7: Deploy and verify on the live cluster
+
+**Files:** none (push + reconcile + observe). Use the repo kubeconfig: `export KUBECONFIG=/Users/luke.evans/GIT/LukeEvansTech/talos-cluster/kubeconfig`.
+
+- [ ] **Step 1: Push the branch and open a PR (only with user go-ahead)**
+
+```bash
+git push -u origin feat/netbox
+gh pr create --fill --base main
+```
+Wait for the `flux-local`, `lint`, and `security-scans` checks to pass, then merge.
+
+- [ ] **Step 2: Reconcile Flux after merge**
+
+```bash
+flux reconcile source git flux-system
+flux reconcile kustomization external-secrets -n external-secrets
+flux reconcile kustomization onepassword -n external-secrets
+flux reconcile kustomization netbox -n default
+```
+Expected: `netbox` Kustomization becomes `Ready`.
+
+- [ ] **Step 3: Verify the secret resolved and the DB was initialized**
+
+```bash
+kubectl -n default get externalsecret netbox
+kubectl -n default get secret netbox-secret -o jsonpath='{.data}' | yq 'keys'
+kubectl -n default get pods -l app.kubernetes.io/name=netbox
+kubectl -n default logs job/$(kubectl -n default get pods -l app.kubernetes.io/name=netbox -o name | head -1) -c init-db 2>/dev/null | tail || true
+```
+Expected: ExternalSecret `SecretSynced`; `netbox-secret` contains the keys from Task 3; web + worker pods `Running`, housekeeping CronJob present; `init-db` reports the `netbox` role/database created (or already exists).
+
+- [ ] **Step 4: Verify HelmRelease, ServiceMonitor, and HTTP reachability**
+
+```bash
+flux get helmrelease netbox -n default
+kubectl -n default get servicemonitor netbox
+kubectl -n default get httproute netbox -o jsonpath='{.status.parents[*].conditions[*].type}'
+```
+Expected: HelmRelease `Ready`; ServiceMonitor present; HTTPRoute `Accepted`/`ResolvedRefs`.
+
+- [ ] **Step 5: Functional check — log in as superuser**
+
+Browse to `https://netbox.${SECRET_INTERNAL_DOMAIN}`. Log in with username `admin` and the `NETBOX_SUPERUSER_PASSWORD` from 1Password.
+Expected: login succeeds (no CSRF/ALLOWED_HOSTS error — those are pre-wired), dashboard loads, and the Gatus `guarded` check for netbox is green.
+
+---
+
+## Out of scope (fast follow, per spec)
+
+- pocket-id OIDC remote auth + auto-create.
+- Public exposure / external hostname.
+- Ceph RGW S3 media backend.
+- NetBox plugins.
+
+## Rollback
+
+`git revert` the merge commit (or delete the app dir + the `./netbox/ks.yaml` line) and reconcile; `prune: true` removes all NetBox resources. The `netbox` database on `postgres18` and the 1Password item persist and must be dropped manually if a clean teardown is wanted.

--- a/docs/superpowers/plans/2026-05-29-netbox.md
+++ b/docs/superpowers/plans/2026-05-29-netbox.md
@@ -10,27 +10,27 @@
 
 ---
 
-## Pre-resolved facts (verified against chart 8.3.3 / appVersion v4.6.1 and this repo)
+## Pre-resolved facts (verified against chart 8.3.3 / appVersion v4.6.1 and this repository)
 
 - Chart: `oci://ghcr.io/netbox-community/netbox-chart/netbox`, tag **8.3.3**.
-- `postgres-init` image (repo standard): `ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7`.
+- `postgres-init` image (repository standard): `ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7`.
 - CNPG: `postgres18-rw.database.svc.cluster.local:5432`; superuser creds in 1Password item `cloudnative-pg` (`POSTGRES_SUPER_USER` / `POSTGRES_SUPER_PASS`).
 - Dragonfly: `dragonfly.database.svc.cluster.local:6379`; password in 1Password item `dragonfly` (`DRAGONFLY_PASSWORD`); auth user `default`.
 - VolSync component creates PVC named `${APP}` (`netbox`) on `ceph-block`, size `VOLSYNC_CAPACITY`. Chart must use `persistence.existingClaim: netbox`.
 - `worker.enabled` and `housekeeping.enabled` default to `true` in the chart.
 - Chart secret-key contract (the projected `secrets` volume, all items **required** unless noted):
-  - global `existingSecret` → keys `secret_key`, `email-password` (required), `api_token_peppers` (optional)
-  - `superuser.existingSecret` → keys `password`, `api_token`
-  - `externalDatabase.existingSecretName` → key set by `externalDatabase.existingSecretKey`
-  - `tasksDatabase` / `cachingDatabase` `existingSecretName` → keys set by their `existingSecretKey`
-  - All five references will point at the single secret `netbox-secret`.
+    - global `existingSecret` → keys `secret_key`, `email-password` (required), `api_token_peppers` (optional)
+    - `superuser.existingSecret` → keys `password`, `api_token`
+    - `externalDatabase.existingSecretName` → key set by `externalDatabase.existingSecretKey`
+    - `tasksDatabase` / `cachingDatabase` `existingSecretName` → keys set by their `existingSecretKey`
+    - All five references will point at the single secret `netbox-secret`.
 - `${TIMEZONE}` and `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` are cluster-secrets substitute vars.
 
 ---
 
 ## File Structure
 
-```
+```text
 kubernetes/apps/default/netbox/
 ├── ks.yaml                      # Flux Kustomization (&app netbox); components volsync + gatus/guarded
 └── app/
@@ -63,18 +63,21 @@ op item create --vault Talos --category login --title netbox \
 - [ ] **Step 2: Verify the item exists with all four fields**
 
 Run:
+
 ```bash
 op item get netbox --vault Talos --fields label=NETBOX_SECRET_KEY,label=NETBOX_SUPERUSER_PASSWORD,label=NETBOX_SUPERUSER_API_TOKEN,label=NETBOX_POSTGRES_PASSWORD
 ```
+
 Expected: four non-empty values printed. (NetBox SECRET_KEY must be 50+ chars — `rand -base64 60` yields ~80.)
 
-No commit (no repo change).
+No commit (no repository change).
 
 ---
 
 ## Task 2: Scaffold the Flux Kustomization and register it
 
 **Files:**
+
 - Create: `kubernetes/apps/default/netbox/ks.yaml`
 - Create: `kubernetes/apps/default/netbox/app/kustomization.yaml`
 - Modify: `kubernetes/apps/default/kustomization.yaml` (add `./netbox/ks.yaml` after `./n8n/ks.yaml`)
@@ -87,35 +90,35 @@ No commit (no repo change).
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: &app netbox
-  namespace: &namespace default
+    name: &app netbox
+    namespace: &namespace default
 spec:
-  commonMetadata:
-    labels:
-      app.kubernetes.io/name: *app
-  components:
-    - ../../../../components/gatus/guarded
-    - ../../../../components/volsync
-  dependsOn:
-    - name: cloudnative-pg-cluster
-      namespace: database
-    - name: dragonfly-cluster
-      namespace: database
-  interval: 1h
-  path: ./kubernetes/apps/default/netbox/app
-  postBuild:
-    substitute:
-      APP: *app
-      VOLSYNC_CAPACITY: 5Gi
-  prune: true
-  retryInterval: 2m
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
-  targetNamespace: *namespace
-  timeout: 5m
-  wait: false
+    commonMetadata:
+        labels:
+            app.kubernetes.io/name: *app
+    components:
+        - ../../../../components/gatus/guarded
+        - ../../../../components/volsync
+    dependsOn:
+        - name: cloudnative-pg-cluster
+          namespace: database
+        - name: dragonfly-cluster
+          namespace: database
+    interval: 1h
+    path: ./kubernetes/apps/default/netbox/app
+    postBuild:
+        substitute:
+            APP: *app
+            VOLSYNC_CAPACITY: 5Gi
+    prune: true
+    retryInterval: 2m
+    sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+    targetNamespace: *namespace
+    timeout: 5m
+    wait: false
 ```
 
 - [ ] **Step 2: Write `app/kustomization.yaml`**
@@ -126,24 +129,26 @@ spec:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./ocirepository.yaml
-  - ./externalsecret.yaml
-  - ./helmrelease.yaml
-  - ./httproute.yaml
+    - ./ocirepository.yaml
+    - ./externalsecret.yaml
+    - ./helmrelease.yaml
+    - ./httproute.yaml
 ```
 
 - [ ] **Step 3: Register in the namespace kustomization**
 
-In `kubernetes/apps/default/kustomization.yaml`, add the line `  - ./netbox/ks.yaml` immediately after `  - ./n8n/ks.yaml` (keeps alphabetical order: n8n < netbox < netronome).
+In `kubernetes/apps/default/kustomization.yaml`, add the entry `./netbox/ks.yaml` immediately after the `./n8n/ks.yaml` entry (keeps alphabetical order: n8n < netbox < netronome). Match the surrounding two-space list indentation.
 
 - [ ] **Step 4: Validate YAML parses**
 
 Run:
+
 ```bash
 yq -e '.' kubernetes/apps/default/netbox/ks.yaml >/dev/null && \
 yq -e '.' kubernetes/apps/default/netbox/app/kustomization.yaml >/dev/null && \
 echo OK
 ```
+
 Expected: `OK`. (Full Flux validation runs in Task 6 once all resources exist — the app/kustomization references files not yet created, so a kustomize build is deferred.)
 
 - [ ] **Step 5: Commit**
@@ -160,6 +165,7 @@ git commit -m "feat(netbox): scaffold flux kustomization"
 ## Task 3: ExternalSecret (`netbox-secret`)
 
 **Files:**
+
 - Create: `kubernetes/apps/default/netbox/app/externalsecret.yaml`
 
 - [ ] **Step 1: Write `externalsecret.yaml`**
@@ -172,41 +178,41 @@ Every key consumed by the chart is templated here. `email-password` is set empty
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: netbox
+    name: netbox
 spec:
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: onepassword-connect
-  target:
-    name: netbox-secret
-    template:
-      engineVersion: v2
-      data:
-        # --- chart: global existingSecret (config) ---
-        secret_key: "{{ .NETBOX_SECRET_KEY }}"
-        email-password: ""
-        # --- chart: superuser.existingSecret ---
-        password: "{{ .NETBOX_SUPERUSER_PASSWORD }}"
-        api_token: "{{ .NETBOX_SUPERUSER_API_TOKEN }}"
-        # --- chart: externalDatabase.existingSecretKey: db_password ---
-        db_password: "{{ .NETBOX_POSTGRES_PASSWORD }}"
-        # --- chart: tasks/caching DB (Dragonfly), existingSecretKey: tasks_password / cache_password ---
-        tasks_password: "{{ .DRAGONFLY_PASSWORD }}"
-        cache_password: "{{ .DRAGONFLY_PASSWORD }}"
-        # --- postgres-init initContainer (envFrom) ---
-        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
-        INIT_POSTGRES_DBNAME: netbox
-        INIT_POSTGRES_USER: netbox
-        INIT_POSTGRES_PASS: "{{ .NETBOX_POSTGRES_PASSWORD }}"
-        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
-        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
-  dataFrom:
-    - extract:
-        key: netbox
-    - extract:
-        key: cloudnative-pg
-    - extract:
-        key: dragonfly
+    secretStoreRef:
+        kind: ClusterSecretStore
+        name: onepassword-connect
+    target:
+        name: netbox-secret
+        template:
+            engineVersion: v2
+            data:
+                # --- chart: global existingSecret (config) ---
+                secret_key: "{{ .NETBOX_SECRET_KEY }}"
+                email-password: ""
+                # --- chart: superuser.existingSecret ---
+                password: "{{ .NETBOX_SUPERUSER_PASSWORD }}"
+                api_token: "{{ .NETBOX_SUPERUSER_API_TOKEN }}"
+                # --- chart: externalDatabase.existingSecretKey: db_password ---
+                db_password: "{{ .NETBOX_POSTGRES_PASSWORD }}"
+                # --- chart: tasks/caching DB (Dragonfly), existingSecretKey: tasks_password / cache_password ---
+                tasks_password: "{{ .DRAGONFLY_PASSWORD }}"
+                cache_password: "{{ .DRAGONFLY_PASSWORD }}"
+                # --- postgres-init initContainer (envFrom) ---
+                INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+                INIT_POSTGRES_DBNAME: netbox
+                INIT_POSTGRES_USER: netbox
+                INIT_POSTGRES_PASS: "{{ .NETBOX_POSTGRES_PASSWORD }}"
+                INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+                INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+    dataFrom:
+        - extract:
+              key: netbox
+        - extract:
+              key: cloudnative-pg
+        - extract:
+              key: dragonfly
 ```
 
 - [ ] **Step 2: Validate YAML parses**
@@ -226,6 +232,7 @@ git commit -m "feat(netbox): add externalsecret"
 ## Task 4: OCIRepository + HelmRelease
 
 **Files:**
+
 - Create: `kubernetes/apps/default/netbox/app/ocirepository.yaml`
 - Create: `kubernetes/apps/default/netbox/app/helmrelease.yaml`
 
@@ -237,15 +244,15 @@ git commit -m "feat(netbox): add externalsecret"
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: netbox
+    name: netbox
 spec:
-  interval: 1h
-  layerSelector:
-    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
-    operation: copy
-  ref:
-    tag: 8.3.3
-  url: oci://ghcr.io/netbox-community/netbox-chart/netbox
+    interval: 1h
+    layerSelector:
+        mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+        operation: copy
+    ref:
+        tag: 8.3.3
+    url: oci://ghcr.io/netbox-community/netbox-chart/netbox
 ```
 
 - [ ] **Step 2: Write `helmrelease.yaml`**
@@ -256,100 +263,102 @@ spec:
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: netbox
-spec:
-  interval: 1h
-  chartRef:
-    kind: OCIRepository
     name: netbox
-  install:
-    remediation:
-      retries: 3
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
-  values:
-    commonAnnotations:
-      reloader.stakater.com/auto: "true"
-    replicaCount: 1
-    timeZone: "${TIMEZONE}"
-    loginRequired: true
-    superuser:
-      name: admin
-      email: "admin@${SECRET_DOMAIN}"
-      existingSecret: netbox-secret
-    existingSecret: netbox-secret
-    allowedHosts:
-      - "netbox.${SECRET_DOMAIN}"
-      - "netbox.${SECRET_INTERNAL_DOMAIN}"
-    allowedHostsIncludesPodIP: true
-    csrf:
-      trustedOrigins:
-        - "https://netbox.${SECRET_DOMAIN}"
-        - "https://netbox.${SECRET_INTERNAL_DOMAIN}"
-    plugins: []
-    persistence:
-      enabled: true
-      existingClaim: netbox
-    resourcesPreset: none
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-      limits:
-        memory: 1Gi
-    initContainers:
-      - name: init-db
-        image: ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
-        envFrom:
-          - secretRef:
-              name: netbox-secret
-    metrics:
-      enabled: true
-      serviceMonitor:
-        enabled: true
-    postgresql:
-      enabled: false
-    externalDatabase:
-      host: postgres18-rw.database.svc.cluster.local
-      port: 5432
-      database: netbox
-      username: netbox
-      existingSecretName: netbox-secret
-      existingSecretKey: db_password
-      options:
-        sslmode: require
-        target_session_attrs: read-write
-    valkey:
-      enabled: false
-    tasksDatabase:
-      host: dragonfly.database.svc.cluster.local
-      port: 6379
-      database: 0
-      username: default
-      existingSecretName: netbox-secret
-      existingSecretKey: tasks_password
-    cachingDatabase:
-      host: dragonfly.database.svc.cluster.local
-      port: 6379
-      database: 1
-      username: default
-      existingSecretName: netbox-secret
-      existingSecretKey: cache_password
-    worker:
-      enabled: true
-    housekeeping:
-      enabled: true
+spec:
+    interval: 1h
+    chartRef:
+        kind: OCIRepository
+        name: netbox
+    install:
+        remediation:
+            retries: 3
+    upgrade:
+        cleanupOnFail: true
+        remediation:
+            retries: 3
+    values:
+        commonAnnotations:
+            reloader.stakater.com/auto: "true"
+        replicaCount: 1
+        timeZone: "${TIMEZONE}"
+        loginRequired: true
+        superuser:
+            name: admin
+            email: "admin@${SECRET_DOMAIN}"
+            existingSecret: netbox-secret
+        existingSecret: netbox-secret
+        allowedHosts:
+            - "netbox.${SECRET_DOMAIN}"
+            - "netbox.${SECRET_INTERNAL_DOMAIN}"
+        allowedHostsIncludesPodIP: true
+        csrf:
+            trustedOrigins:
+                - "https://netbox.${SECRET_DOMAIN}"
+                - "https://netbox.${SECRET_INTERNAL_DOMAIN}"
+        plugins: []
+        persistence:
+            enabled: true
+            existingClaim: netbox
+        resourcesPreset: none
+        resources:
+            requests:
+                cpu: 100m
+                memory: 256Mi
+            limits:
+                memory: 1Gi
+        initContainers:
+            - name: init-db
+              image: ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+              envFrom:
+                  - secretRef:
+                        name: netbox-secret
+        metrics:
+            enabled: true
+            serviceMonitor:
+                enabled: true
+        postgresql:
+            enabled: false
+        externalDatabase:
+            host: postgres18-rw.database.svc.cluster.local
+            port: 5432
+            database: netbox
+            username: netbox
+            existingSecretName: netbox-secret
+            existingSecretKey: db_password
+            options:
+                sslmode: require
+                target_session_attrs: read-write
+        valkey:
+            enabled: false
+        tasksDatabase:
+            host: dragonfly.database.svc.cluster.local
+            port: 6379
+            database: 0
+            username: default
+            existingSecretName: netbox-secret
+            existingSecretKey: tasks_password
+        cachingDatabase:
+            host: dragonfly.database.svc.cluster.local
+            port: 6379
+            database: 1
+            username: default
+            existingSecretName: netbox-secret
+            existingSecretKey: cache_password
+        worker:
+            enabled: true
+        housekeeping:
+            enabled: true
 ```
 
 - [ ] **Step 3: Validate YAML parses**
 
 Run:
+
 ```bash
 yq -e '.' kubernetes/apps/default/netbox/app/ocirepository.yaml >/dev/null && \
 yq -e '.' kubernetes/apps/default/netbox/app/helmrelease.yaml >/dev/null && echo OK
 ```
+
 Expected: `OK`.
 
 - [ ] **Step 4: Commit**
@@ -365,11 +374,12 @@ git commit -m "feat(netbox): add ocirepository and helmrelease"
 ## Task 5: HTTPRoute (internal)
 
 **Files:**
+
 - Create: `kubernetes/apps/default/netbox/app/httproute.yaml`
 
 - [ ] **Step 1: Write `httproute.yaml`**
 
-Both hostnames on `envoy-internal` — per repo convention, listing the `${SECRET_DOMAIN}` host on the internal listener keeps it internal-only (no public exposure). Backend is the chart's `netbox` Service on port 80.
+Both hostnames on `envoy-internal` — per repository convention, listing the `${SECRET_DOMAIN}` host on the internal listener keeps it internal-only (no public exposure). Backend is the chart's `netbox` Service on port 80.
 
 ```yaml
 ---
@@ -377,18 +387,18 @@ Both hostnames on `envoy-internal` — per repo convention, listing the `${SECRE
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: netbox
+    name: netbox
 spec:
-  hostnames:
-    - "netbox.${SECRET_DOMAIN}"
-    - "netbox.${SECRET_INTERNAL_DOMAIN}"
-  parentRefs:
-    - name: envoy-internal
-      namespace: network
-  rules:
-    - backendRefs:
-        - name: netbox
-          port: 80
+    hostnames:
+        - "netbox.${SECRET_DOMAIN}"
+        - "netbox.${SECRET_INTERNAL_DOMAIN}"
+    parentRefs:
+        - name: envoy-internal
+          namespace: network
+    rules:
+        - backendRefs:
+              - name: netbox
+                port: 80
 ```
 
 - [ ] **Step 2: Validate YAML parses**
@@ -412,18 +422,22 @@ git commit -m "feat(netbox): add internal httproute"
 - [ ] **Step 1: Run flux-local against the cluster path**
 
 Run:
+
 ```bash
 flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster --verbose 2>&1 | tail -30
 ```
+
 Expected: completes without error; the `netbox` Kustomization and HelmRelease are built/templated successfully. Common failure to watch for: a `${VAR}` that should have been escaped, or a chart value rejected by the schema.
 
 - [ ] **Step 2: Confirm the rendered HelmRelease wiring (spot check)**
 
 Run:
+
 ```bash
 flux-local build hr netbox -n default --enable-helm --path kubernetes/flux/cluster 2>/dev/null \
   | yq 'select(.kind=="Deployment") | .spec.template.spec.initContainers[].name' | head
 ```
+
 Expected: includes `init-db`. (If `flux-local build hr` syntax differs in the installed version, fall back to inspecting the Task 6 Step 1 output.)
 
 - [ ] **Step 3: Run super-linter locally**
@@ -441,7 +455,7 @@ git add -A && git commit -m "style(netbox): lint fixes" || echo "nothing to comm
 
 ## Task 7: Deploy and verify on the live cluster
 
-**Files:** none (push + reconcile + observe). Use the repo kubeconfig: `export KUBECONFIG=/Users/luke.evans/GIT/LukeEvansTech/talos-cluster/kubeconfig`.
+**Files:** none (push + reconcile + observe). Use the repository kubeconfig: `export KUBECONFIG=/Users/luke.evans/GIT/LukeEvansTech/talos-cluster/kubeconfig`.
 
 - [ ] **Step 1: Push the branch and open a PR (only with user go-ahead)**
 
@@ -449,6 +463,7 @@ git add -A && git commit -m "style(netbox): lint fixes" || echo "nothing to comm
 git push -u origin feat/netbox
 gh pr create --fill --base main
 ```
+
 Wait for the `flux-local`, `lint`, and `security-scans` checks to pass, then merge.
 
 - [ ] **Step 2: Reconcile Flux after merge**
@@ -459,6 +474,7 @@ flux reconcile kustomization external-secrets -n external-secrets
 flux reconcile kustomization onepassword -n external-secrets
 flux reconcile kustomization netbox -n default
 ```
+
 Expected: `netbox` Kustomization becomes `Ready`.
 
 - [ ] **Step 3: Verify the secret resolved and the DB was initialized**
@@ -469,6 +485,7 @@ kubectl -n default get secret netbox-secret -o jsonpath='{.data}' | yq 'keys'
 kubectl -n default get pods -l app.kubernetes.io/name=netbox
 kubectl -n default logs job/$(kubectl -n default get pods -l app.kubernetes.io/name=netbox -o name | head -1) -c init-db 2>/dev/null | tail || true
 ```
+
 Expected: ExternalSecret `SecretSynced`; `netbox-secret` contains the keys from Task 3; web + worker pods `Running`, housekeeping CronJob present; `init-db` reports the `netbox` role/database created (or already exists).
 
 - [ ] **Step 4: Verify HelmRelease, ServiceMonitor, and HTTP reachability**
@@ -478,6 +495,7 @@ flux get helmrelease netbox -n default
 kubectl -n default get servicemonitor netbox
 kubectl -n default get httproute netbox -o jsonpath='{.status.parents[*].conditions[*].type}'
 ```
+
 Expected: HelmRelease `Ready`; ServiceMonitor present; HTTPRoute `Accepted`/`ResolvedRefs`.
 
 - [ ] **Step 5: Functional check — log in as superuser**

--- a/docs/superpowers/specs/2026-05-29-netbox-design.md
+++ b/docs/superpowers/specs/2026-05-29-netbox-design.md
@@ -1,0 +1,164 @@
+# NetBox — Design
+
+**Date:** 2026-05-29
+**Status:** Approved
+**Branch:** `feat/netbox`
+
+## Goal
+
+Stand up [NetBox](https://github.com/netbox-community/netbox) (DCIM/IPAM) on the
+cluster following this repo's standard app patterns — modelled on the existing
+`paperless` app, which is the closest in-repo twin (shared CNPG Postgres +
+`postgres-init`, Dragonfly redis, VolSync media backup, pocket-id OIDC available).
+
+Reference implementations reviewed: `jfroy/flatops` (best structural match —
+CNPG + `postgres-init` + Rook RGW + envoy-internal + VolSync), `drag0n141/home-ops`
+(external Dragonfly + pocket-id OIDC), `Mafyuh/iac` (minimal 4-file layout).
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Namespace | `default` | Matches references and in-repo twins (`paperless`, `tandoor`, `whodb`). |
+| Redis | External **Dragonfly** | Repo standard; `paperless` already uses it. Bundled Valkey disabled. |
+| Media storage | Local **`ceph-block` PVC** + VolSync | Fewest moving parts; proven `paperless` pattern. (Ceph RGW S3 is available but not used here.) |
+| Worker + housekeeping | **Both enabled** | "Real" NetBox: RQ worker for webhooks/scripts/reports + housekeeping CronJob. |
+| Auth | **Superuser only (first pass)** | Get core working; pocket-id OIDC is a fast follow. |
+| Exposure | **Internal only** | DCIM/IPAM is not public. HTTPRoute on `envoy-internal`. |
+
+## File Layout
+
+Standard 4-file app under `kubernetes/apps/default/netbox/`:
+
+```
+kubernetes/apps/default/netbox/
+├── ks.yaml                      # Flux Kustomization (&app netbox)
+└── app/
+    ├── helmrelease.yaml         # OCIRepository + HelmRelease
+    ├── externalsecret.yaml      # 1Password → netbox-secret
+    ├── httproute.yaml           # envoy-internal route
+    └── kustomization.yaml
+```
+
+The namespace `kustomization.yaml` at `kubernetes/apps/default/kustomization.yaml`
+gets a new entry for `./netbox/ks.yaml` (alphabetical order).
+
+## Components
+
+`ks.yaml` `spec.components` (NOT also in `app/kustomization.yaml` — Flux applies
+ks.yaml components on top of the path build):
+
+- `../../../../components/gatus/guarded` — health monitoring
+- `../../../../components/volsync` — media PVC backup (`VOLSYNC_CAPACITY`)
+
+`postBuild.substitute`: `APP: *app`, `VOLSYNC_CAPACITY: 5Gi`.
+
+`dependsOn`:
+- `cloudnative-pg-cluster` (namespace `database`)
+- `dragonfly-cluster` (namespace `database`)
+- `onepassword` is reached via the global chain; the ExternalSecret store
+  `onepassword-connect` is used directly.
+
+## Chart Source
+
+`OCIRepository` → `oci://ghcr.io/netbox-community/netbox-chart/netbox`, pinned to
+the current 8.2.x tag (verified at implementation against the published chart;
+Renovate manages thereafter). `chartRef.kind: OCIRepository` in the HelmRelease.
+
+## Data Plane
+
+### PostgreSQL (shared CNPG `postgres18`)
+
+- `postgresql.enabled: false`
+- `externalDatabase`: host `postgres18-rw.database.svc.cluster.local`, port `5432`,
+  database `netbox`, username `netbox`, password from `netbox-secret`, `sslmode=require`.
+- A `postgres-init` initContainer (`ghcr.io/home-operations/postgres-init`) creates
+  the `netbox` role + database using the CNPG superuser, mirroring `paperless`:
+  - `INIT_POSTGRES_HOST`, `INIT_POSTGRES_DBNAME=netbox`, `INIT_POSTGRES_USER=netbox`,
+    `INIT_POSTGRES_PASS` (app password)
+  - `INIT_POSTGRES_SUPER_USER` / `INIT_POSTGRES_SUPER_PASS` from 1Password `cloudnative-pg`.
+
+### Redis (Dragonfly)
+
+- Bundled `valkey.enabled: false`.
+- `externalRedis` → `dragonfly.database.svc.cluster.local:6379`, auth user `default`,
+  password from 1Password `dragonfly` (`DRAGONFLY_PASSWORD`).
+- Separate logical DB indexes for the tasks queue vs the cache (e.g. tasks `0`,
+  cache `1`) — final index values set per the chart's `externalRedis` schema.
+
+### Media
+
+- `persistence.enabled: true`, `ceph-block` StorageClass PVC, mounted at NetBox's
+  media path. Backed up by the VolSync component.
+
+## Workloads
+
+- **web** (default), **worker** (`worker.enabled: true` — RQ background jobs),
+  **housekeeping** (`housekeeping.enabled: true` — daily CronJob).
+- `metrics.serviceMonitor.enabled: true` (scraped by kube-prometheus-stack).
+- `commonAnnotations: reloader.stakater.com/auto: "true"`.
+- `resourcesPreset` / explicit requests+limits set to sane values at implementation.
+
+## Networking
+
+- `HTTPRoute` `netbox` on `parentRefs: envoy-internal` (namespace `network`).
+- Hostname `netbox.${SECRET_INTERNAL_DOMAIN}` (internal DNS via external-dns → OPNsense).
+- Backend: service `netbox`, port `80`.
+- **Django host guarding:** set `ALLOWED_HOSTS` to include the route host and the
+  in-cluster service name, and set CSRF trusted origins to
+  `https://netbox.${SECRET_INTERNAL_DOMAIN}`. NetBox/Django rejects requests with an
+  unlisted Host header, including kubelet probes — see prior paperless/Prowler
+  ALLOWED_HOSTS lessons.
+
+## Secrets
+
+Single `ExternalSecret` (`onepassword-connect` ClusterSecretStore,
+`engineVersion: v2`) producing `netbox-secret`, with `dataFrom` extracting:
+
+- `cloudnative-pg` — `POSTGRES_SUPER_USER`, `POSTGRES_SUPER_PASS`
+- `dragonfly` — `DRAGONFLY_PASSWORD`
+- `netbox` (NEW item) — superuser password, API token, `SECRET_KEY`, app DB password
+
+The `netbox` 1Password item is created via the `op` CLI into the `Talos` vault
+(never the UI), with values generated locally:
+
+```bash
+op item create --vault Talos --category login --title netbox \
+  NETBOX_SUPERUSER_PASSWORD="$(openssl rand -base64 24)" \
+  NETBOX_SUPERUSER_API_TOKEN="$(openssl rand -hex 20)" \
+  NETBOX_SECRET_KEY="$(openssl rand -base64 60 | tr -d '\n')" \
+  NETBOX_POSTGRES_PASSWORD="$(openssl rand -base64 24)"
+```
+
+(Exact field names reconciled with the chart's expected `existingSecret` keys —
+see "To verify" below.)
+
+## To Verify At Implementation (chart-schema specifics, not assumptions)
+
+1. Pull `netbox-chart` 8.2.x `values.yaml` and confirm:
+   - The exact `existingSecret` **key names** the chart expects
+     (e.g. `db_password`, `redis_password`, `redis_tasks_password`,
+     `superuser_password`, `superuser_api_token`, `secret_key`).
+   - The `externalRedis` value schema (tasks vs caching host/port/db/secret keys)
+     and the correct flag to disable the bundled cache (`valkey.enabled` vs
+     `redis.enabled` for this chart major).
+   - The media mount path and the persistence value keys.
+2. Confirm the current published chart tag.
+3. Map the `netbox` 1Password field names to the chart's `existingSecret` keys.
+
+## Out of Scope (fast follow)
+
+- pocket-id OIDC remote auth + auto-create (mirror `paperless`
+  `PAPERLESS_SOCIALACCOUNT_PROVIDERS` style).
+- Public exposure / external hostname.
+- Ceph RGW S3 media backend.
+- NetBox plugins.
+
+## Verification
+
+- `flux-local test --all-namespaces --enable-helm --path kubernetes/flux/cluster`
+  passes locally and in the `flux-local` CI workflow.
+- `just lint` (super-linter) clean.
+- After deploy: HelmRelease `Ready`, web + worker + housekeeping pods healthy,
+  `postgres-init` completes, NetBox UI reachable at the internal host, login as
+  superuser, Gatus health check green.

--- a/docs/superpowers/specs/2026-05-29-netbox-design.md
+++ b/docs/superpowers/specs/2026-05-29-netbox-design.md
@@ -17,20 +17,20 @@ CNPG + `postgres-init` + Rook RGW + envoy-internal + VolSync), `drag0n141/home-o
 
 ## Decisions
 
-| Decision | Choice | Rationale |
-|---|---|---|
-| Namespace | `default` | Matches references and in-repo twins (`paperless`, `tandoor`, `whodb`). |
-| Redis | External **Dragonfly** | Repo standard; `paperless` already uses it. Bundled Valkey disabled. |
-| Media storage | Local **`ceph-block` PVC** + VolSync | Fewest moving parts; proven `paperless` pattern. (Ceph RGW S3 is available but not used here.) |
-| Worker + housekeeping | **Both enabled** | "Real" NetBox: RQ worker for webhooks/scripts/reports + housekeeping CronJob. |
-| Auth | **Superuser only (first pass)** | Get core working; pocket-id OIDC is a fast follow. |
-| Exposure | **Internal only** | DCIM/IPAM is not public. HTTPRoute on `envoy-internal`. |
+| Decision              | Choice                               | Rationale                                                                                      |
+| --------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| Namespace             | `default`                            | Matches references and in-repo twins (`paperless`, `tandoor`, `whodb`).                        |
+| Redis                 | External **Dragonfly**               | Repository standard; `paperless` already uses it. Bundled Valkey disabled.                     |
+| Media storage         | Local **`ceph-block` PVC** + VolSync | Fewest moving parts; proven `paperless` pattern. (Ceph RGW S3 is available but not used here.) |
+| Worker + housekeeping | **Both enabled**                     | "Real" NetBox: RQ worker for webhooks/scripts/reports + housekeeping CronJob.                  |
+| Auth                  | **Superuser only (first pass)**      | Get core working; pocket-id OIDC is a fast follow.                                             |
+| Exposure              | **Internal only**                    | DCIM/IPAM is not public. HTTPRoute on `envoy-internal`.                                        |
 
 ## File Layout
 
 Standard 4-file app under `kubernetes/apps/default/netbox/`:
 
-```
+```text
 kubernetes/apps/default/netbox/
 ├── ks.yaml                      # Flux Kustomization (&app netbox)
 └── app/
@@ -54,6 +54,7 @@ ks.yaml components on top of the path build):
 `postBuild.substitute`: `APP: *app`, `VOLSYNC_CAPACITY: 5Gi`.
 
 `dependsOn`:
+
 - `cloudnative-pg-cluster` (namespace `database`)
 - `dragonfly-cluster` (namespace `database`)
 - `onepassword` is reached via the global chain; the ExternalSecret store
@@ -74,16 +75,16 @@ Renovate manages thereafter). `chartRef.kind: OCIRepository` in the HelmRelease.
   database `netbox`, username `netbox`, password from `netbox-secret`, `sslmode=require`.
 - A `postgres-init` initContainer (`ghcr.io/home-operations/postgres-init`) creates
   the `netbox` role + database using the CNPG superuser, mirroring `paperless`:
-  - `INIT_POSTGRES_HOST`, `INIT_POSTGRES_DBNAME=netbox`, `INIT_POSTGRES_USER=netbox`,
-    `INIT_POSTGRES_PASS` (app password)
-  - `INIT_POSTGRES_SUPER_USER` / `INIT_POSTGRES_SUPER_PASS` from 1Password `cloudnative-pg`.
+    - `INIT_POSTGRES_HOST`, `INIT_POSTGRES_DBNAME=netbox`, `INIT_POSTGRES_USER=netbox`,
+      `INIT_POSTGRES_PASS` (app password)
+    - `INIT_POSTGRES_SUPER_USER` / `INIT_POSTGRES_SUPER_PASS` from 1Password `cloudnative-pg`.
 
 ### Redis (Dragonfly)
 
 - Bundled `valkey.enabled: false`.
 - `externalRedis` → `dragonfly.database.svc.cluster.local:6379`, auth user `default`,
   password from 1Password `dragonfly` (`DRAGONFLY_PASSWORD`).
-- Separate logical DB indexes for the tasks queue vs the cache (e.g. tasks `0`,
+- Separate logical DB indices for the tasks queue vs the cache (e.g. tasks `0`,
   cache `1`) — final index values set per the chart's `externalRedis` schema.
 
 ### Media
@@ -136,13 +137,13 @@ see "To verify" below.)
 ## To Verify At Implementation (chart-schema specifics, not assumptions)
 
 1. Pull `netbox-chart` 8.2.x `values.yaml` and confirm:
-   - The exact `existingSecret` **key names** the chart expects
-     (e.g. `db_password`, `redis_password`, `redis_tasks_password`,
-     `superuser_password`, `superuser_api_token`, `secret_key`).
-   - The `externalRedis` value schema (tasks vs caching host/port/db/secret keys)
-     and the correct flag to disable the bundled cache (`valkey.enabled` vs
-     `redis.enabled` for this chart major).
-   - The media mount path and the persistence value keys.
+    - The exact `existingSecret` **key names** the chart expects
+      (e.g. `db_password`, `redis_password`, `redis_tasks_password`,
+      `superuser_password`, `superuser_api_token`, `secret_key`).
+    - The `externalRedis` value schema (tasks vs caching host/port/db/secret keys)
+      and the correct flag to disable the bundled cache (`valkey.enabled` vs
+      `redis.enabled` for this chart major).
+    - The media mount path and the persistence value keys.
 2. Confirm the current published chart tag.
 3. Map the `netbox` 1Password field names to the chart's `existingSecret` keys.
 

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -43,6 +43,7 @@ resources:
   - ./manyfold/ks.yaml
   - ./miniflux/ks.yaml
   - ./n8n/ks.yaml
+  - ./netbox/ks.yaml
   - ./netronome/ks.yaml
   - ./notifier/ks.yaml
   - ./pairdrop/ks.yaml

--- a/kubernetes/apps/default/netbox/app/externalsecret.yaml
+++ b/kubernetes/apps/default/netbox/app/externalsecret.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: netbox
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: netbox-secret
+    template:
+      engineVersion: v2
+      data:
+        # --- chart: global existingSecret (config) ---
+        secret_key: "{{ .NETBOX_SECRET_KEY }}"
+        email-password: ""
+        # --- chart: superuser.existingSecret ---
+        password: "{{ .NETBOX_SUPERUSER_PASSWORD }}"
+        api_token: "{{ .NETBOX_SUPERUSER_API_TOKEN }}"
+        # --- chart: externalDatabase.existingSecretKey: db_password ---
+        db_password: "{{ .NETBOX_POSTGRES_PASSWORD }}"
+        # --- chart: tasks/caching DB (Dragonfly) ---
+        tasks_password: "{{ .DRAGONFLY_PASSWORD }}"
+        cache_password: "{{ .DRAGONFLY_PASSWORD }}"
+        # --- postgres-init initContainer (envFrom) ---
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_DBNAME: netbox
+        INIT_POSTGRES_USER: netbox
+        INIT_POSTGRES_PASS: "{{ .NETBOX_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: netbox
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: dragonfly

--- a/kubernetes/apps/default/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/netbox/app/helmrelease.yaml
@@ -1,0 +1,90 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: netbox
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: netbox
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    commonAnnotations:
+      reloader.stakater.com/auto: "true"
+    replicaCount: 1
+    timeZone: "${TIMEZONE}"
+    loginRequired: true
+    superuser:
+      name: admin
+      email: "admin@${SECRET_DOMAIN}"
+      existingSecret: netbox-secret
+    existingSecret: netbox-secret
+    allowedHosts:
+      - "netbox.${SECRET_DOMAIN}"
+      - "netbox.${SECRET_INTERNAL_DOMAIN}"
+    allowedHostsIncludesPodIP: true
+    csrf:
+      trustedOrigins:
+        - "https://netbox.${SECRET_DOMAIN}"
+        - "https://netbox.${SECRET_INTERNAL_DOMAIN}"
+    plugins: []
+    persistence:
+      enabled: true
+      existingClaim: netbox
+    resourcesPreset: none
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+    initContainers:
+      - name: init-db
+        image: ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+        envFrom:
+          - secretRef:
+              name: netbox-secret
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    postgresql:
+      enabled: false
+    externalDatabase:
+      host: postgres18-rw.database.svc.cluster.local
+      port: 5432
+      database: netbox
+      username: netbox
+      existingSecretName: netbox-secret
+      existingSecretKey: db_password
+      options:
+        sslmode: require
+        target_session_attrs: read-write
+    valkey:
+      enabled: false
+    tasksDatabase:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+      database: 0
+      username: default
+      existingSecretName: netbox-secret
+      existingSecretKey: tasks_password
+    cachingDatabase:
+      host: dragonfly.database.svc.cluster.local
+      port: 6379
+      database: 1
+      username: default
+      existingSecretName: netbox-secret
+      existingSecretKey: cache_password
+    worker:
+      enabled: true
+    housekeeping:
+      enabled: true

--- a/kubernetes/apps/default/netbox/app/httproute.yaml
+++ b/kubernetes/apps/default/netbox/app/httproute.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: netbox
+spec:
+  hostnames:
+    - "netbox.${SECRET_DOMAIN}"
+    - "netbox.${SECRET_INTERNAL_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: netbox
+          port: 80

--- a/kubernetes/apps/default/netbox/app/kustomization.yaml
+++ b/kubernetes/apps/default/netbox/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/default/netbox/app/ocirepository.yaml
+++ b/kubernetes/apps/default/netbox/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: netbox
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 8.3.3
+  url: oci://ghcr.io/netbox-community/netbox-chart/netbox

--- a/kubernetes/apps/default/netbox/ks.yaml
+++ b/kubernetes/apps/default/netbox/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app netbox
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: dragonfly-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/default/netbox/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Stands up **NetBox** (DCIM/IPAM) in the `default` namespace, modelled on the existing `paperless` app.

- Chart: `oci://ghcr.io/netbox-community/netbox-chart/netbox` **8.3.3** (appVersion v4.6.1)
- **Postgres**: shared CNPG `postgres18-rw`; `netbox` role/DB created by a `postgres-init` initContainer (superuser creds from 1Password `cloudnative-pg`), `sslmode=require`
- **Redis**: external **Dragonfly** (tasks DB 0 / cache DB 1), bundled Valkey disabled
- **Media**: `ceph-block` PVC owned by the VolSync component (`persistence.existingClaim: netbox`), `VOLSYNC_CAPACITY: 5Gi`
- **Workloads**: web + RQ worker + housekeeping CronJob; `metrics.serviceMonitor.enabled`
- **Secrets**: single `netbox-secret` ExternalSecret satisfies every chart reference (new 1Password item `netbox` in Talos vault)
- **Networking**: internal-only `HTTPRoute` on `envoy-internal`, hosts `netbox.${SECRET_DOMAIN}` + `netbox.${SECRET_INTERNAL_DOMAIN}`, with `ALLOWED_HOSTS` + `CSRF_TRUSTED_ORIGINS` pre-wired

Auth is superuser-only for this pass; pocket-id OIDC, public exposure, and S3 media are deferred fast-follows.

## Validation

- `flux-local build hr netbox` renders cleanly (web+worker Deployments, housekeeping CronJob, ServiceMonitor; `init-db` initContainer present; all secret projections → `netbox-secret`)
- `just lint` (super-linter) exits 0

## Design / plan

- `docs/superpowers/specs/2026-05-29-netbox-design.md`
- `docs/superpowers/plans/2026-05-29-netbox.md`