### PR TITLE
feat(konflate): post PR diff summaries from in-cluster konflate

### DIFF
--- a/.github/workflows/konflate.yaml
+++ b/.github/workflows/konflate.yaml
@@ -36,7 +36,11 @@ jobs:
     steps:
       - name: Trigger render
         env:
-          PUSH_TOKEN: ${{ secrets.KONFLATE_PUSH_TOKEN }}
+          # zizmor secrets-outside-env wants a GitHub deployment environment, but this
+          # runs per-PR; an environment with protection rules would block the
+          # automation, and one without rules adds no security (same stance as
+          # renovate-review.yaml). The token only triggers konflate re-renders.
+          PUSH_TOKEN: ${{ secrets.KONFLATE_PUSH_TOKEN }} # zizmor: ignore[secrets-outside-env]
           PR: ${{ github.event.pull_request.number }}
         run: |
           # Konflate polls every 15m (no webhook); an authenticated refresh
@@ -55,10 +59,10 @@ jobs:
           # flight, so curl --retry waits the render out. Skip (don't fail) if
           # konflate is unreachable — flate.yaml remains the blocking check.
           if status="$(curl -fsS --retry 15 --retry-delay 5 --retry-all-errors \
-               -H 'Accept: text/markdown' \
-               -o summary.md -w '%header{x-konflate-render-status}' \
-               "${KONFLATE_URL}/api/prs/${PR}/summary")" \
-             && [ -s summary.md ]; then
+              -H 'Accept: text/markdown' \
+              -o summary.md -w '%header{x-konflate-render-status}' \
+              "${KONFLATE_URL}/api/prs/${PR}/summary")" \
+            && [ -s summary.md ]; then
             {
               echo "ready=true"
               echo "status=${status}"

--- a/.github/workflows/konflate.yaml
+++ b/.github/workflows/konflate.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Konflate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # In-cluster Service URL — konflate is only exposed via envoy-internal, so
+  # this workflow must run on the in-cluster runner to reach it.
+  KONFLATE_URL: http://konflate.flux-system.svc.cluster.local:8080
+
+jobs:
+  comment:
+    name: Konflate - Comment
+    # Same-repo PRs only: the repo is public and this job runs on a self-hosted
+    # runner, which must never execute fork-originated workflow runs.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: talos-cluster-runner
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Trigger render
+        env:
+          PUSH_TOKEN: ${{ secrets.KONFLATE_PUSH_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # Konflate polls every 15m (no webhook); an authenticated refresh
+          # re-renders this PR's new head now so the summary below is never
+          # stale. Non-fatal: a fresh render may already exist.
+          curl -fsS -X POST -H "Authorization: Bearer ${PUSH_TOKEN}" \
+            "${KONFLATE_URL}/api/prs/${PR}/refresh" \
+            || echo "::warning::konflate refresh failed; summary may lag the latest push"
+
+      - name: Fetch rendered summary
+        id: fetch
+        env:
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          # The markdown summary answers 503 + Retry-After while a render is in
+          # flight, so curl --retry waits the render out. Skip (don't fail) if
+          # konflate is unreachable — flate.yaml remains the blocking check.
+          if status="$(curl -fsS --retry 15 --retry-delay 5 --retry-all-errors \
+               -H 'Accept: text/markdown' \
+               -o summary.md -w '%header{x-konflate-render-status}' \
+               "${KONFLATE_URL}/api/prs/${PR}/summary")" \
+             && [ -s summary.md ]; then
+            {
+              echo "ready=true"
+              echo "status=${status}"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "konflate summary unavailable or empty — skipping; next push retries."
+          fi
+
+      - name: Read Summary
+        if: ${{ steps.fetch.outputs.ready == 'true' }}
+        id: summary
+        run: |
+          {
+            echo 'body<<KONFLATE_EOF'
+            cat summary.md
+            echo 'KONFLATE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Add Comment
+        if: ${{ steps.fetch.outputs.ready == 'true' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          header: konflate
+          message: ${{ steps.summary.outputs.body }}
+
+      - name: Fail on render issue
+        if: ${{ steps.fetch.outputs.ready == 'true' }}
+        env:
+          STATUS: ${{ steps.fetch.outputs.status }}
+        run: |-
+          case "$STATUS" in
+            ok)        echo "konflate render: ok" ;;
+            failures)  echo "::error::konflate render: one or more resources failed to render"; exit 1 ;;
+            error)     echo "::error::konflate render: render errored (no diff)"; exit 1 ;;
+            *)         echo "::warning::konflate render: unexpected status '${STATUS}'" ;;
+          esac

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflate
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: konflate-secret
+    template:
+      engineVersion: v2
+      data:
+        KONFLATE_PUSH_TOKEN: "{{ .KONFLATE_PUSH_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: konflate

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
       repo: github://LukeEvansTech/talos-cluster
       refreshInterval: 15m
       logFormat: json
+    secret:
+      # KONFLATE_PUSH_TOKEN — lets the Konflate PR workflow force a re-render of
+      # the PR's new head (POST /api/prs/{n}/refresh) instead of waiting out the
+      # 15m poll, so the posted summary is never stale.
+      existingSecret: konflate-secret
     httpRoute:
       enabled: true
       parentRefs:
@@ -41,4 +46,7 @@ spec:
       requests:
         cpu: 50m
       limits:
-        memory: 1Gi
+        # With persistence off, a restart re-renders every open PR from cold
+        # (~18 concurrent renders); 1Gi OOM-killed the pod in a crash loop.
+        # GOMEMLIMIT is derived from this (90%), so the GC tracks the ceiling.
+        memory: 2Gi

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./ocirepository.yaml
+  - ./externalsecret.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
## Summary

Adopts onedr0p's konflate-as-CI pattern (home-ops `konflate.yaml`), adapted for our internal-only konflate:

- **New `Konflate` workflow** running on the in-cluster `talos-cluster-runner` (konflate is only reachable via envoy-internal — no external exposure needed). It force-refreshes the PR's render via `POST /api/prs/{n}/refresh` (bearer `KONFLATE_PUSH_TOKEN`), fetches the markdown summary (503+Retry-After handled by `curl --retry`), posts a sticky comment, and fails on `x-konflate-render-status: failures|error`. Guarded to same-repo PRs only (public repo + self-hosted runner).
- **Runs beside `flate.yaml`** — flate stays the blocking check; this job skips quietly if konflate is unreachable.
- **`KONFLATE_PUSH_TOKEN`** wired via ExternalSecret (1Password item `konflate` in the Talos vault, already created); same value set as a repo Actions secret.
- **Memory limit 1Gi → 2Gi**: with persistence off, a restart re-renders all open PRs from cold; 0.1.29's render-concurrency-scaled template cache pushed that burst past 1Gi, OOM-killing konflate in a crash loop (observed today, 6+ restarts).

## Verification

- `flux-local build ks/hr` renders the ExternalSecret, `envFrom secretRef: konflate-secret`, and the 2Gi limit
- `actionlint`, `yamlfmt` + `prettier` clean