### PR TITLE
shelly-operator: deploy v0.3.0 (config-coverage + standardisation)

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.2.0@sha256:ca2ce3f23e2dc6d06b933203ae7a9b20439c353c0953131f1bf9f564e91a7d3c
+      tag: 0.3.0@sha256:aa58ebced0075501d917d0971f53537fb7a765c8ad812eedeaa0b1868d99d2bb
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.0
+    tag: 0.3.0
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator


### PR DESCRIPTION
Bumps the operator chart 0.2.0 -> 0.3.0 and image to 0.3.0@sha256:aa58ebc... (digest-pinned). v0.3.0 = LED/UI section, switch protection limits, BLE, timezone, NTP/location, wifi AP/roam, lock-down (ws + sys.debug.level), device registry (room/appliance labels + dashboard), declarative schedule section, and fleet-health metrics (shelly_device_online/_in_sync/_update_available). `crds: CreateReplace` already set -> new CRD fields apply on upgrade. Pairs with PR #3041 (PrometheusRule) which lights up once these metrics appear.