### PR TITLE
fix(ci): make konflate render-failures advisory, not a gate

### DIFF
--- a/.github/workflows/konflate.yaml
+++ b/.github/workflows/konflate.yaml
@@ -84,7 +84,10 @@ jobs:
         run: |-
           case "$STATUS" in
             ok)        echo "konflate render: ok" ;;
-            failures)  echo "::error::konflate render: one or more resources failed to render"; exit 1 ;;
+            # 'failures' = individual resources couldn't render (e.g. private
+            # GitRepository source not simulated). Known false positive on every
+            # PR due to shelly-fleet-sync cascade — warn but don't block merges.
+            failures)  echo "::warning::konflate render: one or more resources failed to render" ;;
             error)     echo "::error::konflate render: render errored (no diff)"; exit 1 ;;
             *)         echo "::warning::konflate render: unexpected status '${STATUS}'" ;;
           esac


### PR DESCRIPTION
## Summary

- Changes `failures` status in Konflate workflow from `exit 1` to `::warning::`, making it genuinely advisory
- `error` status (whole render failed, no diff produced) still exits 1 as a real gate

## Why

`shelly-fleet-sync` uses a private GitRepository (`home/shelly-fleet`) that requires an SSH deploy key only available at runtime via ExternalSecret. Konflate can't simulate this secret during PR rendering, so every PR gets 4 render-failure annotations cascading from that source:

- `Kustomization home/shelly-fleet-sync` — source not simulated
- `Kustomization home/shelly-fleet` — child not ready
- `Kustomization flux-system/cluster-apps` — cascade
- `Kustomization games/minecraft` — cascade

These are false positives — the live cluster has both KS healthy. The `Konflate - Comment` check has been blocking auto-merge on every Renovate PR as a result.

The root cause (private GitRepository source needing a runtime secret) is tracked alongside the flate v0.3.3 pin in `.github/workflows/flate.yaml`. This fix decouples Konflate from that root-cause fix.

## Test plan

- [ ] Verify `Konflate - Comment` check passes (shows warning annotation, not failure) on this PR
- [ ] Verify existing Renovate PRs now unblock once CI re-runs