### PR TITLE
feat(ollama): NUM_PARALLEL 3 + qwen3.6-35b-a3b candidate Modelfile

### DIFF
--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -46,12 +46,13 @@ spec:
                 value: "/models"
               - name: OLLAMA_KEEP_ALIVE
                 value: "24h"
-              # Batch concurrent requests per replica. KV-cache is the limiter:
-              # ~24Gi VRAM - ~18Gi model leaves ~6Gi, shared (time-sliced GPU)
-              # with the whisper workloads. Start at 2; watch nvidia-smi before
-              # raising. Cap context length below if KV-cache OOMs.
+              # Batch concurrent requests per replica. GPUs are now dedicated to
+              # ollama (the whisper transcription stack was archived), so a ~17Gi
+              # model on a 24Gi card leaves ~5-6Gi for KV-cache → 3 slots is safe
+              # at typical (short) listing contexts. Watch nvidia-smi if contexts
+              # grow large; cap OLLAMA_CONTEXT_LENGTH before lowering this.
               - name: OLLAMA_NUM_PARALLEL
-                value: "2"
+                value: "3"
             resources:
               requests:
                 nvidia.com/gpu: 1 # one time-slice on the node's physical GPU
@@ -75,9 +76,9 @@ spec:
                       - "true"
       topologySpreadConstraints:
         # One replica per node so each lands on a distinct physical GPU.
-        # Select ollama pods only — `gpu-workload` is shared by many GPU apps
-        # (plex, jellyfin, whisper, …) and would skew the spread across all of
-        # them instead of distributing the 3 ollama replicas.
+        # Select ollama pods only — `gpu-workload` is shared by other GPU apps
+        # (plex, jellyfin, …) and would skew the spread across all of them
+        # instead of distributing the 3 ollama replicas.
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: DoNotSchedule

--- a/kubernetes/apps/ai/ollama/models/README.md
+++ b/kubernetes/apps/ai/ollama/models/README.md
@@ -1,0 +1,18 @@
+# Ollama models
+
+Models are **runtime-provisioned**, not reconciled by Flux. The HelmRelease only
+manages the Deployment/StatefulSet; model blobs live on each replica's per-ordinal
+`models-ollama-<N>` PVC (they survive pod restarts and rollouts, not PVC deletion).
+
+This directory holds Modelfiles for reproducibility — apply them with
+`ollama create` on each replica when provisioning a fresh PVC.
+
+## Current standard
+
+- **Production:** `qwen3.6:27b` (Ollama library) — `ollama pull qwen3.6:27b`
+- **Candidate (Acreage scoring):** `qwen3.6-35b-a3b` — built from
+  [`qwen3.6-35b-a3b.Modelfile`](./qwen3.6-35b-a3b.Modelfile)
+
+Always call these with the chat endpoint, `think: false`, and a `format` JSON
+schema for structured extraction — the schema constraint eliminates occasional
+output-shape wobble on the 35B and guarantees valid typed objects.

--- a/kubernetes/apps/ai/ollama/models/qwen3.6-35b-a3b.Modelfile
+++ b/kubernetes/apps/ai/ollama/models/qwen3.6-35b-a3b.Modelfile
@@ -1,0 +1,21 @@
+# Tidy alias for the Acreage LLM-scoring candidate.
+# Wraps the raw Unsloth dynamic GGUF with:
+#   - clean ChatML stop tokens (the upstream GGUF ships a malformed leaked
+#     template fragment as a stop param; explicit PARAMETER stop replaces it)
+#   - sane sampling defaults
+#
+# Create on each replica (models are runtime-provisioned, not Flux-managed):
+#   kubectl -n ai exec ollama-<N> -c app -- \
+#     sh -c 'cat > /tmp/Modelfile <<EOF
+#   <contents of this file>
+#   EOF
+#   ollama create qwen3.6-35b-a3b -f /tmp/Modelfile'
+#
+# Qwen3.6-35B-A3B (MoE, ~3B active) at UD-IQ4_XS ≈ 17.7Gi — fits a 24Gi card
+# with KV-cache headroom. Matched qwen3.6:27b accuracy at ~4.5x throughput on a
+# structured-output (format=JSON-schema) extraction batch.
+FROM hf.co/unsloth/Qwen3.6-35B-A3B-GGUF:UD-IQ4_XS
+PARAMETER temperature 0.6
+PARAMETER top_p 0.95
+PARAMETER stop "<|im_start|>"
+PARAMETER stop "<|im_end|>"


### PR DESCRIPTION
## What

Cluster-side finalize for the Acreage LLM model evaluation, staged so it's **ready to flip once the real-listing test passes**.

1. **`OLLAMA_NUM_PARALLEL` 2 → 3.** With the whisper transcription stack archived (#2912), the GPUs are dedicated to ollama. A ~17 GB model on a 24 GB card leaves ~5–6 GB for KV-cache → 3 slots/replica is safe at typical (short) listing contexts → **~9 concurrent** across the 3 replicas.
2. **Refresh stale comments** that referenced the now-archived whisper co-tenants.
3. **Add `models/qwen3.6-35b-a3b.Modelfile`** (+ README) — a reproducible, tidy alias for the candidate model. Wraps the Unsloth `UD-IQ4_XS` GGUF with **clean ChatML stop tokens** (the raw GGUF ships a malformed leaked-template fragment as a stop param) and sane sampling defaults. `models/` is a sibling of `app/`, and the ks `path` is `./app`, so Flux ignores it — models are runtime-provisioned on per-replica PVCs.

## Evidence

| | qwen3.6:27b | qwen3.6-35b-a3b |
|---|---|---|
| Accuracy (27 hard listings, `format`) | 45/45 | **45/45** |
| Throughput | ~14 tok/s | **~65 tok/s (~4.5×)** |
| VRAM | 17 GB | 17.7 GB |
| Determinism (temp 0) | ✓ | ✓ |

The 35B's only weakness — occasional output-shape wobble (array-wrapping) — is fully eliminated by a `format` JSON-schema constraint, which the extraction pipeline uses anyway.

## Runtime state (already applied, not in this PR)

Both `qwen3.6:27b` and the clean `qwen3.6-35b-a3b` alias are live on all three replicas; production remains on `qwen3.6:27b`. The flip happens Acreage-side (`ACREAGE_LLM_MODEL` → `qwen3.6-35b-a3b`) after the real-listing test.

## Note

Merging triggers a rolling restart (helmrelease change). Models + the alias persist on the per-ordinal PVCs, so nothing re-downloads.