### PR TITLE
fix(tdarr): add runAsNonRoot:false so root pod renders (#2873)

### DIFF
--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -88,6 +88,7 @@ spec:
       # non-root pod. NFS media export is all_squash→1000, so transcoded files
       # land as 1000 regardless of the runtime UID.
       securityContext:
+        runAsNonRoot: false
         runAsUser: 0
         runAsGroup: 0
         fsGroup: 1000


### PR DESCRIPTION
Follow-up to the #2873 revert (#2958). tdarr's revert restored `runAsUser: 0` but omitted `runAsNonRoot: false` (matching the original, which only ran as a stale render). A fresh render hits `CreateContainerConfigError: container's runAsUser breaks non-root policy`. Explicitly set `runAsNonRoot: false` (as gameyfin already has) so the s6 init can start as root.

`flate build hr tdarr` renders cleanly.