### PR TITLE
fix(ci): renovate-review OAuth preflight must use Bearer, not x-api-key

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -156,15 +156,19 @@ jobs:
           # 400/5xx/timeout is "inconclusive" (our request or the network, not the
           # token) so header/model drift can never false-flag.
           #
-          # OAuth tokens (sk-ant-oat01) authenticate via x-api-key (NOT Bearer) and
-          # require the oauth beta header; Haiku is exempt from system-prompt checks.
+          # sk-ant-oat01 OAuth tokens authenticate via `Authorization: Bearer`
+          # (NOT x-api-key — that returns 401 "invalid x-api-key" even for a valid
+          # token), with the `oauth-2025-04-20` beta header AND the exact system
+          # prompt the API requires for OAuth tokens (any other prefix → 401). These
+          # match the Claude Code SDK's own request; verified returning 200 against a
+          # live valid token.
           code=$(curl -s -o /tmp/tokresp.json -w '%{http_code}' --max-time 30 \
             -X POST https://api.anthropic.com/v1/messages \
-            -H "x-api-key: ${CLAUDE_CODE_OAUTH_TOKEN}" \
+            -H "authorization: Bearer ${CLAUDE_CODE_OAUTH_TOKEN}" \
             -H "anthropic-version: 2023-06-01" \
-            -H "anthropic-beta: oauth-2025-04-20,claude-code-20250219" \
+            -H "anthropic-beta: oauth-2025-04-20" \
             -H "content-type: application/json" \
-            -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"system":"You are Claude Code, Anthropic'\''s official CLI for Claude.","messages":[{"role":"user","content":"OK"}]}') \
+            -d '{"model":"claude-haiku-4-5-20251001","max_tokens":1,"system":"You are a Claude agent, built on Anthropic'\''s Claude Agent SDK.","messages":[{"role":"user","content":"OK"}]}') \
             || code="000"
 
           err_type=$(jq -r '.error.type // ""' /tmp/tokresp.json 2>/dev/null || echo "")


### PR DESCRIPTION
## Problem

The OAuth token preflight added in #2794 used the **wrong auth method**. `sk-ant-oat01` OAuth tokens are **not** valid as `x-api-key` — `POST /v1/messages` returns `401 {"type":"authentication_error","message":"invalid x-api-key"}` **even for a perfectly valid token**. So the preflight false-failed *every* gated Renovate PR and wrongly reported the token as expired/revoked.

Confirmed empirically: a known-good token returns `401 invalid x-api-key` via `x-api-key`, and **HTTP 200** via `Authorization: Bearer` with the corrected headers/system-prompt.

## Fix

Match the Claude Code SDK's own request (source-verified + tested 200 against a live token):
- `Authorization: Bearer <token>` (not `x-api-key`)
- `anthropic-beta: oauth-2025-04-20` (dropped the bogus `claude-code-20250219`)
- system prompt **`You are a Claude agent, built on Anthropic's Claude Agent SDK.`** — OAuth tokens require this exact prefix or the API 401s

A `401` now genuinely means expired/revoked; `400`/`5xx`/timeout stay inconclusive (never false-flag).

## Validation
`actionlint`, `yamlfmt -lint`, `zizmor --offline`, shellcheck (via actionlint), lefthook all pass. End-to-end: after merge, rebase #2795 → the Breaking Change Analysis should authenticate and post a real review.