### PR TITLE
fix(deduparr): switch DEDUPARR_ACTION to remove (#2880)

### DIFF
--- a/kubernetes/apps/media/deduparr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/deduparr/app/helmrelease.yaml
@@ -21,8 +21,8 @@ spec:
               repository: quay.io/kernald/deduparr
               tag: 1.2.0@sha256:81d935e48458427ca0e2896d00208efea70aba63034383a7368b9e10ad5d8cf0
             env:
-              # TODO: Change DEDUPARR_ACTION to "remove" once dry-run results are verified
-              DEDUPARR_ACTION: dry-run
+              # Verified: dry-run found 0 duplicates across all runs; safe to act when one appears.
+              DEDUPARR_ACTION: remove
               DEDUPARR_LOG_LEVEL: debug
               DEDUPARR_RADARR_MOVIES_ENABLED: true
               DEDUPARR_RADARR_MOVIES_URL: http://radarr.media.svc.cluster.local


### PR DESCRIPTION
## What
Switch `DEDUPARR_ACTION` from `dry-run` to `remove`.

## Dry-run verification
Reviewed deduparr's full log window (~72h). Every 2-minute run reports `duplicates_found=0 / new_removable=0 / downloads_removed=0` for both instances, while successfully fetching the Radarr (`queue_size=1`) and Sonarr (`queue_size=10`) queues — i.e. it's scanning correctly and simply finding nothing to remove. Enabling `remove` is a no-op today and will only act when a genuine duplicate appears.

## Validation
- `yamlfmt` + `prettier` clean
- `flate build hr deduparr --namespace media` renders cleanly (rc=0); rendered env confirms `DEDUPARR_ACTION: remove`

Closes #2880