### PR TITLE
fix(flux): raise source-controller memory 256Mi → 1Gi (OOM crashloop)

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -80,6 +80,10 @@ spec:
               kind: Deployment
               name: helm-controller
           - # Set resources for source-controller
+            # 256Mi OOM-crashlooped during a burst of merges (artifact server
+            # rebuilds + 10-chart helm cache + --concurrent=10). Observed ~474Mi
+            # while re-fetching the full artifact set, so 512Mi left almost no
+            # headroom — set 1Gi to survive future merge bursts.
             patch: |-
               apiVersion: apps/v1
               kind: Deployment
@@ -93,9 +97,9 @@ spec:
                         resources:
                           requests:
                             cpu: 10m
-                            memory: 256Mi
+                            memory: 1Gi
                           limits:
-                            memory: 256Mi
+                            memory: 1Gi
             target:
               kind: Deployment
               name: source-controller


### PR DESCRIPTION
## Summary
`source-controller` was OOM-crashlooping (10 restarts, 256Mi limit) after a burst of ~14 PR merges. While it was down it couldn't serve chart artifacts, so every HelmRelease failed to load its chart (`context deadline exceeded`) → `FluxHelmReleaseArtifactFailed` alerts cluster-wide.

Raises the source-controller memory patch in the FluxInstance from **256Mi → 1Gi** (request=limit). Observed ~474Mi while re-fetching the full artifact set under `--concurrent=10` + 10-chart helm cache, so 512Mi left almost no headroom.

## Already mitigated live
Recovered the cluster immediately via a break-glass `kubectl replace` on the live FluxInstance CR (flux-operator applies it independently of source-controller, breaking the deadlock where the git fix needs source-controller to apply it). source-controller is now Running at 1Gi, 0 restarts; all HelmReleases are Ready again. This PR makes the value durable so it isn't reverted on the next flux-instance re-render.

## Test plan
- [x] source-controller Ready at 1Gi, 0 restarts
- [x] All HelmReleases Ready (artifact fetches succeed)
- [ ] flate CI green
- [ ] After merge: live FluxInstance and git converge at 1Gi