### PR TITLE
fix(netbox): stop web pod OOMKills (Granian workers + memory)

### DIFF
--- a/kubernetes/apps/default/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/netbox/app/helmrelease.yaml
@@ -43,9 +43,18 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
+        # Web pod's real steady-state is ~500Mi+ with Granian; 256Mi under-reserved it.
+        memory: 512Mi
       limits:
-        memory: 1Gi
+        # NetBox v4 serves HTTP via Granian; each worker loads the full Django app.
+        # At 4 workers the pod crept to ~956Mi and got OOMKilled against a 1Gi limit.
+        # GRANIAN_WORKERS=2 (below) halves the footprint; 1.5Gi gives headroom.
+        memory: 1536Mi
+    extraEnvs:
+      # Default is 4 (`${GRANIAN_WORKERS:-4}` in launch-netbox.sh) — overkill for this
+      # low-concurrency homelab instance and the main driver of the OOM. Drop to 2.
+      - name: GRANIAN_WORKERS
+        value: "2"
     initContainers:
       - name: init-db
         image: ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7


### PR DESCRIPTION
## Problem

The netbox **web** container has been repeatedly **OOMKilled** (exit 137 — 3 restarts in 16h, most recent ones hours apart):

- NetBox v4 serves HTTP via **Granian**, defaulting to **4 workers** (`${GRANIAN_WORKERS:-4}` in `launch-netbox.sh`), each loading the full Django app.
- `kubectl top` showed the pod at **956Mi against the 1Gi limit** — it creeps up over ~8h of uptime and tips over the limit.
- The `request: 256Mi` was also far below the real ~956Mi footprint, so the scheduler under-reserved.

The worker and housekeeping pods are unaffected (worker uses rqworker, not Granian).

## Fix

| Setting | Before | After | Why |
|---|---|---|---|
| `GRANIAN_WORKERS` | 4 (default) | **2** | Halves the worker footprint; 4 is overkill for this low-concurrency instance and was the main OOM driver |
| request memory | 256Mi | **512Mi** | Match real steady-state |
| limit memory | 1Gi | **1.5Gi** | Headroom above the new ~500–600Mi footprint |

## Verification

`flux-local build hr netbox` confirms the web container renders with:

```yaml
env:
- name: GRANIAN_WORKERS
  value: "2"
resources:
  limits:
    memory: 1536Mi
  requests:
    cpu: 100m
    memory: 512Mi
```

If more HTTP concurrency is ever needed, bump `GRANIAN_WORKERS` back up and raise the limit proportionally (~+250–300Mi per worker).