### PR TITLE
feat(digger): self-hosted Digger CE orchestrator (apply-on-merge + UI + drift)

### DIFF
--- a/kubernetes/apps/infrastructure/digger/app/db-init-job.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/db-init-job.yaml
@@ -7,6 +7,15 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: digger-db-init
+  namespace: infrastructure
+  annotations:
+    # CKV_K8S_35: the postgres-init image reads INIT_POSTGRES_* only from environment
+    # variables; it has no file-based secret interface, so secrets-as-files is impossible.
+    checkov.io/skip1: CKV_K8S_35=postgres-init only accepts env vars (no file interface)
+    # CKV2_K8S_6: intra/cross-namespace traffic for this pod is governed by the
+    # infrastructure-namespace CiliumNetworkPolicy, which Checkov does not recognise as a
+    # (native) NetworkPolicy. Egress to postgres18 is already whitelisted in database/netpol.
+    checkov.io/skip2: CKV2_K8S_6=traffic governed by a CiliumNetworkPolicy Checkov can't see
 spec:
   ttlSecondsAfterFinished: 3600
   backoffLimit: 6
@@ -14,6 +23,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: digger-db-init
+      annotations:
+        checkov.io/skip1: CKV_K8S_35=postgres-init only accepts env vars (no file interface)
+        checkov.io/skip2: CKV2_K8S_6=traffic governed by a CiliumNetworkPolicy Checkov can't see
     spec:
       restartPolicy: OnFailure
       automountServiceAccountToken: false
@@ -41,4 +53,5 @@ spec:
               cpu: 10m
               memory: 32Mi
             limits:
+              cpu: 100m
               memory: 64Mi

--- a/kubernetes/apps/infrastructure/digger/app/db-init-job.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/db-init-job.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/batch/job_v1.json
+# Idempotently creates the `digger` role + database on the shared postgres18 CNPG cluster
+# (the digger-backend chart connects to an external Postgres and does NOT bootstrap the
+# role/database itself). Uses the home-operations postgres-init image, same as metabase.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: digger-db-init
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: digger-db-init
+    spec:
+      restartPolicy: OnFailure
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: init-db
+          image: ghcr.io/home-operations/postgres-init:18.4.0@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+          envFrom:
+            - secretRef:
+                name: digger-db-init-secret
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/infrastructure/digger/app/externalsecret-db.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/externalsecret-db.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Credentials for the digger-db-init Job: creates the `digger` role + database on the
+# shared postgres18 CNPG cluster (backup-covered). Superuser comes from the cnpg-managed
+# 1Password item `cloudnative-pg`; the app-role password is the same POSTGRES_PASSWORD the
+# backend uses (1Password item `digger`). Mirrors the metabase init-db convention.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: digger-db-init-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: digger-db-init-secret
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_DBNAME: digger
+        INIT_POSTGRES_USER: digger
+        INIT_POSTGRES_PASS: "{{ .POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: digger

--- a/kubernetes/apps/infrastructure/digger/app/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/externalsecret.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Backend env for the self-hosted Digger control plane. The digger-backend chart loads
+# this Secret wholesale via `envFrom`, so every key here becomes a container env var and
+# MUST match the names the backend expects. Requires 1Password item `digger` (Talos vault)
+# with the fields below. GITHUB_APP_* / GITHUB_WEBHOOK_SECRET are empty placeholders until
+# the GitHub App is created via https://digger.${SECRET_DOMAIN}/github/setup (Part B), then
+# filled in and this Secret refreshes. HOSTNAME + GITHUB_ORG are non-secret and injected via
+# the HelmRelease customEnv instead.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: digger-backend-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: digger-backend-secret
+    template:
+      engineVersion: v2
+      data:
+        # Dashboard HTTP basic auth (the UI/API gate; webhook path is exempt).
+        HTTP_BASIC_AUTH_USERNAME: "{{ .HTTP_BASIC_AUTH_USERNAME }}"
+        HTTP_BASIC_AUTH_PASSWORD: "{{ .HTTP_BASIC_AUTH_PASSWORD }}"
+        # Bearer token the dispatched CI jobs use to report back to the backend.
+        BEARER_AUTH_TOKEN: "{{ .BEARER_AUTH_TOKEN }}"
+        # Password for the `digger` role on the shared postgres18 cluster.
+        POSTGRES_PASSWORD: "{{ .POSTGRES_PASSWORD }}"
+        # GitHub App credentials (filled in Part B). Both the raw PEM and a base64
+        # variant are projected so the backend can read whichever it prefers.
+        GITHUB_APP_ID: '{{ .GITHUB_APP_ID | default "" }}'
+        GITHUB_APP_CLIENT_ID: '{{ .GITHUB_APP_CLIENT_ID | default "" }}'
+        GITHUB_APP_CLIENT_SECRET: '{{ .GITHUB_APP_CLIENT_SECRET | default "" }}'
+        GITHUB_APP_PRIVATE_KEY: '{{ .GITHUB_APP_PRIVATE_KEY | default "" }}'
+        GITHUB_APP_PRIVATE_KEY_BASE64: '{{ .GITHUB_APP_PRIVATE_KEY | default "" | b64enc }}'
+        GITHUB_WEBHOOK_SECRET: '{{ .GITHUB_WEBHOOK_SECRET | default "" }}'
+  dataFrom:
+    - extract:
+        key: digger

