### PR TITLE
fix(garage): automountServiceAccountToken for kubernetes_discovery

### DIFF
--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -85,6 +85,10 @@ spec:
               globalMounts:
                 - path: /mnt/data
     defaultPodOptions:
+      # Required: Garage's kubernetes_discovery reads the in-cluster SA token to
+      # publish/list GarageNode CRs. app-template defaults this to false, which
+      # leaves each node isolated ("failed to read the default namespace").
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
Hotfix for #3071: app-template defaults `automountServiceAccountToken: false`, so Garage's `kubernetes_discovery` couldn't read the in-cluster SA token and the 3 nodes never peered (each isolated, `failed to read the default namespace`). Confirmed fixed live (3 nodes HEALTHY + peered) before committing.