### PR TITLE
fix(victoria-logs): point collector remoteWrite at victoria-logs-server

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/collector/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
     podMonitor:
       enabled: true
     remoteWrite:
-      - url: http://victoria-logs.observability.svc.cluster.local:9428
+      - url: http://victoria-logs-server.observability.svc.cluster.local:9428
         maxDiskUsagePerURL: 10GB
     collector:
       # Stream fields define VictoriaLogs stream cardinality — keep this set small


### PR DESCRIPTION
The `victoria-logs-collector` remoteWrite URL targeted `victoria-logs.observability.svc.cluster.local`, which does not resolve — the `victoria-logs-single` chart names its Service `<fullname>-server` (`victoria-logs-server`, the same target your old fluent-bit used). The collector was healthy but buffering to disk (`no such host`); the `maxDiskUsagePerURL: 10GB` buffer prevented data loss.

One-line fix: `victoria-logs` → `victoria-logs-server`. Buffered logs flush on reconnect.