### PR TITLE
feat(konflate): GitHub webhook mode for instant PR renders

### DIFF
--- a/.github/workflows/konflate.yaml
+++ b/.github/workflows/konflate.yaml
@@ -34,22 +34,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Trigger render
-        env:
-          # zizmor secrets-outside-env wants a GitHub deployment environment, but this
-          # runs per-PR; an environment with protection rules would block the
-          # automation, and one without rules adds no security (same stance as
-          # renovate-review.yaml). The token only triggers konflate re-renders.
-          PUSH_TOKEN: ${{ secrets.KONFLATE_PUSH_TOKEN }} # zizmor: ignore[secrets-outside-env]
-          PR: ${{ github.event.pull_request.number }}
-        run: |
-          # Konflate polls every 15m (no webhook); an authenticated refresh
-          # re-renders this PR's new head now so the summary below is never
-          # stale. Non-fatal: a fresh render may already exist.
-          curl -fsS -X POST -H "Authorization: Bearer ${PUSH_TOKEN}" \
-            "${KONFLATE_URL}/api/prs/${PR}/refresh" \
-            || echo "::warning::konflate refresh failed; summary may lag the latest push"
-
+      # Renders are triggered by the GitHub webhook (HMAC-validated POST
+      # /hooks via the konflate-webhook HTTPRoute); the 15m poll remains as
+      # the missed-webhook backstop. This job only consumes the summary.
       - name: Fetch rendered summary
         id: fetch
         env:

--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -17,6 +17,9 @@ spec:
         # GitHub fine-grained PAT (public-repo read-only) — without it konflate
         # calls the GitHub API anonymously and hits the 60 req/hr IP limit
         KONFLATE_TOKEN: "{{ .KONFLATE_TOKEN }}"
+        # HMAC secret validating GitHub webhook deliveries on POST /hooks —
+        # must match the secret configured on the repo webhook
+        KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
   dataFrom:
     - extract:
         key: konflate

--- a/kubernetes/apps/flux-system/konflate/app/httproute-webhook.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/httproute-webhook.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# Exposes ONLY konflate's webhook endpoint (HMAC-validated) to GitHub.
+# The konflate UI stays internal-only on the chart-managed HTTPRoute.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate-webhook
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+spec:
+  hostnames:
+    - konflate-webhook.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /hooks
+      backendRefs:
+        - name: konflate
+          port: 8080

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./ocirepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute-webhook.yaml


### PR DESCRIPTION
Adopt onedr0p's webhook pattern (home-ops 21f9f4a1): KONFLATE_WEBHOOK_SECRET
joins the existing konflate-secret via ExternalSecret, and a dedicated
path-scoped external HTTPRoute (konflate-webhook.<domain>, /hooks only,
HMAC-validated) lets GitHub deliver events directly — the UI stays
internal-only. The CI 'Trigger render' refresh POST is removed (this was
the source of the transient 'refresh failed' warnings); the 15m poll stays
as the missed-webhook backstop.
