### PR TITLE
fix(opnsense-exporter): map dashboard datasource input DS_PROMETHEUS-K0

### DIFF
--- a/kubernetes/apps/observability/opnsense-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/grafanadashboard.yaml
@@ -9,9 +9,13 @@ spec:
   instanceSelector:
     matchLabels:
       grafana.internal/instance: grafana
+  # Dashboard 21113 declares its datasource __input as "DS_PROMETHEUS-K0" (label
+  # "prometheus-k0") and references ${DS_PROMETHEUS-K0} in all 38 targets + the
+  # opnsense_instance template var. inputName MUST match that exactly or the
+  # operator leaves it unbound → variable errors and every panel reads "No data".
   datasources:
     - datasourceName: prometheus
-      inputName: DS_PROMETHEUS
+      inputName: DS_PROMETHEUS-K0
   grafanaCom:
     # renovate: depName="OPNsense"
     # Official AthennaMind/opnsense-exporter dashboard.


### PR DESCRIPTION
Dashboard 21113 declares its datasource __input as DS_PROMETHEUS-K0 (not
DS_PROMETHEUS) and references ${DS_PROMETHEUS-K0} across all 38 targets and
the opnsense_instance template variable. The CR mapped the wrong inputName so
the operator never substituted the datasource: the variable errored and every
panel read "No data" despite the exporter being up with ~60 opnsense_* series.
