### PR TITLE
fix(konflate): set cache PVC size to 20Gi to match live volume

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -27,7 +27,11 @@ spec:
     persistence:
       enabled: true
       storageClass: ceph-block
-      size: 5Gi
+      # Konflate caches many small OCI/Helm artifacts and exhausted inodes
+      # on 5Gi within ~25h (KubePersistentVolumeInodesFillingUp). Grown to
+      # 20Gi for inode headroom — PVCs can't shrink, so this must stay >=
+      # the live volume's capacity or helm upgrades fail the PVC apply.
+      size: 20Gi
     monitoring:
       serviceMonitor:
         enabled: true


### PR DESCRIPTION
## Problem

`konflate` HelmRelease stuck **Ready=False / RollbackFailed**, retry-looping:

```
Helm upgrade failed ... server-side apply failed for object
flux-system/konflate-cache PersistentVolumeClaim: ... is invalid:
spec.resources.requests.storage: Forbidden: field can not be less than status.capacity
```

The `konflate-cache` PVC was grown **5Gi → 20Gi** out-of-band to relieve inode exhaustion (`KubePersistentVolumeInodesFillingUp`). The HR still declared `5Gi`, so when the chart bumped (0.1.22 → 0.1.28) the helm upgrade re-applied the PVC at 5Gi — forbidden, because PVCs can't shrink below their current capacity. The failed upgrade triggered an auto-rollback that also failed, leaving the release looping (v50–v53 all `failed`). The konflate pod itself stayed healthy (1/1); only the helm reconcile was broken.

## Fix

Set `persistence.size: 20Gi` so the declared size matches the live volume. PVC apply then validates and the upgrade succeeds.

## After merge

Reconcile and confirm the HR returns to `Ready=True` (helm-controller will retry the upgrade with the corrected size; the failed-rollback loop clears). PVC stays at 20Gi.