### PR TITLE
fix(mktxp): copy config to writable dir via initContainer

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml
@@ -1,11 +1,47 @@
 ---
-# Intentionally no pod-management Role: this SA suppresses the chart's
-# auto-created kube-mode SA, so `container:` jobs, service containers, and
-# docker:// actions will fail on this runner — plain `run:` steps only.
-# terraform-cloudflare talks to the Cloudflare API + R2, never the Kubernetes
-# API, so no cluster permissions are required.
+# Kubernetes-mode container-hook RBAC. terraform-cloudflare runs Terrateam, whose
+# action (terrateamio/action) is a *container* action — in ARC kubernetes mode it
+# spawns a workload pod, which the runner SA must be allowed to manage. (This lifts
+# the earlier "run:-only, no pod RBAC" stance: it held for hand-written terraform
+# steps but not for Terrateam's container action.) Scoped to actions-runner-system.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloudflare-runner
   namespace: actions-runner-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloudflare-runner
+  namespace: actions-runner-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloudflare-runner
+  namespace: actions-runner-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloudflare-runner
+subjects:
+  - kind: ServiceAccount
+    name: cloudflare-runner
+    namespace: actions-runner-system

--- a/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
@@ -27,9 +27,18 @@ spec:
               - "sh"
               - "-c"
               - "cp -f /config-src/mktxp.conf /config-src/_mktxp.conf /etc/mktxp/"
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 65534
+              runAsGroup: 65534
               capabilities:
                 drop:
                   - ALL

--- a/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
@@ -14,6 +14,25 @@ spec:
       mktxp:
         annotations:
           reloader.stakater.com/auto: "true"
+        initContainers:
+          # mktxp normalizes its config on load (writes back to mktxp.conf). Copy
+          # the secret-rendered config into a writable emptyDir so that write
+          # succeeds instead of erroring against a read-only secret mount.
+          init-config:
+            image:
+              repository: ghcr.io/akpw/mktxp
+              tag: v1.2.17
+              digest: sha256:bd6f22f7db0a79557c4af8a73aa22517f4c32d54fafa19fb0de29e7332440613
+            command:
+              - "sh"
+              - "-c"
+              - "cp -f /config-src/mktxp.conf /config-src/_mktxp.conf /etc/mktxp/"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
         containers:
           app:
             image:
@@ -51,13 +70,21 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
     persistence:
-      # The rendered config dir (mktxp.conf + _mktxp.conf) from the ExternalSecret.
-      config:
+      # Secret-rendered config (mktxp.conf + _mktxp.conf), mounted read-only on
+      # the init container only; it copies into the writable `config` emptyDir.
+      config-src:
         type: secret
         name: mktxp-secret
+        advancedMounts:
+          mktxp:
+            init-config:
+              - path: /config-src
+                readOnly: true
+      # Writable config dir mktxp reads from (and rewrites on load).
+      config:
+        type: emptyDir
         globalMounts:
           - path: /etc/mktxp
-            readOnly: true
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
Removes the cosmetic startup `[Errno 30] Read-only file system: /etc/mktxp/mktxp.conf` — mktxp normalizes its config on load (writes back), which failed against the read-only secret mount. An init container copies the secret-rendered config into a writable emptyDir; mktxp then reads/rewrites it cleanly. Collection was already working; this just clears the log noise.