### PR TITLE
fix(netbox): co-locate housekeeping CronJob with web pod

### DIFF
--- a/kubernetes/apps/default/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/netbox/app/helmrelease.yaml
@@ -88,3 +88,15 @@ spec:
       enabled: true
     housekeeping:
       enabled: true
+      # The housekeeping CronJob mounts the RWO `media` PVC (ceph-block), which is
+      # attached to whichever node runs the netbox web/worker pods. Without affinity
+      # the job can schedule onto a different node and hang forever in
+      # ContainerCreating (multi-attach). Pin it to the node holding the volume.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: netbox
+                  app.kubernetes.io/component: netbox
+              topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
## Problem

The daily netbox `housekeeping` CronJob (`0 0 * * *`) mounts the **ReadWriteOnce** `media` PVC (ceph-block), which is attached to whichever node runs the netbox web/worker pods. The CronJob had **no node affinity**, so when the scheduler placed it on a different node it could never attach the RWO volume and hung indefinitely in `ContainerCreating` (multi-attach).

This fired `KubeContainerWaiting` in Alertmanager (job stuck 10h on a node not holding the volume).

## Fix

Add a required `podAffinity` on the housekeeping job targeting the netbox web pod (`app.kubernetes.io/instance=netbox`, `app.kubernetes.io/component=netbox`) with `topologyKey: kubernetes.io/hostname`, pinning the job to the node that holds the `media` volume.

## Verification

`flux-local build hr netbox` renders the affinity correctly into the CronJob's pod template:

```yaml
affinity:
  podAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchLabels:
          app.kubernetes.io/component: netbox
          app.kubernetes.io/instance: netbox
      topologyKey: kubernetes.io/hostname
```