### PR TITLE
feat(kromgo): migrate to home-operations/kromgo 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ _... managed with Flux, Renovate, and GitHub Actions_ 🤖
 
 <div align="center">
 
-[![Age-Days](https://kromgo.codelooks.com/cluster_age_days?format=badge&style=flat-square)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Uptime-Days](https://kromgo.codelooks.com/cluster_uptime_days?format=badge&style=flat-square)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Node-Count](https://kromgo.codelooks.com/cluster_node_count?format=badge&style=flat-square)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Pod-Count](https://kromgo.codelooks.com/cluster_pod_count?format=badge&style=flat-square)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![CPU-Usage](https://kromgo.codelooks.com/cluster_cpu_usage?format=badge&style=flat-square)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
-[![Memory-Usage](https://kromgo.codelooks.com/cluster_memory_usage?format=badge&style=flat-square)](https://github.com/kashalls/kromgo/)&nbsp;&nbsp;
+[![Age-Days](https://kromgo.codelooks.com/cluster_birth_age?format=badge&style=flat-square)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Uptime-Days](https://kromgo.codelooks.com/cluster_uptime_age?format=badge&style=flat-square)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Node-Count](https://kromgo.codelooks.com/cluster_node_count?format=badge&style=flat-square)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Pod-Count](https://kromgo.codelooks.com/cluster_pod_count?format=badge&style=flat-square)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![CPU-Usage](https://kromgo.codelooks.com/cluster_cpu_usage?format=badge&style=flat-square)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
+[![Memory-Usage](https://kromgo.codelooks.com/cluster_memory_usage?format=badge&style=flat-square)](https://github.com/home-operations/kromgo/)&nbsp;&nbsp;
 
 </div>
 

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -19,8 +19,8 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/kashalls/kromgo
-              tag: v0.10.0@sha256:965ecc92d68dc1a4a969397855367bbc70da03227a941ea607b73bb7e0b78fd6
+              repository: ghcr.io/home-operations/kromgo
+              tag: 0.14.0@sha256:94ee0e2561048dc4637ca21b9926b76d87c15baf951678c7febb852269b7e10b
             env:
               PROMETHEUS_URL: http://prometheus-operated.observability.svc.cluster.local:9090
               SERVER_PORT: &port 80
@@ -66,7 +66,7 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             group: external
-            conditions: ["[STATUS] == 404"]
+            conditions: ["[STATUS] == 200"]
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
@@ -77,6 +77,6 @@ spec:
         type: configMap
         name: kromgo-configmap
         globalMounts:
-          - path: /kromgo/config.yaml
+          - path: /config/config.yaml
             subPath: config.yaml
             readOnly: true

--- a/kubernetes/apps/observability/kromgo/app/resources/config.yaml
+++ b/kubernetes/apps/observability/kromgo/app/resources/config.yaml
@@ -1,85 +1,67 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kashalls/kromgo/main/config.schema.json
-badge:
-  font: Verdana.ttf
-  size: 12
+# yaml-language-server: $schema=https://raw.githubusercontent.com/home-operations/kromgo/main/config.schema.json
 
-metrics:
-  - name: talos_version
+badges:
+  - title: Talos
+    id: talos_version
     query: label_replace(node_os_info{name="Talos"}, "version_id", "$1", "version_id", "v(.+)")
-    label: version_id
-    title: Talos
+    valueExpr: labels["version_id"]
+    icon: si:talos
 
-  - name: kubernetes_version
+  - title: Kubernetes
+    id: kubernetes_version
     query: label_replace(kubernetes_build_info{service="kubernetes"}, "git_version", "$1", "git_version", "v(.+)")
-    label: git_version
-    title: Kubernetes
+    valueExpr: labels["git_version"]
+    icon: si:kubernetes
 
-  - name: flux_version
+  - title: Flux
+    id: flux_version
     query: label_replace(flux_instance_info, "revision", "$1", "revision", "v(.+)@sha256:.+")
-    label: revision
-    title: Flux
+    valueExpr: labels["revision"]
+    icon: si:flux
 
-  - name: cluster_node_count
+  - title: Nodes
+    id: cluster_node_count
     query: count(count by (node) (kube_node_status_condition{condition="Ready"}))
-    colors:
-      - { color: "green", min: 0, max: 9999 }
-    title: Nodes
+    colorExpr: '"green"'
 
-  - name: cluster_pod_count
+  - title: Pods
+    id: cluster_pod_count
     query: sum(kube_pod_status_phase{phase="Running"})
-    colors:
-      - { color: "green", min: 0, max: 9999 }
-    title: Pods
+    valueExpr: humanizeCommas(result)
+    colorExpr: '"green"'
 
-  - name: cluster_cpu_usage
+  - title: CPU
+    id: cluster_cpu_usage
     query: round(avg(instance:node_cpu_utilisation:rate5m{kubernetes_node!=""}) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: "green", min: 0, max: 35 }
-      - { color: "orange", min: 36, max: 75 }
-      - { color: "red", min: 76, max: 9999 }
-    title: CPU
+    valueExpr: string(result) + "%"
+    colorExpr: 'colorScale(result, [35.0, 75.0], ["green", "orange", "red"])'
 
-  - name: cluster_memory_usage
+  - title: Memory
+    id: cluster_memory_usage
     query: round(sum(node_memory_MemTotal_bytes{kubernetes_node!=""} - node_memory_MemAvailable_bytes{kubernetes_node!=""}) / sum(node_memory_MemTotal_bytes{kubernetes_node!=""}) * 100, 0.1)
-    suffix: "%"
-    colors:
-      - { color: green, min: 0, max: 35 }
-      - { color: orange, min: 36, max: 75 }
-      - { color: red, min: 76, max: 9999 }
-    title: Memory
+    valueExpr: string(result) + "%"
+    colorExpr: 'colorScale(result, [35.0, 75.0], ["green", "orange", "red"])'
 
-  - name: cluster_power_usage
+  - title: Power
+    id: cluster_power_usage
     query: avg(upsAdvOutputActivePower)
-    suffix: "w"
-    colors:
-      - { color: "green", min: 0, max: 400 }
-      - { color: "orange", min: 401, max: 750 }
-      - { color: "red", min: 751, max: 9999 }
-    title: Power
+    valueExpr: humanizeCommas(math.round(result)) + "w"
+    colorExpr: 'colorScale(result, [400.0, 750.0], ["green", "orange", "red"])'
 
-  - name: cluster_age_days
-    query: round((time() - min(kube_node_created) ) / 86400)
-    suffix: "d"
-    colors:
-      - { color: "green", min: 0, max: 180 }
-      - { color: "orange", min: 181, max: 360 }
-      - { color: "red", min: 361, max: 9999 }
-    title: Age
+  - title: Age
+    id: cluster_birth_age
+    query: round(time() - min(kube_node_created))
+    valueExpr: humanizeDurationDays(result)
+    colorExpr: 'colorScale(result, [15552000.0, 31104000.0], ["green", "orange", "red"])'
 
-  - name: cluster_uptime_days
-    query: round(avg(node_time_seconds{kubernetes_node!=""} - node_boot_time_seconds{kubernetes_node!=""}) / 86400)
-    suffix: "d"
-    colors:
-      - { color: "green", min: 0, max: 180 }
-      - { color: "orange", min: 181, max: 360 }
-      - { color: "red", min: 361, max: 9999 }
-    title: Uptime
+  - title: Uptime
+    id: cluster_uptime_age
+    query: round(avg(node_time_seconds{kubernetes_node!=""} - node_boot_time_seconds{kubernetes_node!=""}))
+    valueExpr: humanizeDurationDays(result)
+    colorExpr: 'colorScale(result, [15552000.0, 31104000.0], ["green", "orange", "red"])'
 
-  - name: cluster_alert_count
+  - title: Alerts
+    id: cluster_alert_count
     query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
-    colors:
-      - { color: "green", min: 0, max: 0 }
-      - { color: "red", min: 1, max: 9999 }
-    title: Alerts
+    colorExpr: 'colorScale(result, [1.0], ["green", "red"])'


### PR DESCRIPTION
kashalls/kromgo moved to the **home-operations** org with a breaking config rewrite. Because the image repo changed, Renovate cannot cross-repo-migrate us — we were silently pinned to the now-unmaintained `kashalls/kromgo:v0.10.0`. Adapted from [onedr0p/home-ops](https://github.com/onedr0p/home-ops) `3bd64b9a`.

## Changes
- **Image:** `ghcr.io/kashalls/kromgo:v0.10.0` → `ghcr.io/home-operations/kromgo:0.14.0` (digest-pinned)
- **`config.yaml` rewrite** to the new expression schema: `metrics:`→`badges:`, `label:`/`suffix:`/`colors:` → `valueExpr`/`colorExpr` with `colorScale()`, `humanizeCommas()`, `humanizeDurationDays()`. **Your PromQL queries are kept verbatim** (incl. `upsAdvOutputActivePower`, `kubernetes_node!=""` selectors); added `si:` icons to the version badges.
- **Metric renames:** `cluster_age_days`→`cluster_birth_age`, `cluster_uptime_days`→`cluster_uptime_age` — and the two affected README badge URLs updated (plus the project links → home-operations).
- **Config mount** `/kromgo/config.yaml` → `/config/config.yaml` (new default).
- **Gatus condition** `[STATUS] == 404` → `200` (new kromgo serves 200 at `/`).

Validated: `kustomize build` ✓ · yamlfmt→prettier ✓

> Note: thresholds preserved (180d/360d = 15552000s/31104000s). Omitted onedr0p's cluster-specific gatus "buddy_*" badges.