### PR TITLE
fix(litellm): authenticate Redis cache against dragonfly

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -23,6 +23,7 @@ data:
     router_settings:
       redis_host: os.environ/REDIS_HOST
       redis_port: os.environ/REDIS_PORT
+      redis_password: os.environ/REDIS_PASSWORD
 
     litellm_settings:
       success_callback: ["prometheus"]
@@ -33,6 +34,7 @@ data:
         type: redis
         host: os.environ/REDIS_HOST
         port: os.environ/REDIS_PORT
+        password: os.environ/REDIS_PASSWORD
         ttl: 30
       drop_params: true
       num_retries: 2

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -25,8 +25,11 @@ spec:
         INIT_POSTGRES_PASS: "{{ .LITELLM_POSTGRES_PASS }}"
         INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        REDIS_PASSWORD: "{{ .DRAGONFLY_PASSWORD }}"
   dataFrom:
     - extract:
         key: litellm
     - extract:
         key: cloudnative-pg
+    - extract:
+        key: dragonfly


### PR DESCRIPTION
## Problem

litellm has been spamming ~15 errors/min since its initial deploy (#2560):

```
LiteLLM:ERROR: redis_cache.py:632 - LiteLLM Redis Caching: async set() - Got exception from REDIS Authentication required.
```

Dragonfly requires auth (`authentication.passwordFromSecret` → `DRAGONFLY_PASSWORD`), but litellm's config only ever wired `redis_host`/`redis_port` — no password in env, secret, or config. Every cache/router write fails with `NOAUTH`, so response caching and Redis-backed router state are silently dead (requests still succeed; litellm degrades gracefully).

Reproduced from inside the litellm pod: unauthenticated `PING` → `-NOAUTH Authentication required.`; `AUTH` with the dragonfly password → `+OK`.

## Fix

Match every other dragonfly consumer in this repo (paperless, keeper, netbox, …):

- **externalsecret.yaml**: extract the `dragonfly` 1Password item and template `REDIS_PASSWORD: {{ .DRAGONFLY_PASSWORD }}` into `litellm-secret` (already `envFrom`'d into the pod)
- **configmap.yaml**: `redis_password: os.environ/REDIS_PASSWORD` in `router_settings`, `password: os.environ/REDIS_PASSWORD` in `cache_params`

Reloader restarts litellm on the secret/ConfigMap change.

## Validation

- `just kube flate-build-ks ai litellm` renders all three new keys correctly
- Post-merge: confirm zero new `redis_cache.py` errors and a cache hit on a repeated completion