### PR TITLE
feat(burrito): add github, tailscale, nextdns layers

### DIFF
--- a/kubernetes/apps/burrito-system/layers/app/github.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/github.yaml
@@ -1,0 +1,57 @@
+---
+# GitHub repositories stack — OpenTofu, R2 s3 backend. Provider token + R2 backend creds
+# injected from the github-creds Secret. (owner vars are defaulted in the repo's variables.tf)
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: github-creds
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_REGION: auto
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+        TF_VAR_github_token: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-tfstate
+    - extract:
+        key: github-terraform
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: terraform-github
+spec:
+  repository:
+    url: https://github.com/codelooks-com/terraform-github
+  terraform:
+    enabled: false
+  opentofu:
+    enabled: true
+    version: "1.12.2"
+  remediationStrategy:
+    autoApply: false
+  overrideRunnerSpec:
+    serviceAccountName: runner
+    envFrom:
+      - secretRef:
+          name: github-creds
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: github
+spec:
+  branch: main
+  path: "."
+  repository:
+    name: terraform-github
+    namespace: terraform

--- a/kubernetes/apps/burrito-system/layers/app/kustomization.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/kustomization.yaml
@@ -4,3 +4,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./cloudflare.yaml
+  - ./github.yaml
+  - ./tailscale.yaml
+  - ./nextdns.yaml

--- a/kubernetes/apps/burrito-system/layers/app/nextdns.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/nextdns.yaml
@@ -1,0 +1,57 @@
+---
+# NextDNS profile-as-code stack — OpenTofu, R2 s3 backend. profile_ids are committed in
+# inventory.auto.tfvars (non-secret); only the API key + R2 backend creds are injected.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nextdns-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: nextdns-creds
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_REGION: auto
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+        TF_VAR_nextdns_api_key: "{{ .NEXTDNS_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-tfstate
+    - extract:
+        key: nextdns-terraform
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: terraform-nextdns
+spec:
+  repository:
+    url: https://github.com/codelooks-com/terraform-nextdns
+  terraform:
+    enabled: false
+  opentofu:
+    enabled: true
+    version: "1.12.2"
+  remediationStrategy:
+    autoApply: false
+  overrideRunnerSpec:
+    serviceAccountName: runner
+    envFrom:
+      - secretRef:
+          name: nextdns-creds
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: nextdns
+spec:
+  branch: main
+  path: "."
+  repository:
+    name: terraform-nextdns
+    namespace: terraform

--- a/kubernetes/apps/burrito-system/layers/app/tailscale.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/tailscale.yaml
@@ -1,0 +1,59 @@
+---
+# Tailscale tailnet policy stack — OpenTofu, R2 s3 backend. The ACL lives in acl.hujson at
+# the repo root, so it's covered by the layer's path ".". Creds from tailscale-creds.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tailscale-creds
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tailscale-creds
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_REGION: auto
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+        TF_VAR_tailscale_oauth_client_id: "{{ .TS_OAUTH_CLIENT_ID }}"
+        TF_VAR_tailscale_oauth_client_secret: "{{ .TS_OAUTH_CLIENT_SECRET }}"
+        TF_VAR_tailscale_tailnet: "{{ .TS_TAILNET }}"
+  dataFrom:
+    - extract:
+        key: cloudflare-r2-tfstate
+    - extract:
+        key: tailscale-terraform
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformRepository
+metadata:
+  name: terraform-tailscale
+spec:
+  repository:
+    url: https://github.com/codelooks-com/terraform-tailscale
+  terraform:
+    enabled: false
+  opentofu:
+    enabled: true
+    version: "1.12.2"
+  remediationStrategy:
+    autoApply: false
+  overrideRunnerSpec:
+    serviceAccountName: runner
+    envFrom:
+      - secretRef:
+          name: tailscale-creds
+---
+apiVersion: config.terraform.padok.cloud/v1alpha1
+kind: TerraformLayer
+metadata:
+  name: tailscale
+spec:
+  branch: main
+  path: "."
+  repository:
+    name: terraform-tailscale
+    namespace: terraform


### PR DESCRIPTION
Adds the remaining Burrito layers (TerraformRepository + TerraformLayer + provider-creds ExternalSecret) for terraform-github, terraform-tailscale, terraform-nextdns. Same pattern as the cloudflare canary (OpenTofu 1.12.2, R2 backend, autoApply off). Creds from the Talos vault (github-terraform PAT copied in).