### PR TITLE
feat(isponsorblocktv): enable (#2876)

### DIFF
--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   - ./dispatcharr/ks.yaml
   # - ./huntarr/ks.yaml  # Archived
   - ./imagemaid/ks.yaml
-  # - ./isponsorblocktv/ks.yaml  # TODO: Run iSPBTV setup to pair devices before enabling
+  - ./isponsorblocktv/ks.yaml
   - ./jellyfin/ks.yaml
   - ./kometa/ks.yaml
   - ./seerr/ks.yaml


### PR DESCRIPTION
## What
Enables the staged iSponsorBlockTV app (uncomments its ks in the media kustomization). Brings up the volsync-backed config PVC, RS/RD, ExternalSecrets, and the Deployment.

## Post-merge pairing (manual, interactive)
The app needs `/app/data/config.json` before it runs, created by iSPBTV's interactive setup (enter a YouTube **TV Link Code**). Sequence:
1. Keep the Deployment down; stand up a one-off setup pod mounting the config PVC.
2. `kubectl exec -it ... -- isponsorblocktv --data-dir /app/data --setup-cli` → enter TV Link Code + skip categories → save.
3. Tear down setup pod, bring the Deployment up, verify it connects.

## Validation
- `flate build ks isponsorblocktv` renders cleanly (rc=0): PVC + RS/RD (r2 + nfs) + ExternalSecrets + HelmRelease.

Refs #2876 (closed once pairing is verified)