### PR TITLE
feat(burrito): K8s-native Terraform orchestrator (replaces Digger)

### DIFF
--- a/kubernetes/apps/burrito-system/burrito/app/externalsecret-datastore.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/externalsecret-datastore.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# R2 (S3-compatible) credentials for the Burrito datastore — stores plan artifacts, run
+# logs and git bundles in the `burrito` bucket. Endpoint is passed via AWS_ENDPOINT_URL_S3
+# (the chart's s3 storage config only takes bucket + usePathStyle). Reuses the same R2
+# token as the terraform state backends (1Password Talos/cloudflare-r2-tfstate).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-datastore-r2
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: burrito-datastore-r2
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_REGION: auto
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-tfstate

--- a/kubernetes/apps/burrito-system/burrito/app/externalsecret-github.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/externalsecret-github.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Shared Git credentials for all Burrito layers — reuses the existing GitHub App
+# (digger-codelooks, App 4053936, installation 140309675) for repo read + PR comments +
+# webhook validation. The `credentials.burrito.tf/shared` type + allowed-tenants annotation
+# let layers in the `terraform` tenant namespace use it. Values from 1Password Talos/digger.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: burrito-github-app
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: burrito-github-app
+    template:
+      engineVersion: v2
+      type: credentials.burrito.tf/shared
+      metadata:
+        annotations:
+          burrito.tf/allowed-tenants: terraform
+      data:
+        provider: github
+        url: https://github.com/codelooks-com
+        githubAppID: "{{ .GITHUB_APP_ID }}"
+        githubAppInstallationID: "140309675"
+        githubAppPrivateKey: "{{ .GITHUB_APP_PRIVATE_KEY }}"
+        webhookSecret: "{{ .GITHUB_WEBHOOK_SECRET }}"
+  dataFrom:
+    - extract:
+        key: digger

--- a/kubernetes/apps/burrito-system/burrito/app/helmrelease.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/helmrelease.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: burrito
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: burrito
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  values:
+    config:
+      burrito:
+        controller:
+          # Namespaces the controllers watch for Terraform* resources.
+          namespaces:
+            - terraform
+          timers:
+            driftDetection: 10m
+            repositorySync: 5m
+        datastore:
+          # Plan artifacts / run logs / git bundles live in the Cloudflare R2 bucket
+          # `burrito` (S3-compatible). Endpoint + keys come from the env Secret below.
+          storage:
+            s3:
+              bucket: burrito
+              usePathStyle: true # R2 has no virtual-hosted-style; path-style required
+        server:
+          # UI/API behind basic auth (the webhook path is exempt + HMAC-validated).
+          basicAuth:
+            enabled: true
+    # Routing via Gateway-API HTTPRoutes, not the chart's native Ingress.
+    server:
+      ingress:
+        enabled: false
+    # Inject the R2 credentials (AWS_* + endpoint) into the datastore pod.
+    datastore:
+      deployment:
+        envFrom:
+          - secretRef:
+              name: burrito-datastore-r2
+    # Create the single tenant namespace + runner service account.
+    tenants:
+      - namespace:
+          create: true
+          name: terraform
+        serviceAccounts:
+          - name: runner

