### PR TITLE
fix(invio): writable /app/backend so deno can refresh its stale lockfile

### DIFF
--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
         containers:
           app:
             image:
-              # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
+              &image # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
               repository: ghcr.io/kittendevv/invio
               tag: v2.0.2@sha256:faf00642514e27f34135083ecfe17f4f28b87f3dc8850476287f3f12e8e9e8a1
             # The image's default Cmd lets supervisord default its main logfile
@@ -70,6 +70,21 @@ spec:
                 drop:
                   - ALL
               readOnlyRootFilesystem: false
+        initContainers:
+          # The image ships /app/backend root-owned with a stale deno.lock that
+          # deno 2.6.8 insists on rewriting at startup. User 1000 can't write the
+          # root-owned dir, so `deno task start` fails ("Failed writing lockfile
+          # ... Permission denied") and the backend crash-loops into FATAL —
+          # which makes the frontend return 500 ("Unable to connect"). Copy
+          # /app/backend into a writable emptyDir (cp runs as uid 1000, so the
+          # copies become user-owned) and mount it over /app/backend so deno can
+          # refresh its lockfile in place.
+          init-backend:
+            image: *image
+            command:
+              - sh
+              - -c
+              - cp -a /app/backend/. /writable-backend/
 
     defaultPodOptions:
       automountServiceAccountToken: false
@@ -119,3 +134,13 @@ spec:
           app:
             app:
               - path: /.cache
+      # Writable copy of the image's /app/backend (populated by the
+      # init-backend initContainer) so deno can rewrite its stale lockfile.
+      backend:
+        type: emptyDir
+        advancedMounts:
+          app:
+            init-backend:
+              - path: /writable-backend
+            app:
+              - path: /app/backend


### PR DESCRIPTION
## Problem

invio returns **HTTP 500** in the browser. The pod is `1/1 Running` but its **backend crash-loops**:

```
error: Failed writing lockfile
  Permission denied (os error 13) (for '/app/backend/deno.lock')
...
backend entered FATAL state, too many start retries too quickly
[500] GET / — Error: Unable to connect. Is the computer able to access the url?
```

The SvelteKit frontend 500s because it can't reach the dead backend.

## Root cause

- The `v2.0.2` image ships `/app/backend` **root-owned**, containing a `deno.lock` that **deno 2.6.8 considers out of date**.
- On `deno task start`, deno tries to **rewrite** the lockfile; user `1000` can't write the root-owned dir → crash-loop.
- `DENO_NO_LOCK` env is **not honoured** (verified in-pod), and the deno invocation is baked into the image's supervisord config, so `--no-lock` / `--lock=<writable>` can't be injected via the HelmRelease.

## Fix

An `init-backend` initContainer copies `/app/backend` into an emptyDir, which the app container mounts over `/app/backend`. The copy runs as **uid 1000**, so the copied files (incl. `deno.lock`) become **user-owned and writable**, letting deno refresh the lockfile in place. The image is shared via a YAML anchor so Renovate keeps a single update point.

This is consistent with the existing emptyDir patches in this HR for `/.cache` and `/tmp/supervisord.log` (same root-owned-dir-as-uid-1000 class of problem).

## Validation

- **In-pod:** `cp -a /app/backend → writable dir` as uid 1000 makes `deno.lock` user-owned; `deno run … src/app.ts` then binds successfully ("Listening on …").
- **`kustomize build`** renders the anchor (`init-backend.image` = full `repository`/`tag@sha256`) and the `backend` emptyDir advancedMounts correctly.
- `yamlfmt` → `prettier` clean.

## Context

Found while fixing a separate routing issue: redditvault/invio/speakr HTTPRoutes had drifted to `*.example.com` placeholders and were served by the error-pages catch-all (404). Those routes were corrected live (delete + helm recreate). invio's routing is now fixed too; this PR addresses its remaining app-level 500.