### PR TITLE
fix(mktxp): provide complete _mktxp.conf key set

### DIFF
--- a/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
@@ -44,14 +44,33 @@ spec:
               hostname = {{ .host_nonpoe }}
               poe = False
         _mktxp.conf: |
+          # mktxp requires the full [MKTXP] key set (it reads keys like
+          # compact_default_conf_values without a default). Overrides from the
+          # upstream defaults: listen, parallel fetch, no on-disk dhcp cache
+          # (config dir is a read-only secret mount).
           [MKTXP]
               listen = '0.0.0.0:49090'
+              socket_timeout = 5
+              initial_delay_on_failure = 120
+              max_delay_on_failure = 900
+              delay_inc_div = 5
+              bandwidth = False
+              bandwidth_test_dns_server = 8.8.8.8
+              bandwidth_test_interval = 600
+              minimal_collect_interval = 5
+              verbose_mode = False
               fetch_routers_in_parallel = True
               max_worker_threads = 5
               max_scrape_duration = 30
               total_max_scrape_duration = 90
+              http_server_threads = 16
+              persistent_router_connection_pool = True
               persistent_dhcp_cache = False
-              verbose_mode = False
+              compact_default_conf_values = False
+              prometheus_headers_deduplication = False
+              probe_connection_pool = False
+              probe_connection_pool_ttl = 300
+              probe_connection_pool_max_size = 128
   dataFrom:
     - extract:
         key: mktxp


### PR DESCRIPTION
mktxp #3073 crash-looped with `KeyError: 'compact_default_conf_values'` — mktxp reads the full `[MKTXP]` key set without defaults, so a minimal `_mktxp.conf` is fatal. Render all upstream keys, keeping our overrides (listen :49090, parallel fetch, `persistent_dhcp_cache=False` since the config dir is a read-only secret mount).