### PR TITLE
fix(burrito): TENV_GITHUB_TOKEN for runners (avoid GitHub rate limits)

### DIFF
--- a/kubernetes/apps/burrito-system/layers/app/cloudflare.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/cloudflare.yaml
@@ -49,6 +49,8 @@ spec:
     envFrom:
       - secretRef:
           name: cloudflare-creds
+      - secretRef:
+          name: tenv-token
 ---
 apiVersion: config.terraform.padok.cloud/v1alpha1
 kind: TerraformLayer

--- a/kubernetes/apps/burrito-system/layers/app/github.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/github.yaml
@@ -44,6 +44,8 @@ spec:
     envFrom:
       - secretRef:
           name: github-creds
+      - secretRef:
+          name: tenv-token
 ---
 apiVersion: config.terraform.padok.cloud/v1alpha1
 kind: TerraformLayer

--- a/kubernetes/apps/burrito-system/layers/app/kustomization.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./tenv-token.yaml
   - ./cloudflare.yaml
   - ./github.yaml
   - ./tailscale.yaml

--- a/kubernetes/apps/burrito-system/layers/app/nextdns.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/nextdns.yaml
@@ -44,6 +44,8 @@ spec:
     envFrom:
       - secretRef:
           name: nextdns-creds
+      - secretRef:
+          name: tenv-token
 ---
 apiVersion: config.terraform.padok.cloud/v1alpha1
 kind: TerraformLayer

--- a/kubernetes/apps/burrito-system/layers/app/tailscale.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/tailscale.yaml
@@ -46,6 +46,8 @@ spec:
     envFrom:
       - secretRef:
           name: tailscale-creds
+      - secretRef:
+          name: tenv-token
 ---
 apiVersion: config.terraform.padok.cloud/v1alpha1
 kind: TerraformLayer

--- a/kubernetes/apps/burrito-system/layers/app/tenv-token.yaml
+++ b/kubernetes/apps/burrito-system/layers/app/tenv-token.yaml
@@ -1,0 +1,21 @@
+---
+# Shared GitHub token for the runners' `tenv` binary downloader — without it, tenv hits
+# GitHub's anonymous API rate limit (60/h) when fetching the OpenTofu binary and runs fail.
+# Reuses the github-terraform PAT (public-read is all tenv needs).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tenv-token
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tenv-token
+    template:
+      engineVersion: v2
+      data:
+        TENV_GITHUB_TOKEN: "{{ .GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: github-terraform


### PR DESCRIPTION
Runner pods use tenv to fetch the OpenTofu binary from GitHub; the anonymous 60/h API rate limit was failing plan runs. Adds a shared `tenv-token` secret (TENV_GITHUB_TOKEN) to every layer's runner env.