### PR TITLE
feat(flux-system): add konflate PR rendered-diff review + kguardian spike

### DIFF
--- a/docs/spikes/kguardian/README.md
+++ b/docs/spikes/kguardian/README.md
@@ -12,19 +12,19 @@ synthesises least-privilege **NetworkPolicy**, **CiliumNetworkPolicy**, and
 
 ## Talos compatibility assessment
 
-| Requirement | This cluster | Verdict |
-|-------------|--------------|---------|
-| Kernel 6.2+ (eBPF CO-RE) | Talos v1.13.2 → **Linux 6.12** | ✅ |
-| containerd socket `/run/containerd/containerd.sock` | Talos CRI containerd default path | ✅ (no override, unlike k3s) |
-| runtime bundle `/run/containerd/io.containerd.runtime.v2.task` | Talos CRI default | ✅ |
-| `/sys/fs/bpf`, `/sys/kernel/debug`, `/sys/kernel/tracing`, `/proc` hostPath | present on Talos nodes | ✅ |
-| `privileged: true` + `CAP_BPF` + `hostNetwork` DaemonSet | Talos enforces PSA | ⚠️ needs **privileged** namespace (see `namespace.yaml`) |
-| PostgreSQL backend | bundled PG18 on `ceph-block` (spike) / CNPG (prod) | ✅ |
-| Tolerates `node-role.kubernetes.io/control-plane:NoSchedule` | 3× control-plane nodes | ✅ runs on all nodes |
+| Requirement                                                                 | This cluster                                       | Verdict                                                  |
+| --------------------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------- |
+| Kernel 6.2+ (eBPF CO-RE)                                                    | Talos v1.13.2 → **Linux 6.18**                     | ✅                                                       |
+| containerd socket `/run/containerd/containerd.sock`                         | Talos CRI containerd default path                  | ✅ (no override, unlike k3s)                             |
+| runtime bundle `/run/containerd/io.containerd.runtime.v2.task`              | Talos CRI default                                  | ✅                                                       |
+| `/sys/fs/bpf`, `/sys/kernel/debug`, `/sys/kernel/tracing`, `/proc` hostPath | present on Talos nodes                             | ✅                                                       |
+| `privileged: true` + `CAP_BPF` + `hostNetwork` DaemonSet                    | Talos enforces PSA                                 | ⚠️ needs **privileged** namespace (see `namespace.yaml`) |
+| PostgreSQL backend                                                          | bundled PG18 on `ceph-block` (spike) / CNPG (prod) | ✅                                                       |
+| Tolerates `node-role.kubernetes.io/control-plane:NoSchedule`                | 3× control-plane nodes                             | ✅ runs on all nodes                                     |
 
 **The one real risk** — `hostNetwork: true`. We've had a `hostNetwork`
 conntrack-flood incident on this cluster before (scanopy). kguardian is
-*passive* eBPF observation (not active scanning), so it should not flood
+_passive_ eBPF observation (not active scanning), so it should not flood
 conntrack — but watch node conntrack while it runs:
 `talosctl -n <node> read /proc/sys/net/netfilter/nf_conntrack_count`.
 

