### PR TITLE
feat(garage): garage-webui admin UI at garage.${SECRET_DOMAIN}

### DIFF
--- a/kubernetes/apps/storage/garage/ks.yaml
+++ b/kubernetes/apps/storage/garage/ks.yaml
@@ -30,3 +30,31 @@ spec:
   targetNamespace: *namespace
   timeout: 5m
   wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-webui
+  namespace: &namespace storage
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: garage
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/storage/garage/webui
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/storage/garage/webui/externalsecret.yaml
+++ b/kubernetes/apps/storage/garage/webui/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# garage-webui needs the Garage admin token (same one the server uses) to call the
+# admin API, plus a built-in login (user:bcrypt). Both come from the Talos `garage` item.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-webui
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: garage-webui-secret
+    template:
+      engineVersion: v2
+      data:
+        API_ADMIN_KEY: "{{ .GARAGE_ADMIN_TOKEN }}"
+        AUTH_USER_PASS: "{{ .WEBUI_AUTH_USER_PASS }}"
+  dataFrom:
+    - extract:
+        key: garage

--- a/kubernetes/apps/storage/garage/webui/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/webui/helmrelease.yaml
@@ -1,0 +1,95 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: garage-webui
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: garage-webui
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      garage-webui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/khairul169/garage-webui
+              tag: 1.1.0@sha256:17c793551873155065bf9a022dabcde874de808a1f26e648d4b82e168806439c
+            env:
+              TZ: ${TIMEZONE}
+              PORT: "3909"
+              API_BASE_URL: http://garage.storage.svc.cluster.local:3903
+              S3_ENDPOINT_URL: http://garage.storage.svc.cluster.local:3900
+              S3_REGION: us-east-1
+            envFrom:
+              - secretRef:
+                  name: garage-webui-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3909
+                  initialDelaySeconds: 15
+                  periodSeconds: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3909
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+            resources:
+              requests:
+                cpu: 5m
+                memory: 50Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: garage-webui
+        ports:
+          http:
+            port: 3909
+    route:
+      app:
+        hostnames:
+          - "garage.${SECRET_DOMAIN}"
+          - "garage.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - name: garage-webui
+                port: 3909

--- a/kubernetes/apps/storage/garage/webui/kustomization.yaml
+++ b/kubernetes/apps/storage/garage/webui/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/storage/garage/webui/ocirepository.yaml
+++ b/kubernetes/apps/storage/garage/webui/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: garage-webui
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
Adds the **garage-webui** (khairul169/garage-webui) management UI as a separate app-template HelmRelease, per the drag0n141/home-ops reference. Env-only config (admin token via `garage-secret`, no toml mount → keeps the Trivy-clean design), built-in login (`AUTH_USER_PASS`, user `admin`, password in 1Password `Talos/garage`). Points at the in-cluster Garage admin API (:3903) + S3 (:3900). Second Flux Kustomization `garage-webui` (dependsOn `garage`).