### PR TITLE
chore(renovate): pin flate <0.3.4 (v0.3.4+ DAG cascade)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -441,5 +441,18 @@
       matchPackageNames: ["docker.io/lakker/pulsarr"],
       allowedVersions: "<1.0.0",
     },
+    {
+      // flate v0.3.4 made the DAG fixpoint scheduler the default. On this repo's
+      // recursive root Kustomization (cluster-apps, path ./kubernetes), the
+      // skipped private shelly-fleet GitRepository (SSH key only exists at
+      // runtime) no longer propagates its skip to the consuming KS — instead it
+      // cascades the root to a timeout, blocking ~209 dependents (0 failed, 1
+      // skipped, 209 blocked). v0.3.3 is the last release with the old engine
+      // (0 blocked). Pin <0.3.4 until upstream fixes the skip→blocked cascade.
+      description: "Pin flate <0.3.4 — v0.3.4+ DAG scheduler cascades skipped source to 209-blocked",
+      matchDatasources: ["github-releases"],
+      matchPackageNames: ["home-operations/flate"],
+      allowedVersions: "<0.3.4",
+    },
   ],
 }

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -449,6 +449,7 @@
       // cascades the root to a timeout, blocking ~209 dependents (0 failed, 1
       // skipped, 209 blocked). v0.3.3 is the last release with the old engine
       // (0 blocked). Pin <0.3.4 until upstream fixes the skip→blocked cascade.
+      // Tracked upstream: home-operations/flate#752.
       description: "Pin flate <0.3.4 — v0.3.4+ DAG scheduler cascades skipped source to 209-blocked",
       matchDatasources: ["github-releases"],
       matchPackageNames: ["home-operations/flate"],


### PR DESCRIPTION
flate v0.3.4 made the DAG fixpoint scheduler the default. On this repo's
recursive root Kustomization (cluster-apps, path ./kubernetes), a skipped
private GitRepository (shelly-fleet, SSH key only at runtime) no longer
propagates its skip to the consuming KS — it cascades the root to a timeout,
blocking ~209 dependents (verified on v0.4.5: 179 passed · 1 skipped · 209
blocked, 0 failed). v0.3.3 (last pre-DAG release) renders 0 blocked.

Stops Renovate from proposing the broken v0.3.4+ bumps. Revisit if upstream
fixes the skip→blocked cascade.
