### PR TITLE
feat(tuppr): enable chart-native ServiceMonitor + dashboard (0.1.40)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -17,3 +17,16 @@ spec:
         memory: 256Mi
       limits:
         memory: 512Mi
+    monitoring:
+      serviceMonitor:
+        enabled: true
+      # Keep our hand-tuned rules in upgrades/prometheusrule.yaml (thresholds
+      # tuned to our tuppr powercycle/stuck-reboot history) instead of the chart's.
+      prometheusRule:
+        enabled: false
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            grafana.internal/instance: grafana

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:


### PR DESCRIPTION
Adopted from onedr0p/home-ops May review.

**Problem:** tuppr metrics were never scraped — no ServiceMonitor existed anywhere — so the hand-written alerts in `upgrades/prometheusrule.yaml` (TalosUpgradeStuck/Failed etc.) had no data feeding them.

**Change:** bump chart 0.1.39 → 0.1.40 and enable:
- `monitoring.serviceMonitor.enabled: true` (the fix)
- `monitoring.dashboards` via grafana-operator (`instanceSelector: grafana.internal/instance=grafana`)
- `monitoring.prometheusRule.enabled: false` — keep our hand-tuned rules (thresholds tuned to our powercycle/stuck-reboot history)

**Validation:** `flate build hr tuppr` renders a ServiceMonitor, a GrafanaDashboard with the correct selector, and no chart PrometheusRule.