### PR TITLE
fix(invio): initContainer cp -r (not -a) + drop image anchor

### DIFF
--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
         containers:
           app:
             image:
-              &image # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
+              # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
               repository: ghcr.io/kittendevv/invio
               tag: v2.0.2@sha256:faf00642514e27f34135083ecfe17f4f28b87f3dc8850476287f3f12e8e9e8a1
             # The image's default Cmd lets supervisord default its main logfile
@@ -80,11 +80,18 @@ spec:
           # copies become user-owned) and mount it over /app/backend so deno can
           # refresh its lockfile in place.
           init-backend:
-            image: *image
+            image:
+              # renovate: datasource=docker depName=ghcr.io/kittendevv/invio
+              repository: ghcr.io/kittendevv/invio
+              tag: v2.0.2@sha256:faf00642514e27f34135083ecfe17f4f28b87f3dc8850476287f3f12e8e9e8a1
             command:
               - sh
               - -c
-              - cp -a /app/backend/. /writable-backend/
+              # cp -r (not -a): cp as uid 1000 can't preserve timestamps on the
+              # emptyDir mount root, and we don't want to preserve the source's
+              # root ownership anyway — files copied as uid 1000 are what makes
+              # deno.lock writable.
+              - cp -r /app/backend/. /writable-backend/
 
     defaultPodOptions:
       automountServiceAccountToken: false


### PR DESCRIPTION
## Follow-up to #2739

#2739 added an `init-backend` initContainer to make `/app/backend` writable, but it had two issues:

1. **`cp -a` crash-loops the initContainer.** As uid 1000 it fails with:
   ```
   cp: preserving times for '/writable-backend/.': Operation not permitted
   ```
   (can't set timestamps on the emptyDir mount root) → `Init:CrashLoopBackOff` → invio stays down.
   **Fix:** `cp -r` — no attribute preservation; files are created owned by uid 1000, which is exactly what makes `deno.lock` writable. Verified in a throwaway pod with a real emptyDir: copy succeeds, `deno.lock` is `1000`-owned, backend binds.

2. **The `&image` YAML anchor wasn't formatter-idempotent.** Combined with the Renovate comment, `yamlfmt`/`prettier` relocated the comment on each pass (diff churn vs main).
   **Fix:** drop the anchor; the initContainer carries its own `image:` block with its own `# renovate:` annotation. Renovate groups the same `depName`, so both image refs stay in sync.

## Validation

- `cp -r` + deno verified in-pod with a real emptyDir mount.
- `yamlfmt` → `prettier` now **idempotent** (stable across two passes).
- `kustomize build` renders both image blocks fully pinned.

The invio HelmRelease is currently suspended (to stop the 5m upgrade-thrash from the crash-looping init); will resume + reconcile after merge.