### PR TITLE
fix(netbox): co-locate web pod with worker (RWO media volume)

### DIFF
--- a/kubernetes/apps/default/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/netbox/app/helmrelease.yaml
@@ -39,6 +39,18 @@ spec:
     persistence:
       enabled: true
       existingClaim: netbox
+    # The web, worker and housekeeping pods all mount the same RWO `media` PVC
+    # (ceph-block), so they must run on one node. The worker is the stable anchor
+    # (web rolls on every image update); pin the web pod to the worker's node so a
+    # rollout's surge pod can't land elsewhere and deadlock on multi-attach.
+    affinity:
+      podAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: netbox
+                app.kubernetes.io/component: worker
+            topologyKey: kubernetes.io/hostname
     resourcesPreset: none
     resources:
       requests:


### PR DESCRIPTION
## Problem

The netbox web, worker, and housekeeping pods all mount the same **ReadWriteOnce** `media` PVC (ceph-block), so they must run on a single node. Nothing enforced this on the **web Deployment** — so during a rollout the `RollingUpdate` surge pod could schedule onto a different node than the one holding the volume and deadlock:

```
Multi-Attach error for volume "pvc-768a…" Volume is already used by pod(s) netbox-worker-…, netbox-…
```

This stalled the rollout that applies the OOM fix (#2734): the new web pod landed on a node without the volume and hung in `Init` indefinitely while the old (OOM-prone) pod kept serving.

## Fix

Pin the web pod to the **worker's** node via required `podAffinity`. The worker is the stable anchor (web rolls on every image update; the worker rarely reschedules), keeping web + worker + housekeeping converged on the node that holds the `media` volume. Complements #2732 (housekeeping → web).

## Verification

`flux-local build hr netbox` renders the affinity onto the web Deployment:

```yaml
affinity:
  podAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchLabels:
          app.kubernetes.io/component: worker
          app.kubernetes.io/instance: netbox
      topologyKey: kubernetes.io/hostname
```

## Note

The durable alternative is a ReadWriteMany `media` volume (cephfs) so the pods could spread freely with no co-location needed — larger change, deferred.