### PR TITLE
fix(ci): guard fallible commands in renovate-review fingerprint step

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -101,28 +101,35 @@ jobs:
           USAGE_MARKER: "<!-- claude-renovate-usage -->"
         run: |
           set -uo pipefail
+          # NOTE: GitHub runs run-steps with `bash -e` (errexit), and `set -uo
+          # pipefail` does NOT disable it. So every fallible command below needs an
+          # explicit `|| true`, or the step dies. In particular `grep` exits 1 when
+          # there's no stored fingerprint yet (first review of a PR) - that is the
+          # expected path, not an error.
+          #
           # Renovate rebases its branches onto fresh main constantly without
           # changing the actual version bump. When the effective PR diff is
           # byte-identical to the last reviewed diff, skip the (paid) Claude step
           # entirely and let the status step re-post the prior verdict. This is a
           # PRE-LLM gate: the prompt has its own "skip redundant re-reviews" check,
           # but that one still spins Claude up and burns turns to decide to skip.
-          fingerprint=$(gh pr diff "$PR" 2>/dev/null | sha256sum | cut -d' ' -f1)
+          fingerprint=$(gh pr diff "$PR" 2>/dev/null | sha256sum | cut -d' ' -f1 || true)
           fingerprint="${fingerprint:-none}"
           echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
 
           # Stored fingerprint lives in a hidden marker inside the sticky usage
           # comment, written by report-claude-usage.sh only when a real review ran.
+          # grep exits 1 on no match (first run) -> guard with || true.
           stored=$(gh api "repos/$REPO/issues/$PR/comments" --paginate \
             --jq "[.[] | select(.user.login==\"github-actions[bot]\" and (.body|contains(\"$USAGE_MARKER\")))] | last | .body // \"\"" \
-            2>/dev/null | grep -oE 'fingerprint:[0-9a-f]{64}' | head -1 | cut -d: -f2)
+            2>/dev/null | grep -oE 'fingerprint:[0-9a-f]{64}' | head -1 | cut -d: -f2 || true)
 
           # A prior verdict must exist for the skip to be safe — the status step
           # re-derives success/failure from it.
           prior=$(gh api "repos/$REPO/pulls/$PR/reviews" --paginate \
             --jq '[.[] | select(.user.login=="claude[bot]" or .user.login=="github-actions[bot]")
                   | select(.state=="APPROVED" or .state=="CHANGES_REQUESTED")] | last | .state // ""' \
-            2>/dev/null)
+            2>/dev/null || true)
 
           skip=false
           if [[ -n "$stored" && "$stored" == "$fingerprint" && -n "$prior" ]]; then


### PR DESCRIPTION
## Problem

On PR #2795 (the first real **Renovate** PR through the new AI reviewer) the `Breaking Change Analysis` job failed at the **Fingerprint check** step:

```
##[error]Process completed with exit code 1.
```

## Root cause

GitHub runs `run:` steps with `bash -e {0}` — errexit is **on by default**, and `set -uo pipefail` does **not** disable it. On a PR with no prior review, there's no stored fingerprint comment yet, so:

```bash
stored=$(gh api ... | grep -oE 'fingerprint:[0-9a-f]{64}' | head -1 | cut -d: -f2)
```

`grep` exits 1 (no match — the *expected* first-run path), and with `-e` + `pipefail` the whole step dies.

PRs #2793/#2794 never exposed it because they were non-Renovate (gated steps skipped). The status still passed through, so **auto-merge was never wedged** — but the job went red and no review ran.

## Fix

Guard the fallible substitutions (`gh pr diff` hash, the `grep` pipeline, the `prior` lookup) with `|| true`, and add a comment documenting the inherited-errexit gotcha so future commands don't re-trip it. The `token_check` step is already guarded (`|| code=000`, `|| echo ""`).

## Validation
`actionlint`, `yamlfmt -lint`, `zizmor --offline`, shellcheck (via actionlint), lefthook pre-commit all pass. End-to-end validation: after merge, re-run the reviewer on a Renovate PR (e.g. #2795) and confirm the Fingerprint check step is green.