### PR TITLE
feat(snmp-exporter): Onyx environmentals via ENTITY-SENSOR-MIB

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/configmap-entity-sensor.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/configmap-entity-sensor.yaml
@@ -1,0 +1,80 @@
+---
+# Custom snmp_exporter module for ENTITY-SENSOR-MIB (RFC 3433) — temperature,
+# fan, voltage and PSU sensors exposed by the Mellanox Onyx SN2700 (and any
+# device implementing the standard MIB). Merged with the image's bundled
+# snmp.yml via a second --config.file (see helmrelease extraArgs); reuses the
+# bundled public_v2 auth.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snmp-exporter-entity-sensor
+  namespace: observability
+data:
+  snmp.yml: |-
+    modules:
+      entity_sensor:
+        walk:
+          - 1.3.6.1.2.1.47.1.1.1.1.2   # entPhysicalDescr
+          - 1.3.6.1.2.1.47.1.1.1.1.7   # entPhysicalName
+          - 1.3.6.1.2.1.99.1.1.1       # entPhySensorEntry
+        metrics:
+          - name: entPhySensorValue
+            oid: 1.3.6.1.2.1.99.1.1.1.4
+            type: gauge
+            help: ENTITY-SENSOR-MIB entPhySensorValue (scale by entPhySensorPrecision)
+            indexes:
+              - labelname: entPhysicalIndex
+                type: gauge
+            lookups:
+              - labels: [entPhysicalIndex]
+                labelname: entPhysicalName
+                oid: 1.3.6.1.2.1.47.1.1.1.1.7
+                type: DisplayString
+              - labels: [entPhysicalIndex]
+                labelname: entPhysicalDescr
+                oid: 1.3.6.1.2.1.47.1.1.1.1.2
+                type: DisplayString
+          - name: entPhySensorType
+            oid: 1.3.6.1.2.1.99.1.1.1.1
+            type: EnumAsInfo
+            help: ENTITY-SENSOR-MIB entPhySensorType
+            enum_values:
+              1: other
+              2: unknown
+              3: voltsAC
+              4: voltsDC
+              5: amperes
+              6: watts
+              7: hertz
+              8: celsius
+              9: percentRH
+              10: rpm
+              11: cmm
+              12: truthvalue
+            indexes:
+              - labelname: entPhysicalIndex
+                type: gauge
+            lookups:
+              - labels: [entPhysicalIndex]
+                labelname: entPhysicalName
+                oid: 1.3.6.1.2.1.47.1.1.1.1.7
+                type: DisplayString
+          - name: entPhySensorPrecision
+            oid: 1.3.6.1.2.1.99.1.1.1.3
+            type: gauge
+            help: ENTITY-SENSOR-MIB entPhySensorPrecision (decimal places)
+            indexes:
+              - labelname: entPhysicalIndex
+                type: gauge
+          - name: entPhySensorOperStatus
+            oid: 1.3.6.1.2.1.99.1.1.1.5
+            type: gauge
+            help: ENTITY-SENSOR-MIB entPhySensorOperStatus (1=ok 2=unavailable 3=nonoperational)
+            indexes:
+              - labelname: entPhysicalIndex
+                type: gauge
+            lookups:
+              - labels: [entPhysicalIndex]
+                labelname: entPhysicalName
+                oid: 1.3.6.1.2.1.47.1.1.1.1.7
+                type: DisplayString

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -14,6 +14,16 @@ spec:
     image:
       repository: quay.io/prometheus/snmp-exporter
       tag: v0.30.1@sha256:e5fd5e8b43ace6c088fe9bf0b37b7fff0e04380bee352be7ec41b853a4dd5859
+    # Merge a custom ENTITY-SENSOR-MIB module (temp/fan/PSU/optics) alongside the
+    # image's bundled snmp.yml. snmp_exporter combines multiple --config.file.
+    extraArgs:
+      - --config.file=/etc/snmp_exporter/snmp.yml
+      - --config.file=/run/snmp-extra/snmp.yml
+    extraConfigmapMounts:
+      - name: entity-sensor
+        configMap: snmp-exporter-entity-sensor
+        mountPath: /run/snmp-extra
+        readOnly: true
     # chart 9.14.0 reads scrape targets from serviceMonitor.params[] (not a
     # top-level params:); per-entry module/auth fall back to the globals here.
     serviceMonitor:
@@ -31,6 +41,7 @@ spec:
           target: 10.32.8.195
           module:
             - if_mib
+            - entity_sensor
           auth:
             - public_v2
           interval: 60s

--- a/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   # - ./configmap.yaml  # Not needed - using chart's built-in SNMP configs
+  - ./configmap-entity-sensor.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./grafanadashboard.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/snmp-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/prometheusrule.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: snmp-exporter.rules
+spec:
+  groups:
+    - name: snmp-exporter.rules
+      rules:
+        - alert: SnmpTargetDown
+          annotations:
+            summary: "SNMP target {{ $labels.instance }} is not being scraped."
+          expr: |-
+            up{job="snmp-exporter"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # entPhySensorOperStatus: 1=ok, 2=unavailable, 3=nonoperational. Catches
+        # fan/PSU/temperature sensor hardware faults on the Onyx core switch.
+        # (entPhySensorValue carries the readings for dashboards; raw value must
+        # be divided by 10^entPhySensorPrecision for the real figure.)
+        - alert: OnyxSensorFault
+          annotations:
+            summary: "Onyx sensor {{ $labels.entPhysicalName }} (idx {{ $labels.entPhysicalIndex }}) is faulted (operStatus {{ $value }})."
+          expr: |-
+            entPhySensorOperStatus{job="snmp-exporter"} > 1
+          for: 5m
+          labels:
+            severity: warning


### PR DESCRIPTION
## What

Adds temperature / fan / PSU / optical-power monitoring for the **Onyx SN2700** core switch via a custom **ENTITY-SENSOR-MIB** (`entity_sensor`) module — the switch implements the standard MIB, so no proprietary MIBs needed.

- `configmap-entity-sensor.yaml` — the `entity_sensor` module (entPhySensorValue/Type/Precision/OperStatus, labelled by `entPhysicalName`/`entPhysicalDescr`).
- Merged with the image's bundled `snmp.yml` via a **second `--config.file`** (snmp_exporter combines them) — keeps `if_mib` intact, reuses the bundled `public_v2` auth.
- Onyx target now scrapes `module: [if_mib, entity_sensor]`.
- `prometheusrule.yaml` — SNMP target-down + `OnyxSensorFault` (`entPhySensorOperStatus > 1`).

## Validated before merge

Ran a throwaway snmp_exporter pod with this exact config against the live switch — it returns `entPhySensorValue` for temps, fans, PSU and per-port optics (e.g. `Eth1/1 ... Rx Power, Channel 1`) with labels resolving correctly. The config merge works.

## Notes

- Raw `entPhySensorValue` ÷ `10^entPhySensorPrecision` = real figure (Onyx temps use precision 1, e.g. 360 → 36 °C).
- A sensor dashboard + temp/fan thresholds are a sensible follow-up; `OnyxSensorFault` covers hardware faults generically. Built in an isolated worktree.