### PR TITLE
fix(konflate): move cache to ephemeral emptyDir to stop inode exhaustion

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -25,13 +25,15 @@ spec:
         - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
     persistence:
-      enabled: true
-      storageClass: ceph-block
-      # Konflate caches many small OCI/Helm artifacts and exhausted inodes
-      # on 5Gi within ~25h (KubePersistentVolumeInodesFillingUp). Grown to
-      # 20Gi for inode headroom — PVCs can't shrink, so this must stay >=
-      # the live volume's capacity or helm upgrades fail the PVC apply.
-      size: 20Gi
+      # Ephemeral cache on the node filesystem (chart default). Konflate's
+      # source/render/stage caches are millions of tiny files (~1.3M inodes
+      # at only ~5.6GB), which exhaust a fixed-inode ceph-block RBD volume
+      # long before its byte budget (repeatedly fired
+      # KubePersistentVolumeInodesFillingUp). The caches are bounded by bytes
+      # + TTL, not inodes, so emptyDir on Talos /var (xfs, dynamic inodes) is
+      # the right home. Tradeoff: open-PR diffs re-render and the merged-PR
+      # shelf is lost on a konflate restart — acceptable for a diff UI.
+      enabled: false
     monitoring:
       serviceMonitor:
         enabled: true


### PR DESCRIPTION
## Problem

`konflate-cache` PVC repeatedly fires `KubePersistentVolumeInodesFillingUp` (twice in one day). It's **inode-bound, not space-bound**:

```
inodes total: 1,310,720   inodes used: 1,309,926  (99.94%, 794 free)
disk used:    5.6 GiB of 19.6 GiB                  (28% space)
```

konflate's source/render/stage caches are millions of tiny files (git mirrors, unpacked Helm charts, kustomize stages). The chart bounds these caches by **bytes + TTL** (`helmRenderCacheMb` 1024, `stageCacheMb` 2048, `cacheTtl` 7d, `closedPrMax` 25, `closedPrTtl` 14d) but **never by inode count**, so a fixed-inode ceph-block RBD volume exhausts inodes long before its byte budget. Growing 5Gi→20Gi only bought ~a day (and the out-of-band grow diverged from git, breaking the 0.1.28 upgrade — see #2921).

## Fix

Set `persistence.enabled: false` (the chart **default**). Per `templates/deployment.tpl`, the cache volume then mounts an `emptyDir` at `/var/cache/konflate` on the node filesystem (Talos `/var` = xfs, dynamic inodes — no fixed-inode ceiling). Helm removes the now-unused 20Gi PVC, which also clears the alert at the source.

## Tradeoff

The PVC existed only to persist rendered diffs across restarts (upstream PR #98). With emptyDir, open-PR diffs re-render and the merged-PR shelf is lost on a konflate restart. Acceptable for an in-cluster diff UI; it rebuilds within a refresh cycle.

## Follow-up

No upstream issue exists for inode exhaustion on RBD-backed caches — worth filing against home-operations/konflate (caches should be inode-aware, or the chart should document the inode footprint when recommending persistence).