### PR TITLE
chore(fetcharr): missing-only — Profilarr v2 Upgrades owns quality upgrades

### DIFF
--- a/kubernetes/apps/media/fetcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/fetcharr/app/helmrelease.yaml
@@ -24,7 +24,9 @@ spec:
               SEARCH_INTERVAL: 1hour
               SEARCH_AMOUNT: "5"
               MONITORED_ONLY: "true"
-              MISSING_ONLY: "false"
+              # Missing-only: Profilarr v2 Upgrades now owns quality upgrades
+              # (cutoff-unmet re-search). fetcharr only acquires missing items.
+              MISSING_ONLY: "true"
               RADARR_0_URL: http://radarr.media.svc.cluster.local
               SONARR_0_URL: http://sonarr.media.svc.cluster.local
             envFrom:


### PR DESCRIPTION
## What

`fetcharr` now acquires **only missing items** (`MISSING_ONLY: "false" → "true"`).

## Why

Profilarr v2 ships an **Upgrades** feature (cutoff-unmet quality re-search), now enabled on Radarr (5/hr) and Sonarr (1/hr), lowest-score-first. Profilarr Upgrades is **upgrade-only** (no missing-item acquisition), so the two are split to avoid double-searching indexers:

- **Profilarr Upgrades** → quality upgrades
- **fetcharr** → missing-item acquisition only

Replaces the retired Huntarr's role, cleanly divided.