### PR TITLE
feat(opnsense-exporter): OPNsense Prometheus exporter, dashboard, alerts

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ./netdata/ks.yaml
   - ./network-ups-tools/ks.yaml
   - ./nut-exporter/ks.yaml
+  - ./opnsense-exporter/ks.yaml
   - ./oxidized/ks.yaml
   - ./peanut/ks.yaml
   - ./silence-operator/ks.yaml

--- a/kubernetes/apps/observability/opnsense-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opnsense-exporter
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: opnsense-exporter-secret
+    template:
+      data:
+        # Mapped straight to the exporter's expected env var names (envFrom below).
+        OPNSENSE_EXPORTER_OPS_API_KEY: "{{ .OPNSENSE_API_KEY }}"
+        OPNSENSE_EXPORTER_OPS_API_SECRET: "{{ .OPNSENSE_API_SECRET }}"
+        # OPS_API must be a bare host[:port] WITHOUT scheme (protocol is set separately
+        # via env). The shared `opnsense` item stores OPNSENSE_HOST WITH an https://
+        # scheme (the external-dns webhook needs it), so strip it here rather than
+        # mutating the shared item.
+        OPNSENSE_EXPORTER_OPS_API: '{{ .OPNSENSE_HOST | trimPrefix "https://" | trimPrefix "http://" }}'
+  dataFrom:
+    - extract:
+        key: opnsense

--- a/kubernetes/apps/observability/opnsense-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: opnsense-exporter
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  grafanaCom:
+    # renovate: depName="OPNsense"
+    # Official AthennaMind/opnsense-exporter dashboard.
+    id: 21113
+    revision: 3

--- a/kubernetes/apps/observability/opnsense-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/helmrelease.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app opnsense-exporter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      opnsense-exporter:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/athennamind/opnsense-exporter
+              tag: "0.0.16"
+              digest: sha256:64469206eb955b6c87ec2737cd4884b0bec01b518408cf1ac6d5c153f6c0cf1f
+            env:
+              # OPS_API / OPS_API_KEY / OPS_API_SECRET come from the secret (envFrom).
+              OPNSENSE_EXPORTER_OPS_PROTOCOL: https
+              # OPNsense ships a self-signed cert by default — skip verification.
+              OPNSENSE_EXPORTER_OPS_INSECURE: "true"
+              OPNSENSE_EXPORTER_INSTANCE_LABEL: opnsense
+              OPNSENSE_EXPORTER_WEB_LISTEN_ADDRESS: :8080
+            envFrom:
+              - secretRef:
+                  name: opnsense-exporter-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    service:
+      app:
+        controller: *app
+        ports:
+          metrics:
+            port: 8080
+            protocol: TCP

--- a/kubernetes/apps/observability/opnsense-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/opnsense-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1

--- a/kubernetes/apps/observability/opnsense-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/prometheusrule.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: opnsense-exporter.rules
+spec:
+  groups:
+    - name: opnsense-exporter.rules
+      rules:
+        - alert: OPNsenseExporterDown
+          annotations:
+            summary: "OPNsense exporter ({{ $labels.instance }}) is not being scraped."
+          expr: |-
+            up{job="opnsense-exporter"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # NOTE: confirm the gateway metric name/label encoding against live /metrics.
+        # AthennaMind exposes opnsense_gateways_status with a status label
+        # (e.g. "online"/"down"); adjust the matcher if your version differs.
+        - alert: OPNsenseGatewayDown
+          annotations:
+            summary: "OPNsense gateway {{ $labels.name }} is not online (status {{ $labels.status }})."
+          expr: |-
+            opnsense_gateways_status{job="opnsense-exporter", status!="online"} == 1
+          for: 5m
+          labels:
+            severity: critical
+        # Unbound (the resolver behind opnsense-dns / split-horizon) being down
+        # breaks internal name resolution cluster-wide.
+        - alert: OPNsenseUnboundDown
+          annotations:
+            summary: "OPNsense Unbound DNS service is not running."
+          expr: |-
+            opnsense_unbound_uptime_seconds{job="opnsense-exporter"} == 0
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/opnsense-exporter/app/servicemonitor.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/servicemonitor.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app opnsense-exporter
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *app
+  endpoints:
+    - port: metrics
+      interval: 60s
+      path: /metrics

--- a/kubernetes/apps/observability/opnsense-exporter/ks.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app opnsense-exporter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/opnsense-exporter/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
## What

Adds `observability/opnsense-exporter` — brings OPNsense firewall/gateway/DNS metrics into Prometheus via the community-standard [`AthennaMind/opnsense-exporter`](https://github.com/AthennaMind/opnsense-exporter) (`0.0.16`), wrapped in the bjw-s `app-template`.

- **HelmRelease** (app-template) + ServiceMonitor, talks to the OPNsense API
- **GrafanaDashboard** — official grafana.com **21113**
- **PrometheusRule**: exporter-down, gateway-down (WAN), Unbound-down

## Credentials

Reuses the existing 1Password `opnsense` item (API key/secret already present — no new secret needed). `OPS_API` strips the `https://` scheme **in-template**, so the shared item (also consumed by external-dns / opnsense-dns) is left untouched.

## Verification

`kustomize build` clean (per-app + aggregate); yamlfmt→prettier clean.

> ⚠️ The `opnsense_gateways_status{status=…}` / `opnsense_unbound_*` alert encodings are flagged inline — confirm against live `/metrics` once the exporter is up.