### PR TITLE
fix(kopiur): allow kopiur-system in the nas ClusterRepository namespaces

### DIFF
--- a/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/repository/clusterrepository.yaml
@@ -29,10 +29,13 @@ spec:
     # lets mover Jobs in allowed namespaces receive the repository credentials.
     allowed: true
   allowedNamespaces:
-    # Trial scope: only the namespace holding the trial apps (apprise, atuin).
-    # Widen (or switch to all: true) after the evaluation period.
+    # Trial scope: the namespace holding the trial apps (apprise, atuin) PLUS
+    # the operator's own namespace — the managed Maintenance CR is created in
+    # kopiur-system and is webhook-gated by this same list (onedr0p hit the
+    # identical issue, home-ops 90232c18). Widen after the evaluation period.
     list:
       - default
+      - kopiur-system
   identityDefaults:
     hostnameExpr: namespace
     usernameExpr: namespace + '-' + policyName

--- a/kubernetes/components/kopiur/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/snapshotschedule.yaml
@@ -15,3 +15,8 @@ spec:
     # Trial: take a first snapshot immediately on creation so the
     # repository and identity wiring are validated without waiting a day.
     runOnCreate: true
+    # SUSPENDED until kopiur ships source staging (home-operations/kopiur#82):
+    # in <=0.3.2, copyMethod Snapshot still mounts the live RWO PVC into the
+    # mover, which Multi-Attach-wedges whenever the mover lands on a different
+    # node than the app. Unsuspend when the chart bump carrying #82 merges.
+    suspend: true


### PR DESCRIPTION
The operator creates its managed Maintenance CR in kopiur-system, which the
admission webhook gates on the same allowedNamespaces list — with only
'default' allowed, maintenance was rejected in a tight retry loop
(MaintenanceConfigured=False). Same fix as onedr0p's home-ops 90232c18.
