### PR TITLE
fix(gameyfin,tdarr): revert to root, keep NFS mounts (#2873)

### DIFF
--- a/kubernetes/apps/games/gameyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/games/gameyfin/app/helmrelease.yaml
@@ -39,11 +39,14 @@ spec:
                 memory: 2Gi
 
     defaultPodOptions:
+      # Image entrypoint runs groupmod and must start as root; it can't run as a
+      # non-root pod. NFS games export is all_squash→1000, so writes land as 1000
+      # regardless of the runtime UID.
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
         fsGroupChangePolicy: OnRootMismatch
 
     service:

--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -84,10 +84,12 @@ spec:
           labelSelector:
             matchLabels:
               gpu-workload: "true"
+      # s6 init runs s6-applyuidgid and must start as root; it can't run as a
+      # non-root pod. NFS media export is all_squash→1000, so transcoded files
+      # land as 1000 regardless of the runtime UID.
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
+        runAsUser: 0
+        runAsGroup: 0
         fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
         supplementalGroups:


### PR DESCRIPTION
## What
Reverts the non-root flip from the prior #2873 commit (#2957). **Keeps** the new NFS mounts (`/media`, `/games`).

## Why
Both images are s6/LinuxServer-style and **must start as root** to drop privileges — they crashloop as a non-root pod:
- gameyfin: `groupmod: Permission denied` (exit 10)
- tdarr: `s6-applyuidgid: fatal: unable to set supplementary group list: Operation not permitted`

The NFS-compat goal is still met: `pool/media` and `pool/games` both export `all_squash → 1000`, so files written by these apps land as `1000:1000` regardless of the pod UID (verified: tdarr wrote `/media/.tdarr_w` owned `1000:1000` even mid-flip).

Process-level non-root via PUID/PGID could be explored later, but isn't needed for NFS compat.

Restores both apps to their known-good root config with NFS now wired.