### PR TITLE
fix(rook-ceph): spread RGW gateway replicas across nodes (Prometheus duplicate-timestamp warnings)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -178,6 +178,21 @@ spec:
                 memory: 2Gi
             instances: 2
             priorityClassName: system-cluster-critical
+            # Spread the gateway replicas across nodes. Both share instance_id
+            # "a", so co-locating them makes a node's ceph-exporter emit every
+            # ceph_rgw_* series twice with identical labels -> Prometheus
+            # "different value but same timestamp" drops. Spreading also gives
+            # the object store real HA. Soft (ScheduleAnyway) so both still
+            # schedule during single-node maintenance/upgrades.
+            placement:
+              topologySpreadConstraints:
+                - maxSkew: 1
+                  topologyKey: kubernetes.io/hostname
+                  whenUnsatisfiable: ScheduleAnyway
+                  labelSelector:
+                    matchLabels:
+                      app: rook-ceph-rgw
+                      rook_object_store: ceph-objectstore
           healthCheck:
             bucket:
               interval: 60s


### PR DESCRIPTION
## Symptom

Prometheus logs every 10s, only from cr-talos-02's ceph-exporter:

```
scrape_pool=serviceMonitor/rook-ceph/rook-ceph-exporter/0 target=http://10.32.8.81:9926/metrics
msg="Error on ingesting samples with different value but same timestamp" num_dropped=62
```

## Root cause

The Rook **ceph-exporter** runs one pod per node and reads the admin sockets of **every Ceph daemon on its own node**. Both `ceph-objectstore` RGW replicas — `…-qwgsd` and `…-ww9b9`, *both* gateway `instance_id="a"` — were scheduled onto **cr-talos-02** because `gateway.placement` was empty (`{}`). So that node's exporter emits every `ceph_rgw_*{instance_id="a"}` series twice (4× with sub-sections) with identical labels; Prometheus keeps one and drops the rest with the WARN. The other two nodes host no RGW and are clean.

Verified by reading `:9926/metrics` directly: `ceph_rgw_*{instance_id="a"}` ×4, plus co-located-daemon `ceph_AsyncMessenger_Worker_*`/`ceph_objecter_*` collisions.

## Fix

Add a **soft** `topologySpreadConstraint` (`maxSkew: 1` over `kubernetes.io/hostname`, `whenUnsatisfiable: ScheduleAnyway`) to the gateway placement so the two replicas land on different nodes.

- Each node's exporter then sees ≤1 RGW daemon → the `ceph_rgw_*` duplicate series (the bulk of the differing-value drops) disappear.
- Bonus: the object store gains real HA — previously a cr-talos-02 outage took down all RGW + the `rgw-s3-backup` cronjob.
- Soft (not `DoNotSchedule`) so both stay schedulable during single-node maintenance/upgrades (cf. #2728 reboot history).

Residual low-priority `AsyncMessenger`/`objecter` internal-counter dups are inherent (no per-thread label) and out of scope here; can be trimmed later via `cephClusterSpec.monitoring.exporter.perfCountersPrioLimit` if desired.

## Rollout note

After merge + reconcile, Rook will reschedule one RGW pod onto another node. Confirm with:
`kubectl get pods -n rook-ceph -l app=rook-ceph-rgw -o wide` (should show two different nodes), then the cr-talos-02 exporter WARN should stop.