### PR TITLE
fix(autopulse): drop unused media NFS mount blocking minimal deploy

### DIFF
--- a/kubernetes/apps/media/autopulse/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autopulse/app/helmrelease.yaml
@@ -69,13 +69,6 @@ spec:
           - path: /app/config.yaml
             subPath: config.yaml
             readOnly: true
-      media:
-        type: nfs
-        server: nas01.${SECRET_INTERNAL_DOMAIN}
-        path: /mnt/data/media
-        globalMounts:
-          - path: /mnt/data/media
-            readOnly: true
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
Follow-up to #2866. The pod was stuck in ContainerCreating: `mount.nfs: Failed to resolve server nas01.core.codelooks.com`. That read-only media share was inherited from the dormant draft — no other media app uses that host, and the minimal config (no triggers/targets) doesn't need it. Removing it; re-add with the correct NFS host when integrations are added. Data PVC, config secret, and tmp mounts are unchanged.