### PR TITLE
feat(kopiur): trial Kopia-native backup operator alongside VolSync

### DIFF
--- a/kubernetes/apps/default/apprise/ks.yaml
+++ b/kubernetes/apps/default/apprise/ks.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
+    - ../../../../components/kopiur
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -11,6 +11,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/gatus/guarded
+    - ../../../../components/kopiur
     - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/default/atuin/app

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kopiur
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: kopiur
+  values:
+    installScope: cluster
+    grafanaDashboard:
+      enabled: true
+      grafanaOperator:
+        enabled: true
+        matchLabels:
+          grafana.internal/instance: grafana
+    metrics:
+      serviceMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+    secretProjection:
+      enabled: true
+    webhook:
+      tls:
+        mode: self
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kopiur
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.2
+  url: oci://ghcr.io/home-operations/charts/kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/ks.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/ks.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kopiur
+  namespace: &namespace kopiur-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kopiur
+      namespace: kopiur-system
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kopiur-repository
+  namespace: &namespace kopiur-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kopiur
+      namespace: kopiur-system
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/kopiur-system/kopiur/repository
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/clusterrepository_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: ClusterRepository
+metadata:
+  name: nas
+spec:
+  backend:
+    filesystem:
+      # Dedicated subdirectory inside the existing VolSync NFS export —
+      # isolated from the volsync kopia repository at the export root.
+      # Promote to a dedicated TrueNAS dataset if the trial sticks.
+      path: /kopiur
+      volume:
+        nfs:
+          server: ${SECRET_STORAGE_SERVER}
+          path: ${SECRET_STORAGE_SERVER_VOLSYNC_NFS}
+  encryption:
+    passwordSecretRef:
+      name: kopiur-nas-secret
+      namespace: kopiur-system
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true
+  allowedNamespaces:
+    # Trial scope: only the namespace holding the trial apps (apprise, atuin).
+    # Widen (or switch to all: true) after the evaluation period.
+    list:
+      - default
+  identityDefaults:
+    hostnameExpr: namespace
+    usernameExpr: namespace + '-' + policyName
+  moverDefaults:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 1000
+    podSecurityContext:
+      fsGroup: 1000
+      fsGroupChangePolicy: OnRootMismatch
+    ttlSecondsAfterFinished: 86400
+  maintenance:
+    enabled: true

--- a/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopiur-nas
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: kopiur-nas-secret
+    template:
+      data:
+        # Filesystem/NFS backend needs only the repository encryption password.
+        KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: kopiur

--- a/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./clusterrepository.yaml

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kopiur-system
+components:
+  - ../../components/global-vars
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./kopiur/ks.yaml

--- a/kubernetes/apps/kopiur-system/namespace.yaml
+++ b/kubernetes/apps/kopiur-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/components/kopiur/kustomization.yaml
+++ b/kubernetes/components/kopiur/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./snapshotpolicy.yaml
+  - ./snapshotschedule.yaml

--- a/kubernetes/components/kopiur/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/snapshotpolicy.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotpolicy_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: ${APP}
+spec:
+  repository:
+    kind: ClusterRepository
+    name: nas
+  credentialProjection:
+    enabled: true
+  sources:
+    - pvc:
+        name: ${APP}
+  # Snapshot copyMethod backs up from a CSI VolumeSnapshot clone, so it never
+  # contends with the running app or VolSync movers on the live RWO PVC.
+  copyMethod: Snapshot
+  volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}
+  retention:
+    keepDaily: 7
+    keepWeekly: 4

--- a/kubernetes/components/kopiur/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/snapshotschedule.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kopiur.home-operations.com/snapshotschedule_v1alpha1.json
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotSchedule
+metadata:
+  name: ${APP}
+spec:
+  policyRef:
+    name: ${APP}
+  schedule:
+    # Jenkins-style H pins a deterministic per-schedule minute.
+    cron: "H 4 * * *"
+    jitter: 2m
+    timezone: Europe/London
+    # Trial: take a first snapshot immediately on creation so the
+    # repository and identity wiring are validated without waiting a day.
+    runOnCreate: true


### PR DESCRIPTION
Deploy home-operations/kopiur 0.3.2 (alpha) following onedr0p's pattern:
operator in kopiur-system (cluster scope, secretProjection, monitoring,
Grafana dashboard) plus a 'nas' ClusterRepository on the existing VolSync
NFS export under a dedicated /kopiur subdirectory, namespace-gated to
'default'. New backup-only components/kopiur (SnapshotPolicy +
SnapshotSchedule, copyMethod Snapshot) attached to apprise and atuin —
running CONCURRENTLY with VolSync to evaluate effectiveness before any
migration decision. CSI-snapshot clones mean no RWO contention with the
apps or VolSync movers. Encryption password lives in the new 'kopiur'
1Password item; promotion path is a dedicated TrueNAS dataset.
