### PR TITLE
feat(shelly-operator): 0.2.0 (firmware auto-update)

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -9,10 +9,17 @@ spec:
   chartRef:
     kind: OCIRepository
     name: shelly-operator
+  # The chart ships CRDs in crds/; helm-controller skips CRD upgrades by
+  # default, so 0.2.0's new fields (firmware section, availableFirmware)
+  # need an explicit CreateReplace policy.
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.1.1@sha256:5532885087a503efe2af5f2a29a8f94b6a101b5587420b2b0051b73f5841de05
+      tag: 0.2.0@sha256:ca2ce3f23e2dc6d06b933203ae7a9b20439c353c0953131f1bf9f564e91a7d3c
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.1
+    tag: 0.2.0
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator


### PR DESCRIPTION
Bumps shelly-operator chart+image 0.1.1 -> 0.2.0 (digest-pinned, cosign-signed). 0.2.0 adds the declarative firmware.autoUpdate profile section and status.availableFirmware (LukeEvansTech/shelly-operator#14). Also sets install/upgrade crds: CreateReplace so the chart's CRD updates actually apply (helm-controller skips CRD upgrades by default). No behavior change until the fleet repo adds the firmware section to a profile.