### PR TITLE
feat(truenas-exporter): ZFS metrics via graphite bridge, dashboards, alerts

### DIFF
--- a/docs/truenas-monitoring.md
+++ b/docs/truenas-monitoring.md
@@ -8,10 +8,13 @@ The monitoring setup uses TrueNAS SCALE's Docker integration to run Prometheus e
 
 ## Exporters
 
-Two exporters are configured:
+Three exporters are configured:
 
 1. **node-exporter** (port 9100) - System metrics (CPU, memory, network, filesystem)
 2. **smartctl-exporter** (port 9633) - SMART disk health metrics
+3. **truenas-graphite-exporter** (ingest 9109 / metrics 9108) - TrueNAS/ZFS-native metrics (ZFS pool state, ARC, per-dataset and per-disk I/O, temperatures), bridged from the built-in netdata Graphite output via [`Supporterino/truenas-graphite-to-prometheus`](https://github.com/Supporterino/truenas-graphite-to-prometheus)
+
+The first two treat TrueNAS as a generic Linux host. The third surfaces the ZFS internals that node-exporter cannot see — pool health, ARC hit ratio, scrub state — which are the highest-value storage signals.
 
 ## TrueNAS Setup
 
@@ -69,7 +72,27 @@ services:
 
 4. Click **Install**
 
-### 3. Verify Exporters are Running
+### 3. Install TrueNAS Graphite Exporter (ZFS / netdata metrics)
+
+This exporter bundles `prometheus/graphite_exporter` with a TrueNAS-specific mapping. TrueNAS's built-in netdata pushes Graphite-formatted metrics into it (ingest port `9109`); it re-exposes them as Prometheus metrics on port `9108`.
+
+1. Repeat the Custom App process. Set the image to `ghcr.io/supporterino/truenas-graphite-to-prometheus:latest`.
+2. Add two port mappings (host network or node ports):
+   - Container `9109` → host `9109` (TCP) — Graphite ingest
+   - Container `9108` → host `9108` (TCP) — Prometheus metrics
+3. Click **Install**.
+
+Then point TrueNAS at it:
+
+1. Deploy the project's `netdata.conf` to `/etc/netdata/netdata.conf` on TrueNAS (enables the netdata Graphite backend; see the [upstream `TRUENAS.md`](https://github.com/Supporterino/truenas-graphite-to-prometheus/blob/main/TRUENAS.md)).
+2. In TrueNAS go to **Reporting → Exporters → Add** and create a **Graphite** exporter:
+   - **Destination IP / Port**: the exporter host and `9109`
+   - **Prefix**: `truenas`
+   - **Update every**: match your Prometheus scrape interval
+
+> The exporter ships with the mapping config baked into the image, so no mapping file mount is required. Only `netdata.conf` and the Reporting exporter need to be configured TrueNAS-side.
+
+### 4. Verify Exporters are Running
 
 From the TrueNAS shell or via SSH:
 
@@ -79,44 +102,50 @@ curl http://localhost:9100/metrics
 
 # Test smartctl-exporter
 curl http://localhost:9633/metrics
+
+# Test truenas-graphite-exporter (should show zfs_*, disk_*, cpu_* series once netdata is pushing)
+curl http://localhost:9108/metrics
 ```
 
-### 4. Configure TrueNAS Firewall (if needed)
+### 5. Configure TrueNAS Firewall (if needed)
 
-If TrueNAS has a firewall enabled, ensure ports 9100 and 9633 are accessible from your Kubernetes cluster network.
+If TrueNAS has a firewall enabled, ensure ports 9100, 9633, and 9108 are accessible from your Kubernetes cluster network. Port 9109 only needs to be reachable from netdata on the TrueNAS host itself.
 
 ## Kubernetes Configuration
 
-The Prometheus ScrapeConfigs are defined in `app/scrapeconfig.yaml` and automatically discovered by kube-prometheus-stack.
+ScrapeConfigs are automatically discovered by kube-prometheus-stack. They are split across two locations:
+
+- `kube-prometheus-stack/app/scrapeconfig.yaml` — the host-level exporters
+- `truenas-exporter/app/scrapeconfig.yaml` — the Graphite exporter (this app also carries its dashboards and alert rules)
 
 ### ScrapeConfig Resources
 
 - **node-exporter**: Scrapes `${SECRET_STORAGE_SERVER}:9100`
 - **smartctl-exporter**: Scrapes `${SECRET_STORAGE_SERVER}:9633`
+- **truenas-graphite-exporter**: Scrapes `${SECRET_STORAGE_SERVER}:9108`
 
 These use the `SECRET_STORAGE_SERVER` variable from cluster secrets to dynamically configure the target hostname.
 
+### Dashboards and Alerts (GitOps-managed)
+
+Dashboards and alert rules are reconciled by Flux — no manual import. The `truenas-exporter` app provisions:
+
+- **GrafanaDashboard** CRs (`grafanadashboard.yaml`) pulling the five upstream dashboards (`truenas_scale`, `disk_insights`, `temperatures`, `cgroups`, `applications_k3s`) pinned to a release tag, with the dashboards' `DS_MIMIR` datasource input remapped onto the cluster `prometheus` datasource.
+- A **PrometheusRule** (`prometheusrule.yaml`) with exporter-down, ZFS-pool-unhealthy, and disk/CPU over-temperature alerts.
+
+> The ZFS-pool alert's `zfs_pool` label/value encoding (netdata dimensions) should be confirmed against live `/metrics` output — see the inline note in `prometheusrule.yaml`.
+
 ## Grafana Dashboards
 
-### Recommended Dashboards
+All dashboards are provisioned as `GrafanaDashboard` CRs via grafana-operator — do not import by hand, or changes will be overwritten on reconcile.
 
-Import these community dashboards in Grafana:
+| Dashboard | Source | Provisioned by |
+| --- | --- | --- |
+| Node Exporter Full | grafana.com 1860 | `kube-prometheus-stack/app/grafanadashboard-node-exporter.yaml` |
+| SMART Disk Monitoring | grafana.com 22604 | `smartctl-exporter/app/grafanadashboard.yaml` |
+| TrueNAS SCALE (+ disk insights, temperatures, cgroups, apps) | upstream repository JSON | `truenas-exporter/app/grafanadashboard.yaml` |
 
-1. **Node Exporter Full** - Dashboard ID: 1860
-    - Comprehensive system metrics (CPU, memory, disk, network)
-
-2. **Node Exporter for Prometheus** - Dashboard ID: 11074
-    - Simplified system overview
-
-3. **SMART Disk Monitoring** - Dashboard ID: 10530
-    - Disk health and SMART attributes
-
-### Import via Grafana UI
-
-1. Go to Grafana → Dashboards → Import
-2. Enter the Dashboard ID
-3. Select the Prometheus data source
-4. Click Import
+To add another, drop a new `GrafanaDashboard` CR into the relevant app and let Flux reconcile.
 
 ## Metrics Examples
 
@@ -153,6 +182,27 @@ smartctl_device_power_on_seconds / 3600
 smartctl_device_attribute_value{attribute_name="Reallocated_Sector_Ct"}
 ```
 
+### TrueNAS Graphite Exporter Metrics (ZFS)
+
+These come from the netdata Graphite bridge (`job="truenas-graphite-exporter"`). See the upstream [`METRICS.md`](https://github.com/Supporterino/truenas-graphite-to-prometheus/blob/main/METRICS.md) for the full list; exact label keys depend on your netdata version, so confirm against live `/metrics`.
+
+```promql
+# ZFS ARC size
+zfs_arc_size{job="truenas-graphite-exporter"}
+
+# ZFS ARC hit rate
+zfs_hits_rate{job="truenas-graphite-exporter"}
+
+# ZFS pool state (dimension/value encoding is netdata-specific — verify)
+zfs_pool{job="truenas-graphite-exporter"}
+
+# Per-disk temperature
+disk_temperature{job="truenas-graphite-exporter"}
+
+# CPU temperature
+cpu_temperature{job="truenas-graphite-exporter"}
+```
+
 ## Troubleshooting
 
 ### Exporters Not Starting
@@ -169,7 +219,7 @@ kubectl get scrapeconfig -n observability
 
 # Check Prometheus targets
 # Go to Prometheus UI → Status → Targets
-# Look for node-exporter and smartctl-exporter jobs
+# Look for node-exporter, smartctl-exporter, and truenas-graphite-exporter jobs
 ```
 
 ### Metrics Not Showing in Grafana

--- a/docs/truenas-monitoring.md
+++ b/docs/truenas-monitoring.md
@@ -78,17 +78,17 @@ This exporter bundles `prometheus/graphite_exporter` with a TrueNAS-specific map
 
 1. Repeat the Custom App process. Set the image to `ghcr.io/supporterino/truenas-graphite-to-prometheus:latest`.
 2. Add two port mappings (host network or node ports):
-   - Container `9109` → host `9109` (TCP) — Graphite ingest
-   - Container `9108` → host `9108` (TCP) — Prometheus metrics
+    - Container `9109` → host `9109` (TCP) — Graphite ingest
+    - Container `9108` → host `9108` (TCP) — Prometheus metrics
 3. Click **Install**.
 
 Then point TrueNAS at it:
 
 1. Deploy the project's `netdata.conf` to `/etc/netdata/netdata.conf` on TrueNAS (enables the netdata Graphite backend; see the [upstream `TRUENAS.md`](https://github.com/Supporterino/truenas-graphite-to-prometheus/blob/main/TRUENAS.md)).
 2. In TrueNAS go to **Reporting → Exporters → Add** and create a **Graphite** exporter:
-   - **Destination IP / Port**: the exporter host and `9109`
-   - **Prefix**: `truenas`
-   - **Update every**: match your Prometheus scrape interval
+    - **Destination IP / Port**: the exporter host and `9109`
+    - **Prefix**: `truenas`
+    - **Update every**: match your Prometheus scrape interval
 
 > The exporter ships with the mapping config baked into the image, so no mapping file mount is required. Only `netdata.conf` and the Reporting exporter need to be configured TrueNAS-side.
 
@@ -139,11 +139,11 @@ Dashboards and alert rules are reconciled by Flux — no manual import. The `tru
 
 All dashboards are provisioned as `GrafanaDashboard` CRs via grafana-operator — do not import by hand, or changes will be overwritten on reconcile.
 
-| Dashboard | Source | Provisioned by |
-| --- | --- | --- |
-| Node Exporter Full | grafana.com 1860 | `kube-prometheus-stack/app/grafanadashboard-node-exporter.yaml` |
-| SMART Disk Monitoring | grafana.com 22604 | `smartctl-exporter/app/grafanadashboard.yaml` |
-| TrueNAS SCALE (+ disk insights, temperatures, cgroups, apps) | upstream repository JSON | `truenas-exporter/app/grafanadashboard.yaml` |
+| Dashboard                                                    | Source                   | Provisioned by                                                  |
+| ------------------------------------------------------------ | ------------------------ | --------------------------------------------------------------- |
+| Node Exporter Full                                           | grafana.com 1860         | `kube-prometheus-stack/app/grafanadashboard-node-exporter.yaml` |
+| SMART Disk Monitoring                                        | grafana.com 22604        | `smartctl-exporter/app/grafanadashboard.yaml`                   |
+| TrueNAS SCALE (+ disk insights, temperatures, cgroups, apps) | upstream repository JSON | `truenas-exporter/app/grafanadashboard.yaml`                    |
 
 To add another, drop a new `GrafanaDashboard` CR into the relevant app and let Flux reconcile.
 

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -24,4 +24,5 @@ resources:
   - ./silence-operator/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./snmp-exporter/ks.yaml
+  - ./truenas-exporter/ks.yaml
   - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/observability/truenas-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  # Author ships these with a Mimir datasource input (DS_MIMIR); remap it onto
+  # our Prometheus datasource so panels bind on import.
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale-disk-insights
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale_disk_insights.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale-temperatures
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale_temperatures.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale-cgroups
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale_cgroups.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: truenas-scale-applications-k3s
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_MIMIR
+  # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
+  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale_applications_k3s.json

--- a/kubernetes/apps/observability/truenas-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./scrapeconfig.yaml
+  - ./grafanadashboard.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: truenas-exporter.rules
+spec:
+  groups:
+    - name: truenas-exporter.rules
+      rules:
+        - alert: TrueNASGraphiteExporterDown
+          annotations:
+            summary: "TrueNAS graphite exporter ({{ $labels.instance }}) is not being scraped."
+          expr: |-
+            up{job="truenas-graphite-exporter"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # NOTE: zfs_pool encodes pool state as netdata dimensions. Confirm the exact
+        # label key/value against the live /metrics output (or METRICS.md) before
+        # relying on this — if the label schema differs the rule is a silent no-op.
+        - alert: TrueNASZFSPoolNotHealthy
+          annotations:
+            summary: "TrueNAS ZFS pool {{ $labels.pool }} is not ONLINE (state {{ $labels.state }})."
+          expr: |-
+            zfs_pool{job="truenas-graphite-exporter", state="online"} != 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: TrueNASDiskTemperatureHigh
+          annotations:
+            summary: "TrueNAS disk {{ $labels.disk }} temperature is {{ $value }}°C."
+          expr: |-
+            disk_temperature{job="truenas-graphite-exporter"} > 60
+          for: 10m
+          labels:
+            severity: warning
+        - alert: TrueNASCPUTemperatureHigh
+          annotations:
+            summary: "TrueNAS CPU temperature is {{ $value }}°C."
+          expr: |-
+            cpu_temperature{job="truenas-graphite-exporter"} > 85
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name truenas-graphite-exporter
+spec:
+  # TrueNAS netdata pushes Graphite metrics into the bundled graphite_exporter
+  # (ingest :9109), which re-exposes them in Prometheus format on :9108.
+  # See docs/truenas-monitoring.md for the TrueNAS-side Custom App + Reporting setup.
+  staticConfigs:
+    - targets:
+        - ${SECRET_STORAGE_SERVER}:9108
+  metricsPath: /metrics
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name

--- a/kubernetes/apps/observability/truenas-exporter/ks.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app truenas-exporter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/truenas-exporter/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  # CR-only app (the exporter itself runs on TrueNAS as a Custom App) — nothing
+  # in-cluster to health-check, so don't block reconciliation waiting.
+  wait: false


### PR DESCRIPTION
## What

Adds `observability/truenas-exporter` — surfaces TrueNAS **ZFS-native** metrics (pool state, ARC, per-dataset/disk I/O, temperatures) that node-exporter/smartctl-exporter can't see, via the community-standard [`Supporterino/truenas-graphite-to-prometheus`](https://github.com/Supporterino/truenas-graphite-to-prometheus) bridge (TrueNAS netdata → bundled `graphite_exporter`).

- **ScrapeConfig** `truenas-graphite-exporter` → `${SECRET_STORAGE_SERVER}:9108`
- **5× GrafanaDashboard** CRs (upstream JSON, pinned `v2.2.1`, `DS_MIMIR`→`prometheus` remap)
- **PrometheusRule**: exporter-down, ZFS-pool-unhealthy, disk/CPU over-temp
- Rewrote `docs/truenas-monitoring.md` with the TrueNAS Custom App + netdata/Reporting steps and the GitOps dashboard model

## Manual prerequisite (TrueNAS side)

Install the Custom App (`ghcr.io/supporterino/truenas-graphite-to-prometheus`, ports 9109 ingest / 9108 metrics), deploy `netdata.conf`, and add a **Graphite** Reporting exporter (prefix `truenas`). See the doc.

## Verification

`kustomize build` clean (per-app + aggregate); yamlfmt→prettier clean; markdownlint 0 errors.

> ⚠️ The `zfs_pool{state=…}` alert encoding is flagged inline — confirm against live `/metrics` once data flows (a wrong matcher is a silent no-op, not a false alert).