### PR TITLE
feat(mktxp): MikroTik RouterOS metrics (both CRS354 switches)

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - ./headlamp/ks.yaml
   - ./kromgo/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
+  - ./mktxp/ks.yaml
   - ./netdata/ks.yaml
   - ./network-ups-tools/ks.yaml
   - ./nut-exporter/ks.yaml

--- a/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mktxp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: mktxp-secret
+    template:
+      # Render the full mktxp config dir. The dedicated read-only RouterOS user
+      # (group prometheus, policy api,read) connects over api-ssl (8729) — the
+      # switches present a self-signed cert, hence ssl_certificate_verify=False.
+      data:
+        mktxp.conf: |
+          [default]
+              username = {{ .username }}
+              password = {{ .password }}
+              port = 8729
+              use_ssl = True
+              no_ssl_certificate = False
+              ssl_certificate_verify = False
+              plaintext_login = True
+              enabled = True
+              # CRS354 switches: no wireless/capsman/DNS, but switch-port + PoE matter.
+              wireless = False
+              wireless_clients = False
+              capsman = False
+              capsman_clients = False
+              netwatch = False
+              public_ip = False
+              dns = False
+              user = False
+              switch_port = True
+              poe = True
+
+          [CRS354-PoE]
+              hostname = {{ .host_poe }}
+
+          [CRS354-NonPoE]
+              hostname = {{ .host_nonpoe }}
+              poe = False
+        _mktxp.conf: |
+          [MKTXP]
+              listen = '0.0.0.0:49090'
+              fetch_routers_in_parallel = True
+              max_worker_threads = 5
+              max_scrape_duration = 30
+              total_max_scrape_duration = 90
+              persistent_dhcp_cache = False
+              verbose_mode = False
+  dataFrom:
+    - extract:
+        key: mktxp

--- a/kubernetes/apps/observability/mktxp/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/mktxp/app/grafanadashboard.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: mktxp
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  grafanaCom:
+    # renovate: depName="Mikrotik MKTXP Exporter"
+    id: 13679
+    revision: 18

--- a/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mktxp
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      mktxp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/akpw/mktxp
+              tag: v1.2.17
+              digest: sha256:bd6f22f7db0a79557c4af8a73aa22517f4c32d54fafa19fb0de29e7332440613
+            command:
+              - "mktxp"
+              - "-cfg-dir"
+              - "/etc/mktxp"
+              - "export"
+            env:
+              TZ: ${TIMEZONE:=UTC}
+              HOME: /tmp
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+    persistence:
+      # The rendered config dir (mktxp.conf + _mktxp.conf) from the ExternalSecret.
+      config:
+        type: secret
+        name: mktxp-secret
+        globalMounts:
+          - path: /etc/mktxp
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    service:
+      app:
+        controller: *app
+        ports:
+          metrics:
+            port: 49090
+            protocol: TCP

--- a/kubernetes/apps/observability/mktxp/app/kustomization.yaml
+++ b/kubernetes/apps/observability/mktxp/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/mktxp/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/mktxp/app/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1

--- a/kubernetes/apps/observability/mktxp/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/mktxp/app/prometheusrule.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: mktxp.rules
+spec:
+  groups:
+    - name: mktxp.rules
+      rules:
+        - alert: MktxpExporterDown
+          annotations:
+            summary: "mktxp exporter ({{ $labels.instance }}) is not being scraped."
+          expr: |-
+            up{job="mktxp"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # mktxp drops a router's series when it can't reach it. Confirm the exact
+        # uptime metric/label against live /metrics before relying on this.
+        - alert: MktxpRouterUnreachable
+          annotations:
+            summary: "mktxp cannot collect from RouterOS device {{ $labels.routerboard_name }}{{ $labels.name }}."
+          expr: |-
+            mktxp_system_routerboard_uptime == 0
+            or
+            absent(mktxp_system_routerboard_uptime)
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/mktxp/app/servicemonitor.yaml
+++ b/kubernetes/apps/observability/mktxp/app/servicemonitor.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app mktxp
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *app
+  endpoints:
+    - port: metrics
+      # mktxp fetches both routers on each scrape — allow headroom.
+      interval: 60s
+      scrapeTimeout: 45s
+      path: /metrics

--- a/kubernetes/apps/observability/mktxp/ks.yaml
+++ b/kubernetes/apps/observability/mktxp/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app mktxp
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/mktxp/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
## What

Adds `observability/mktxp` — RouterOS metrics for both **CRS354** switches via the community-standard [`akpw/mktxp`](https://github.com/akpw/mktxp) (`v1.2.17`), wrapped in app-template. mktxp talks the RouterOS **binary API**, so it captures far more than SNMP would (interfaces, **switch-port**, **PoE**, DHCP, health, firewall, routes).

- **ExternalSecret** renders `mktxp.conf` (+ `_mktxp.conf`) from the `mktxp` 1Password item — `[default]` section holds creds; per-switch sections just set hostname.
- **ServiceMonitor** on `:49090`, **GrafanaDashboard** grafana.com **13679**, PrometheusRule (exporter-down, router-unreachable).

## Prereqs (done out-of-band, least-privilege)

- Dedicated read-only RouterOS user `mktxp` (`group=prometheus, policy=api,read`) created on **both** switches.
- **api-ssl (8729) enabled** with each switch's existing cert, **source-restricted to the 3 node IPs** (`10.32.8.80-82`) — no plaintext API. mktxp uses `use_ssl=True`, `ssl_certificate_verify=False` (self-signed).
- Creds stored in the `mktxp` 1Password item (vault `Talos`).

## Verification

`kustomize build` clean (per-app + aggregate). Post-merge: confirm `up{job="mktxp"}=1` and `mktxp_*` series for both routerboards.

> ⚠️ The `mktxp_system_routerboard_uptime` alert metric name is flagged inline — confirm against live `/metrics`.