--- a/docs/spikes/kguardian/README.md
+++ b/docs/spikes/kguardian/README.md
@@ -1,0 +1,98 @@
+# kguardian spike
+
+A **time-boxed evaluation** of [kguardian-dev/kguardian](https://github.com/kguardian-dev/kguardian):
+an eBPF runtime-observability tool that watches real pod traffic/syscalls and
+synthesises least-privilege **NetworkPolicy**, **CiliumNetworkPolicy**, and
+**seccomp** profiles via a `kubectl` plugin.
+
+> **Why this lives in `docs/spikes/` and not `kubernetes/`:** the controller is a
+> privileged, `hostNetwork`, host-mounting eBPF DaemonSet. It should be run by
+> hand, vetted, used to harvest policies, then removed — not committed to the
+> auto-reconciling Flux tree. Nothing here is picked up by Flux.
+
+## Talos compatibility assessment
+
+| Requirement | This cluster | Verdict |
+|-------------|--------------|---------|
+| Kernel 6.2+ (eBPF CO-RE) | Talos v1.13.2 → **Linux 6.12** | ✅ |
+| containerd socket `/run/containerd/containerd.sock` | Talos CRI containerd default path | ✅ (no override, unlike k3s) |
+| runtime bundle `/run/containerd/io.containerd.runtime.v2.task` | Talos CRI default | ✅ |
+| `/sys/fs/bpf`, `/sys/kernel/debug`, `/sys/kernel/tracing`, `/proc` hostPath | present on Talos nodes | ✅ |
+| `privileged: true` + `CAP_BPF` + `hostNetwork` DaemonSet | Talos enforces PSA | ⚠️ needs **privileged** namespace (see `namespace.yaml`) |
+| PostgreSQL backend | bundled PG18 on `ceph-block` (spike) / CNPG (prod) | ✅ |
+| Tolerates `node-role.kubernetes.io/control-plane:NoSchedule` | 3× control-plane nodes | ✅ runs on all nodes |
+
+**The one real risk** — `hostNetwork: true`. We've had a `hostNetwork`
+conntrack-flood incident on this cluster before (scanopy). kguardian is
+*passive* eBPF observation (not active scanning), so it should not flood
+conntrack — but watch node conntrack while it runs:
+`talosctl -n <node> read /proc/sys/net/netfilter/nf_conntrack_count`.
+
+**Licensing note:** BSL 1.1 (converts to Apache-2.0 on 2029-01-01), not OSI-OSS today.
+
+## Run the spike
+
+```bash
+# 1. Privileged namespace (Talos PSA requires this for the eBPF DaemonSet)
+kubectl apply -f docs/spikes/kguardian/namespace.yaml
+
+# 2. Install the chart (bundled Postgres on ceph-block)
+helm install kguardian oci://ghcr.io/kguardian-dev/charts/kguardian \
+  --version 1.12.0 \
+  --namespace kguardian \
+  --values docs/spikes/kguardian/values.yaml \
+  --wait
+
+# 3. Verify — controller (DaemonSet, 1/node), broker, db, frontend
+kubectl get pods -n kguardian -o wide
+
+# 4. Install the kubectl plugin
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/kguardian-dev/kguardian/main/scripts/quick-install.sh)"
+kubectl kguardian --version
+```
+
+## Harvest policies for one namespace
+
+kguardian learns from observed behaviour, so **let the target workload run
+5–15 min** after install before generating. `--dry-run=true` is the default —
+it writes YAML to `--output-dir` and applies nothing.
+
+```bash
+# Pick a self-contained app to profile, e.g. it-tools in `default`.
+# Generate a Cilium policy (this cluster's CNI) — dry-run, written to ./policies
+kubectl kguardian gen ciliumnetworkpolicy -n default --output-dir ./policies
+
+# Or a single workload + a plain NetworkPolicy / seccomp profile
+kubectl kguardian gen networkpolicy <pod> -n default --output-dir ./policies
+kubectl kguardian gen seccomp        <pod> -n default --output-dir ./policies
+
+# Review before doing anything with it
+ls ./policies && cat ./policies/*.yaml
+```
+
+Run `kubectl kguardian gen --help` for the full subcommand/flag set.
+
+## Teardown
+
+```bash
+helm uninstall kguardian -n kguardian
+kubectl delete -f docs/spikes/kguardian/namespace.yaml   # also removes the bundled PVC
+```
+
+## Productionising (only if the spike proves out)
+
+- Move to Flux under `kubernetes/apps/security/kguardian/` (standard 4-file pattern).
+- Point the broker at **CNPG** instead of bundled Postgres:
+  `database.enabled=false`, `database.external.host=<cnpg-rw-svc>`,
+  `database.external.sslMode=require` (matches the cluster's CNPG TLS default),
+  and provide creds via `database.existingSecret` sourced from a 1Password
+  ExternalSecret. Pre-create the `rust` role + `kube` database on CNPG.
+- Decide whether the controller runs continuously (drift detection) or is
+  spun up periodically just to regenerate policies.
+
+## What this spike does NOT do
+
+These files are a **vetted, ready-to-run** install + runbook. They do **not**
+deploy kguardian or produce generated policies on their own — that needs a live
+`helm install` against the cluster plus real workload traffic. Running it is a
+privileged, live-cluster operation, so it's left as an explicit manual step.

--- a/docs/spikes/kguardian/namespace.yaml
+++ b/docs/spikes/kguardian/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/namespace.json
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kguardian
+  labels:
+    # The eBPF controller DaemonSet runs privileged + hostNetwork + hostPath
+    # (containerd socket, /sys/fs/bpf, debugfs). Talos enforces PSA; this
+    # namespace must be privileged or the controller pods are rejected.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/docs/spikes/kguardian/values.yaml
+++ b/docs/spikes/kguardian/values.yaml
@@ -1,0 +1,47 @@
+---
+# Talos-tuned values for a kguardian SPIKE (manual `helm install`, not GitOps).
+# Chart: oci://ghcr.io/kguardian-dev/charts/kguardian  (chart v1.12.0)
+#
+# Self-contained: uses the chart's bundled PostgreSQL on ceph-block so the spike
+# can be torn down cleanly. For a real deployment, point the broker at CNPG
+# instead (see README "Productionising").
+
+controller:
+  # privileged: true / CAP_BPF / hostNetwork / hostPath are chart defaults and
+  # are REQUIRED for eBPF — do not override. The Talos CRI containerd socket is
+  # at the chart's default path, so containerdSockPath / containerdBundlePath
+  # need no change (unlike k3s).
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+  # Keep the controller off cluster-critical / high-churn namespaces during the
+  # spike to reduce eBPF noise and conntrack pressure on hostNetwork.
+  excludedNamespaces:
+    - kguardian
+    - kube-system
+    - flux-system
+    - rook-ceph
+    - cert-manager
+    - external-secrets
+  ignoreDaemonSet: true
+
+broker:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+# Bundled in-cluster PostgreSQL (PG18-alpine) on Rook-Ceph block storage.
+database:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClassName: ceph-block
+# Frontend/UI: no Gateway route for the spike — reach it over port-forward (see
+# README). Keeps a throwaway eval off the public/internal gateways.

--- a/kubernetes/apps/flux-system/konflate/README.md
+++ b/kubernetes/apps/flux-system/konflate/README.md
@@ -1,9 +1,10 @@
 # konflate
 
 Read-only **Flux PR rendered-diff** review UI ([home-operations/konflate](https://github.com/home-operations/konflate)).
-Renders this repo's Flux config at each open PR's merge-base vs head and shows the
-*rendered* Kubernetes diff (blast radius, image changes, render failures) — the
-impact a one-line HelmRelease bump actually has, which a git diff hides.
+Renders this repository's Flux config at each open PR's merge-base vs head and
+shows the _rendered_ Kubernetes diff (blast radius, image changes, render
+failures) — the impact a one-line HelmRelease bump actually has, which a
+file-level diff hides.
 
 Reached at `https://konflate.${SECRET_DOMAIN}` (envoy-internal).
 
@@ -21,35 +22,35 @@ webhook secret (mirrors onedr0p/home-ops):
    (a random string).
 2. Add `app/externalsecret.yaml`:
 
-   ```yaml
-   ---
-   # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
-   apiVersion: external-secrets.io/v1
-   kind: ExternalSecret
-   metadata:
-     name: konflate-webhook-token
-   spec:
-     secretStoreRef:
-       kind: ClusterSecretStore
-       name: onepassword-connect
-     target:
-       name: konflate-webhook-token-secret
-       template:
-         data:
-           KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
-     dataFrom:
-       - extract:
-           key: konflate
-   ```
+    ```yaml
+    ---
+    # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+    apiVersion: external-secrets.io/v1
+    kind: ExternalSecret
+    metadata:
+        name: konflate-webhook-token
+    spec:
+        secretStoreRef:
+            kind: ClusterSecretStore
+            name: onepassword-connect
+        target:
+            name: konflate-webhook-token-secret
+            template:
+                data:
+                    KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+        dataFrom:
+            - extract:
+                  key: konflate
+    ```
 
 3. Add `./externalsecret.yaml` to `app/kustomization.yaml` and set in the
    HelmRelease values:
 
-   ```yaml
-   secret:
-     existingSecret: konflate-webhook-token-secret
-   ```
+    ```yaml
+    secret:
+        existingSecret: konflate-webhook-token-secret
+    ```
 
-4. In GitHub repo settings → Webhooks, POST `https://konflate.${SECRET_DOMAIN}/hooks`
+4. In GitHub repository settings → Webhooks, POST `https://konflate.${SECRET_DOMAIN}/hooks`
    (content-type `application/json`, secret = the same value, events =
    Pull requests + Pushes).

--- a/kubernetes/apps/flux-system/konflate/README.md
+++ b/kubernetes/apps/flux-system/konflate/README.md
@@ -1,0 +1,55 @@
+# konflate
+
+Read-only **Flux PR rendered-diff** review UI ([home-operations/konflate](https://github.com/home-operations/konflate)).
+Renders this repo's Flux config at each open PR's merge-base vs head and shows the
+*rendered* Kubernetes diff (blast radius, image changes, render failures) — the
+impact a one-line HelmRelease bump actually has, which a git diff hides.
+
+Reached at `https://konflate.${SECRET_DOMAIN}` (envoy-internal).
+
+## Current mode: anonymous
+
+`LukeEvansTech/talos-cluster` is **public**, so konflate reviews PRs anonymously
+(no forge token). Open PRs re-render on `config.refreshInterval` (15m).
+
+## Optional upgrade: webhook-driven (instant PR refresh)
+
+To refresh a PR the moment it's pushed instead of waiting up to 15m, add a
+webhook secret (mirrors onedr0p/home-ops):
+
+1. Create a 1Password item `konflate` with field `KONFLATE_WEBHOOK_SECRET`
+   (a random string).
+2. Add `app/externalsecret.yaml`:
+
+   ```yaml
+   ---
+   # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+   apiVersion: external-secrets.io/v1
+   kind: ExternalSecret
+   metadata:
+     name: konflate-webhook-token
+   spec:
+     secretStoreRef:
+       kind: ClusterSecretStore
+       name: onepassword-connect
+     target:
+       name: konflate-webhook-token-secret
+       template:
+         data:
+           KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+     dataFrom:
+       - extract:
+           key: konflate
+   ```
+
+3. Add `./externalsecret.yaml` to `app/kustomization.yaml` and set in the
+   HelmRelease values:
+
+   ```yaml
+   secret:
+     existingSecret: konflate-webhook-token-secret
+   ```
+
+4. In GitHub repo settings → Webhooks, POST `https://konflate.${SECRET_DOMAIN}/hooks`
+   (content-type `application/json`, secret = the same value, events =
+   Pull requests + Pushes).

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: konflate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: konflate
+  interval: 1h
+  values:
+    config:
+      # Public repo → anonymous read is sufficient. A missed-webhook backstop
+      # re-renders open PRs (and reconciles the PR list) on this interval.
+      repo: github://LukeEvansTech/talos-cluster
+      refreshInterval: 15m
+      logFormat: json
+    httpRoute:
+      enabled: true
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+      hostnames:
+        - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+    persistence:
+      enabled: true
+      storageClass: ceph-block
+      size: 5Gi
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 50m
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: konflate
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.16
+  url: oci://ghcr.io/home-operations/charts/konflate

--- a/kubernetes/apps/flux-system/konflate/ks.yaml
+++ b/kubernetes/apps/flux-system/konflate/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app konflate
+  namespace: &namespace flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/konflate/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./netpol.yaml
   - ./flux-instance/ks.yaml
   - ./flux-operator/ks.yaml
+  - ./konflate/ks.yaml


### PR DESCRIPTION
## konflate — adopt (Flux app)

Deploys [home-operations/konflate](https://github.com/home-operations/konflate) as a `flux-system` app following onedr0p's pattern, adapted to this repo's conventions:

- OCI chart `oci://ghcr.io/home-operations/charts/konflate` @ `0.1.16`
- **Anonymous read** of this **public** repo (no token needed); 15m refresh backstop. README documents the optional webhook upgrade (1Password item + GitHub webhook) for instant PR refresh.
- `envoy-internal` route → `konflate.${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}`
- `ceph-block` cache PVC (5Gi), `gatus/guarded` + ServiceMonitor, single replica (in-memory state)

Validated with `flux-local build ks` (OCIRepository + HelmRelease + gatus ConfigMap render), yamlfmt + prettier clean.

**Why:** complements the existing Renovate + Claude review gate — konflate shows the *rendered* blast radius of a HelmRelease bump that a git diff hides (cf. the HelmRelease-thrash / HTTPRoute-drift incidents).

## kguardian — spike (manual, not GitOps)

eBPF runtime policy generator. Lives in `docs/spikes/kguardian/` **outside** the Flux tree — it's a privileged `hostNetwork` eBPF DaemonSet that should be run by hand, used to harvest policies, then removed.

- **Talos compat: green** — kernel 6.12 ✓, Talos CRI containerd socket paths match chart defaults ✓; needs a `privileged` PSA namespace (included).
- Self-contained: bundled PG18 on `ceph-block`; CNPG path documented for productionising.
- One risk flagged: `hostNetwork` (cf. the scanopy conntrack-flood) — passive eBPF, but watch node conntrack.
- Includes a harvest runbook (`kubectl kguardian gen ciliumnetworkpolicy …`).
- **kopiur** evaluated and skipped: overlaps existing VolSync, alpha API.

## Test plan
- [ ] CI lint + flux-local pass
- [ ] After merge: konflate reconciles, UI reachable at the internal route