### PR TITLE
fix(ollama): spread on ollama label, not shared gpu-workload

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -75,12 +75,15 @@ spec:
                       - "true"
       topologySpreadConstraints:
         # One replica per node so each lands on a distinct physical GPU.
+        # Select ollama pods only — `gpu-workload` is shared by many GPU apps
+        # (plex, jellyfin, whisper, …) and would skew the spread across all of
+        # them instead of distributing the 3 ollama replicas.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels:
-              gpu-workload: "true"
+              app.kubernetes.io/name: ollama
     service:
       app:
         controller: ollama


### PR DESCRIPTION
## Bug

PR #2894 set the StatefulSet's `topologySpreadConstraints.labelSelector` to `gpu-workload: "true"`. That label is shared by **every** GPU app in the cluster (plex, jellyfin, whisper, openaiwhisper, tdarr, pinchflat, dispatcharr). So the scheduler balanced the *combined* `gpu-workload` pod count across nodes instead of distributing the 3 ollama replicas.

Observed after rollout:

| Pod | Node |
|---|---|
| ollama-0 | cr-talos-01 |
| ollama-1 | cr-talos-02 |
| ollama-2 | **cr-talos-01** |

→ two replicas on cr-talos-01 (two ~18 GB models contending for one 24 GB time-sliced GPU → VRAM OOM risk) and **cr-talos-03's GPU unused**.

## Fix

Select `app.kubernetes.io/name: ollama` (verified unique to the 3 ollama pods) so `maxSkew: 1` / `DoNotSchedule` distributes them one-per-node.

Validated with `helm template`. Will confirm one-per-node placement after merge + reconcile.