### PR TITLE
fix(volsync): bump kopia server memory to 2Gi to stop OOM crashloop

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -51,8 +51,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-              limits:
                 memory: 1Gi
+              limits:
+                memory: 2Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Problem

The kopia repository server (`volsync-system/kopia`) was OOMKilling in a crashloop — **146 restarts** at its `1Gi` limit (`Last State: Terminated, Reason: OOMKilled, Exit Code: 137`). Even a trivial `kopia maintenance info` exec OOMs.

## Root cause

The VolSync Kopia repo has grown large:

```
GC found 3417632 in-use contents (319.8 GB)
... 3462 index blobs
```

The server loads the full index into memory on start, and ~320 GB / 3.4M contents no longer fits in 1Gi.

This is **not** a maintenance failure — the `KopiaMaintenance` cronjob (`kopia-maint-daily-…`, every 4h) runs **full maintenance successfully** (owner check passes, GC + epoch compaction complete, `MAINTENANCE_STATUS: SUCCESS` in ~380s). The "too many index blobs" warning is kopia being noisy about repo size, which maintenance can't drive much lower given the genuine content count.

## Change

- `limits.memory`: `1Gi` → `2Gi`
- add `requests.memory: 1Gi` as a scheduling floor

## Verification

- yamlfmt/prettier hooks pass
- CI flate will validate the render
- Post-merge: watch `kubectl get pod -n volsync-system -l app.kubernetes.io/name=kopia -w` — restart count should stop climbing. If it still OOMs at 2Gi, raise to 3–4Gi (repo will keep growing).