### PR TITLE
feat(ci): expose konflate externally (flate stays v0.3.3)

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -16,10 +16,13 @@ permissions:
 
 env:
   # renovate: datasource=github-releases depName=home-operations/flate
-  # Pinned to v0.3.3: v0.4.4 cascades a skipped GitRepository source to block
-  # all dependents (shelly-fleet-sync → 209 blocked). v0.3.3 marks the source
-  # skipped and leaves dependents unblocked. TODO: upgrade once
-  # shelly-fleet-sync is restructured to not use a private-key-gated source.
+  # Pinned to v0.3.3: v0.4.4+ cascades an unresolvable source (the private
+  # shelly-fleet GitRepository, whose SSH deploy key only exists at runtime)
+  # to BLOCK every dependent — ~209 blocked. v0.3.3 marks the source skipped
+  # and leaves dependents unblocked. A placeholder secret doesn't help: flate
+  # then parses the bogus key and fails the source loud (still cascades).
+  # Real fixes tracked separately (drop flate-test in favour of konflate, or
+  # restructure shelly-fleet to bootstrap from the private repo).
   FLATE_VERSION: "v0.3.3"
 
 jobs:

--- a/.github/workflows/konflate.yaml
+++ b/.github/workflows/konflate.yaml
@@ -19,17 +19,19 @@ permissions:
   contents: read
 
 env:
-  # In-cluster Service URL — konflate is only exposed via envoy-internal, so
-  # this workflow must run on the in-cluster runner to reach it.
-  KONFLATE_URL: http://konflate.flux-system.svc.cluster.local:8080
+  # External Konflate URL — set via repo variable KONFLATE_URL
+  # (e.g. https://konflate.<your-domain>). Falls back to the in-cluster
+  # service URL if the variable is not set (self-hosted runner path).
+  KONFLATE_URL: ${{ vars.KONFLATE_URL || 'http://konflate.flux-system.svc.cluster.local:8080' }}
 
 jobs:
   comment:
     name: Konflate - Comment
-    # Same-repo PRs only: the repo is public and this job runs on a self-hosted
-    # runner, which must never execute fork-originated workflow runs.
+    # Same-repo PRs only: Konflate renders against our cluster state so there
+    # is no value running it for external forks, and the fallback path still
+    # uses a self-hosted runner.
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: talos-cluster-runner
+    runs-on: ${{ vars.KONFLATE_URL && 'ubuntu-latest' || 'talos-cluster-runner' }}
     permissions:
       contents: read
       pull-requests: write

--- a/kubernetes/apps/flux-system/konflate/app/httproute.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/httproute.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# Exposes the Konflate UI externally via cloudflare so GitHub Actions
+# standard runners (ubuntu-latest) can reach the summary API.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: konflate-external
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+spec:
+  hostnames:
+    - "konflate.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: konflate
+          port: 8080

--- a/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./ocirepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./httproute-webhook.yaml


### PR DESCRIPTION
## Summary

Originally aimed to fix the shelly-fleet cascade so flate could upgrade to v0.4.5. That turned out to be a dead-end (see below), so this PR is now **konflate external exposure only** + a documented flate pin.

### Konflate external exposure
- Adds `httproute.yaml` — konflate-external HTTPRoute on `envoy-external` with an external-dns target. UI/summary API reachable at `konflate.${SECRET_DOMAIN}` via cloudflare (webhook route stays separate).
- Workflow uses `${{ vars.KONFLATE_URL }}` with in-cluster fallback; auto-selects `ubuntu-latest` when the repo variable is set, else `talos-cluster-runner`. Summary fetch degrades gracefully (skips, never fails, if konflate is unreachable).
- Repo variable `KONFLATE_URL=https://konflate.codelooks.com` is already set.

### flate stays on v0.3.3
flate v0.4.4+ cascades an *unresolvable* source to **block every dependent** (~209 blocked). The shelly-fleet private GitRepository's SSH deploy key only exists at runtime, so its source is always unresolvable in CI:
- **No secret** → flate marks the source `skipped` → v0.4.5 cascades to blocked.
- **Placeholder secret** → flate parses the bogus key, fails the source `loud` → still cascades.

So v0.4.5 can't work with the current structure. The pin comment now records this. Real fixes (separate work):
1. Drop `flate test`/`flate diff` as the blocking gate and rely on konflate (onedr0p's model — konflate handles the private source as `skipped (missing secret)` and renders the rest with advisory failures).
2. Restructure shelly-fleet to bootstrap its sync Kustomization from the private repo, out of flate's DAG.

## Note
The "all CIs failing" incident this PR was opened during was a **separate** issue: konflate's in-pod git mirror had a phantom object (a force-pushed-away commit) and was failing *every* render with `object not found`. Fixed by restarting the konflate pod (emptyDir mirror → fresh clone). All open PRs are green again.

## Test plan
- [ ] #3020 CI green (flate v0.3.3 = no cascade; konflate advisory)
- [ ] After merge: `kubectl get httproute konflate-external -n flux-system` Accepted
- [ ] `https://konflate.codelooks.com` resolves + serves UI
- [ ] Next PR runs konflate on `ubuntu-latest` and passes