### PR TITLE
fix(opnsense-exporter): use dedicated read-only API key

### DIFF
--- a/kubernetes/apps/observability/opnsense-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/externalsecret.yaml
@@ -13,13 +13,13 @@ spec:
     template:
       data:
         # Mapped straight to the exporter's expected env var names (envFrom below).
-        OPNSENSE_EXPORTER_OPS_API_KEY: "{{ .OPNSENSE_API_KEY }}"
-        OPNSENSE_EXPORTER_OPS_API_SECRET: "{{ .OPNSENSE_API_SECRET }}"
-        # OPS_API must be a bare host[:port] WITHOUT scheme (protocol is set separately
-        # via env). The shared `opnsense` item stores OPNSENSE_HOST WITH an https://
-        # scheme (the external-dns webhook needs it), so strip it here rather than
-        # mutating the shared item.
-        OPNSENSE_EXPORTER_OPS_API: '{{ .OPNSENSE_HOST | trimPrefix "https://" | trimPrefix "http://" }}'
+        # Backed by a DEDICATED, least-privilege OPNsense API key (user
+        # svc-prometheus, group prometheus-exporter) — not the DNS-scoped shared
+        # `opnsense` item, whose key 403s on the exporter's endpoints. The host is
+        # stored bare here, so no scheme-stripping is needed.
+        OPNSENSE_EXPORTER_OPS_API_KEY: "{{ .api_key }}"
+        OPNSENSE_EXPORTER_OPS_API_SECRET: "{{ .api_secret }}"
+        OPNSENSE_EXPORTER_OPS_API: "{{ .host }}"
   dataFrom:
     - extract:
-        key: opnsense
+        key: opnsense-exporter


### PR DESCRIPTION
## Why

opnsense-exporter (deployed in #3065) reused the shared `opnsense` 1Password item, whose API key is scoped for the **external-dns / opnsense-dns Unbound webhook only**. In-cluster the exporter authenticates but gets **403 Forbidden** on nearly every collector endpoint → only ~3 `opnsense_*` series.

## What

Repoint the ExternalSecret at a new **dedicated, least-privilege** 1Password item `opnsense-exporter` (vault `Talos`):

- OPNsense user `svc-prometheus` in group `prometheus-exporter`, granted exactly the ACLs the exporter's collectors need (ARP, firewall stats, netstat, traffic, unbound, Kea v4/v6, gateways, firmware, cron, system status, IPsec/OpenVPN/WireGuard, services).
- Host stored **bare**, so the `trimPrefix` scheme-strip hack is removed.
- The shared `opnsense` item (used by external-dns) is left untouched.

Consistent with the least-privilege read-only account used for the VMware exporter.

## Verification

`kustomize build` clean. Post-merge: reconcile, confirm the pod's 403s clear and `opnsense_*` series populate.