### PR TITLE
fix(kopiur): mount /kopiur export subdirectory, not the export root

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -7,14 +7,16 @@ metadata:
 spec:
   backend:
     filesystem:
-      # Dedicated subdirectory inside the existing VolSync NFS export —
-      # isolated from the volsync kopia repository at the export root.
-      # Promote to a dedicated TrueNAS dataset if the trial sticks.
-      path: /kopiur
+      # `path` is the volume MOUNTPOINT inside mover pods (the repo lives at
+      # its root), so isolation from the volsync kopia repo at the export
+      # root must happen at the NFS layer: mount the /kopiur subdirectory of
+      # the export (pre-created on the NAS). Promote to a dedicated TrueNAS
+      # dataset if the trial sticks.
+      path: /repo
       volume:
         nfs:
           server: ${SECRET_STORAGE_SERVER}
-          path: ${SECRET_STORAGE_SERVER_VOLSYNC_NFS}
+          path: ${SECRET_STORAGE_SERVER_VOLSYNC_NFS}/kopiur
   encryption:
     passwordSecretRef:
       name: kopiur-nas-secret


### PR DESCRIPTION
filesystem.path is the volume mountpoint (repo at its root), not a
directory selector — the bootstrap job mounted the export root and tried
our password against the VolSync kopia repository living there (AuthFailure,
'invalid repository password'). Mount the pre-created /kopiur subdirectory
of the export instead, mirroring onedr0p's mountpoint convention (path /repo).
