### PR TITLE
fix(konflate): add GitHub PAT so API calls are authenticated

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -14,6 +14,9 @@ spec:
       engineVersion: v2
       data:
         KONFLATE_PUSH_TOKEN: "{{ .KONFLATE_PUSH_TOKEN }}"
+        # GitHub fine-grained PAT (public-repo read-only) — without it konflate
+        # calls the GitHub API anonymously and hits the 60 req/hr IP limit
+        KONFLATE_TOKEN: "{{ .KONFLATE_TOKEN }}"
   dataFrom:
     - extract:
         key: konflate


### PR DESCRIPTION
Konflate has been running with authenticated=false, calling the GitHub
API anonymously at the 60 req/hr per-IP limit — exceeded during today's
PR sweep (403 rate limit at 13:45Z, refresh/list silently lagging).
Template KONFLATE_TOKEN from the konflate 1Password item (new
fine-grained PAT, public-repo read-only) into konflate-secret; the
deployment's existing envFrom picks it up. Raises the limit to 5000/hr.
