### PR TITLE
feat(shelly): deploy operator, fleet sync, and exporter in home namespace

### DIFF
--- a/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
         containers:
           app:
             image:
-              repository: ghcr.io/lukeevanstech/shelly_exporter
+              repository: ghcr.io/lukeevanstech/shelly-prometheus-exporter
               tag: 0.3.1@sha256:3d123b1c26a6dc8ed2ce0927d56a66212401da8c7102c20abd21c1158e9c1d7f
             args:
               - --config


### PR DESCRIPTION
## Summary

- Deploys `shelly-operator` via OCI chart (handles device discovery, exporter feed, dashboard)
- Adds `shelly-fleet` to sync private fleet repo via deploy-key GitRepository
- Moves `shelly-exporter` from observability to home namespace; config now comes from operator-rendered ConfigMap instead of ExternalSecret
- Updates exporter image to `ghcr.io/lukeevanstech/shelly-prometheus-exporter` (repo renamed from `shelly_exporter`)

## Test plan

- [ ] Flux reconciles without errors on all three Kustomizations
- [ ] `shelly-operator` pod running in `home` namespace
- [ ] `shelly-exporter-config` ConfigMap created by operator
- [ ] `shelly-exporter` pod running and scraping devices
- [ ] Metrics visible in Grafana dashboard