### PR TITLE
feat(shelly-operator): bump 0.3.1 -- friendly names in alerts

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.3.0@sha256:aa58ebced0075501d917d0971f53537fb7a765c8ad812eedeaa0b1868d99d2bb
+      tag: 0.3.1@sha256:8c0c019036f4f219345e85a865a0cbd883bc96e8d12b4c7332dc59119986ba63
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.3.0
+    tag: 0.3.1
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator

--- a/kubernetes/apps/home/shelly-operator/app/prometheusrule.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/prometheusrule.yaml
@@ -19,8 +19,9 @@ spec:
           annotations:
             summary: Shelly device offline.
             description: >-
-              {{ $labels.name }} ({{ $labels.mac }}) has been offline
-              (undiscovered by the operator sweep) for over 15m.
+              {{ $labels.name }}{{ with $labels.room }} in {{ . }}{{ end }}
+              ({{ $labels.mac }}) has been offline (undiscovered by the
+              operator sweep) for over 15m.
           expr: shelly_device_online == 0
           for: 15m
           labels:
@@ -29,9 +30,9 @@ spec:
           annotations:
             summary: Shelly device config drift not converging.
             description: >-
-              {{ $labels.name }} ({{ $labels.mac }}) is online but its config
-              has not matched its profile for over 1h (enforcement failing or
-              damped).
+              {{ $labels.name }}{{ with $labels.room }} in {{ . }}{{ end }}
+              ({{ $labels.mac }}) is online but its config has not matched its
+              profile for over 1h (enforcement failing or damped).
           # Online only -- an offline device is covered by ShellyDeviceOffline.
           expr: (shelly_device_in_sync == 0) and on(mac, name) (shelly_device_online == 1)
           for: 1h
@@ -41,9 +42,10 @@ spec:
           annotations:
             summary: Shelly device has a pending firmware update.
             description: >-
-              {{ $labels.name }} ({{ $labels.mac }}) has had a stable firmware
-              update available for over 24h -- auto-update may not be working
-              (it should apply at the device's daily 00:00 window).
+              {{ $labels.name }}{{ with $labels.room }} in {{ . }}{{ end }}
+              ({{ $labels.mac }}) has had a stable firmware update available for
+              over 24h -- auto-update may not be working (it should apply at the
+              device's daily 00:00 window).
           expr: shelly_device_update_available == 1
           for: 24h
           labels:


### PR DESCRIPTION
## What
shelly-operator **v0.3.1** resolves the `shelly_device_*` metrics' `name` label from the **device registry** instead of the (empty) on-device name, and adds `room` + `appliance` labels. This fixes AlertManager alerts that showed raw MACs (`2cbcbb2e77a8 (...) has been offline`) -- they now show friendly names, even for offline devices.

## Changes
- `ocirepository.yaml`: chart `0.3.0` -> `0.3.1`
- `helmrelease.yaml`: image `0.3.1@sha256:8c0c019…`
- `prometheusrule.yaml`: enrich all 3 alert descriptions with the new `room` label via `{{ with $labels.room }} in {{ . }}{{ end }}` -- roomed devices read *"DAC/Amp in Office (MAC)"*, roomless ones (PDU-01/02) stay clean.

No CRD field changes in v0.3.1 (metrics-only), so `CreateReplace` is a no-op this bump.

## After merge
Flux reconciles the operator to 0.3.1; the next scrape carries friendly names, and the firing ShellyDeviceOffline (DAC/Amp) re-renders readably.