### PR TITLE
fix(deduparr): loosen liveness probe to tolerate in-run health stalls

### DIFF
--- a/kubernetes/apps/media/deduparr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/deduparr/app/helmrelease.yaml
@@ -37,6 +37,10 @@ spec:
               - secretRef:
                   name: deduparr-secret
             probes:
+              # deduparr runs a dedup cycle every DEDUPARR_SERVICE__INTERVAL (2m),
+              # during which its single-threaded HTTP server stalls /health/ready
+              # for ~13s. Tolerant liveness (3 x 30s, 10s timeout = ~90s) rides out
+              # the in-run stall while still restarting a genuinely hung process.
               liveness:
                 enabled: true
                 custom: true
@@ -44,9 +48,9 @@ spec:
                   httpGet:
                     path: /health/ready
                     port: *port
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+                  timeoutSeconds: 10
                   failureThreshold: 3
               readiness:
                 enabled: true


### PR DESCRIPTION
## Problem

`media/deduparr` was in **CrashLoopBackOff with 59 restarts**. It runs a dedup cycle every 2m (`DEDUPARR_SERVICE__INTERVAL`); during each run its single-threaded HTTP server stalls `/health/ready` for ~13s:

```
Liveness probe failed: Get "http://.../health/ready": context deadline exceeded
Container app failed liveness probe, will be restarted
```

The liveness probe (`periodSeconds: 10`, `timeoutSeconds: 1`, `failureThreshold: 3`) tripped on every cycle → kubelet killed the pod ~every 3 min.

## Fix

Widen liveness to `periodSeconds: 30`, `timeoutSeconds: 10`, `failureThreshold: 3` (~90s tolerance) so a normal in-run stall is ridden out, while a genuinely hung process is still restarted within ~90s. Readiness left as-is (flapping there is harmless — it only affects the metrics endpoint).

Found while investigating cluster-wide DNS/networking issues (unrelated root cause — a node-reboot Cilium reconciliation problem — already resolved separately).