### PR TITLE
fix(plex): drop unused supplementalGroups [44,10000] (#2882)

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -112,11 +112,8 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
-        supplementalGroups:
-          - 44
-          - 10000
         seccompProfile: { type: RuntimeDefault }
-    service: # TODO: Tidy up supplementalGroups when we have a better understanding of what's needed from a TrueNAS perspective
+    service:
       app:
         controller: plex
         type: LoadBalancer


### PR DESCRIPTION
## What
Removes `supplementalGroups: [44, 10000]` from plex's pod securityContext (keeps `fsGroup: 1000`).

## Investigation (live pod)
All mounts are group-owned by **gid 1000**, which plex already has as its primary group:
- `/config` → `0:1000` · `/media` → `1000:1000` · `/transcode` → `0:1000`
- GPU render devices `/dev/dri/{card0,renderD128}` → `1000:1000` (renderD128 world-rw)

So neither **44 (video)** nor **10000** gated any access — both were vestigial. NVIDIA GPU allocation is via the device plugin + nvidia runtime, independent of group membership.

## Validation plan
- `flate build hr plex` renders cleanly (rc=0), securityContext no longer lists supplementalGroups.
- Post-merge: confirm pod healthy, `/media` readable, `/transcode`+`/config` writable, GPU still visible (HW transcode intact). Revert if anything regresses.

Closes #2882