### PR TITLE
chore(storage): drop dangling garage reference after archive

### DIFF
--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -8,5 +8,3 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
-  # TODO: Update externalsecret with garage.toml config before enabling
-  # - ./garage/ks.yaml


### PR DESCRIPTION
Follow-up to #2947. That PR archived `garage` to `.archive/` but left the commented-out `# - ./garage/ks.yaml` line (and its TODO) in the storage kustomization, pointing at the now-moved path. Removes the dead reference.

`kustomize build kubernetes/apps/storage` OK.