### PR TITLE
fix(shelly-exporter): drop secretKeyRef.optional (failed helm upgrade to 0.4.0)

### DIFF
--- a/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-exporter/app/helmrelease.yaml
@@ -28,18 +28,18 @@ spec:
               - /config/config.yaml
             env:
               TZ: ${TIMEZONE:=UTC}
-              # Shelly device admin auth (fleet auth rollout SP-2). optional:
-              # true so the exporter keeps running UNauthenticated until the
-              # auth-credentials Secret exists (created by the shelly-fleet
-              # externalsecret-auth.yaml, SP-3) -- a missing Secret will not
-              # block the pod from starting.
+              # Shelly device admin auth (fleet auth rollout). The
+              # auth-credentials Secret already exists (created by the
+              # shelly-fleet externalsecret-auth.yaml, SP-3). NOTE: app-template's
+              # env schema does NOT allow `optional` on secretKeyRef, so it is
+              # omitted -- the Secret is present and managed, so a hard ref is
+              # fine. Digest auth is a no-op against non-auth devices.
               SHELLY_USERNAME: admin
               SHELLY_PASSWORD:
                 valueFrom:
                   secretKeyRef:
                     name: auth-credentials
                     key: password
-                    optional: true
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
The 0.4.0 exporter upgrade (#3032) failed app-template schema validation: `secretKeyRef` does not allow `optional`. Exporter stayed on 0.3.1 (no outage). Removes `optional` (the auth-credentials Secret exists, SP-3). Unblocks the digest-auth exporter deploy.