### PR TITLE
ci: rename flux-local workflow to flate (it runs flate, not flux-local)

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: "Flux Local"
+name: "Flate"
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ env:
 
 jobs:
   filter:
-    name: Flux Local - Filter
+    name: Flate - Filter
     runs-on: ubuntu-latest
     outputs:
       changed-files: ${{ steps.changed-files.outputs.changed_files }}
@@ -34,7 +34,7 @@ jobs:
   test:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
-    name: Flux Local - Test
+    name: Flate - Test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,7 +83,7 @@ jobs:
   diff:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
     needs: filter
-    name: Flux Local - Diff
+    name: Flate - Diff
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -124,7 +124,8 @@ jobs:
           RESOURCE: ${{ matrix.resource }}
         run: |
           # flate uses short kind names (hr/ks); keep the matrix values verbose
-          # so the required status-check names stay stable for branch protection.
+          # so the job/check names stay descriptive (Renovate auto-merge gates on
+          # all checks green, so the names just need to be stable + readable).
           case "${RESOURCE}" in
             helmrelease) KIND=hr ;;
             kustomization) KIND=ks ;;
@@ -185,7 +186,7 @@ jobs:
     needs:
       - test
       - diff
-    name: Flux Local - Success
+    name: Flate - Success
     runs-on: ubuntu-latest
     steps:
       - name: Any jobs failed?

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -610,7 +610,7 @@ back to 0.
 
 ### Issue
 
-CI's `Flux Local - Test` job (`.github/workflows/flux-local.yaml`, now powered
+CI's `Flate - Test` job (`.github/workflows/flate.yaml`, now powered
 by [flate](https://github.com/home-operations/flate) instead of flux-local)
 loops `flate test all --namespace <ns>` over every directory under
 `kubernetes/apps/`. It **explicitly skips the `gpu-operator` namespace** with:
@@ -644,7 +644,7 @@ the chart fine, so this only affects the flate-based CI check.
 ### Workaround
 
 The per-namespace loop in CI skips `gpu-operator` (see the `TODO(flate)` marker
-in `.github/workflows/flux-local.yaml`). Everything else is still tested. To
+in `.github/workflows/flate.yaml`). Everything else is still tested. To
 validate gpu-operator manifests locally, render the HelmRelease directly rather
 than via flate's chart pull, or rely on the live cluster's Flux reconcile.
 


### PR DESCRIPTION
## Why

The `Flux Local` workflow hasn't used flux-local for a while — it installs and runs **[flate](https://github.com/home-operations/flate)** (`flate test` / `flate diff`) end to end. The `flux-local.yaml` filename and `Flux Local - *` job names were stale labels.

## What

- `git mv .github/workflows/flux-local.yaml → flate.yaml`
- `name: "Flux Local"` → `"Flate"`; jobs `Flux Local - {Filter,Test,Diff,Success}` → `Flate - …`
- Updated the now-moot "keep names stable for branch protection" comment and the `docs/known-issues.md` references.

## Why it's safe to rename the checks

- `required_status_checks` on `main` is **null** and there are **no rulesets** — nothing in branch protection pins the old job names.
- Renovate auto-merge gates on *all checks green* (name-agnostic), so the rename doesn't affect the merge pipeline.

(CLAUDE.md is gitignored/local-only, so its matching updates aren't in this PR.)

## Validation
`actionlint`, `yamlfmt -lint`, `zizmor --offline`, shellcheck (via actionlint), lefthook pre-commit all pass. Note: this PR doesn't touch `kubernetes/**`, so the flate jobs themselves filter out (skip) here — the rename is exercised on the next PR that touches manifests.