### PR TITLE
feat(terrateam): self-hosted control plane (draft — needs GitHub App + dry-run)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/externalsecret.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudflare-runner-secret
+    template:
+      engineVersion: v2
+      data:
+        github_app_id: "{{ .ACTIONS_RUNNER_APP_ID }}"
+        github_app_installation_id: "{{ .ACTIONS_RUNNER_INSTALLATION_ID }}"
+        github_app_private_key: "{{ .ACTIONS_RUNNER_PRIVATE_KEY }}"
+  dataFrom:
+    - extract:
+        key: github-codelooks
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-tf-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudflare-tf-creds
+    template:
+      engineVersion: v2
+      data:
+        # Surfaced to Terraform as TF_VAR_<name>; AWS_* drive the R2 s3 backend.
+        TF_VAR_cloudflare_api_token: "{{ .CLOUDFLARE_API_TOKEN }}"
+        TF_VAR_cloudflare_account_id: "{{ .CLOUDFLARE_ACCOUNT_ID }}"
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-terraform
+    - extract:
+        key: cloudflare-r2-tfstate

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/helmrelease.yaml
@@ -1,0 +1,50 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name cloudflare-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-cloudflare
+  interval: 1h
+  values:
+    fullnameOverride: *name
+    githubConfigUrl: https://github.com/codelooks-com/terraform-cloudflare
+    githubConfigSecret: cloudflare-runner-secret
+    runnerGroup: default
+    runnerScaleSetName: terraform-cloudflare
+    maxRunners: 2
+    minRunners: 0
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes:
+          - "ReadWriteOnce"
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            # Remote state + small providers — terraform needs little scratch.
+            storage: 5Gi
+    template:
+      spec:
+        serviceAccountName: cloudflare-runner
+        containers:
+          - name: runner
+            # Generic home-operations runner (same digest as terraform-vsphere).
+            # The IaC binary (tofu/terraform) is installed by the workflow/Terrateam.
+            # Renovate manages this digest.
+            image: ghcr.io/home-operations/actions-runner:2.335.1@sha256:3d544e5eed58722c0b6a97212a31eada0f9f2e99f189c41911a5573a23d7386a
+            command:
+              - "/home/runner/run.sh"
+            env:
+              # kubernetes mode defaults this to "true" (refuses plain run: jobs).
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+            envFrom:
+              - secretRef:
+                  name: cloudflare-tf-creds
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./talos-cluster
-  - ./packer
-  - ./terraform-vsphere
-  - ./cloudflare
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-cloudflare
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml
@@ -1,0 +1,11 @@
+---
+# Intentionally no pod-management Role: this SA suppresses the chart's
+# auto-created kube-mode SA, so `container:` jobs, service containers, and
+# docker:// actions will fail on this runner — plain `run:` steps only.
+# terraform-cloudflare talks to the Cloudflare API + R2, never the Kubernetes
+# API, so no cluster permissions are required.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudflare-runner
+  namespace: actions-runner-system

--- a/kubernetes/apps/infrastructure/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - ./cupdate/ks.yaml
   - ./nextdns/ks.yaml
   - ./smtp-relay/ks.yaml
+  - ./terrateam/ks.yaml
   - ./vlmcsd/ks.yaml

--- a/kubernetes/apps/infrastructure/terrateam/app/cluster.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/cluster.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/postgresql.cnpg.io/cluster_v1.json
+# Dedicated single-instance Postgres for Terrateam (CNPG operator already runs in
+# the cluster). CNPG generates the connection secret `terrateam-db-app` with keys
+# username/password/dbname/host/port (consumed by the HelmRelease db.* values).
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: terrateam-db
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4
+  primaryUpdateStrategy: unsupervised
+  storage:
+    size: 5Gi
+    storageClass: openebs-hostpath
+  bootstrap:
+    initdb:
+      database: terrateam
+      owner: terrateam
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi

--- a/kubernetes/apps/infrastructure/terrateam/app/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# GitHub App credentials for the self-hosted Terrateam control plane.
+# Requires 1Password item `terrateam` (Talos vault) with the fields below,
+# created in Task 0 (register the Terrateam GitHub App via its setup wizard).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: terrateam-github
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: terrateam-github
+    template:
+      engineVersion: v2
+      data:
+        app-id: "{{ .APP_ID }}"
+        client-id: "{{ .CLIENT_ID }}"
+        client-secret: "{{ .CLIENT_SECRET }}"
+        webhook-secret: "{{ .WEBHOOK_SECRET }}"
+        private-key: "{{ .PRIVATE_KEY_PEM }}"
+  dataFrom:
+    - extract:
+        key: terrateam

