### PR TITLE
fix(mktxp): use --cfg-dir flag (double dash)

### DIFF
--- a/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
               digest: sha256:bd6f22f7db0a79557c4af8a73aa22517f4c32d54fafa19fb0de29e7332440613
             command:
               - "mktxp"
-              - "-cfg-dir"
+              - "--cfg-dir"
               - "/etc/mktxp"
               - "export"
             env:


### PR DESCRIPTION
mktxp #3073 crash-looped: its CLI flag is `--cfg-dir`, but the manifest used `-cfg-dir` (single dash), so argparse read `/etc/mktxp` as the subcommand (`invalid choice: '/etc/mktxp'`). One-char fix.