### PR TITLE
feat(observability): reference switches by DNS name, not raw IP

### DIFF
--- a/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
@@ -37,11 +37,13 @@ spec:
               switch_port = True
               poe = True
 
+          # Hostnames are cluster-settings vars (Flux substitutes ${...} before
+          # ESO renders the {{ }} fields) — DNS names, not hardcoded IPs.
           [CRS354-PoE]
-              hostname = {{ .host_poe }}
+              hostname = ${MIKROTIK_POE_ADDR}
 
           [CRS354-NonPoE]
-              hostname = {{ .host_nonpoe }}
+              hostname = ${MIKROTIK_NONPOE_ADDR}
               poe = False
         _mktxp.conf: |
           # mktxp requires the full [MKTXP] key set (it reads keys like

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -38,7 +38,7 @@ spec:
         # counters/status; entity_sensor adds temp/fan/PSU/optics. auth onyx_ro
         # uses the dedicated cr-onyx-ro community (see configmap-entity-sensor).
         - name: onyx-core
-          target: 10.32.8.195
+          target: ${ONYX_ADDR}
           module:
             - if_mib
             - entity_sensor

--- a/kubernetes/components/global-vars/cluster-settings.yaml
+++ b/kubernetes/components/global-vars/cluster-settings.yaml
@@ -16,3 +16,9 @@ data:
   # move every consumer (contracthound, subspy, loupe, litellm, …) at once.
   OLLAMA_MODEL: qwen3.6-35b-a3b
   OLLAMA_BASE_URL: http://ollama.ai.svc.cluster.local:11434
+  # Network switch addresses (DNS names; host-overrides managed in network-ops
+  # opnsense-dns.yml). Monitoring references these so a renumber is a one-line
+  # DNS edit, not a hunt for hardcoded IPs.
+  ONYX_ADDR: sw-main-core.core.codelooks.com
+  MIKROTIK_POE_ADDR: sw-comms-access.core.codelooks.com
+  MIKROTIK_NONPOE_ADDR: sw-main-mgmt.core.codelooks.com


### PR DESCRIPTION
Replaces hardcoded switch IPs in monitoring with cluster-settings vars pointing at DNS names (host-overrides added in network-ops #60): `ONYX_ADDR`, `MIKROTIK_POE_ADDR`, `MIKROTIK_NONPOE_ADDR`. snmp-exporter's Onyx target and the mktxp config reference `${...}` (Flux substitutes before ESO renders). Renumber = one DNS edit.