### PR TITLE
chore(ci): bump shared-workflows super-linter SHA to pick up slim default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
       pull-requests: write
-    uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@2410829c6d03158086d6cab16e15153942c5d4b8 # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@e3efd7f9ca56bbc415a1934eeb9cfcee3a960e95 # v1
     with:
       # Kubeconform validates raw YAML source. On this Flux GitOps repo the
       # source is meaningless until kustomize substitutes vars


### PR DESCRIPTION
## Summary

- Bumps `LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml` from `2410829` → `e3efd7f` to pick up [shared-workflows#6](https://github.com/LukeEvansTech/shared-workflows/pull/6).
- That PR adds a `slim: boolean` input (default `true`), switching the reusable workflow to `super-linter/super-linter/slim@<sha>` — the ~1.5 GB slim image instead of the ~3.5 GB full image. Saves ~1–2 min of image-pull time per lint run.
- This repo doesn't contain Rust, .NET, PowerShell, or ARM templates, so the slim drops (Rustfmt, Rust Clippy, ARM-TTK, PSScriptAnalyzer, `dotnet`) are not relevant. No `slim: false` override needed.

## Test plan

- [ ] Lint workflow runs `lint / lint` and reports green
- [ ] `Pull down action image` step pulls `super-linter-slim:v8` (not the full image)
- [ ] Same linters that ran before still run: EDITORCONFIG, GITHUB_ACTIONS, GITHUB_ACTIONS_ZIZMOR, GIT_MERGE_CONFLICT_MARKERS, PRE_COMMIT, SPELL_CODESPELL, YAML, YAML_PRETTIER