--- a/kubernetes/apps/infrastructure/digger/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: digger-backend
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: digger-backend
+      version: 0.1.12
+      sourceRef:
+        kind: HelmRepository
+        name: digger
+        namespace: infrastructure
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    # Pin the rendered Service to `digger-backend-web` (chart appends `-web`).
+    fullnameOverride: digger-backend
+    digger:
+      image:
+        repository: ghcr.io/diggerhq/digger_backend
+        # Aligned with the diggerhq/digger action/CLI version pinned in the repos.
+        tag: v0.6.146@sha256:485d855e92af1fb844e603b8a50e8cbea9cabdb453e2e5ea2b3da4e4d637a7ac
+      logLevel: INFO
+      # Routing is handled by Gateway-API HTTPRoutes, not the chart's native Ingress.
+      ingress:
+        enabled: false
+      service:
+        type: ClusterIP
+        port: 3000
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+      # Backend env is supplied by the digger-backend-secret ExternalSecret (envFrom).
+      secret:
+        useExistingSecret: true
+        existingSecretName: digger-backend-secret
+      # External Postgres = the shared, backup-covered postgres18 CNPG cluster. The
+      # `digger` role + database are created by the digger-db-init Job. Password is read
+      # from the same secret (key POSTGRES_PASSWORD).
+      postgres:
+        existingSecretName: digger-backend-secret
+        existingSecretKey: POSTGRES_PASSWORD
+        sslmode: disable
+        user: digger
+        database: digger
+        host: postgres18-rw.database.svc.cluster.local
+        port: "5432"
+        # First reconcile runs migrations against a fresh schema; flip to true in Part B
+        # once the schema exists so subsequent upgrades don't refuse a dirty DB.
+        allow_dirty: false
+      # Non-secret env injected here (Flux substitutes ${SECRET_DOMAIN}). HOSTNAME must be
+      # the PUBLIC URL so GitHub can deliver webhooks.
+      customEnv:
+        - name: HOSTNAME
+          value: https://digger.${SECRET_DOMAIN}
+        - name: GITHUB_ORG
+          value: codelooks-com
+    # Do not deploy the chart's bundled (ephemeral, test-only) Postgres.
+    postgres:
+      enabled: false

--- a/kubernetes/apps/infrastructure/digger/app/helmrepository.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: digger
+spec:
+  interval: 1h
+  url: https://diggerhq.github.io/helm-charts

--- a/kubernetes/apps/infrastructure/digger/app/httproute-internal.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/httproute-internal.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# INTERNAL route: the full Digger app — dashboard/UI, run history, project pages, the
+# /github/setup wizard and OAuth callback — reachable only on the internal network via the
+# internal gateway. Split-horizon DNS resolves digger.${SECRET_DOMAIN} to the internal
+# gateway for in-cluster/VPN clients, so the UI is never exposed publicly. GitHub only ever
+# needs the webhook, which is the one path served publicly (httproute.yaml).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: digger-internal
+spec:
+  hostnames:
+    - digger.${SECRET_DOMAIN}
+    - digger.${SECRET_INTERNAL_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: digger-backend-web
+          port: 3000

--- a/kubernetes/apps/infrastructure/digger/app/httproute.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/httproute.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# PUBLIC route: only the GitHub App plumbing is exposed via the external gateway —
+# the webhook (/github/webhook + the legacy /github-app-webhook), plus the setup/callback
+# endpoints under /github/ (basic-auth protected). The dashboard, run history and bearer
+# APIs live at other paths and are served ONLY by the internal route, so they are never
+# reachable from the public internet. Backend Service is `digger-backend-web:3000`.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: digger
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+spec:
+  hostnames:
+    - digger.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /github/
+        - path:
+            type: PathPrefix
+            value: /github-app-webhook
+      backendRefs:
+        - name: digger-backend-web
+          port: 3000

--- a/kubernetes/apps/infrastructure/digger/app/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/digger/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./externalsecret.yaml
+  - ./externalsecret-db.yaml
+  - ./db-init-job.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./httproute-internal.yaml

--- a/kubernetes/apps/infrastructure/digger/ks.yaml
+++ b/kubernetes/apps/infrastructure/digger/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app digger
+  namespace: &namespace infrastructure
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/infrastructure/digger/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/infrastructure/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./certwarden/ks.yaml
   - ./certwarden/cert-deployment-ks.yaml
   - ./cupdate/ks.yaml
+  - ./digger/ks.yaml
   - ./nextdns/ks.yaml
   - ./smtp-relay/ks.yaml
   - ./vlmcsd/ks.yaml


### PR DESCRIPTION
## What

Self-hosts the **Digger Community-Edition orchestrator** (`digger-backend`) in `infrastructure`,
giving the terraform repos (cloudflare, github, tailscale, nextdns) Terraform-Cloud-style
**PR plans, apply-on-merge, a web UI, and drift detection** — free, self-hosted. Replaces the
retired Terrateam control plane (#3090), modelled on its structure.

## How

- **Chart:** `digger-backend` 0.1.12, image `ghcr.io/diggerhq/digger_backend:v0.6.146` (pinned by digest, aligned with the action/CLI version in the repos). Native Ingress disabled.
- **DB:** shared **postgres18** CNPG (backup-covered). `digger` role+database created by a hardened `postgres-init` Job; backend connects as `digger`.
- **Secrets:** 1Password `Talos/digger` (backend env via `envFrom`) + `cloudnative-pg` (DB superuser for the init Job).
- **Routing:** `digger.${SECRET_DOMAIN}` — **public** exposes only the `/github/` webhook+setup plumbing (`envoy-external`); the **dashboard/UI is internal-only** (`envoy-internal`, split-horizon).

## Follow-up (not in this PR)

- **Part B (interactive):** create the GitHub App at `https://digger.${SECRET_DOMAIN}/github/setup`, install on the 4 repos, store creds in `Talos/digger`, flip `allow_dirty: true`.
- **Part C:** repoint each repo's workflow to backend (`workflow_dispatch` + `digger-spec`) mode.

GitHub App fields in `Talos/digger` are intentionally **empty** so the backend boots into the setup state.