### PR TITLE
feat(snmp-exporter): monitor Onyx SN2700 core switch (if_mib)

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -16,16 +16,18 @@ spec:
       tag: v0.30.1@sha256:e5fd5e8b43ace6c088fe9bf0b37b7fff0e04380bee352be7ec41b853a4dd5859
     serviceMonitor:
       enabled: true
-    params: []
-    # Add your UPS devices here once you have targets, e.g.:
-    # - name: ups01
-    #   module:
-    #     - if_mib
-    #   target: ups01.${SECRET_DOMAIN_INT}
-    #   auth:
-    #     - public_v2
+    params:
+      # Mellanox Onyx SN2700 core switch (sw-main-core). if_mib gives all port
+      # counters/status; auth public_v2 maps to the bundled community "public"
+      # (the switch's existing read-only SNMP community).
+      - name: onyx-core
+        module:
+          - if_mib
+        target: 10.32.8.195
+        auth:
+          - public_v2
     path: /snmp
-    scrapeTimeout: 10s
+    scrapeTimeout: 30s
     relabelings:
       - sourceLabels:
           - __param_target


### PR DESCRIPTION
## What

Brings the **Mellanox Onyx SN2700** core switch (`sw-main-core`, `10.32.8.195`) into monitoring by **reusing the existing `snmp-exporter`** — no new app, the buy/reuse choice (there's no dedicated Onyx exporter).

- Adds one `params` entry: module `if_mib`, auth `public_v2`, target the switch.
- `if_mib` + `public_v2` (community `public`) both come from the chart's bundled `snmp.yml` — no config changes.
- Gives all port-level counters/status (traffic, errors, admin/oper state, 64-bit HC counters) auto-mapped by `ifIndex`/`ifName`.

## Prereq

SNMP was already enabled on the switch (read-only community `public`, VRF `mgmt`). Note: hardening to a dedicated named community (`cr-onyx-ro`, like `cr-apc-ro`) is a trivial follow-up — `public` is read-only and on the isolated mgmt VLAN.

## Follow-up ideas

- A custom `mellanox` generator module for environmentals (temp/fan/PSU/CPU) — `if_mib` is interface-only.
- A switch-interface Grafana dashboard.

## Verification

`kustomize build` clean. Post-merge: confirm the `onyx-core` target is `up=1` and interface metrics populate.