### PR TITLE
feat(packer-runner): gha-runner-scale-set for packer-vsphere builds

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/externalsecret.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: packer-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: packer-runner-secret
+    template:
+      engineVersion: v2
+      data:
+        github_app_id: "{{ .ACTIONS_RUNNER_APP_ID }}"
+        github_app_installation_id: "{{ .ACTIONS_RUNNER_INSTALLATION_ID }}"
+        github_app_private_key: "{{ .ACTIONS_RUNNER_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: github-codelooks
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: packer-vsphere-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: packer-vsphere-creds
+    template:
+      engineVersion: v2
+      data:
+        # Surfaced to Packer as PKR_VAR_<name> so HCL variables bind from env.
+        PKR_VAR_vsphere_endpoint: "{{ .VSPHERE_ENDPOINT }}"
+        PKR_VAR_vsphere_username: "{{ .VSPHERE_USERNAME }}"
+        PKR_VAR_vsphere_password: "{{ .VSPHERE_PASSWORD }}"
+        PKR_VAR_vsphere_datacenter: "{{ .VSPHERE_DATACENTER }}"
+        PKR_VAR_vsphere_cluster: "{{ .VSPHERE_CLUSTER }}"
+        PKR_VAR_vsphere_datastore: "{{ .VSPHERE_DATASTORE }}"
+        PKR_VAR_vsphere_network: "{{ .VSPHERE_NETWORK }}"
+        PKR_VAR_vsphere_folder: "{{ .VSPHERE_FOLDER }}"
+        # Literal, not a 1Password field: vCenter presents a VMCA cert the pod
+        # does not trust.
+        PKR_VAR_vsphere_insecure_connection: "true"
+        PKR_VAR_common_content_library: "{{ .VSPHERE_CONTENT_LIBRARY }}"
+        PKR_VAR_common_iso_content_library: "{{ .VSPHERE_ISO_CONTENT_LIBRARY }}"
+        PKR_VAR_build_username: "{{ .BUILD_USERNAME }}"
+        PKR_VAR_build_password: "{{ .BUILD_PASSWORD }}"
+        PKR_VAR_build_password_encrypted: "{{ .BUILD_PASSWORD_ENCRYPTED }}"
+        PKR_VAR_build_key: "{{ .BUILD_KEY }}"
+  dataFrom:
+    - extract:
+        key: vsphere-packer

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name packer-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-packer
+  interval: 1h
+  values:
+    fullnameOverride: *name
+    githubConfigUrl: https://github.com/codelooks-com/packer-vsphere
+    githubConfigSecret: packer-runner-secret
+    runnerGroup: default
+    runnerScaleSetName: packer-vsphere
+    maxRunners: 3
+    minRunners: 0
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            storage: 40Gi
+    template:
+      spec:
+        serviceAccountName: packer-runner
+        containers:
+          - name: runner
+            image: ghcr.io/codelooks-com/packer-runner:latest
+            command: ["/home/runner/run.sh"]
+            env:
+              # containerMode: kubernetes defaults this to "true", which REFUSES
+              # plain `run:` jobs. Our tools live in the runner image and steps run
+              # directly on it, so this must be "false" (the existing
+              # talos-cluster-runner sets it too).
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+            envFrom:
+              - secretRef:
+                  name: packer-vsphere-creds
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./talos-cluster
-  - ./packer
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-packer
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/rbac.yaml
@@ -1,4 +1,8 @@
 ---
+# Intentionally no pod-management Role: this SA suppresses the chart's
+# auto-created kube-mode SA, so `container:` jobs, service containers, and
+# docker:// actions will fail on this runner — plain `run:` steps only.
+# See the ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER note in helmrelease.yaml.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/rbac.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: packer-runner
+  namespace: actions-runner-system


### PR DESCRIPTION
## Summary
New ARC runner scale set `packer-vsphere` under `kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/`:
- ExternalSecrets: GitHub App creds from 1Password `github-codelooks` (App 4009320, installation 139140471) + vCenter creds as `PKR_VAR_*` from `vsphere-packer`
- OCIRepository `gha-runner-scale-set-packer` (chart 0.14.2, covered by existing Renovate group rule)
- HelmRelease: `containerMode: kubernetes` (40Gi openebs-hostpath), `minRunners: 0` / `maxRunners: 3`, image `ghcr.io/codelooks-com/packer-runner:latest`, `ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER=false`
- Intentionally minimal ServiceAccount (no pod-management Role) — plain `run:` jobs only

## Notes
- Safe to merge before the runner image exists: `wait: false`, `minRunners: 0`, retry on failure — listener simply restarts until ghcr.io/codelooks-com/packer-runner is published (PR in codelooks-com/packer-vsphere builds it)
- Validated with `kubectl kustomize` on the runners tree