### PR TITLE
fix(prowler): use /api/auth/session probe to avoid ProbeWarning

### DIFF
--- a/kubernetes/apps/security/prowler/app/helmrelease-ui.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-ui.yaml
@@ -39,14 +39,14 @@ spec:
               - secretRef:
                   name: prowler-ui-secret
             probes:
-              # Probe `/` (returns 307 redirect to /sign-in — accepted as 2xx-3xx
-              # by kubelet). Prowler-UI's `/api/health` returns 404 in 5.26.1.
+              # /api/auth/session is a standard NextAuth endpoint that returns
+              # {} with HTTP 200 for unauthenticated requests — no redirect.
               liveness: &uiProbe
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
-                    path: /
+                    path: /api/auth/session
                     port: &port 3000
                   initialDelaySeconds: 30
                   periodSeconds: 30


### PR DESCRIPTION
## Summary

- Changes the Prowler UI liveness/readiness probe from `httpGet path: /` to `httpGet path: /api/auth/session`
- The root endpoint returns a 307 redirect to `/sign-in` for unauthenticated requests, which causes Kubernetes to emit a `ProbeWarning` event on every probe cycle (K8s ≥1.25 warns when HTTP probes follow redirects)
- `/api/auth/session` is a standard NextAuth endpoint that returns `HTTP 200 {}` for unauthenticated requests — no redirect, no warning

## Test plan

- [ ] Prowler UI pod shows no further `ProbeWarning` events after rollout
- [ ] Liveness and readiness probes pass (pod stays `Running`)