### PR TITLE
shelly-exporter: device-auth env (fleet auth rollout SP-2)

### DIFF
--- a/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
@@ -18,11 +18,11 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/shelly-prometheus-exporter
-              # TODO(auth SP-2): bump to the digest-auth release once
-              # LukeEvansTech/shelly-prometheus-exporter PR #1 is merged and CI
-              # publishes a new tag. Digest auth is a no-op on this old image,
-              # so the SHELLY_* env below is inert until this is bumped.
-              tag: 0.3.1@sha256:3d123b1c26a6dc8ed2ce0927d56a66212401da8c7102c20abd21c1158e9c1d7f
+              # 0.4.0 adds Shelly Gen2 digest auth; with SHELLY_PASSWORD (env
+              # below, from the auth-credentials Secret) it authenticates to
+              # plugs that have auth on, and is a clean no-op on those that
+              # don't (digest only engages on a 401).
+              tag: 0.4.0@sha256:807220f4c0ea659e8e7c72fe52b74ef430bafd660b4ea3b56e83cc14f5a03648
             args:
               - --config
               - /config/config.yaml

--- a/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
@@ -18,12 +18,28 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/shelly-prometheus-exporter
+              # TODO(auth SP-2): bump to the digest-auth release once
+              # LukeEvansTech/shelly-prometheus-exporter PR #1 is merged and CI
+              # publishes a new tag. Digest auth is a no-op on this old image,
+              # so the SHELLY_* env below is inert until this is bumped.
               tag: 0.3.1@sha256:3d123b1c26a6dc8ed2ce0927d56a66212401da8c7102c20abd21c1158e9c1d7f
             args:
               - --config
               - /config/config.yaml
             env:
               TZ: ${TIMEZONE:=UTC}
+              # Shelly device admin auth (fleet auth rollout SP-2). optional:
+              # true so the exporter keeps running UNauthenticated until the
+              # auth-credentials Secret exists (created by the shelly-fleet
+              # externalsecret-auth.yaml, SP-3) -- a missing Secret will not
+              # block the pod from starting.
+              SHELLY_USERNAME: admin
+              SHELLY_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: auth-credentials
+                    key: password
+                    optional: true
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
DRAFT / pre-staged. Part of the Shelly fleet device-auth rollout (SP-2).

Adds to the shelly-exporter HelmRelease:
- `SHELLY_USERNAME: admin`
- `SHELLY_PASSWORD` from Secret `auth-credentials` key `password`, **optional: true** (pod keeps running unauthenticated if the Secret is absent).

The `auth-credentials` Secret is created by shelly-fleet `externalsecret-auth.yaml` (SP-3, after the 1P field is set). `optional: true` means this is safe to land in any order.

**Before marking ready / merging:** bump the image tag to the digest-auth release once `LukeEvansTech/shelly-prometheus-exporter` PR #1 is merged and CI publishes it (digest auth is a no-op on the current 0.3.1 image, so the env is inert until then).

See shelly-fleet `docs/auth-rollout.md`.