### PR TITLE
fix(ci): flate diff --output markdown → github (flate 0.2.6 dropped markdown)

### DIFF
--- a/.github/workflows/flux-local.yaml
+++ b/.github/workflows/flux-local.yaml
@@ -153,7 +153,7 @@ jobs:
               --path-orig default/kubernetes/flux/cluster \
               --strip-attr caBundle \
               --allow-missing-secrets \
-              --output markdown >> diff.md || rc=1
+              --output github >> diff.md || rc=1
           done
           # Cap to stay within GitHub's ~65k-char comment limit
           if [ "$(wc -c < diff.md)" -gt 60000 ]; then


### PR DESCRIPTION
## Problem

Flux Local **diff** jobs (`Flux Local - Diff (helmrelease)` / `(kustomization)`) are failing on every PR with:

```
flate error: invalid argument "markdown" for "-o, --output" flag:
must be one of: human, github, diff, html, brief, gitlab, gitea
```

(seen on #2795, but it's repo-wide — any PR touching `kubernetes/**`).

## Root cause

The flate **0.2.6** bump (#2788, merged earlier today) **removed the `markdown` output format**. `FLATE_VERSION` in `flux-local.yaml` is Renovate-managed, so CI picked up 0.2.6 immediately, but `flate diff` was still called with `--output markdown`.

Verified against the flate 0.2.6 binary:
```
-o, --output string   output format: human, github, diff, html, brief, gitlab, gitea (default "human")
```

## Fix

`--output markdown` → `--output github`. The diff is appended to `diff.md` and posted as a sticky PR comment, so `github` (GitHub-flavored markdown) is the correct successor to the old `markdown`. All other flags (`--strip-attr`, `--path`, `--path-orig`, `--allow-missing-secrets`) still exist in 0.2.6. `flate test` is unaffected (it takes no `--output`).