### PR TITLE
fix(ci): skip gpu-operator in flate diff job (NGC HelmRepository URL bug)

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -130,17 +130,38 @@ jobs:
             kustomization) KIND=ks ;;
             *) KIND="${RESOURCE}" ;;
           esac
-          flate diff "${KIND}" \
-            --path pull/kubernetes/flux/cluster \
-            --path-orig default/kubernetes/flux/cluster \
-            --strip-attr caBundle \
-            --allow-missing-secrets \
-            --output markdown > diff.md
+          # Diff per-namespace so we can skip gpu-operator: flate mis-resolves
+          # NGC's HelmRepository relative chart URL (404), and a single failed
+          # reconcile aborts the entire `flate diff`. Any PR touching a
+          # gpu-operator file would otherwise pull it into the diff and fail.
+          # TODO(flate): drop the gpu-operator skip + restore a single global
+          # `flate diff` once home-operations/flate fixes NGC HelmRepository
+          # relative-URL resolution. Tracking: https://github.com/home-operations/flate
+          mapfile -t namespaces < <(
+            find pull/kubernetes/apps default/kubernetes/apps \
+              -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -u
+          )
+          : > diff.md
+          rc=0
+          for ns in "${namespaces[@]}"; do
+            if [ "${ns}" = "gpu-operator" ]; then
+              echo "::warning title=flate::skipping gpu-operator diff (flate NGC HelmRepository URL bug)"
+              continue
+            fi
+            flate diff "${KIND}" --namespace "${ns}" \
+              --path pull/kubernetes/flux/cluster \
+              --path-orig default/kubernetes/flux/cluster \
+              --strip-attr caBundle \
+              --allow-missing-secrets \
+              --output markdown >> diff.md || rc=1
+          done
           # Cap to stay within GitHub's ~65k-char comment limit
           if [ "$(wc -c < diff.md)" -gt 60000 ]; then
             head -c 60000 diff.md > diff.trunc && mv diff.trunc diff.md
             printf '\n\n_…diff truncated; see workflow logs for the full output._\n' >> diff.md
           fi
+          # Fail the job if any (non-gpu-operator) namespace diff errored.
+          exit "${rc}"
 
       - name: Read Diff
         id: diff


### PR DESCRIPTION
## What

The flate `diff` job reconciles changed namespaces and **hard-fails if any single HelmRelease reconcile fails**. `gpu-operator` hits flate's NGC HelmRepository relative-URL bug (requests `helm.ngc.nvidia.com/charts/…` → 404 instead of `…/nvidia/charts/…`), so **any PR touching a `gpu-operator` file** pulled it into the diff scope and aborted the whole job.

This surfaced on #2749 (schema host swap), which edits the `$schema=` comment in every yaml — including `gpu-operator/*.yaml`.

## Fix

Mirror the existing `test` job: loop the diff **per-namespace and skip `gpu-operator`**, while still `exit`-ing non-zero on any genuine diff error. Tracked with a `TODO(flate)` marker (`grep -rn 'TODO(flate)' .github/`), to be removed once [home-operations/flate](https://github.com/home-operations/flate) fixes NGC HelmRepository relative-URL resolution. See `docs/known-issues.md`.

## Validation

The `test`/`diff` jobs are filtered out on this PR (no `kubernetes/**` changes), so validated locally: per-namespace loop over all 22 non-gpu namespaces completes in ~131s, `rc=0`, empty diff (schema-comment swaps render-identical). Real exercise lands when #2749 reruns on top of this.