### PR TITLE
feat(opengist): deploy self-hosted gist/snippet store

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -46,6 +46,7 @@ resources:
   - ./netbox/ks.yaml
   - ./netronome/ks.yaml
   - ./notifier/ks.yaml
+  - ./opengist/ks.yaml
   - ./pairdrop/ks.yaml
   - ./paperless/ks.yaml
   - ./privatebin/ks.yaml

--- a/kubernetes/apps/default/opengist/app/externalsecret.yaml
+++ b/kubernetes/apps/default/opengist/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opengist
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: opengist-secret
+    template:
+      engineVersion: v2
+      data:
+        OG_SECRET_KEY: "{{ .OG_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: opengist

--- a/kubernetes/apps/default/opengist/app/helmrelease.yaml
+++ b/kubernetes/apps/default/opengist/app/helmrelease.yaml
@@ -1,0 +1,100 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opengist
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: opengist
+  values:
+    controllers:
+      opengist:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/thomiceli/opengist
+              tag: 1.12.2@sha256:5cdaaeaf2d73a9c87100fed850416bc258e5ef1fe5208cfa9153f992a6285be5
+            command:
+              - "./opengist"
+            env:
+              OG_HTTP_PORT: &port 80
+              OG_OPENGIST_HOME: /config
+              OG_CUSTOM_NAME: Opengist
+              OG_EXTERNAL_URL: https://opengist.${SECRET_DOMAIN}
+              OG_SSH_GIT_ENABLED: false
+              OG_METRICS_ENABLED: true
+              OG_METRICS_HOST: 0.0.0.0
+              OG_METRICS_PORT: &metricsPort 8080
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthcheck
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /config
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/default/opengist/app/kustomization.yaml
+++ b/kubernetes/apps/default/opengist/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/opengist/app/ocirepository.yaml
+++ b/kubernetes/apps/default/opengist/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: opengist
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/opengist/ks.yaml
+++ b/kubernetes/apps/default/opengist/ks.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app opengist
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/external
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/opengist/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
New app: [opengist](https://github.com/thomiceli/opengist) (self-hosted GitHub Gist clone). bjw-s `app-template` in the `default` namespace, routed via `envoy-external` at `opengist.${SECRET_DOMAIN}`. Adapted from [onedr0p/home-ops](https://github.com/onedr0p/home-ops) `7164ce60`.

## Details
- Standard 4-file pattern: `ks.yaml` + `app/{externalsecret,helmrelease,ocirepository,kustomization}.yaml`
- `gatus/external` + `volsync` components (5Gi PVC backup of `/config`)
- Security baseline: `runAsNonRoot`, `readOnlyRootFilesystem`, `drop: ["ALL"]`, fsGroup 1000
- SSH-git disabled; Prometheus metrics + ServiceMonitor on `:8080`; `TZ: ${TIMEZONE}`

## ⚠️ Action required before merge/reconcile
Create a 1Password item named **`opengist`** with a field **`OG_SECRET_KEY`** (a random secret, e.g. `openssl rand -hex 32`) in the vault your `onepassword-connect` ClusterSecretStore reads. Without it the ExternalSecret stays `SecretSyncedError` and the pod won't start.

Validated: `kustomize build` (app + default namespace) ✓ · yamlfmt→prettier ✓