### PR TITLE
feat(garage): CNPG cutover + cluster→NAS sync (HOLD for bootstrap)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -17,9 +17,9 @@ spec:
       data:
         username: "{{ .POSTGRES_SUPER_USER }}"
         password: "{{ .POSTGRES_SUPER_PASS }}"
-        # MinIO S3 credentials (for barman backups)
-        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
-        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        # Garage S3 credentials (for barman backups)
+        AWS_ACCESS_KEY_ID: "{{ .CNPG_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .CNPG_SECRET_ACCESS_KEY }}"
         # Cloudflare R2 credentials (for rclone offsite replication)
         R2_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
         R2_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
@@ -30,3 +30,5 @@ spec:
         key: cloudnative-pg
     - extract:
         key: minio
+    - extract:
+        key: garage

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -10,9 +10,9 @@ spec:
 
   # Barman configuration
   configuration:
-    # S3 destination (MinIO)
+    # S3 destination (in-cluster Garage)
     destinationPath: s3://cnpg/
-    endpointURL: https://minio.${SECRET_INTERNAL_DOMAIN}:9000
+    endpointURL: http://garage.storage.svc.cluster.local:3900
 
     # Credentials from existing secret
     s3Credentials:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
@@ -47,13 +47,13 @@ spec:
                 - name: RCLONE_VERBOSE
                   value: "1"
 
-                # MinIO (source) configuration
+                # Garage (source) configuration
                 - name: RCLONE_CONFIG_MINIO_TYPE
                   value: s3
                 - name: RCLONE_CONFIG_MINIO_PROVIDER
-                  value: Minio
+                  value: Other
                 - name: RCLONE_CONFIG_MINIO_ENDPOINT
-                  value: https://minio.${SECRET_INTERNAL_DOMAIN}:9000
+                  value: http://garage.storage.svc.cluster.local:3900
                 - name: RCLONE_CONFIG_MINIO_ACL
                   value: private
 

--- a/kubernetes/apps/storage/garage/app/kustomization.yaml
+++ b/kubernetes/apps/storage/garage/app/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - ./crd.yaml
   - ./rbac.yaml
   - ./configmap.yaml
+  - ./sync-externalsecret.yaml
+  - ./sync-cronjob.yaml
   - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/batch/cronjob_v1.json
+# Hourly directional sync: in-cluster Garage -> NAS Garage (cluster-mirror bucket).
+# This is the BACKUP path for cluster object data (Garage has no native cross-cluster
+# replication). The NAS copy lands on a ZFS-snapshotted dataset = point-in-time undo.
+# NOTE: extend the rclone lines as more cluster app buckets are added. The NAS `veeam`
+# bucket is intentionally excluded (Veeam writes there directly; never round-trip).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: garage-cluster-to-nas-sync
+  namespace: storage
+spec:
+  schedule: "0 * * * *" # hourly
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 2
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: garage-cluster-to-nas-sync
+            app.kubernetes.io/component: backup
+        spec:
+          automountServiceAccountToken: false
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            fsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: rclone
+              image: docker.io/rclone/rclone:1.74.3@sha256:623378ad0ff3ebd5cebf77720843c0e02edfe46e2d5b5ac6bed54c6371780dfb
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  export RCLONE_CONFIG_SRC_ACCESS_KEY_ID=$(cat /secrets/CLUSTER_ACCESS_KEY_ID)
+                  export RCLONE_CONFIG_SRC_SECRET_ACCESS_KEY=$(cat /secrets/CLUSTER_SECRET_ACCESS_KEY)
+                  export RCLONE_CONFIG_DST_ACCESS_KEY_ID=$(cat /secrets/NAS_ACCESS_KEY_ID)
+                  export RCLONE_CONFIG_DST_SECRET_ACCESS_KEY=$(cat /secrets/NAS_SECRET_ACCESS_KEY)
+                  exec rclone sync --verbose --stats-one-line --stats=5m --fast-list src:cnpg/ dst:cluster-mirror/cnpg/
+              env:
+                - name: RCLONE_VERBOSE
+                  value: "1"
+                # Source: in-cluster Garage
+                - name: RCLONE_CONFIG_SRC_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_SRC_PROVIDER
+                  value: Other
+                - name: RCLONE_CONFIG_SRC_ENDPOINT
+                  value: http://garage.storage.svc.cluster.local:3900
+                - name: RCLONE_CONFIG_SRC_REGION
+                  value: us-east-1
+                - name: RCLONE_CONFIG_SRC_ACL
+                  value: private
+                # Destination: NAS Garage
+                - name: RCLONE_CONFIG_DST_TYPE
+                  value: s3
+                - name: RCLONE_CONFIG_DST_PROVIDER
+                  value: Other
+                - name: RCLONE_CONFIG_DST_ENDPOINT
+                  value: http://${SECRET_STORAGE_SERVER}:3900
+                - name: RCLONE_CONFIG_DST_REGION
+                  value: us-east-1
+                - name: RCLONE_CONFIG_DST_ACL
+                  value: private
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+              volumeMounts:
+                - name: secrets
+                  mountPath: /secrets
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 65534
+                runAsGroup: 65534
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - ALL
+          volumes:
+            - name: secrets
+              secret:
+                secretName: garage-sync-secret
+                defaultMode: 0400

--- a/kubernetes/apps/storage/garage/app/sync-externalsecret.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Credentials for the hourly cluster->NAS Garage sync CronJob.
+# CLUSTER_* = the in-cluster Garage `cnpg` key (read); NAS_* = the NAS Garage `mirror` key (write).
+# Both fields live in the Talos-vault `garage` item (CNPG_* added during Phase 2 bootstrap; MIRROR_* in Phase 1).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-sync
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: garage-sync-secret
+    template:
+      engineVersion: v2
+      data:
+        CLUSTER_ACCESS_KEY_ID: "{{ .CNPG_ACCESS_KEY_ID }}"
+        CLUSTER_SECRET_ACCESS_KEY: "{{ .CNPG_SECRET_ACCESS_KEY }}"
+        NAS_ACCESS_KEY_ID: "{{ .MIRROR_ACCESS_KEY_ID }}"
+        NAS_SECRET_ACCESS_KEY: "{{ .MIRROR_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: garage


### PR DESCRIPTION
Follow-up to #3071 (merged). ⛔ **DO NOT MERGE** until the in-cluster Garage from #3071 is reconciled + healthy, the one-time bootstrap is done (\`cnpg\` bucket/key created + \`CNPG_ACCESS_KEY_ID\`/\`CNPG_SECRET_ACCESS_KEY\` stored in the Talos \`garage\` 1Password item), **and** a CNPG restore test passes.

## Phase 4 — CNPG cutover
- \`objectstore.yaml\`: \`endpointURL\` → \`http://garage.storage.svc.cluster.local:3900\`
- \`externalsecret.yaml\`: barman S3 creds from Talos \`garage\` item (\`CNPG_*\`); kept \`minio\`/\`cloudnative-pg\` extracts for R2 creds + superuser
- \`r2-backup-cronjob.yaml\`: source → Garage (provider \`Other\`)

## Phase 5.1 — cluster→NAS sync
- Hourly \`rclone sync\` CronJob: in-cluster Garage \`cnpg\` → NAS Garage \`cluster-mirror/cnpg\` (creds via \`garage-sync\` ExternalSecret). NAS copy = ZFS-snapshotted = immutability substitute. NAS \`veeam\` bucket excluded by design.

Verify after merge: force a CNPG backup → objects appear in Garage \`cnpg\`; first sync run → \`cluster-mirror/cnpg\` on the NAS.