### PR TITLE
feat(konflate): enable native status-check + PR-comment write-back

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/externalsecret.yaml
@@ -13,9 +13,14 @@ spec:
     template:
       engineVersion: v2
       data:
+        # GitHub App identity (konflate-bot) — konflate uses these for read
+        # (rate-limit lift) AND write-back (commit statuses + PR comments).
+        # Loaded into konflate via envFrom on konflate-secret.
+        KONFLATE_APP_CLIENT_ID: "{{ .KONFLATE_APP_CLIENT_ID }}"
+        KONFLATE_APP_PRIVATE_KEY: "{{ .KONFLATE_APP_PRIVATE_KEY }}"
         KONFLATE_PUSH_TOKEN: "{{ .KONFLATE_PUSH_TOKEN }}"
-        # GitHub fine-grained PAT (public-repo read-only) — without it konflate
-        # calls the GitHub API anonymously and hits the 60 req/hr IP limit
+        # GitHub fine-grained PAT (public-repo read-only) — kept as a read
+        # fallback until App write-back is proven; dropped at cutover.
         KONFLATE_TOKEN: "{{ .KONFLATE_TOKEN }}"
         # HMAC secret validating GitHub webhook deliveries on POST /hooks —
         # must match the secret configured on the repo webhook

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -11,11 +11,18 @@ spec:
   interval: 1h
   values:
     config:
-      # Public repo → anonymous read is sufficient. A missed-webhook backstop
-      # re-renders open PRs (and reconciles the PR list) on this interval.
+      # Public repo → App auth lifts the API rate limit and supplies the write
+      # identity. A missed-webhook backstop re-renders open PRs (and reconciles
+      # the PR list) on this interval.
       repo: github://LukeEvansTech/talos-cluster
       refreshInterval: 15m
       logFormat: json
+      # Post the native `Konflate` commit status + PR summary comment per
+      # render (replaces the flate.yaml/konflate.yaml CI gate). statusCheckName
+      # left unset → defaults to "Konflate" (the required branch-protection check).
+      statusChecks: true
+      prComments: true
+      publicUrl: "https://konflate.${SECRET_DOMAIN}"
     secret:
       # KONFLATE_PUSH_TOKEN — lets the Konflate PR workflow force a re-render of
       # the PR's new head (POST /api/prs/{n}/refresh) instead of waiting out the


### PR DESCRIPTION
Adds the konflate-bot GitHub App creds (KONFLATE_APP_CLIENT_ID +
KONFLATE_APP_PRIVATE_KEY) to the konflate ExternalSecret and enables
config.statusChecks + prComments + publicUrl. konflate now posts a native
`Konflate` commit status and PR summary comment.

KONFLATE_TOKEN is kept as a read fallback until App write-back is proven on
a live PR; it (and the flate/konflate CI gate) are removed at cutover.
First step of docs/flate-to-konflate-migration.md.
