### PR TITLE
fix(mktxp): remove literal ${...} from comment breaking envsubst

### DIFF
--- a/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/mktxp/app/externalsecret.yaml
@@ -37,8 +37,8 @@ spec:
               switch_port = True
               poe = True
 
-          # Hostnames are cluster-settings vars (Flux substitutes ${...} before
-          # ESO renders the {{ }} fields) — DNS names, not hardcoded IPs.
+          # Hostnames come from cluster-settings vars (Flux postBuild substitutes
+          # them before ESO renders the templated fields) — DNS names, not IPs.
           [CRS354-PoE]
               hostname = ${MIKROTIK_POE_ADDR}
 


### PR DESCRIPTION
The mktxp ExternalSecret comment contained a literal `${...}`, which Flux's postBuild envsubst parsed as a variable named `...` → `unable to parse variable name`. The ks failed post-build, so the DNS-hostname ExternalSecret (#3088) never applied (hosts stayed as IPs). Reworded the comment — no functional change.