### PR TITLE
fix(terrateam): disable bundled Postgres + allow server->CNPG netpol

### DIFF
--- a/kubernetes/apps/infrastructure/terrateam/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/helmrelease.yaml
@@ -26,7 +26,6 @@ spec:
         fqdn: terrateam.${SECRET_DOMAIN}
         uiBase: https://terrateam.${SECRET_DOMAIN}
         github:
-          # VERIFY: set to the app slug from Task 0 (github.com/apps/<slug>)
           appUrl: https://github.com/apps/terrateam-codelooks
           appIdSecretName: terrateam-github
           appIdSecretKey: app-id
@@ -45,3 +44,8 @@ spec:
           username: terrateam
           passwordSecretName: terrateam-db-app
           passwordSecretKey: password
+    # Use the dedicated CNPG cluster (cluster.yaml) — disable the chart's bundled Postgres,
+    # which otherwise deploys a second "terrateam-db" Deployment that fails on a missing
+    # terrateam-db-password secret and an unbound PVC.
+    db:
+      enabled: false

--- a/kubernetes/apps/infrastructure/terrateam/app/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./cluster.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./networkpolicy.yaml
   - ./httproute.yaml
   - ./httproute-internal.yaml

--- a/kubernetes/apps/infrastructure/terrateam/app/networkpolicy.yaml
+++ b/kubernetes/apps/infrastructure/terrateam/app/networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+# The namespace policy (allow-cross-namespace-ingress, endpointSelector {}) puts every
+# infrastructure pod in default-deny ingress, permitting only the `network` namespace and
+# world. Terrateam is the first infra app with an intra-namespace dependency, so the
+# server's connection to its CNPG Postgres is dropped. Allow it explicitly.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: terrateam-db-allow-server
+spec:
+  description: Allow the Terrateam server to reach its CNPG Postgres within the namespace.
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: terrateam-db
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: terrateam-server


### PR DESCRIPTION
Follow-up to #3062. The live deploy surfaced two bugs:

1. **Bundled Postgres not disabled** — chart `db.enabled` defaulted `true`, so a second `terrateam-db` Deployment was created alongside the CNPG cluster; it's stuck (`CreateContainerConfigError`: missing `terrateam-db-password` secret + unbound PVC). Set `db.enabled: false` to use the dedicated CNPG cluster only.
2. **Server can't reach CNPG** — `[pgsql.pool] EAGAIN` connecting to `terrateam-db-rw`. The namespace policy `allow-cross-namespace-ingress` (`endpointSelector: {}`) default-denies ingress, permitting only the `network` namespace + world; terrateam is the first infra app with an intra-namespace (server→db) dependency. Adds a CiliumNetworkPolicy allowing `terrateam-server` → the `terrateam-db` CNPG pods.

`kubectl kustomize` builds clean (9 resources). App DB config was already correct (`db_host=terrateam-db-rw`).