### PR TITLE
fix(tuppr): enable drain-first on TalosUpgrade to avoid Ceph unmount stall (#2728)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -10,6 +10,14 @@ spec:
     version: v1.13.2
   policy:
     rebootMode: default
+  # Drain each node before its reboot. With Rook-Ceph (ceph-block) this lets the
+  # node flush/unmount its Ceph volumes while the mons on the other two nodes are
+  # still alive — avoiding the shutdown-time unmount stall that wedges the node
+  # half-down and requires an IPMI reset (GH #2728). Combined with the default
+  # parallelism: 1 (one node at a time) and the CephCluster HEALTH_OK gate below,
+  # this is the "drain-first, one-node-at-a-time" mitigation #2728 identified.
+  drain:
+    enabled: true
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource


### PR DESCRIPTION
## What

Adds `spec.drain.enabled: true` to the `TalosUpgrade` CR.

## Why

tuppr **0.2.0** (#2820, already merged) replaced the implicit drain trigger (`spec.drain != nil`) with an explicit `spec.drain.enabled` toggle. Our `TalosUpgrade` had **no `drain` block at all**, so tuppr-driven Talos upgrades were rebooting nodes **without draining first** — both before and after the 0.2.0 bump.

On this Rook-Ceph (`ceph-block`) cluster that is exactly the trigger for the shutdown-time volume-unmount stall documented in #2728: Talos stops the k8s stack, then **hangs trying to unmount Ceph volumes** and never reaches the kernel reboot (base OS keeps its uptime, kexec never reached). Only an IPMI/BMC hard reset recovers.

The root-cause analysis in #2728 prescribes **drain-first, one-node-at-a-time**: draining before reboot lets Ceph flush/unmount while the mons on the other two nodes are still alive, which avoids the stall.

## How this delivers that mitigation

- `drain.enabled: true` → node is cordoned + drained before its reboot.
- `parallelism` stays unset → default **1** (one node at a time).
- Existing `CephCluster` `HEALTH_OK` healthCheck → gates the next node until Ceph recovers.

## Verification

- tuppr HR reconciled to 0.2.0 in-cluster; confirmed the live `talosupgrades` CRD now exposes `drain.{enabled (required), disableEviction}`, so the field is valid at runtime.
- Flux ordering is safe: `tuppr-upgrades` `dependsOn: tuppr`, so the 0.2.0 chart/CRD applies before this CR.

## Note

Separate known quirk (not addressed here): tuppr can false-fail its leader node (cordons it, needs manual uncordon + CR reset). Worth watching on the first 0.2.0 upgrade run.

Closes #2728