--- a/kubernetes/apps/burrito-system/burrito/app/httproute-internal.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/httproute-internal.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# INTERNAL route: the Burrito web UI + its data API, reachable only on the internal network
+# via the internal gateway (split-horizon DNS). The UI is behind basic auth; GitHub only
+# ever needs /api/webhook, which is the single path served publicly (httproute.yaml).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: burrito-ui
+spec:
+  hostnames:
+    - burrito.${SECRET_DOMAIN}
+    - burrito.${SECRET_INTERNAL_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: burrito-server
+          port: 80

--- a/kubernetes/apps/burrito-system/burrito/app/httproute.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/httproute.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+# PUBLIC route: only the GitHub webhook receiver is exposed via the external gateway.
+# GitHub POSTs push/pull_request events to /api/webhook (HMAC-validated with the shared
+# webhookSecret). Everything else — the dashboard UI and its data API — is internal-only
+# (httproute-internal.yaml), so the minimal public surface is just this one path.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: burrito-webhook
+  annotations:
+    external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+spec:
+  hostnames:
+    - burrito.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/webhook
+      backendRefs:
+        - name: burrito-server
+          port: 80

--- a/kubernetes/apps/burrito-system/burrito/app/kustomization.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret-datastore.yaml
+  - ./externalsecret-github.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./httproute-internal.yaml

--- a/kubernetes/apps/burrito-system/burrito/app/ocirepository.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: burrito
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: "0.12.0"
+  url: oci://ghcr.io/padok-team/charts/burrito

--- a/kubernetes/apps/burrito-system/burrito/ks.yaml
+++ b/kubernetes/apps/burrito-system/burrito/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app burrito
+  namespace: &namespace burrito-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/burrito-system/burrito/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  # Wait so the CRDs + the `terraform` tenant namespace exist before the layers apply.
+  wait: true

--- a/kubernetes/apps/burrito-system/kustomization.yaml
+++ b/kubernetes/apps/burrito-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: burrito-system
+components:
+  - ../../components/global-vars
+resources:
+  - ./namespace.yaml
+  - ./burrito/ks.yaml
+  - ./layers/ks.yaml

--- a/kubernetes/apps/burrito-system/layers/app/cloudflare.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/cloudflare.yaml
@@ -1,0 +1,62 @@
+---
+# Cloudflare DNS stack — OpenTofu, R2 s3 backend. Runner creds (R2 backend + Cloudflare
+# provider token) are injected from the cloudflare-creds Secret below.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: cloudflare-creds
+    template:
+      engineVersion: v2
+      data:
+        # R2 s3 backend (endpoint via env; providers.tf has no endpoints block).
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_REGION: auto
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+        # Cloudflare provider + required account-id variable.
+        TF_VAR_cloudflare_api_token: "{{ .CLOUDFLARE_API_TOKEN }}"
+        TF_VAR_cloudflare_account_id: "{{ .CLOUDFLARE_ACCOUNT_ID }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-tfstate
+    - extract:
+        key: cloudflare-terraform
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: terraform-cloudflare
+spec:
+  repository:
+    url: https://github.com/codelooks-com/terraform-cloudflare
+  terraform:
+    enabled: false
+  opentofu:
+    enabled: true
+    version: "1.12.2"
+  remediationStrategy:
+    # Plan on PR + on drift; apply is manual for now (flip to true per layer for
+    # apply-on-merge + drift self-healing once you're comfortable).
+    autoApply: false
+  overrideRunnerSpec:
+    serviceAccountName: runner
+    envFrom:
+      - secretRef:
+          name: cloudflare-creds
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: cloudflare
+spec:
+  branch: main
+  path: "."
+  repository:
+    name: terraform-cloudflare
+    namespace: terraform

--- a/kubernetes/apps/burrito-system/layers/app/kustomization.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./cloudflare.yaml

--- a/kubernetes/apps/burrito-system/layers/ks.yaml
+++ b/kubernetes/apps/burrito-system/layers/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app burrito-layers
+  namespace: burrito-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  # Needs the Terraform* CRDs + the `terraform` tenant namespace from the burrito release.
+  dependsOn:
+    - name: burrito
+      namespace: burrito-system
+  interval: 1h
+  path: ./kubernetes/apps/burrito-system/layers/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: terraform
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/burrito-system/namespace.yaml
+++ b/kubernetes/apps/burrito-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## What

Replaces the Digger control plane with **Burrito** (padok-team) — a Kubernetes-native TACoS that runs terraform in **in-cluster runner pods**, so nothing reaches back into the cluster from public runners (the architecture mismatch that made Digger's self-host painful here). Gives **plan-on-PR comments, first-class drift detection, and a web UI**.

## How

- **Operator** (`burrito-system`): controllers + server + datastore via OCI Helm chart `oci://ghcr.io/padok-team/charts/burrito` 0.12.0.
- **Datastore**: plan artifacts / logs / git bundles in the Cloudflare **R2 `burrito` bucket** (endpoint via `AWS_ENDPOINT_URL_S3`).
- **Git creds**: reuses the existing GitHub App (`digger-codelooks`, App 4053936, installation 140309675) as a shared `credentials.burrito.tf/shared` Secret.
- **Routing**: public `envoy-external` exposes only `/api/webhook`; the UI is internal-only (`envoy-internal`).
- **Tenant** `terraform` + runner SA. **Canary layer**: `terraform-cloudflare` (OpenTofu 1.12.2, R2 backend), `autoApply: false`.

## Follow-up (not in this PR)

- Point the GitHub App webhook at `https://burrito.${SECRET_DOMAIN}/api/webhook`, verify a PR plan comment.
- Add the github/tailscale/nextdns layers.
- Tear down the Digger backend (`infrastructure/digger`) + repo workflows once Burrito is green.