### PR TITLE
fix(imgur-proxy): clear stale wireguard ip rules on gluetun (re)start

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -121,6 +121,19 @@ spec:
                   periodSeconds: 10
                   failureThreshold: 30
             restartPolicy: Always
+            # gluetun shares the pod netns across container restarts, so an
+            # abrupt exit leaves an orphaned policy-routing rule for the
+            # wireguard table. The next start then fails with
+            # "adding ip rule 101 ... table 51820: file exists" and never
+            # connects. Clear stale v4/v6 rules on (re)start so gluetun can
+            # re-add them cleanly. See gluetun-wiki setup/advanced/kubernetes.
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - "/bin/sh"
+                    - "-c"
+                    - "(ip rule del table 51820; ip -6 rule del table 51820) || true"
             securityContext:
               runAsUser: 0
               runAsNonRoot: false


### PR DESCRIPTION
## Problem

`KubeDeploymentReplicasMismatch` firing for `downloads/imgur-proxy` — Deployment stuck at **0/1** with the gluetun init container at **761 restarts**, never Ready.

Root cause from gluetun logs:
```
ERROR [vpn] adding IPv6 rule: adding ip rule 101: from all to all table 51820: file exists
INFO  [vpn] retrying in 2m0s ...
```
gluetun's policy-routing rule for the wireguard table (51820) survives container restarts in the shared pod netns. After an abrupt exit, the next start can't re-add the rule (`file exists`), the VPN never connects, and nginx stays blocked behind the init container.

## Fix

Add a `postStart` lifecycle hook that deletes any stale v4/v6 rules for table 51820 so gluetun re-adds them cleanly on each start. The controller already uses `strategy: Recreate`, and the gluetun container already has `NET_ADMIN` and runs as root, so no other changes are needed.

Ref: [gluetun-wiki — Kubernetes / adding IPv6 rule … file exists](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/kubernetes.md#adding-ipv6-rule--file-exists)

## Validation

- YAML well-formed (`yq` parses the `lifecycle` block).
- app-template **5.0.1** (deployed chart version) schema explicitly defines `lifecycle.postStart.exec.command` on a container (schema is strict `additionalProperties: false`), so the render is valid. (Local `flate build` hung on a network fetch — unrelated flake; CI flate is authoritative.)