### PR TITLE
fix(snmp-exporter): dedicated cr-onyx-ro community for Onyx

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/configmap-entity-sensor.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/configmap-entity-sensor.yaml
@@ -2,8 +2,9 @@
 # Custom snmp_exporter module for ENTITY-SENSOR-MIB (RFC 3433) — temperature,
 # fan, voltage and PSU sensors exposed by the Mellanox Onyx SN2700 (and any
 # device implementing the standard MIB). Merged with the image's bundled
-# snmp.yml via a second --config.file (see helmrelease extraArgs); reuses the
-# bundled public_v2 auth.
+# snmp.yml via a second --config.file (see helmrelease extraArgs).
+# Also defines the dedicated read-only auth (community cr-onyx-ro) used in
+# place of the default "public" community.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +12,11 @@ metadata:
   namespace: observability
 data:
   snmp.yml: |-
+    auths:
+      onyx_ro:
+        community: cr-onyx-ro
+        security_level: noAuthNoPriv
+        version: 2
     modules:
       entity_sensor:
         walk:

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -35,15 +35,15 @@ spec:
         - public_v2
       params:
         # Mellanox Onyx SN2700 core switch (sw-main-core). if_mib gives all port
-        # counters/status; auth public_v2 maps to the bundled community "public"
-        # (the switch's existing read-only SNMP community).
+        # counters/status; entity_sensor adds temp/fan/PSU/optics. auth onyx_ro
+        # uses the dedicated cr-onyx-ro community (see configmap-entity-sensor).
         - name: onyx-core
           target: 10.32.8.195
           module:
             - if_mib
             - entity_sensor
           auth:
-            - public_v2
+            - onyx_ro
           interval: 60s
           scrapeTimeout: 30s
           relabelings:


### PR DESCRIPTION
Hardens Onyx SNMP off the default `public` community. Adds an `onyx_ro` auth (community `cr-onyx-ro`, v2c) to the merged entity-sensor config and switches the Onyx target to it. `cr-onyx-ro` was added on the switch (alongside `public` for a zero-gap transition); once this is confirmed scraping, `public` will be removed from the switch.