### PR TITLE
fix(opnsense-exporter): pin dashboard to grafana.com revision 1

### DIFF
--- a/kubernetes/apps/observability/opnsense-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/grafanadashboard.yaml
@@ -15,5 +15,7 @@ spec:
   grafanaCom:
     # renovate: depName="OPNsense"
     # Official AthennaMind/opnsense-exporter dashboard.
+    # NOTE: grafana.com dashboard 21113 only publishes revision 1; revisions >1
+    # 404 and leave the CR in InvalidModelResolution (dashboard never loads).
     id: 21113
-    revision: 3
+    revision: 1


### PR DESCRIPTION
Dashboard 21113 only publishes revision 1; the pinned revision 3 returns
404, leaving the GrafanaDashboard CR in InvalidModelResolution so the
dashboard never loads into Grafana despite the exporter being up and
emitting ~60 opnsense_* series.
