### PR TITLE
feat(global-vars): centralize OLLAMA_MODEL via cluster-settings ConfigMap

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -8,10 +8,12 @@ metadata:
 data:
   config.yaml: |-
     model_list:
+      # NB: `model_name` is the litellm-exposed alias (kept stable for existing
+      # clients); the backend is centralized via ${OLLAMA_MODEL}/${OLLAMA_BASE_URL}.
       - model_name: ollama/gemma4
         litellm_params:
-          model: ollama_chat/gemma4:26b
-          api_base: http://ollama.ai.svc.cluster.local:11434
+          model: ollama_chat/${OLLAMA_MODEL}
+          api_base: ${OLLAMA_BASE_URL}
 
       - model_name: openrouter/auto
         litellm_params:

--- a/kubernetes/apps/custom/loupe/app/helmrelease.yaml
+++ b/kubernetes/apps/custom/loupe/app/helmrelease.yaml
@@ -28,9 +28,9 @@ spec:
               - name: DATABASE_URL
                 value: "sqlite:///./data/loupe.db"
               - name: OLLAMA_BASE_URL
-                value: http://ollama.ai.svc.cluster.local:11434
+                value: ${OLLAMA_BASE_URL}
               - name: OLLAMA_MODEL
-                value: gemma4:26b
+                value: ${OLLAMA_MODEL}
               - name: ADMIN_USERNAME
                 value: admin
               - name: ADMIN_PASSWORD

--- a/kubernetes/apps/default/contracthound/app/helmrelease.yaml
+++ b/kubernetes/apps/default/contracthound/app/helmrelease.yaml
@@ -23,8 +23,8 @@ spec:
               TZ: ${TIMEZONE}
               DATABASE_URL: sqlite:///./data/contracthound.db
               OLLAMA_ENABLED: "true"
-              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
-              OLLAMA_MODEL: gemma4:26b
+              OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+              OLLAMA_MODEL: ${OLLAMA_MODEL}
               APP_URL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"
               OIDC_ENABLED: "true"
             envFrom:

--- a/kubernetes/apps/default/subspy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/subspy/app/helmrelease.yaml
@@ -24,8 +24,8 @@ spec:
               TZ: ${TIMEZONE}
               DATABASE_URL: sqlite:///./data/subspy.db
               OLLAMA_ENABLED: "true"
-              OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
-              OLLAMA_MODEL: gemma4:26b
+              OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+              OLLAMA_MODEL: ${OLLAMA_MODEL}
             envFrom:
               - secretRef:
                   name: subspy-secret

--- a/kubernetes/components/global-vars/cluster-settings.yaml
+++ b/kubernetes/components/global-vars/cluster-settings.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/configmap.json
+# Non-secret cluster-wide settings, substituted into apps via the root
+# cluster-apps Kustomization postBuild (alongside the cluster-secrets Secret).
+# Unlike cluster-secrets, values live in Git — change them here in a PR and
+# every consumer picks them up on reconcile.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  annotations:
+    # Namespace is provided by Kustomize component usage
+    checkov.io/skip1: CKV_K8S_21=Namespace provided by kustomization overlay
+data:
+  # The local LLM that in-cluster apps target via ollama. Flip this one line to
+  # move every consumer (contracthound, subspy, loupe, litellm, …) at once.
+  OLLAMA_MODEL: qwen3.6-35b-a3b
+  OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434

--- a/kubernetes/components/global-vars/kustomization.yaml
+++ b/kubernetes/components/global-vars/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   # ExternalSecret overwrites it with real values in-cluster.
   - ./cluster-secrets.yaml
   - ./cluster-secrets-externalsecret.yaml
+  # Non-secret cluster-wide settings (Git-tracked, no ExternalSecret needed).
+  - ./cluster-settings.yaml

--- a/kubernetes/flux/cluster/ks.yaml
+++ b/kubernetes/flux/cluster/ks.yaml
@@ -31,6 +31,9 @@ spec:
               - kind: Secret
                 name: cluster-secrets
                 optional: true
+              - kind: ConfigMap
+                name: cluster-settings
+                optional: true
           patches:
             - patch: |-
                 apiVersion: helm.toolkit.fluxcd.io/v2


### PR DESCRIPTION
## Problem

Four apps hardcoded `OLLAMA_MODEL: gemma4:26b` — a model **no longer on ollama** (the StatefulSet rebuild dropped the old model PVC; only `qwen3.6:27b` + `qwen3.6-35b-a3b` are pulled now). Their LLM features were 404ing at runtime (pods up, RESTARTS=1, AI calls failing):

- `default/contracthound`, `default/subspy`, `custom/loupe` (`OLLAMA_MODEL` env)
- `ai/litellm` (configmap backend)

## Fix — the GitOps central knob

Add a **Git-tracked `cluster-settings` ConfigMap** to the `global-vars` component (created per-namespace, like `cluster-secrets`) and wire it into the root `cluster-apps` `postBuild.substituteFrom`. Apps reference `${OLLAMA_MODEL}` / `${OLLAMA_BASE_URL}`.

```yaml
# kubernetes/components/global-vars/cluster-settings.yaml
data:
  OLLAMA_MODEL: qwen3.6-35b-a3b
  OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
```

**Result:** every in-cluster LLM consumer moves with a **one-line edit** to that ConfigMap — pure GitOps, PR-reviewable, no per-app edits, no 1Password round-trip. Default set to `qwen3.6-35b-a3b` (already on all 3 replicas), which fixes the breakage *and* adopts the new MoE model cluster-wide.

## Notes

- Unlike `cluster-secrets` (Secret from 1Password + CI placeholder), `cluster-settings` holds non-secret values directly in Git, so the same resource serves CI and production — no ExternalSecret/placeholder needed.
- `substituteFrom` entry is `optional: true`, matching `cluster-secrets`.
- litellm's exposed `model_name: ollama/gemma4` alias is **kept stable** (outward-facing; external clients may call it). Only its backend is centralized — the alias name is now legacy and can be renamed in a follow-up if nothing depends on it.
- Acreage's `ACREAGE_LLM_MODEL` is separate (external app) and unaffected.

## Validation

`flux-local` render confirms `${OLLAMA_MODEL}` resolves: contracthound → `OLLAMA_MODEL: qwen3.6-35b-a3b`; litellm → `model: ollama_chat/qwen3.6-35b-a3b`.