### PR TITLE
chore(flate): adopt v0.4.6 on the CI gate, drop obsolete Renovate pin

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -15,15 +15,14 @@ permissions:
   contents: read
 
 env:
+  # flate v0.4.6 fixed the skip→blocked cascade where the unresolvable private
+  # shelly-fleet GitRepository (SSH deploy key only exists at runtime) blocked
+  # every dependent (~209) under the v0.3.4–0.4.5 DAG scheduler. Fix shipped in
+  # v0.4.6 via home-operations/flate#757 (closes #752). Keep the annotation
+  # directly above the value below so Renovate targets FLATE_VERSION, not this
+  # comment.
   # renovate: datasource=github-releases depName=home-operations/flate
-  # Pinned to v0.3.3: v0.4.6 cascades an unresolvable source (the private
-  # shelly-fleet GitRepository, whose SSH deploy key only exists at runtime)
-  # to BLOCK every dependent — ~209 blocked. v0.3.3 marks the source skipped
-  # and leaves dependents unblocked. A placeholder secret doesn't help: flate
-  # then parses the bogus key and fails the source loud (still cascades).
-  # Real fixes tracked separately (drop flate-test in favour of konflate, or
-  # restructure shelly-fleet to bootstrap from the private repo).
-  FLATE_VERSION: "v0.3.3"
+  FLATE_VERSION: "v0.4.6"
 
 jobs:
   filter:

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -441,21 +441,5 @@
       matchPackageNames: ["docker.io/lakker/pulsarr"],
       allowedVersions: "<1.0.0",
     },
-    {
-      // flate v0.3.4 made the DAG fixpoint scheduler the default. On this repo's
-      // recursive root Kustomization (cluster-apps, path ./kubernetes), the
-      // skipped private shelly-fleet GitRepository (SSH key only exists at
-      // runtime) no longer propagated its skip to the consuming KS — instead it
-      // cascaded the root to a timeout, blocking ~209 dependents (0 failed, 1
-      // skipped, 209 blocked). v0.3.3 was the last release with the old engine
-      // (0 blocked). Fixed upstream by home-operations/flate#757 (closes #752),
-      // which first ships in v0.4.6. Accept >=0.4.6 and keep the broken
-      // 0.3.4–0.4.5 line blocked; flate-test + claude/renovate-review validate
-      // the bump before it merges.
-      description: "Allow flate >=0.4.6 — skip→blocked cascade fixed by home-operations/flate#757; block broken 0.3.4-0.4.5",
-      matchDatasources: ["github-releases"],
-      matchPackageNames: ["home-operations/flate"],
-      allowedVersions: ">=0.4.6",
-    },
   ],
 }


### PR DESCRIPTION
## What

- Bump `FLATE_VERSION` in `.github/workflows/flate.yaml` **v0.3.3 → v0.4.6**.
- Reorder the env block so the `# renovate:` annotation sits directly above the value.
- Remove the now-obsolete `home-operations/flate` `allowedVersions: ">=0.4.6"` rule from `.renovaterc.json5`.

## Why

#3054 ("update release home-operations/flate to v0.4.6") **didn't move the blocking gate**. Renovate's annotated manager matched the version string *inside the comment* (`v0.4.4`) and bumped that, while the real `FLATE_VERSION: "v0.3.3"` was left untouched — and the comment ended up mangled to a contradiction (`v0.4.6 cascades…`, which is false). So `flate-test`/`flate-diff` were still running the old v0.3.3 engine, and `image-pull.yaml` was the only file actually moved to v0.4.6.

flate **v0.4.6** ships the fix for the shelly-fleet skip→blocked cascade ([home-operations/flate#757](https://github.com/home-operations/flate/pull/757), closes [#752](https://github.com/home-operations/flate/issues/752)), so the workaround pin is no longer needed.

## Validation

This PR's own `flate-test`/`flate-diff` run on **v0.4.6** against the live private `shelly-fleet` GitRepository — if v0.4.6 truly resolves the cascade, those checks pass green. That's the real test of the fix.

## Not covered here

konflate (in-cluster render service) still vendors flate v0.4.5, so its 4 render-failure *warnings* persist (non-blocking) until upstream ships a konflate build on flate ≥0.4.6.