### PR TITLE
fix(tdarr): set 15m HelmRelease timeout to avoid upgrade thrash

### DIFF
--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -6,6 +6,10 @@ metadata:
   name: tdarr
 spec:
   interval: 1h
+  # tdarr ships large images (~1.5GB app + ~1.2GB node) and uses a Recreate
+  # rollout, so an upgrade can exceed helm-controller's 5m default wait and trip
+  # RemediateOnFailure into an upgrade<->rollback thrash loop. Give it headroom.
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: tdarr


### PR DESCRIPTION
## Problem

On 2026-05-31, after the renovate `2.76.01 → 2.77.01` bump (#2725) merged, the tdarr HelmRelease fell into an **upgrade↔rollback thrash loop** that fired `FluxHelmReleaseUpgradeFailed` + `FluxHelmReleaseRollbackFailed`.

Root cause:
- tdarr uses `strategy: Recreate` and ships large images (~1.5 GB `app` + ~1.2 GB `node`).
- The cluster's HR default patch (`kubernetes/flux/cluster/ks.yaml`) sets `upgrade.strategy: RemediateOnFailure` with `retries: 2` but **no `spec.timeout`**, so helm-controller uses its built-in **5m default**.
- When a rollout can't reach Ready inside 5m (here: an old pod stuck `Terminating` blocked the Recreate swap), helm times out → rolls back → hits the same wall → thrashes.

## Fix

Add a per-HR `spec.timeout: 15m` to tdarr so a slow/large rollout completes before `RemediateOnFailure` triggers. Scoped to tdarr only — it's the cluster's largest-image app and the only repeat offender; the 5m default stays appropriate everywhere else.

## Validation

- `yamlfmt` then `prettier` clean (no changes).
- Image tags untouched (branched off latest `origin/main`, so 2.77.01 is preserved).
- The live thrash was already manually resolved during the incident (tdarr is Ready on 2.77.01, 2/2); this prevents recurrence on the next upgrade.