### PR TITLE
feat(gameyfin,tdarr): run non-root 1000:1000 + wire NFS (#2873)

### DIFF
--- a/kubernetes/apps/games/gameyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/games/gameyfin/app/helmrelease.yaml
@@ -38,13 +38,12 @@ spec:
               limits:
                 memory: 2Gi
 
-    # TODO: Test running as 1000:1000 instead of root for NFS compatibility
     defaultPodOptions:
       securityContext:
-        runAsNonRoot: false
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
 
     service:
@@ -77,12 +76,12 @@ spec:
                 subPath: db
               - path: /opt/gameyfin/plugindata
                 subPath: plugin
-      # games:
-      #   type: nfs
-      #   server: ${SECRET_STORAGE_SERVER}
-      #   path: /path/to/games  # TODO: Configure your games library path
-      #   globalMounts:
-      #     - path: /games
+      games:
+        type: nfs
+        server: ${SECRET_STORAGE_SERVER}
+        path: /mnt/pool/games
+        globalMounts:
+          - path: /games
       tmp:
         type: emptyDir
         advancedMounts:

--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -84,10 +84,10 @@ spec:
           labelSelector:
             matchLabels:
               gpu-workload: "true"
-      # TODO: Test running as 1000:1000 instead of root for NFS compatibility
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         supplementalGroups:
@@ -124,11 +124,9 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /cache
-            # NFS mounts for media - uncomment and configure when ready
-            # media:
-            #   type: nfs
-            #   server: ${SECRET_STORAGE_SERVER}
-            #   path: /path/to/media
-            #   globalMounts:
-            #     - path: /media
-            #       readOnly: false
+      media:
+        type: nfs
+        server: ${SECRET_STORAGE_SERVER}
+        path: /mnt/pool/media
+        globalMounts:
+          - path: /media


### PR DESCRIPTION
## What
Both apps ran as **root** with **no NFS media/games mounted**. This wires the NFS libraries and flips them to non-root `1000:1000`.

| App | Change |
|---|---|
| **tdarr** | + media NFS `${SECRET_STORAGE_SERVER}:/mnt/pool/media → /media` (RW); root → `1000:1000` (keeps `fsGroup 1000`, GPU groups 44/10000) |
| **gameyfin** | + games NFS `${SECRET_STORAGE_SERVER}:/mnt/pool/games → /games`; root → `1000:1000` |

## Why non-root 1000:1000
The NFS-compat goal: transcoded/written files land as `1000:1000` (matching the rest of the media library) instead of root. The new `pool/games` export uses `mapall=1000/all_squash`, so gameyfin writes resolve to 1000 regardless.

## Notes
- Path hardcoded (`/mnt/pool/{media,games}`) per repo convention (sonarr/radarr do the same); only the server is a secret var. No `cluster-secrets`/SOPS change needed.
- gameyfin library registration (UI → `/games`) is a follow-up UI step.

## Validation
- `flate build hr` renders cleanly (rc=0) for both: non-root 1000 + correct NFS paths.
- Post-merge: confirm both pods run as 1000, NFS mounts readable/writable, tdarr GPU intact. Revert if anything regresses.

Closes #2873