### PR TITLE
fix(scanopy): scope daemon to LAN NIC, single scanner (conntrack saturation)

### DIFF
--- a/kubernetes/apps/network/scanopy/app/daemon-helmrelease.yaml
+++ b/kubernetes/apps/network/scanopy/app/daemon-helmrelease.yaml
@@ -20,7 +20,13 @@ spec:
   values:
     controllers:
       scanopy-daemon:
-        type: daemonset
+        # Single scanner (Deployment, 1 replica): the nodes share one flat LAN
+        # (10.32.8.0/24), so a per-node DaemonSet would scan the same /24 three
+        # times. Recreate avoids two hostNetwork pods contending for host port
+        # 60073 during a rollout.
+        type: deployment
+        replicas: 1
+        strategy: Recreate
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -33,10 +39,16 @@ spec:
               SCANOPY_LOG_LEVEL: info
               SCANOPY_SERVER_URL: http://scanopy.network.svc.cluster.local:60072
               SCANOPY_ENABLE_LOCAL_DOCKER_SOCKET: "false"
-              SCANOPY_NAME:
-                valueFrom:
-                  fieldRef:
-                    fieldPath: spec.nodeName
+              # Restrict scanning to the physical LAN NIC. Without this the
+              # hostNetwork daemon auto-scans every node interface — including
+              # the Cilium pod/service CIDRs (10.42/10.43.0.0/16, ~131k IPs) —
+              # and saturates node conntrack. enp1s0np0 = LAN 10.32.8.0/24
+              # (same kernel name on all three nodes).
+              SCANOPY_INTERFACES: enp1s0np0
+              # Cap simultaneous host scans (default auto-detects ~10-20).
+              SCANOPY_CONCURRENT_SCANS: "5"
+              # Stable identity for the single scanner (was per-node nodeName).
+              SCANOPY_NAME: scanopy-codelooks
             envFrom:
               - secretRef:
                   name: scanopy-secret


### PR DESCRIPTION
## Problem
On first deploy, the scanopy **daemon** (DaemonPoll, hostNetwork, one per node) saturated **every node's conntrack table to 100%** (`262144/262144`), firing `NodeHighNumberConntrackEntriesUsed` on all 3 nodes — a cluster-wide hazard (nodes drop new connections). Root cause: a daemon auto-scans every subnet its host has an interface on, and on a `hostNetwork` Talos/Cilium node that includes the **pod/service CIDRs** (`10.42.0.0/16` + `10.43.0.0/16`, ~131k IPs), port-scanned at 500pps. Stopping the daemons drained conntrack to <2%, confirming the cause.

## Fix
- **`SCANOPY_INTERFACES=enp1s0np0`** — restrict scanning to the physical LAN NIC (`10.32.8.0/24`, ~254 hosts) so it never touches the Cilium CIDRs. `enp1s0np0` is the kernel NIC name on all 3 nodes (Talos aliases it `wan` by MAC; scanopy needs the kernel name).
- **`SCANOPY_CONCURRENT_SCANS=5`** — cap concurrency (default auto ~10-20).
- **DaemonSet → single-replica Deployment** — the nodes share one flat LAN, so a per-node DaemonSet scanned the same /24 three times. `Recreate` strategy (avoids two hostNetwork pods contending for host port 60073); stable `SCANOPY_NAME`.

Scan **rate** is configured per-discovery in the UI "Speed" tab in v0.15.0+ (daemon-level rate flags are ignored) — will set a conservative profile there post-merge.

## Test plan
- [x] `kustomize build` renders; `type: deployment`, `strategy: Recreate`, `SCANOPY_INTERFACES`, `SCANOPY_CONCURRENT_SCANS` present
- [ ] Post-merge controlled re-enable: `flux resume hr scanopy-daemon` + reconcile, then watch one scan with `nf_conntrack_count` staying low; confirm daemon registers and discovers LAN hosts