--- a/kubernetes/apps/infrastructure/terrateam/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: terrateam
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: terrateam
+      version: 1.3.1
+      sourceRef:
+        kind: HelmRepository
+        name: terrateamio
+        namespace: infrastructure
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    terrateam:
+      config:
+        fqdn: terrateam.${SECRET_DOMAIN}
+        uiBase: https://terrateam.${SECRET_DOMAIN}
+        github:
+          # VERIFY: set to the app slug from Task 0 (github.com/apps/<slug>)
+          appUrl: https://github.com/apps/terrateam-codelooks
+          appIdSecretName: terrateam-github
+          appIdSecretKey: app-id
+          appClientIdSecretName: terrateam-github
+          appClientIdSecretKey: client-id
+          appClientSecretSecretName: terrateam-github
+          appClientSecretSecretKey: client-secret
+          appPrivatePemCertificateSecretName: terrateam-github
+          appPrivatePemCertificateSecretKey: private-key
+          webhookSecretName: terrateam-github
+          webhookSecretKey: webhook-secret
+        db:
+          hostname: terrateam-db-rw
+          port: 5432
+          databaseName: terrateam
+          username: terrateam
+          passwordSecretName: terrateam-db-app
+          passwordSecretKey: password

--- a/kubernetes/apps/infrastructure/terrateam/app/helmrepository.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: terrateamio
+spec:
+  interval: 1h
+  url: https://terrateamio.github.io/helm-charts

--- a/kubernetes/apps/infrastructure/terrateam/app/httproute-internal.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/httproute-internal.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# INTERNAL route: the Terrateam dashboard/UI and OAuth callback, reachable only on the
+# internal network via the internal gateway. Split-horizon DNS resolves the hostname to
+# the internal gateway for in-cluster/VPN clients, so the login page is never exposed
+# publicly. GitHub never needs this route — only the webhook path is public (httproute.yaml).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: terrateam-internal
+spec:
+  hostnames:
+    - terrateam.${SECRET_DOMAIN}
+    - terrateam.${SECRET_INTERNAL_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: terrateam-server
+          port: 8080

--- a/kubernetes/apps/infrastructure/terrateam/app/httproute.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/httproute.yaml
@@ -1,7 +1,10 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
-# Exposes the Terrateam server to GitHub webhooks + OAuth via the external gateway.
-# VERIFY the backend service name/port against the chart render (default svc port 8080).
+# PUBLIC route: only the GitHub webhook API is exposed via the external gateway.
+# GitHub delivers events to /api/github/v1/events; everything else (the dashboard/UI)
+# is served by the internal route (httproute-internal.yaml) so it is not reachable from
+# the public internet. Backend Service is `terrateam-server` — the chart renders the
+# Service as {applicationName}-{terrateam.name}, and terrateam.name defaults to "server".
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -18,7 +21,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: /
+            value: /api/github/v1/
       backendRefs:
-        - name: terrateam
+        - name: terrateam-server
           port: 8080

--- a/kubernetes/apps/infrastructure/terrateam/app/httproute.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/httproute.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# Exposes the Terrateam server to GitHub webhooks + OAuth via the external gateway.
+# VERIFY the backend service name/port against the chart render (default svc port 8080).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: terrateam
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+spec:
+  hostnames:
+    - terrateam.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: terrateam
+          port: 8080

--- a/kubernetes/apps/infrastructure/terrateam/app/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./httproute-internal.yaml

--- a/kubernetes/apps/infrastructure/terrateam/app/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/infrastructure/terrateam/ks.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app terrateam
+  namespace: &namespace infrastructure
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/infrastructure/terrateam/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Stands up the self-hosted **Terrateam** control plane in `infrastructure/` so the codelooks-com Terraform repos (starting with `terraform-cloudflare`) get PR-driven plan/apply on the ARC runners.

## Contents
- **HelmRelease** `terrateamio/terrateam` chart **1.3.1** (`terrateam.config.*` values).
- **CNPG** dedicated single-instance `terrateam-db` Cluster (generates `terrateam-db-app` secret → `db.*` values).
- **ExternalSecret** `terrateam-github` ← 1Password `terrateam` item.
- **HTTPRoute** `terrateam.${SECRET_DOMAIN}` on `envoy-external` (webhook + OAuth).
- Registered in the `infrastructure` group kustomization. `kubectl kustomize` builds clean.

## ⚠️ Draft — blockers before merge
1. **Task 0 (human):** register the self-hosted Terrateam GitHub App (webhook `https://terrateam.<domain>/api/github/v1/events`, callback `/api/github/v1/callback`), then create 1Password `terrateam` (Talos) with `APP_ID`, `CLIENT_ID`, `CLIENT_SECRET`, `WEBHOOK_SECRET`, `PRIVATE_KEY_PEM`.
2. **No local `helm`** — `flux build` / dry-run the HelmRelease in-cluster before merging.
3. **VERIFY** the chart's service name/port (HTTPRoute backend) and set `github.appUrl` to the real app slug.

After merge: install the Terrateam App on `codelooks-com/terraform-cloudflare`; the `.terrateam/config.yml` is already in that repo.