### PR TITLE
fix(kopiur): grant credentialProjection on the nas ClusterRepository

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -24,6 +24,10 @@ spec:
       key: KOPIA_PASSWORD
   create:
     enabled: true
+  credentialProjection:
+    # Owner-side grant matching the components' credentialProjection.enabled —
+    # lets mover Jobs in allowed namespaces receive the repository credentials.
+    allowed: true
   allowedNamespaces:
     # Trial scope: only the namespace holding the trial apps (apprise, atuin).
     # Widen (or switch to all: true) after the evaluation period.


### PR DESCRIPTION
Mover Jobs in 'default' were stuck transient-retrying: the components'
credentialProjection.enabled (consumer side) also requires the repository
owner's grant — credentialProjection.allowed: true — before the controller
will project kopiur-nas-secret into mover namespaces.
