### PR TITLE
fix(netbox): add superuser username/email secret keys

### DIFF
--- a/kubernetes/apps/default/netbox/app/externalsecret.yaml
+++ b/kubernetes/apps/default/netbox/app/externalsecret.yaml
@@ -18,7 +18,9 @@ spec:
         # chart projects the global existingSecret's email key as `email_password`
         # (underscore) when no separate email.existingSecretName is set
         email_password: ""
-        # --- chart: superuser.existingSecret ---
+        # --- chart: superuser.existingSecret (reads username/email via env too) ---
+        username: admin
+        email: "admin@${SECRET_DOMAIN}"
         password: "{{ .NETBOX_SUPERUSER_PASSWORD }}"
         api_token: "{{ .NETBOX_SUPERUSER_API_TOKEN }}"
         # --- chart: externalDatabase.existingSecretKey: db_password ---


### PR DESCRIPTION
The chart reads `SUPERUSER_NAME`←`username` and `SUPERUSER_EMAIL`←`email` as env from `superuser.existingSecret` (= `netbox-secret`). The initial secret only had `password`/`api_token`, so the main container failed with `couldn't find key username`. Adds `username: admin` and `email` (the only two remaining secret keys the chart references — verified by grepping all chart templates). postgres-init already completed successfully.