### PR TITLE
chore(renovate): allow flate >=0.4.6 (cascade fix lands upstream)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -445,15 +445,17 @@
       // flate v0.3.4 made the DAG fixpoint scheduler the default. On this repo's
       // recursive root Kustomization (cluster-apps, path ./kubernetes), the
       // skipped private shelly-fleet GitRepository (SSH key only exists at
-      // runtime) no longer propagates its skip to the consuming KS — instead it
-      // cascades the root to a timeout, blocking ~209 dependents (0 failed, 1
-      // skipped, 209 blocked). v0.3.3 is the last release with the old engine
-      // (0 blocked). Pin <0.3.4 until upstream fixes the skip→blocked cascade.
-      // Tracked upstream: home-operations/flate#752.
-      description: "Pin flate <0.3.4 — v0.3.4+ DAG scheduler cascades skipped source to 209-blocked",
+      // runtime) no longer propagated its skip to the consuming KS — instead it
+      // cascaded the root to a timeout, blocking ~209 dependents (0 failed, 1
+      // skipped, 209 blocked). v0.3.3 was the last release with the old engine
+      // (0 blocked). Fixed upstream by home-operations/flate#757 (closes #752),
+      // which first ships in v0.4.6. Accept >=0.4.6 and keep the broken
+      // 0.3.4–0.4.5 line blocked; flate-test + claude/renovate-review validate
+      // the bump before it merges.
+      description: "Allow flate >=0.4.6 — skip→blocked cascade fixed by home-operations/flate#757; block broken 0.3.4-0.4.5",
       matchDatasources: ["github-releases"],
       matchPackageNames: ["home-operations/flate"],
-      allowedVersions: "<0.3.4",
+      allowedVersions: ">=0.4.6",
     },
   ],
 }


### PR DESCRIPTION
## What

Retarget the Renovate version constraint for `home-operations/flate` from `allowedVersions: "<0.3.4"` to `">=0.4.6"`.

## Why

The `<0.3.4` pin was a workaround for [home-operations/flate#752](https://github.com/home-operations/flate/issues/752): the v0.3.4+ DAG fixpoint scheduler let the skipped private `shelly-fleet` GitRepository cascade the recursive root Kustomization to a timeout, blocking ~209 dependents.

That's now fixed upstream by [home-operations/flate#757](https://github.com/home-operations/flate/pull/757) (`fix(loader): don't let an external-sourced Kustomization claim the local tree`), which closes #752. The fix first ships in **v0.4.6** (release-please PR [#739](https://github.com/home-operations/flate/pull/739), not yet tagged at time of writing).

## Effect

- Renovate will auto-raise the `FLATE_VERSION` bump in `.github/workflows/flate.yaml` the moment **v0.4.6** publishes.
- The broken **0.3.4–0.4.5** line stays blocked (those still carry the cascade bug).
- The workflow stays pinned to **v0.3.3** until that Renovate bump PR lands and `flate-test` + `claude/renovate-review` validate v0.4.6.