### PR TITLE
fix(external-dns): add %{record_type} to cloudflare txtPrefix

### DIFF
--- a/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-dns/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
     sources:
       - "crd"
       - "gateway-httproute"
-    txtPrefix: k8s.
+    txtPrefix: k8s.%{record_type}-
     txtOwnerId: default
     domainFilters:
       - "${SECRET_DOMAIN}"


### PR DESCRIPTION
Adds the record-type token to cloudflare-dns `txtPrefix` (`k8s.` → `k8s.%{record_type}-`), so A/AAAA/CNAME records each get their own ownership TXT record instead of contending for one. Prevents the classic external-dns registry ownership collision. Adapted from [onedr0p/home-ops](https://github.com/onedr0p/home-ops) `ec2b6d30`.

**Migration note:** after this rolls out, external-dns creates new-format TXT records (`k8s.a-…`, `k8s.cname-…`) and the old `k8s.…` TXT records become orphaned — clean them up manually in Cloudflare once the new ones are confirmed.

Not applicable to `opnsense-dns` (uses `registry: noop`, no TXT records).