### PR TITLE
chore(burrito): point git-creds ExternalSecret at renamed Talos/burrito item

### DIFF
--- a/kubernetes/apps/burrito-system/burrito/app/externalsecret-github.yaml
+++ b/kubernetes/apps/burrito-system/burrito/app/externalsecret-github.yaml
@@ -3,7 +3,7 @@
 # Shared Git credentials for all Burrito layers — reuses the existing GitHub App
 # (digger-codelooks, App 4053936, installation 140309675) for repo read + PR comments +
 # webhook validation. The `credentials.burrito.tf/shared` type + allowed-tenants annotation
-# let layers in the `terraform` tenant namespace use it. Values from 1Password Talos/digger.
+# let layers in the `terraform` tenant namespace use it. Values from 1Password Talos/burrito.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -29,4 +29,4 @@ spec:
         webhookSecret: "{{ .GITHUB_WEBHOOK_SECRET }}"
   dataFrom:
     - extract:
-        key: digger
+        key: burrito


### PR DESCRIPTION
Follow-up to the GitHub-App/1Password rename. The Talos vault item `digger` was renamed to `burrito`; update Burrito's shared git-credentials ExternalSecret `extract.key` to `burrito` so it keeps resolving.