### PR TITLE
feat(gpu-operator): migrate to OCI chart mirror, drop flate skip

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -58,38 +58,14 @@ jobs:
 
       - name: Run flate test
         run: |
-          # Test per-namespace so we can skip gpu-operator: flate mis-resolves
-          # NGC's HelmRepository relative chart URL (requests /charts/... 404
-          # instead of /nvidia/charts/...). The cluster's flux pulls it fine;
-          # this is a flate bug — see home-operations/flate.
-          # TODO(flate): remove the gpu-operator skip below + restore plain
-          # `flate test all` once home-operations/flate fixes NGC HelmRepository
-          # relative-URL resolution. Tracking: https://github.com/home-operations/flate
-
           # flate test is occasionally flaky: it intermittently exits non-zero with
           # "0 failed" in the output (substitution-cache nondeterminism). Retry once
-          # per namespace before declaring a real failure.
-          flate_test() {
-            local ns="$1"
-            flate test all --namespace "${ns}" \
-              --path kubernetes/flux/cluster --allow-missing-secrets && return 0
-            echo "::warning title=flate::flate test ${ns} failed; retrying once (flate is occasionally flaky)"
-            flate test all --namespace "${ns}" \
-              --path kubernetes/flux/cluster --allow-missing-secrets
-          }
-
-          rc=0
-          for ns in kubernetes/apps/*/; do
-            ns="$(basename "${ns}")"
-            if [ "${ns}" = "gpu-operator" ]; then
-              echo "::warning title=flate::skipping gpu-operator (flate NGC HelmRepository URL bug)"
-              continue
-            fi
-            echo "::group::flate test ${ns}"
-            flate_test "${ns}" || rc=1
-            echo "::endgroup::"
-          done
-          exit "${rc}"
+          # before declaring a real failure.
+          flate test all \
+            --path kubernetes/flux/cluster --allow-missing-secrets && exit 0
+          echo "::warning title=flate::flate test failed; retrying once (flate is occasionally flaky)"
+          flate test all \
+            --path kubernetes/flux/cluster --allow-missing-secrets
 
   diff:
     if: ${{ needs.filter.outputs.changed-files != '[]' }}
@@ -142,37 +118,19 @@ jobs:
             kustomization) KIND=ks ;;
             *) KIND="${RESOURCE}" ;;
           esac
-          # Diff per-namespace so we can skip gpu-operator: flate mis-resolves
-          # NGC's HelmRepository relative chart URL (404), and a single failed
-          # reconcile aborts the entire `flate diff`. Any PR touching a
-          # gpu-operator file would otherwise pull it into the diff and fail.
-          # TODO(flate): drop the gpu-operator skip + restore a single global
-          # `flate diff` once home-operations/flate fixes NGC HelmRepository
-          # relative-URL resolution. Tracking: https://github.com/home-operations/flate
-          mapfile -t namespaces < <(
-            find pull/kubernetes/apps default/kubernetes/apps \
-              -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort -u
-          )
           : > diff.md
           rc=0
-          for ns in "${namespaces[@]}"; do
-            if [ "${ns}" = "gpu-operator" ]; then
-              echo "::warning title=flate::skipping gpu-operator diff (flate NGC HelmRepository URL bug)"
-              continue
-            fi
-            flate diff "${KIND}" --namespace "${ns}" \
-              --path pull/kubernetes/flux/cluster \
-              --path-orig default/kubernetes/flux/cluster \
-              --strip-attr caBundle \
-              --allow-missing-secrets \
-              --output github >> diff.md || rc=1
-          done
+          flate diff "${KIND}" \
+            --path pull/kubernetes/flux/cluster \
+            --path-orig default/kubernetes/flux/cluster \
+            --strip-attr caBundle \
+            --allow-missing-secrets \
+            --output github >> diff.md || rc=1
           # Cap to stay within GitHub's ~65k-char comment limit
           if [ "$(wc -c < diff.md)" -gt 60000 ]; then
             head -c 60000 diff.md > diff.trunc && mv diff.trunc diff.md
             printf '\n\n_…diff truncated; see workflow logs for the full output._\n' >> diff.md
           fi
-          # Fail the job if any (non-gpu-operator) namespace diff errored.
           exit "${rc}"
 
       - name: Read Diff

--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -47,7 +47,11 @@ jobs:
 
       - name: Install flate
         run: |
-          curl -fsSL "https://github.com/home-operations/flate/releases/download/${FLATE_VERSION}/flate_${FLATE_VERSION}_linux_amd64.tar.gz" \
+          # Tag carries the leading "v" (v0.3.2); goreleaser strips it from the
+          # asset filename (flate_0.3.2_...). Keep ${FLATE_VERSION} in the path,
+          # use ${FLATE_VERSION#v} for the filename so both v- and bare-version
+          # tags resolve.
+          curl -fsSL "https://github.com/home-operations/flate/releases/download/${FLATE_VERSION}/flate_${FLATE_VERSION#v}_linux_amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin flate
 
       - name: Authenticate to GHCR
@@ -97,7 +101,11 @@ jobs:
 
       - name: Install flate
         run: |
-          curl -fsSL "https://github.com/home-operations/flate/releases/download/${FLATE_VERSION}/flate_${FLATE_VERSION}_linux_amd64.tar.gz" \
+          # Tag carries the leading "v" (v0.3.2); goreleaser strips it from the
+          # asset filename (flate_0.3.2_...). Keep ${FLATE_VERSION} in the path,
+          # use ${FLATE_VERSION#v} for the filename so both v- and bare-version
+          # tags resolve.
+          curl -fsSL "https://github.com/home-operations/flate/releases/download/${FLATE_VERSION}/flate_${FLATE_VERSION#v}_linux_amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin flate
 
       - name: Authenticate to GHCR

--- a/kubernetes/apps/default/feather/app/helmrelease.yaml
+++ b/kubernetes/apps/default/feather/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: feather
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: feather
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      feather:
+        containers:
+          app:
+            image:
+              repository: docker.io/nginxinc/nginx-unprivileged
+              tag: 1.29-alpine@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6
+            env:
+              TZ: ${TIMEZONE}
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /apps.json
+                    port: &port 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    service:
+      app:
+        controller: feather
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          # static IPA source; skip Gatus auto-monitoring (mirrors rackula)
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      # Served content, read-only over NFS from the TrueNAS sideload export.
+      # Fed by: Mac ~/sideload --Syncthing--> /mnt/pool/syncthing/sideload (NFS share id 25, ro).
+      www:
+        type: custom
+        volumeSpec:
+          nfs:
+            server: "${SECRET_STORAGE_SERVER}"
+            path: /mnt/pool/syncthing/sideload
+        globalMounts:
+          - path: /usr/share/nginx/html
+            readOnly: true
+      # writable scratch for nginx with a read-only root filesystem
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /var/cache/nginx
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run

--- a/kubernetes/apps/default/feather/app/kustomization.yaml
+++ b/kubernetes/apps/default/feather/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/feather/app/ocirepository.yaml
+++ b/kubernetes/apps/default/feather/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: feather
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/feather/ks.yaml
+++ b/kubernetes/apps/default/feather/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app feather
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/default/feather/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ./domain-watchdog/ks.yaml
   - ./echo-server/ks.yaml
   - ./erugo/ks.yaml
+  - ./feather/ks.yaml
   - ./filebrowser/ks.yaml
   - ./forgejo/ks.yaml
   - ./gotify/ks.yaml

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/helmrelease.yaml
@@ -6,15 +6,9 @@ metadata:
   name: gpu-operator
 spec:
   interval: 1h
-  chart:
-    spec:
-      # renovate: registryUrl=https://helm.ngc.nvidia.com/nvidia
-      chart: gpu-operator
-      version: v26.3.2
-      sourceRef:
-        kind: HelmRepository
-        name: nvidia
-      interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: gpu-operator
   values:
     driver:
       enabled: false

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/kustomization.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/kustomization.yaml
@@ -4,7 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./grafanadashboard.yaml
-  - ./helmrepository.yaml
+  - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
   - ./runtimeclass.yaml

--- a/kubernetes/apps/gpu-operator/gpu-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/ocirepository.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gpu-operator
+spec:
+  # Community OCI mirror of the NGC chart (home-operations/charts-mirror).
+  # NVIDIA OCI support is tracked upstream in NVIDIA/gpu-operator#2520; the
+  # mirror deprecates 6 months after official OCI artifacts land. Migrating off
+  # the NGC HelmRepository also fixes flate's relative-chart-URL 404 bug, which
+  # had forced a per-namespace gpu-operator skip in the Flate workflow.
+  interval: 6h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  url: oci://ghcr.io/home-operations/charts-mirror/nvidia-gpu-operator
+  ref:
+    # renovate: datasource=docker
+    tag: 26.3.2


### PR DESCRIPTION
## What

Migrate `gpu-operator` from the NGC `HelmRepository` to the [home-operations/charts-mirror](https://github.com/home-operations/charts-mirror) `OCIRepository` (`chartRef`), and remove the per-namespace `gpu-operator` skips from the Flate workflow.

## Why

flate mis-resolves NGC's `HelmRepository` *relative* chart URL (requests `/charts/...` → 404 instead of `/nvidia/charts/...`). That forced a `gpu-operator` skip in both `flate test` and `flate diff`, with the per-namespace loops that existed only to support the skip. The chart is now mirrored as an OCI artifact, which flate resolves correctly.

- Mirror published: home-operations/charts-mirror#544 (`oci://ghcr.io/home-operations/charts-mirror/nvidia-gpu-operator`)
- Consumption pattern: Tanguille/cluster#3125
- Upstream OCI tracking: NVIDIA/gpu-operator#2520 (mirror deprecates 6 months after official OCI lands)

## Changes

- `app/helmrepository.yaml` → `app/ocirepository.yaml` (tag `26.3.2`, Renovate `datasource=docker`)
- HelmRelease: `chart.spec` + `sourceRef` → `chartRef`
- `flate.yaml`: dropped both gpu-operator skip blocks + per-namespace loops; restored plain `flate test all` and a single global `flate diff`

## Validation (flate v0.3.2, matches CI)

- `flate test all --namespace gpu-operator`: **3 passed, 0 failed** (Kustomization + HelmRelease + OCIRepository)
- `flate build hr`: renders **27 objects** from the mirror, no errors