### PR TITLE
chore(kopiur): TODO(#2989) on the suspended trial schedules

### DIFF
--- a/kubernetes/components/kopiur/snapshotschedule.yaml
+++ b/kubernetes/components/kopiur/snapshotschedule.yaml
@@ -15,8 +15,10 @@ spec:
     # Trial: take a first snapshot immediately on creation so the
     # repository and identity wiring are validated without waiting a day.
     runOnCreate: true
-    # SUSPENDED until kopiur ships source staging (home-operations/kopiur#82):
-    # in <=0.3.2, copyMethod Snapshot still mounts the live RWO PVC into the
-    # mover, which Multi-Attach-wedges whenever the mover lands on a different
-    # node than the app. Unsuspend when the chart bump carrying #82 merges.
+    # TODO(#2989): unsuspend once the kopiur chart bump carrying
+    # home-operations/kopiur#82 (source staging) lands — see the resume
+    # checklist on the issue. SUSPENDED because in <=0.3.2 copyMethod
+    # Snapshot still mounts the live RWO PVC into the mover, which
+    # Multi-Attach-wedges whenever the mover lands on a different node
+    # than the app.
     suspend: true


### PR DESCRIPTION
Link the suspension to the tracking issue carrying the resume checklist
for when upstream source staging (home-operations/kopiur#82) ships.
