### PR TITLE
feat(default): add feather IPA source

### DIFF
--- a/kubernetes/apps/default/feather/app/helmrelease.yaml
+++ b/kubernetes/apps/default/feather/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: feather
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: feather
+  uninstall:
+    keepHistory: false
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      feather:
+        containers:
+          app:
+            image:
+              repository: docker.io/nginxinc/nginx-unprivileged
+              tag: 1.29-alpine@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6
+            env:
+              TZ: ${TIMEZONE}
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /apps.json
+                    port: &port 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    service:
+      app:
+        controller: feather
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          # static IPA source; skip Gatus auto-monitoring (mirrors rackula)
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      # Served content, read-only over NFS from the TrueNAS sideload export.
+      # Fed by: Mac ~/sideload --Syncthing--> /mnt/pool/syncthing/sideload (NFS share id 25, ro).
+      www:
+        type: custom
+        volumeSpec:
+          nfs:
+            server: "${SECRET_STORAGE_SERVER}"
+            path: /mnt/pool/syncthing/sideload
+        globalMounts:
+          - path: /usr/share/nginx/html
+            readOnly: true
+      # writable scratch for nginx with a read-only root filesystem
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /var/cache/nginx
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run

--- a/kubernetes/apps/default/feather/app/kustomization.yaml
+++ b/kubernetes/apps/default/feather/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/feather/app/ocirepository.yaml
+++ b/kubernetes/apps/default/feather/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: feather
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/feather/ks.yaml
+++ b/kubernetes/apps/default/feather/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app feather
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: envoy-gateway
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/default/feather/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - ./domain-watchdog/ks.yaml
   - ./echo-server/ks.yaml
   - ./erugo/ks.yaml
+  - ./feather/ks.yaml
   - ./filebrowser/ks.yaml
   - ./forgejo/ks.yaml
   - ./gotify/ks.yaml


### PR DESCRIPTION
## What
Cluster half of the private iOS sideloading pipeline — nginx serving the AltStore source at **feather.${SECRET_DOMAIN}** (tailnet-only, via `envoy-internal`).

## How
- `nginxinc/nginx-unprivileged` (uid 101, readonly rootfs + emptyDirs), digest-pinned.
- Mounts the TrueNAS sideload export **read-only** at the web root:
  `nfs: ${SECRET_STORAGE_SERVER}:/mnt/pool/syncthing/sideload` → `/usr/share/nginx/html`.
- Content flow: workstation `~/sideload` --Syncthing--> `/mnt/pool/syncthing/sideload` (NFS share, ro, hosts = the 3 nodes) --> this pod.
- Probes hit `/apps.json`; Gatus auto-monitoring disabled (mirrors `rackula`).
- Registered in `kubernetes/apps/default/kustomization.yaml`.

## Verify after merge
```
curl https://feather.codelooks.com/apps.json   # from a tailnet device
```
Validated with `kubectl kustomize` (app + namespace build clean).