### PR TITLE
feat(arc): add terraform-vsphere runner scale set

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/externalsecret.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: terraform-vsphere-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: terraform-vsphere-runner-secret
+    template:
+      engineVersion: v2
+      data:
+        github_app_id: "{{ .ACTIONS_RUNNER_APP_ID }}"
+        github_app_installation_id: "{{ .ACTIONS_RUNNER_INSTALLATION_ID }}"
+        github_app_private_key: "{{ .ACTIONS_RUNNER_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: github-codelooks
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: terraform-vsphere-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: terraform-vsphere-creds
+    template:
+      engineVersion: v2
+      data:
+        # Surfaced to Terraform as TF_VAR_<name> so variables bind from env.
+        # Variable names are snake_case (see Plan 2 rename).
+        TF_VAR_vsphere_user: "{{ .VSPHERE_USERNAME }}"
+        TF_VAR_vsphere_password: "{{ .VSPHERE_PASSWORD }}"
+        TF_VAR_vsphere_vcenter: "{{ .VSPHERE_ENDPOINT }}"
+        TF_VAR_vsphere_datacenter: "{{ .VSPHERE_DATACENTER }}"
+        # Literal: vCenter presents a VMCA cert the pod does not trust.
+        TF_VAR_vsphere_unverified_ssl: "true"
+        TF_VAR_vm_domain_admin: "{{ .DOMAIN_ADMIN_USER }}"
+        TF_VAR_vm_domain_admin_password: "{{ .DOMAIN_ADMIN_PASSWORD }}"
+        # NOTE: Cloudflare R2 keys (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+        # are ADDED to this block in Plan 2, once the R2 bucket exists.
+  dataFrom:
+    - extract:
+        key: vsphere-terraform

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/helmrelease.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name terraform-vsphere-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-terraform-vsphere
+  interval: 1h
+  values:
+    fullnameOverride: *name
+    githubConfigUrl: https://github.com/codelooks-com/terraform-vsphere
+    githubConfigSecret: terraform-vsphere-runner-secret
+    runnerGroup: default
+    runnerScaleSetName: terraform-vsphere
+    maxRunners: 2
+    minRunners: 0
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes:
+          - "ReadWriteOnce"
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            # Remote state + small providers — terraform needs little scratch.
+            storage: 5Gi
+    template:
+      spec:
+        serviceAccountName: terraform-vsphere-runner
+        containers:
+          - name: runner
+            # Generic home-operations runner (same digest as talos-cluster-runner).
+            # The IaC binary (tofu/terraform) is installed by the workflow in Plan 4.
+            # Renovate manages this digest.
+            image: ghcr.io/home-operations/actions-runner:2.335.1@sha256:3d544e5eed58722c0b6a97212a31eada0f9f2e99f189c41911a5573a23d7386a
+            command:
+              - "/home/runner/run.sh"
+            env:
+              # kubernetes mode defaults this to "true" (refuses plain run: jobs).
+              # Our steps run directly on the runner, so it must be "false".
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+            envFrom:
+              - secretRef:
+                  name: terraform-vsphere-creds
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./talos-cluster
-  - ./packer
-  - ./terraform-vsphere
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-terraform-vsphere
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/rbac.yaml
@@ -1,0 +1,11 @@
+---
+# Intentionally no pod-management Role: this SA suppresses the chart's
+# auto-created kube-mode SA, so `container:` jobs, service containers, and
+# docker:// actions will fail on this runner — plain `run:` steps only.
+# terraform-vsphere talks to vCenter + Cloudflare R2, never the Kubernetes API,
+# so no cluster permissions are required.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terraform-vsphere-runner
+  namespace: actions-runner-system


### PR DESCRIPTION
Adds a self-hosted GitHub Actions runner scale set `terraform-vsphere` (ARC, kubernetes mode), mirroring `packer-runner`. Serves codelooks-com/terraform-vsphere. Creds via ExternalSecret (1Password `vsphere-terraform`; R2 keys added later). Part of the terraform-vsphere modernization (Plan 1). kustomize build validated.