### PR TITLE
fix(truenas-exporter): reconcile alerts + dashboards to TrueNAS 25.10 native metrics

### DIFF
--- a/docs/truenas-monitoring.md
+++ b/docs/truenas-monitoring.md
@@ -90,7 +90,23 @@ Then point TrueNAS at it:
     - **Prefix**: `truenas`
     - **Update every**: match your Prometheus scrape interval
 
-> The exporter ships with the mapping config baked into the image, so no mapping file mount is required. Only `netdata.conf` and the Reporting exporter need to be configured TrueNAS-side.
+> The exporter ships with the mapping config baked into the image, so no mapping file mount is required.
+
+**Preferred (no hand-edited config):** create the Reporting exporter via the REST API instead of the
+GUI — it reconfigures the built-in netdata's exporting engine the supported way, with no
+`/etc/netdata/netdata.conf` hand-edit (which TrueNAS middleware manages/overwrites):
+
+```bash
+midclt call reporting.exporters.create '{"enabled": true, "name": "prometheus-graphite",
+  "attributes": {"exporter_type": "GRAPHITE", "destination_ip": "127.0.0.1",
+  "destination_port": 9109, "prefix": "truenas", "namespace": "truenas",
+  "update_every": 10, "send_names_instead_of_ids": true, "matching_charts": "*"}}'
+```
+
+> **Do NOT** deploy the upstream `netdata.conf` on 25.10 unless you accept the trade-off: it
+> switches netdata to vanilla charts (so the upstream dashboards match) but degrades the native
+> TrueNAS **Reporting UI** and is overwritten on update. `prefix` MUST be `truenas` (the bridge
+> mapping hardcodes it).
 
 ### 4. Verify Exporters are Running
 
@@ -103,13 +119,36 @@ curl http://localhost:9100/metrics
 # Test smartctl-exporter
 curl http://localhost:9633/metrics
 
