### PR TITLE
fix(netbox): correct email secret key (email_password)

### DIFF
--- a/kubernetes/apps/default/netbox/app/externalsecret.yaml
+++ b/kubernetes/apps/default/netbox/app/externalsecret.yaml
@@ -15,7 +15,9 @@ spec:
       data:
         # --- chart: global existingSecret (config) ---
         secret_key: "{{ .NETBOX_SECRET_KEY }}"
-        email-password: ""
+        # chart projects the global existingSecret's email key as `email_password`
+        # (underscore) when no separate email.existingSecretName is set
+        email_password: ""
         # --- chart: superuser.existingSecret ---
         password: "{{ .NETBOX_SUPERUSER_PASSWORD }}"
         api_token: "{{ .NETBOX_SUPERUSER_API_TOKEN }}"


### PR DESCRIPTION
The netbox-chart projects the global `existingSecret`'s email password under key `email_password` (underscore) when no separate `email.existingSecretName` is set (confirmed via `netbox.email.secretKey` chart helper). The initial deploy used `email-password` (hyphen), so the projected `secrets` volume failed with `references non-existent secret key: email_password` and pods were stuck in init. One-character fix.