### PR TITLE
fix(arc): cloudflare-runner kube-mode RBAC for Terrateam

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -32,3 +32,29 @@ misconfigurations:
       — the strings (`echo "APC Username`, `export APC_USERNAME`,
       `self.username`, `username`) are variable / parameter names inside
       an embedded Python script, not actual usernames.
+
+  # The cloudflare-runner Role grants the ARC kubernetes-mode container-hook
+  # permissions (manage pods, pods/exec, pods/log, jobs, secrets in
+  # actions-runner-system). Terrateam's action is a container action, so the
+  # runner MUST spawn/exec/clean up its job pod + per-job secret — these verbs
+  # are required, minimal, and namespace-scoped. Not reducible.
+  - id: KSV-0048
+    paths:
+      - "kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml"
+    statement: |-
+      Required ARC kubernetes-mode container-hook RBAC: the runner spawns and
+      deletes the workload pod/job for Terrateam's container action. Scoped to
+      the actions-runner-system namespace.
+  - id: KSV-0053
+    paths:
+      - "kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml"
+    statement: |-
+      Required ARC kubernetes-mode container-hook RBAC: the runner execs into
+      its own job pod to stream the action. Scoped to actions-runner-system.
+  - id: KSV-0113
+    paths:
+      - "kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml"
+    statement: |-
+      Required ARC kubernetes-mode container-hook RBAC: the hook creates and
+      deletes a per-job secret to inject the workflow context. Scoped to
+      actions-runner-system.

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/cloudflare/rbac.yaml
@@ -1,11 +1,47 @@
 ---
-# Intentionally no pod-management Role: this SA suppresses the chart's
-# auto-created kube-mode SA, so `container:` jobs, service containers, and
-# docker:// actions will fail on this runner — plain `run:` steps only.
-# terraform-cloudflare talks to the Cloudflare API + R2, never the Kubernetes
-# API, so no cluster permissions are required.
+# Kubernetes-mode container-hook RBAC. terraform-cloudflare runs Terrateam, whose
+# action (terrateamio/action) is a *container* action — in ARC kubernetes mode it
+# spawns a workload pod, which the runner SA must be allowed to manage. (This lifts
+# the earlier "run:-only, no pod RBAC" stance: it held for hand-written terraform
+# steps but not for Terrateam's container action.) Scoped to actions-runner-system.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloudflare-runner
   namespace: actions-runner-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloudflare-runner
+  namespace: actions-runner-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cloudflare-runner
+  namespace: actions-runner-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cloudflare-runner
+subjects:
+  - kind: ServiceAccount
+    name: cloudflare-runner
+    namespace: actions-runner-system


### PR DESCRIPTION
Terrateam's `terrateamio/action` is a container action; in ARC kubernetes mode it spawns a workload pod, which failed with *"The Service account needs … pods, pods/exec, pods/log, jobs, secrets … in 'actions-runner-system'"*.

Adds the standard container-hook `Role` + `RoleBinding` (scoped to `actions-runner-system`) to `cloudflare-runner`, lifting the prior `run:`-only / no-pod-RBAC stance (which held for hand-written terraform steps but not for Terrateam's container action).

Authored in an isolated worktree off main.