-# Test truenas-graphite-exporter (should show zfs_*, disk_*, cpu_* series once netdata is pushing)
+# Test truenas-graphite-exporter (should show truenas_arcstats, disk_io, cpu_temperature,
+# cgroup_*, nfs_*, interface_* series once netdata is pushing — see "Metric reality" below)
 curl http://localhost:9108/metrics
 ```
 
 ### 5. Configure TrueNAS Firewall (if needed)
 
 If TrueNAS has a firewall enabled, ensure ports 9100, 9633, and 9108 are accessible from your Kubernetes cluster network. Port 9109 only needs to be reachable from netdata on the TrueNAS host itself.
+
+## Metric reality on TrueNAS SCALE 25.10 (verified 2026-06-14)
+
+25.10's netdata emits a **reduced, custom-named** chart set, so the bridge does **not** reproduce
+the full vanilla-netdata metric set the upstream mapping + dashboards assume. Confirmed against live
+`/metrics` on `cr-storage`:
+
+| Area                     | Present                                             | Notes                                                                                                                                                           |
+| ------------------------ | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Disk I/O                 | `disk_io`, `disk_io_ops`, `disk_busy`               | no `disk_await/utilization/qops/size/iotime/backlog`                                                                                                            |
+| CPU temp                 | `cpu_temperature`                                   | ✅                                                                                                                                                              |
+| cgroups / k8s            | `cgroup_*`                                          | ✅ full                                                                                                                                                         |
+| NFS / network / services | `nfs_*`, `interface_*`, `services_*`, `system_load` | ✅                                                                                                                                                              |
+| ZFS ARC                  | `truenas_arcstats{type=...}`                        | raw chart — **not** vanilla `zfs.arc_size`; bridged to `zfs_arc_size` / `zfs_arc_free_bytes` / `zfs_arc_hit_ratio` via recording rules in `prometheusrule.yaml` |
+| ZFS pool state           | **absent**                                          | no `zfs_pool`/scrub metric — rely on TrueNAS native ZFS event detection + alerts                                                                                |
+| Disk temperature         | **absent** from graphite                            | use `smartctl_device_temperature` (smartctl-exporter) — the disk-temp alert is repointed there                                                                  |
+| Memory / detailed CPU    | **absent**                                          | `physical_memory`/`memory_*`/`cpu_frequency` not emitted                                                                                                        |
+
+Consequence for the bundled dashboards: **cgroups** is fully populated; **disk_insights**,
+**temperatures**, and the main **truenas_scale** dashboard are partial (empty panels for the absent
+metrics); **applications_k3s** was removed (it targets `k3s_pod_*` — this box runs Talos separately).
+A faithful ZFS dashboard needs either the netdata.conf swap (declined above) or a bespoke dashboard.
 
 ## Kubernetes Configuration
 

--- a/kubernetes/apps/observability/truenas-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/grafanadashboard.yaml
@@ -1,4 +1,15 @@
 ---
+# COVERAGE NOTE (TrueNAS SCALE 25.10 "Goldeye", verified against live /metrics 2026-06-14):
+# 25.10's netdata emits a reduced, custom-named chart set vs the vanilla netdata these
+# upstream dashboards target. Real coverage on this box:
+#   • cgroups        — ✅ full (all cgroup_* present)
+#   • disk_insights  — ⚠️ partial (disk_io/io_ops/busy yes; await/utilization/qops/size/iotime no)
+#   • temperatures   — ⚠️ cpu_temperature yes; disk_temperature absent (disk temps via smartctl-exporter)
+#   • truenas_scale  — ⚠️ system/disk-io/nfs/interface/services yes; ARC size via the zfs_arc_size
+#                        recording rule (prometheusrule.yaml); memory_*, detailed cpu, zfs_pool absent
+# applications_k3s removed — it queries k3s_pod_* (k3s-on-TrueNAS); this box runs Talos separately.
+# Faithfully reproducing the ZFS/memory panels needs either the upstream netdata.conf swap
+# (declined — impacts the TrueNAS Reporting UI) or a bespoke dashboard. See docs/truenas-monitoring.md.
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -68,20 +79,3 @@ spec:
       inputName: DS_MIMIR
   # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
   url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale_cgroups.json
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
-apiVersion: grafana.integreatly.org/v1beta1
-kind: GrafanaDashboard
-metadata:
-  name: truenas-scale-applications-k3s
-spec:
-  allowCrossNamespaceImport: true
-  instanceSelector:
-    matchLabels:
-      grafana.internal/instance: grafana
-  resyncPeriod: 1h
-  datasources:
-    - datasourceName: prometheus
-      inputName: DS_MIMIR
-  # renovate: depName="Supporterino/truenas-graphite-to-prometheus" datasource=github-tags
-  url: https://raw.githubusercontent.com/Supporterino/truenas-graphite-to-prometheus/v2.2.1/dashboards/truenas_scale_applications_k3s.json

--- a/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
@@ -6,6 +6,30 @@ metadata:
   name: truenas-exporter.rules
 spec:
   groups:
+    # ------------------------------------------------------------------
+    # Recording rules — bridge TrueNAS SCALE 25.10's raw netdata arcstats
+    # into conventional zfs_arc_* series. 25.10 emits `truenas_arcstats{type=...}`
+    # (a rawer chart than vanilla netdata's zfs.arc_size), so the upstream
+    # dashboard's zfs_arc_size panel is otherwise empty. Verified against live
+    # /metrics 2026-06-14 — see docs/truenas-monitoring.md "metric reality".
+    # ------------------------------------------------------------------
+    - name: truenas-exporter.recording
+      rules:
+        # Current ARC size (bytes). op="arcsz" matches the upstream panel's
+        # zfs_arc_size{op=~"arcsz|target"} (no separate "target" series exists).
+        - record: zfs_arc_size
+          expr: |-
+            label_replace(truenas_arcstats{job="truenas-graphite-exporter", type="size"}, "op", "arcsz", "", "")
+        - record: zfs_arc_free_bytes
+          expr: |-
+            truenas_arcstats{job="truenas-graphite-exporter", type="free"}
+        # ARC hit ratio (%), from demand data+metadata hits vs hits+misses.
+        - record: zfs_arc_hit_ratio
+          expr: |-
+            100
+            * sum by (instance) (truenas_arcstats{job="truenas-graphite-exporter", type=~"dmhit|ddhit"})
+            / clamp_min(sum by (instance) (truenas_arcstats{job="truenas-graphite-exporter", type=~"dmhit|ddhit|dmmis|ddmis"}), 1)
+
     - name: truenas-exporter.rules
       rules:
         - alert: TrueNASGraphiteExporterDown
@@ -16,22 +40,14 @@ spec:
           for: 5m
           labels:
             severity: critical
-        # NOTE: zfs_pool encodes pool state as netdata dimensions. Confirm the exact
-        # label key/value against the live /metrics output (or METRICS.md) before
-        # relying on this — if the label schema differs the rule is a silent no-op.
-        - alert: TrueNASZFSPoolNotHealthy
-          annotations:
-            summary: "TrueNAS ZFS pool {{ $labels.pool }} is not ONLINE (state {{ $labels.state }})."
-          expr: |-
-            zfs_pool{job="truenas-graphite-exporter", state="online"} != 1
-          for: 5m
-          labels:
-            severity: critical
+        # Disk temperature comes from smartctl-exporter (per-device, already scraped),
+        # NOT the graphite bridge: TrueNAS 25.10 netdata does not export a
+        # disk_temperature series (only cpu_temperature). See docs/truenas-monitoring.md.
         - alert: TrueNASDiskTemperatureHigh
           annotations:
-            summary: "TrueNAS disk {{ $labels.disk }} temperature is {{ $value }}°C."
+            summary: "TrueNAS disk {{ $labels.device }} temperature is {{ $value }}°C."
           expr: |-
-            disk_temperature{job="truenas-graphite-exporter"} > 60
+            smartctl_device_temperature{job="smartctl-exporter", temperature_type="current"} > 60
           for: 10m
           labels:
             severity: warning
@@ -43,3 +59,9 @@ spec:
           for: 10m
           labels:
             severity: warning
+        # NOTE: no ZFS pool-state alert here. TrueNAS 25.10 netdata exposes no
+        # zfs_pool/scrub-state metric via the graphite bridge (only the absent
+        # truenas_pool.usage chart). Pool degradation/scrub failures are covered by
+        # TrueNAS's own real-time ZFS event detection + system alerts. Revisit if a
+        # pool-state metric becomes available (e.g. the netdata.conf swap, declined
+        # for its impact on the TrueNAS Reporting UI).


### PR DESCRIPTION
The graphite bridge is now `up=1`, but TrueNAS SCALE 25.10 netdata emits a **reduced, custom-named** chart set vs the vanilla netdata the upstream alerts/dashboards assume (verified against live `/metrics`). This reconciles the cluster side to what actually exists.

## Alerts (`prometheusrule.yaml`)
- ❌→ **Remove** `TrueNASZFSPoolNotHealthy` — no `zfs_pool`/scrub metric exists on 25.10 (was a silent no-op). Pool degradation is covered by TrueNAS's own real-time ZFS event detection + alerts.
- 🔁 **Repoint** `TrueNASDiskTemperatureHigh` to `smartctl_device_temperature` (smartctl-exporter, already scraped — **90 series @ ~38°C**); the graphite bridge has no `disk_temperature`.
- ✅ Keep exporter-down + cpu-temp.
- ➕ **Recording rules** bridging raw `truenas_arcstats{type=…}` → `zfs_arc_size` (**223 GB**), `zfs_arc_free_bytes`, `zfs_arc_hit_ratio` (**99.1%**). All exprs validated against live Prometheus.

## Dashboards (`grafanadashboard.yaml`)
- **Remove** `applications_k3s` (queries `k3s_pod_*` — this box runs Talos separately).
- Document coverage: **cgroups** full; **disk_insights / temperatures / truenas_scale** partial (empty panels for absent `zfs_*`/`memory_*`/`disk_*` detail metrics).

## Docs
- Prefer `reporting.exporters` REST API over hand-editing `/etc/netdata/netdata.conf` (middleware-managed); add a **Metric reality on 25.10** table.

> A faithful ZFS/memory dashboard would need either the upstream `netdata.conf` swap (declined — degrades the TrueNAS Reporting UI + overwritten on update) or a bespoke dashboard.