### PR TITLE
fix(downloads): use ipinfo for gluetun public IP check (#2870)

### DIFF
--- a/kubernetes/apps/downloads/nzbget/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/nzbget/app/helmrelease.yaml
@@ -74,8 +74,9 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              #TODO - Enable when ready - https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md. Getting ""ERROR public ip check settings: API name: API name is not valid: "cloudflare" can only be "ipinfo" or "ip2location""
-              # PUBLICIP_API: cloudflare
+              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
+              PUBLICIP_API: ipinfo
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -37,8 +37,9 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              #TODO - Enable when ready - https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md. Getting ""ERROR public ip check settings: API name: API name is not valid: "cloudflare" can only be "ipinfo" or "ip2location""
-              # PUBLICIP_API: cloudflare
+              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
+              PUBLICIP_API: ipinfo
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -137,8 +137,9 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              #TODO - Enable when ready - https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md. Getting ""ERROR public ip check settings: API name: API name is not valid: "cloudflare" can only be "ipinfo" or "ip2location""
-              # PUBLICIP_API: cloudflare
+              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
+              PUBLICIP_API: ipinfo
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -134,8 +134,9 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              #TODO - Enable when ready - https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md. Getting ""ERROR public ip check settings: API name: API name is not valid: "cloudflare" can only be "ipinfo" or "ip2location""
-              # PUBLICIP_API: cloudflare
+              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
+              PUBLICIP_API: ipinfo
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h


### PR DESCRIPTION
## What

Enables gluetun's public IP check across all four download apps (nzbget, prowlarr, qbittorrent, sabnzbd) by switching `PUBLICIP_API` from the invalid `cloudflare` to `ipinfo`.

## Why

gluetun only accepts `ipinfo` or `ip2location` for `PUBLICIP_API`. The previous value caused:

```
ERROR public ip check settings: API name: API name is not valid: "cloudflare" can only be "ipinfo" or "ip2location"
```

so the option was left commented out. `ipinfo` is the gluetun default and needs no token.

## Validation

- `yamlfmt` + `prettier` clean
- `flate build hr <app> --namespace downloads` renders cleanly (rc=0) for all four; rendered env confirms `PUBLICIP_API: ipinfo`

Closes #2870