### PR TITLE
fix(arc): pin packer-runner image to immutable digest

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
@@ -20,7 +20,8 @@ spec:
     containerMode:
       type: kubernetes
       kubernetesModeWorkVolumeClaim:
-        accessModes: ["ReadWriteOnce"]
+        accessModes:
+          - "ReadWriteOnce"
         storageClassName: openebs-hostpath
         resources:
           requests:
@@ -30,8 +31,14 @@ spec:
         serviceAccountName: packer-runner
         containers:
           - name: runner
-            image: ghcr.io/codelooks-com/packer-runner:latest
-            command: ["/home/runner/run.sh"]
+            # Pinned to an immutable digest (matches the home-operations
+            # actions-runner convention). Mutable :latest let nodes keep a
+            # stale cached image whose baked ansible venv/pywinrm was absent,
+            # so Windows WinRM provisioning failed with "No module named
+            # 'winrm'". Renovate bumps the digest as new images are built.
+            image: ghcr.io/codelooks-com/packer-runner:latest@sha256:bac14351c202dd8684b3aa061abb5c3a299ad99f88ce98b5a44a7fa218bf6c94
+            command:
+              - "/home/runner/run.sh"
             env:
               # containerMode: kubernetes defaults this to "true", which REFUSES
               # plain `run:` jobs. Our tools live in the runner image and steps run


### PR DESCRIPTION
Windows golden-image builds (codelooks-com/packer-vsphere) fail at the Ansible-over-WinRM step with `No module named 'winrm'`.

**Root cause:** the ARC `packer-vsphere` runner pods reference mutable `packer-runner:latest` with no `imagePullPolicy`, so nodes keep a **stale cached image** whose baked ansible venv was absent (pywinrm is pip-installed into that venv as a post-`mise install` Docker layer). The current registry `:latest` (digest `bac143…`) *does* contain `pywinrm 0.5.0` — verified by pulling the image and importing it.

**Fix:** pin to the immutable digest so nodes run the verified image; matches the digest-pin convention already used by the home-operations actions-runner. Renovate keeps the digest bumped.

Once merged + reconciled, the next `build-templates` run for `windows-server-2025` should clear the WinRM/ansible step.