### PR TITLE
docs(autopulse): integration TODO markers (#2868)

### DIFF
--- a/kubernetes/apps/media/autopulse/app/externalsecret.yaml
+++ b/kubernetes/apps/media/autopulse/app/externalsecret.yaml
@@ -13,6 +13,10 @@ spec:
     name: autopulse-secret
     template:
       engineVersion: v2
+      # TODO(autopulse-integrations): minimal config (no triggers/targets). Expand the block
+      # below with triggers:/targets: (e.g. sonarr/radarr -> plex/jellyfin); add any required
+      # tokens as fields on the autopulse 1Password item, referenced here as {{ .field }}.
+      # https://github.com/LukeEvansTech/talos-cluster/issues/2868
       data:
         config.yaml: |
           app:

--- a/kubernetes/apps/media/autopulse/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autopulse/app/helmrelease.yaml
@@ -69,6 +69,10 @@ spec:
           - path: /app/config.yaml
             subPath: config.yaml
             readOnly: true
+      # TODO(autopulse-integrations): when wiring triggers/targets, re-add a read-only media
+      # volume here using the resolvable internal NFS host the other media apps use (the prior
+      # draft host did not resolve and blocked startup; removed in #2867).
+      # https://github.com/LukeEvansTech/talos-cluster/issues/2868
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
Adds `TODO(autopulse-integrations)` comments in the autopulse externalsecret + helmrelease pointing to #2868, so the minimal-deploy follow-ups (triggers/targets config; re-add media volume with a resolvable NFS host) are captured in-code. No functional/rendered change — comments only; verified the config.yaml render is unchanged.