### PR TITLE
ci(flate): retry flate test once per namespace before failing

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -65,6 +65,19 @@ jobs:
           # TODO(flate): remove the gpu-operator skip below + restore plain
           # `flate test all` once home-operations/flate fixes NGC HelmRepository
           # relative-URL resolution. Tracking: https://github.com/home-operations/flate
+
+          # flate test is occasionally flaky: it intermittently exits non-zero with
+          # "0 failed" in the output (substitution-cache nondeterminism). Retry once
+          # per namespace before declaring a real failure.
+          flate_test() {
+            local ns="$1"
+            flate test all --namespace "${ns}" \
+              --path kubernetes/flux/cluster --allow-missing-secrets && return 0
+            echo "::warning title=flate::flate test ${ns} failed; retrying once (flate is occasionally flaky)"
+            flate test all --namespace "${ns}" \
+              --path kubernetes/flux/cluster --allow-missing-secrets
+          }
+
           rc=0
           for ns in kubernetes/apps/*/; do
             ns="$(basename "${ns}")"
@@ -73,9 +86,7 @@ jobs:
               continue
             fi
             echo "::group::flate test ${ns}"
-            flate test all --namespace "${ns}" \
-              --path kubernetes/flux/cluster \
-              --allow-missing-secrets || rc=1
+            flate_test "${ns}" || rc=1
             echo "::endgroup::"
           done
           exit "${rc}"


### PR DESCRIPTION
## Why

`flate test` is occasionally flaky — it intermittently exits non-zero while every namespace reports `0 failed` in the output (the flate substitution-cache nondeterminism). Today #2791 hit it: `Flate - Test` failed with `0 failed` everywhere (only the unrelated `kopia → volsync` orphaned-dependency WARN), and a plain re-run passed the identical tree. 1 of 8 PRs flaked.

## What

Wrap the per-namespace `flate test` in a `flate_test()` helper that retries **once** before declaring failure. A real render error (fails twice) still fails the job; a single flaky exit no longer does.

`flate diff` is intentionally left as-is — it appends to `diff.md`, so a clean retry there needs temp-file capture; revisit only if it actually flakes.

## Validation
`actionlint` (+shellcheck), `yamlfmt -lint`, `zizmor --offline`, lefthook all pass.