### PR TITLE
feat(ai): LLM stack — LiteLLM uplift, ToolHive MCP, memini, llmkube

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -58,3 +58,13 @@ misconfigurations:
       Required ARC kubernetes-mode container-hook RBAC: the hook creates and
       deletes a per-job secret to inject the workflow context. Scoped to
       actions-runner-system.
+
+  - id: KSV-0046
+    paths:
+      - "kubernetes/apps/ai/toolhive/mcp-servers/kubectl/rbac.yaml"
+    statement: |-
+      Intentional read-only ClusterRole. kubectl-mcp-readonly grants only
+      get/list/watch for the kubectl + flux MCP servers. resources: ["*"]
+      applies to non-core API groups only (Secret objects live in the core
+      "" group, which is listed explicitly with `secrets` omitted). The
+      breadth lets the MCP inspect any CRD; no write or management verbs.

--- a/docs/ai-llm-stack.md
+++ b/docs/ai-llm-stack.md
@@ -11,7 +11,7 @@ re-targeted to this cluster — **NVIDIA L4 GPUs + Ollama** instead of his AMD/M
 | `litellm`    | OpenAI-compatible gateway: routing, fallbacks, cache, metrics, MCP | live              |
 | `ollama`     | local inference (3× L4, one per node); embeddings + general chat   | live              |
 | `open-webui` | chat UI                                                            | live              |
-| `toolhive`   | MCP server fleet, aggregated + proxied to LiteLLM                  | Layer 2 (planned) |
+| `toolhive`   | MCP servers (kubectl/flux/talos/searxng) wired into LiteLLM        | live              |
 | `memini`     | agent long-term memory                                             | Layer 3 (planned) |
 | `llmkube`    | llama.cpp serving for select hot models on L4 (CUDA)               | Layer 4 (planned) |
 
@@ -36,14 +36,15 @@ llama.cpp backends to the existing `self-hosted` group with no client change.
 
 1. **LiteLLM uplift** — model-groups + router fallbacks + commented hooks for MCP / embeddings /
    cloud providers.
-2. **ToolHive + MCP** — operator + curated MCP servers (kubectl, flux, talos, github, grafana,
-   searxng), aggregated via `VirtualMCPServer`; wired into LiteLLM `mcp_servers` + semantic filter.
+2. **ToolHive + MCP** — operator + curated MCP servers (kubectl, flux, talos, searxng) wired into
+   LiteLLM `mcp_servers`. (VirtualMCPServer aggregate + semantic filter deferred — see below.)
 3. **memini** — agent memory; embeddings via Ollama, consolidation via LiteLLM.
 4. **llmkube** — llama.cpp `Model` + `InferenceService` CRs on L4 (CUDA); registered as
    `self-hosted` group backends. Optional ComfyUI image gen.
 
-Each layer is its own PR. Cross-layer wiring (e.g. `mcp_servers`) is staged as commented blocks in
-`litellm/app/configmap.yaml` and switched on when the producing layer lands.
+Each layer is a separate commit on one branch (one PR). Cross-layer wiring (e.g. `mcp_servers`) is
+staged as commented blocks in `litellm/app/configmap.yaml` and switched on when the producing layer
+lands.
 
 > Not ported from Jory's repo: `hermes`, `openclaw` (agent runtimes), and `agentmemory` (whose main
 > consumers are hermes/openclaw).
@@ -57,6 +58,74 @@ Each layer is its own PR. Cross-layer wiring (e.g. `mcp_servers`) is staged as c
   `configmap.yaml`. Don't reference an `os.environ/KEY` that isn't in the secret — the pod env read
   fails at startup.
 - **Fallbacks** — `router_settings.fallbacks` is a list of `{model_name: [fallback, …]}`.
+
+## MCP tools (ToolHive)
+
+Layer 2 runs the [StackLok ToolHive](https://github.com/stacklok/toolhive) operator (`0.29.3`,
+separate CRDs + operator charts) in `ai`, an `MCPGroup` (`mcp-tools`), and these MCP servers, all
+wired into LiteLLM's `mcp_servers`:
+
+| Server    | Source                          | Access                              |
+| --------- | ------------------------------- | ----------------------------------- |
+| `kubectl` | kubectl-mcp-server              | cluster read-only, secrets excluded |
+| `flux`    | flux-operator-mcp               | Flux read-only (write is opt-in)    |
+| `talos`   | talos-mcp                       | Talos `os:reader` (talosconfig SA)  |
+| `searxng` | mcp-searxng → `searxng.default` | web search                          |
+
+kubectl + flux share one read-only `ClusterRole` (`kubectl-mcp-readonly`) built from this cluster's
+API groups with core `secrets` omitted — keep it in sync with `kubectl api-resources` as you add
+CRDs. The talos MCP mounts a `talos.dev` `ServiceAccount`-minted `os:reader` talosconfig.
+
+Deferred (add later): the `VirtualMCPServer` aggregate + `EmbeddingServer` (a single
+`mcp.<domain>` endpoint for non-LiteLLM clients — it's what pulls in a Dragonfly + embedder),
+`github` (needs a PAT in 1Password), `grafana-mcp` (needs a grafana MCP server), and LiteLLM's
+`mcp_semantic_tool_filter` (only worth enabling past ~50 tools).
+
+### Enabling flux-mcp write access
+
+The flux MCP is read-only by default. To let it — and therefore any model behind LiteLLM —
+reconcile / suspend / resume / apply / delete Flux objects, append to
+`toolhive/mcp-servers/flux/rbac.yaml` and add it to that dir's `kustomization.yaml`:
+
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: flux-mcp-write
+rules:
+    - apiGroups:
+          - fluxcd.controlplane.io
+          - helm.toolkit.fluxcd.io
+          - image.toolkit.fluxcd.io
+          - kustomize.toolkit.fluxcd.io
+          - notification.toolkit.fluxcd.io
+          - source.toolkit.fluxcd.io
+      resources: ["*"]
+      verbs: ["create", "patch", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: flux-mcp-write
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: flux-mcp-write
+subjects:
+    - kind: ServiceAccount
+      name: flux-mcp
+      namespace: ai
+```
+
+This grants an LLM mutate access to the cluster's GitOps controller — enable only if you trust the
+calling chain.
+
+### Adding an MCP server
+
+Drop an `MCPServer` (operator-managed) or `MCPServerEntry` (remote URL) with `groupRef: mcp-tools`
+under `toolhive/mcp-servers/<name>/`, list it in that dir's `kustomization.yaml`, then add its
+endpoint to LiteLLM's `mcp_servers`. The service is `mcp-<name>` on the spec's `mcpPort`.
 
 ## Gotchas
 

--- a/docs/ai-llm-stack.md
+++ b/docs/ai-llm-stack.md
@@ -1,0 +1,70 @@
+# AI / LLM stack
+
+Self-hosted LLM stack in the `ai` namespace, fronted by **LiteLLM**. Patterns adapted from
+[joryirving/home-ops](https://github.com/joryirving/home-ops/tree/main/kubernetes/apps/base/llm),
+re-targeted to this cluster — **NVIDIA L4 GPUs + Ollama** instead of his AMD/Mac/llama.cpp gear.
+
+## Components
+
+| App          | Role                                                               | Status            |
+| ------------ | ------------------------------------------------------------------ | ----------------- |
+| `litellm`    | OpenAI-compatible gateway: routing, fallbacks, cache, metrics, MCP | live              |
+| `ollama`     | local inference (3× L4, one per node); embeddings + general chat   | live              |
+| `open-webui` | chat UI                                                            | live              |
+| `toolhive`   | MCP server fleet, aggregated + proxied to LiteLLM                  | Layer 2 (planned) |
+| `memini`     | agent long-term memory                                             | Layer 3 (planned) |
+| `llmkube`    | llama.cpp serving for select hot models on L4 (CUDA)               | Layer 4 (planned) |
+
+LiteLLM persists to CNPG `postgres18` (`litellm` db) and caches in Dragonfly. Internal-only route
+(`litellm.${SECRET_INTERNAL_DOMAIN}`, envoy-internal).
+
+## Ollama vs llama.cpp
+
+Not either/or — **pick per model, LiteLLM fronts both**:
+
+- **Ollama** = the "it just works" tier: embeddings, zero-fuss model pulls, auto model-swap,
+  keep-alive. Already running on 3 nodes. Default backend for `self-hosted` and embeddings.
+- **llama.cpp** (Layer 4, via llmkube) = the tuned tier for the 1–2 hot models where the knobs pay
+  off on a 24 GB L4: KV-cache quant (`q8_0` ≈ 2× context), speculative decoding, flash-attn,
+  reasoning budgets, per-model `llamacpp_*` metrics. Cost: you own GGUF staging + one model/server.
+
+LiteLLM model-**groups** make this transparent: several backends share one client-facing
+`model_name` with an `order:`, and LiteLLM load-balances / fails over across them. So Layer 4 adds
+llama.cpp backends to the existing `self-hosted` group with no client change.
+
+## Rollout (staged)
+
+1. **LiteLLM uplift** — model-groups + router fallbacks + commented hooks for MCP / embeddings /
+   cloud providers.
+2. **ToolHive + MCP** — operator + curated MCP servers (kubectl, flux, talos, github, grafana,
+   searxng), aggregated via `VirtualMCPServer`; wired into LiteLLM `mcp_servers` + semantic filter.
+3. **memini** — agent memory; embeddings via Ollama, consolidation via LiteLLM.
+4. **llmkube** — llama.cpp `Model` + `InferenceService` CRs on L4 (CUDA); registered as
+   `self-hosted` group backends. Optional ComfyUI image gen.
+
+Each layer is its own PR. Cross-layer wiring (e.g. `mcp_servers`) is staged as commented blocks in
+`litellm/app/configmap.yaml` and switched on when the producing layer lands.
+
+> Not ported from Jory's repo: `hermes`, `openclaw` (agent runtimes), and `agentmemory` (whose main
+> consumers are hermes/openclaw).
+
+## How to extend LiteLLM
+
+- **Add a backend to a group** — add a `model_list` entry with an existing `model_name` and the
+  next `order:`. LiteLLM balances / fails over within the group.
+- **Add a cloud provider** — add the key to the `litellm` 1Password item, add a line to
+  `externalsecret.yaml`'s `target.template.data`, then uncomment the matching stub in
+  `configmap.yaml`. Don't reference an `os.environ/KEY` that isn't in the secret — the pod env read
+  fails at startup.
+- **Fallbacks** — `router_settings.fallbacks` is a list of `{model_name: [fallback, …]}`.
+
+## Gotchas
+
+- **Public repo** — no LAN IPs / internal hostnames in git (see `CLAUDE.md`). Cluster service DNS
+  and `${SECRET_*}` placeholders are fine.
+- **Metrics** — `require_auth_for_metrics_endpoint: false` **and** ServiceMonitor path `/metrics/`
+  (trailing slash, no redirect-follow) are both required for in-cluster Prometheus scraping.
+- **Ollama embeddings** — the StatefulSet has 3 separate RWO PVCs, so an embedding model must be
+  pulled on **every** replica or requests routed to a replica that lacks it fail.
+- **ConfigMap reloads** — the `litellm` controller is annotated `reloader.stakater.com/auto`, so
+  Stakater Reloader restarts it automatically when the configmap changes.

--- a/docs/ai-llm-stack.md
+++ b/docs/ai-llm-stack.md
@@ -12,7 +12,7 @@ re-targeted to this cluster — **NVIDIA L4 GPUs + Ollama** instead of his AMD/M
 | `ollama`     | local inference (3× L4, one per node); embeddings + general chat   | live              |
 | `open-webui` | chat UI                                                            | live              |
 | `toolhive`   | MCP servers (kubectl/flux/talos/searxng) wired into LiteLLM        | live              |
-| `memini`     | agent long-term memory                                             | Layer 3 (planned) |
+| `memini`     | agent long-term memory (sqlite + CPU embed/rerank)                 | live              |
 | `llmkube`    | llama.cpp serving for select hot models on L4 (CUDA)               | Layer 4 (planned) |
 
 LiteLLM persists to CNPG `postgres18` (`litellm` db) and caches in Dragonfly. Internal-only route
@@ -38,7 +38,8 @@ llama.cpp backends to the existing `self-hosted` group with no client change.
    cloud providers.
 2. **ToolHive + MCP** — operator + curated MCP servers (kubectl, flux, talos, searxng) wired into
    LiteLLM `mcp_servers`. (VirtualMCPServer aggregate + semantic filter deferred — see below.)
-3. **memini** — agent memory; embeddings via Ollama, consolidation via LiteLLM.
+3. **memini** — agent memory; embeddings + rerank via tiny CPU llama.cpp servers, consolidation via
+   LiteLLM.
 4. **llmkube** — llama.cpp `Model` + `InferenceService` CRs on L4 (CUDA); registered as
    `self-hosted` group backends. Optional ComfyUI image gen.
 
@@ -126,6 +127,25 @@ calling chain.
 Drop an `MCPServer` (operator-managed) or `MCPServerEntry` (remote URL) with `groupRef: mcp-tools`
 under `toolhive/mcp-servers/<name>/`, list it in that dir's `kustomization.yaml`, then add its
 endpoint to LiteLLM's `mcp_servers`. The service is `mcp-<name>` on the spec's `mcpPort`.
+
+## Agent memory (memini)
+
+Layer 3 runs [memini](https://github.com/eleboucher/memini) (sqlite backend) for agent long-term
+memory, plus two tiny CPU `llama.cpp` model servers in `ai`:
+
+- `llama-embed` — all-MiniLM-L6-v2 (384-dim), `--embeddings`, OpenAI `/v1`.
+- `llama-rerank` — Qwen3-Reranker-0.6B, `--rerank`.
+
+Both are the same models Jory serves, but run on **CPU** (`ghcr.io/ggml-org/llama.cpp:server`,
+GPU/Vulkan bits stripped) — the L4s are spoken for by Ollama and these models are small (~30 MB /
+~600 MB). memini's consolidation LLM is LiteLLM's `self-hosted` group (→ Ollama).
+
+Secrets: a generated `MEMINI_API_KEY` (Talos vault item `memini`) + `LITELLM_MASTER_KEY` (reused
+from the `litellm` item). Data PVC via the volsync component (10Gi). Route:
+`memini.${SECRET_INTERNAL_DOMAIN}` (internal).
+
+To move embeddings onto the GPU later, swap `llama-embed`/`llama-rerank` for llmkube
+`InferenceService`s (Layer 4) and repoint `MEMINI_EMBED_BASE_URL` / `MEMINI_RERANK`.
 
 ## Gotchas
 

--- a/docs/ai-llm-stack.md
+++ b/docs/ai-llm-stack.md
@@ -12,7 +12,7 @@ re-targeted to this cluster — **NVIDIA L4 GPUs + Ollama** instead of his AMD/M
 | `ollama`     | local inference (3× L4, one per node); embeddings + general chat   | live          |
 | `open-webui` | chat UI                                                            | live          |
 | `toolhive`   | MCP servers (kubectl/flux/talos/searxng) wired into LiteLLM        | live          |
-| `memini`     | agent long-term memory (sqlite + CPU embed/rerank)                 | live          |
+| `memini`     | agent long-term memory (SQLite + CPU embed/rerank)                 | live          |
 | `llmkube`    | llama.cpp model-serving operator (CUDA); model template staged     | operator live |
 
 LiteLLM persists to CNPG `postgres18` (`litellm` db) and caches in Dragonfly. Internal-only route
@@ -48,7 +48,7 @@ Each layer is a separate commit on one branch (one PR). Cross-layer wiring (e.g.
 staged as commented blocks in `litellm/app/configmap.yaml` and switched on when the producing layer
 lands.
 
-> Not ported from Jory's repo: `hermes`, `openclaw` (agent runtimes), and `agentmemory` (whose main
+> Not ported from Jory's repository: `hermes`, `openclaw` (agent runtimes), and `agentmemory` (whose main
 > consumers are hermes/openclaw).
 
 ## How to extend LiteLLM
@@ -131,7 +131,7 @@ endpoint to LiteLLM's `mcp_servers`. The service is `mcp-<name>` on the spec's `
 
 ## Agent memory (memini)
 
-Layer 3 runs [memini](https://github.com/eleboucher/memini) (sqlite backend) for agent long-term
+Layer 3 runs [memini](https://github.com/eleboucher/memini) (SQLite backend) for agent long-term
 memory, plus two tiny CPU `llama.cpp` model servers in `ai`:
 
 - `llama-embed` — all-MiniLM-L6-v2 (384-dim), `--embeddings`, OpenAI `/v1`.
@@ -217,7 +217,7 @@ over automatically — no client change.
 
 ## Gotchas
 
-- **Public repo** — no LAN IPs / internal hostnames in git (see `CLAUDE.md`). Cluster service DNS
+- **Public repository** — no LAN IPs / internal hostnames in Git (see `CLAUDE.md`). Cluster service DNS
   and `${SECRET_*}` placeholders are fine.
 - **Metrics** — `require_auth_for_metrics_endpoint: false` **and** ServiceMonitor path `/metrics/`
   (trailing slash, no redirect-follow) are both required for in-cluster Prometheus scraping.

--- a/docs/ai-llm-stack.md
+++ b/docs/ai-llm-stack.md
@@ -6,14 +6,14 @@ re-targeted to this cluster — **NVIDIA L4 GPUs + Ollama** instead of his AMD/M
 
 ## Components
 
-| App          | Role                                                               | Status            |
-| ------------ | ------------------------------------------------------------------ | ----------------- |
-| `litellm`    | OpenAI-compatible gateway: routing, fallbacks, cache, metrics, MCP | live              |
-| `ollama`     | local inference (3× L4, one per node); embeddings + general chat   | live              |
-| `open-webui` | chat UI                                                            | live              |
-| `toolhive`   | MCP servers (kubectl/flux/talos/searxng) wired into LiteLLM        | live              |
-| `memini`     | agent long-term memory (sqlite + CPU embed/rerank)                 | live              |
-| `llmkube`    | llama.cpp serving for select hot models on L4 (CUDA)               | Layer 4 (planned) |
+| App          | Role                                                               | Status        |
+| ------------ | ------------------------------------------------------------------ | ------------- |
+| `litellm`    | OpenAI-compatible gateway: routing, fallbacks, cache, metrics, MCP | live          |
+| `ollama`     | local inference (3× L4, one per node); embeddings + general chat   | live          |
+| `open-webui` | chat UI                                                            | live          |
+| `toolhive`   | MCP servers (kubectl/flux/talos/searxng) wired into LiteLLM        | live          |
+| `memini`     | agent long-term memory (sqlite + CPU embed/rerank)                 | live          |
+| `llmkube`    | llama.cpp model-serving operator (CUDA); model template staged     | operator live |
 
 LiteLLM persists to CNPG `postgres18` (`litellm` db) and caches in Dragonfly. Internal-only route
 (`litellm.${SECRET_INTERNAL_DOMAIN}`, envoy-internal).
@@ -40,8 +40,9 @@ llama.cpp backends to the existing `self-hosted` group with no client change.
    LiteLLM `mcp_servers`. (VirtualMCPServer aggregate + semantic filter deferred — see below.)
 3. **memini** — agent memory; embeddings + rerank via tiny CPU llama.cpp servers, consolidation via
    LiteLLM.
-4. **llmkube** — llama.cpp `Model` + `InferenceService` CRs on L4 (CUDA); registered as
-   `self-hosted` group backends. Optional ComfyUI image gen.
+4. **llmkube** — operator installed; a CUDA `Model` + `InferenceService` template is documented
+   below (running it needs GPU headroom from Ollama + model storage). ComfyUI image gen skipped
+   (also GPU-bound, AMD-only upstream).
 
 Each layer is a separate commit on one branch (one PR). Cross-layer wiring (e.g. `mcp_servers`) is
 staged as commented blocks in `litellm/app/configmap.yaml` and switched on when the producing layer
@@ -146,6 +147,73 @@ from the `litellm` item). Data PVC via the volsync component (10Gi). Route:
 
 To move embeddings onto the GPU later, swap `llama-embed`/`llama-rerank` for llmkube
 `InferenceService`s (Layer 4) and repoint `MEMINI_EMBED_BASE_URL` / `MEMINI_RERANK`.
+
+## Layer 4 — llama.cpp serving (llmkube)
+
+The [llmkube](https://github.com/defilantech/LLMKube) operator (`0.8.7`) is installed in `ai`. It
+serves llama.cpp models declaratively: a `Model` CR (weights source + hardware) plus an
+`InferenceService` CR (the serving pod). **No model runs by default** — two prerequisites must be
+met first:
+
+1. **GPU memory.** Each L4 (24 GB) is already ~17 GB into Ollama. A 27B llama.cpp model needs
+   another ~17 GB, which won't fit alongside Ollama on the same card (time-slicing shares compute,
+   not memory). To run one, scale Ollama down (fewer replicas / smaller model / lower
+   `OLLAMA_NUM_PARALLEL`) or choose a small model that fits the ~5–6 GB headroom.
+2. **Model storage.** This cluster has only RWO `ceph-block`; llmkube's shared download cache and
+   `pvc://` staging assume RWX (`ceph-filesystem`). A single `InferenceService` works on an RWO
+   `ceph-block` PVC (one pod); for an `https://` source set `modelCache.enabled: true` in the
+   operator HR and give it a cache PVC.
+
+### A CUDA model template
+
+Drop this under `llmkube/models/` (its own Flux Kustomization, `dependsOn: llmkube`) and add the
+path to `ai/kustomization.yaml`. `replicas: 0` keeps it staged until you scale it up:
+
+```yaml
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+    name: qwen3.6-27b
+spec:
+    source: https://huggingface.co/<org>/<repo>-GGUF/resolve/main/<file>.gguf # direct GGUF URL
+    format: gguf
+    quantization: UD-Q4_K_XL
+    hardware:
+        accelerator: cuda
+        gpu: { enabled: true, vendor: nvidia, count: 1, layers: 99 }
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: InferenceService
+metadata:
+    name: llama-nvidia
+spec:
+    modelRef: qwen3.6-27b
+    runtime: llamacpp
+    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    replicas: 0 # scale to 1 once GPU headroom exists
+    runtimeClassName: nvidia
+    contextSize: 131072
+    flashAttention: true
+    cacheTypeK: q8_0
+    cacheTypeV: q8_0
+    resources: { gpu: 1, cpu: "500m", memory: 16Gi }
+    endpoint: { port: 8080, type: ClusterIP }
+```
+
+Then add it to LiteLLM's `self-hosted` group (in `litellm/app/configmap.yaml`) as `order: 2`:
+
+```yaml
+- model_name: self-hosted
+  litellm_params:
+      model: openai/llama-nvidia
+      api_base: http://llama-nvidia.ai.svc.cluster.local:8080/v1
+      api_key: llama-nvidia
+      order: 2
+```
+
+LiteLLM then load-balances `self-hosted` across Ollama (order 1) and llama.cpp (order 2), failing
+over automatically — no client change.
 
 ## Gotchas
 

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./netpol.yaml
   - ./litellm/ks.yaml
+  - ./memini/ks.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./netpol.yaml
   - ./litellm/ks.yaml
+  - ./llmkube/ks.yaml
   - ./memini/ks.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./litellm/ks.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml
+  - ./toolhive/ks.yaml

--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -8,22 +8,91 @@ metadata:
 data:
   config.yaml: |-
     model_list:
-      # NB: `model_name` is the litellm-exposed alias (kept stable for existing
-      # clients); the backend is centralized via ${OLLAMA_MODEL}/${OLLAMA_BASE_URL}.
+      # ------------------------------------------------------------------
+      # Local — Ollama (qwen3.6-35b-a3b). Backend centralized via the cluster
+      # vars ${OLLAMA_MODEL}/${OLLAMA_BASE_URL} (components/global-vars).
+      # ------------------------------------------------------------------
+
+      # Backward-compatible alias for any client already pointing at this name.
       - model_name: ollama/gemma4
         litellm_params:
           model: ollama_chat/${OLLAMA_MODEL}
           api_base: ${OLLAMA_BASE_URL}
 
+      # Stable "self-hosted" group. One backend today (Ollama, order 1). Layer 4
+      # (llama.cpp via llmkube) appends entries with the SAME model_name and a
+      # higher order: LiteLLM then load-balances / fails over across them with no
+      # client change.
+      - model_name: self-hosted
+        model_info:
+          mode: chat
+          supports_function_calling: true
+          supports_vision: false
+        litellm_params:
+          model: ollama_chat/${OLLAMA_MODEL}
+          api_base: ${OLLAMA_BASE_URL}
+          max_parallel_requests: 3
+          order: 1
+
+      # ------------------------------------------------------------------
+      # Cloud
+      # ------------------------------------------------------------------
       - model_name: openrouter/auto
         litellm_params:
           model: openrouter/openrouter/auto
           api_key: os.environ/OPENROUTER_API_KEY
 
+      # ------------------------------------------------------------------
+      # Embedding — enabled in Layer 2 (semantic tool filter + memory).
+      # Needs an embedding model present on EVERY Ollama replica first (the
+      # StatefulSet has 3 separate RWO PVCs); Layer 2 stages it. Commented so
+      # the proxy doesn't health-check an absent model.
+      # ------------------------------------------------------------------
+      # - model_name: nomic-embed-text
+      #   model_info:
+      #     mode: embedding
+      #   litellm_params:
+      #     model: ollama/nomic-embed-text
+      #     api_base: ${OLLAMA_BASE_URL}
+
+      # ------------------------------------------------------------------
+      # Optional cloud providers (Jory's set). To enable one: add its key to the
+      # `litellm` 1Password item, add the matching line to externalsecret.yaml's
+      # template, then uncomment. Disabled by default so a missing key can't fail
+      # the deploy.
+      # ------------------------------------------------------------------
+      # - model_name: kimi-k2                       # Moonshot
+      #   model_info: {mode: chat, supports_function_calling: true}
+      #   litellm_params:
+      #     model: moonshot/kimi-k2
+      #     api_base: https://api.moonshot.ai/v1
+      #     api_key: os.environ/MOONSHOT_API_KEY
+      # - model_name: MiniMax                       # MiniMax (Anthropic-format)
+      #   model_info: {mode: messages, supports_function_calling: true, supports_vision: true}
+      #   litellm_params:
+      #     model: minimax/MiniMax-M2
+      #     api_base: https://api.minimax.io/anthropic/v1/messages
+      #     api_key: os.environ/MINIMAX_API_KEY
+      #     cache_control_injection_points:
+      #       - {location: message, role: system}
+      #       - {location: message, index: -1}
+      # - model_name: zen/glm                       # OpenCode "zen" (one key, many models)
+      #   model_info: {mode: chat, supports_function_calling: true}
+      #   litellm_params:
+      #     model: openai/glm-4.6
+      #     api_base: https://opencode.ai/zen/go/v1
+      #     api_key: os.environ/OPENCODE_API_KEY
+
     router_settings:
       redis_host: os.environ/REDIS_HOST
       redis_port: os.environ/REDIS_PORT
       redis_password: os.environ/REDIS_PASSWORD
+      cooldown_time: 30
+      enable_pre_call_checks: true
+      # If the local model is cooling-down / unhealthy, spill to cloud.
+      fallbacks:
+        - self-hosted: ["openrouter/auto"]
+        - ollama/gemma4: ["openrouter/auto"]
 
     litellm_settings:
       success_callback: ["prometheus"]
@@ -39,6 +108,20 @@ data:
       drop_params: true
       num_retries: 2
       request_timeout: 600
+      # Enabled in Layer 2: surfaces only the top-k relevant MCP tools per request
+      # (needs the embedding model above + ToolHive MCP servers).
+      # mcp_semantic_tool_filter:
+      #   enabled: true
+      #   embedding_model: nomic-embed-text
+      #   top_k: 6
+      #   similarity_threshold: 0.3
+
+    # MCP servers proxied to clients — populated in Layer 2 (ToolHive endpoints).
+    # mcp_servers:
+    #   kubectl:
+    #     url: http://mcp-kubectl.ai:8080/mcp
+    #   flux:
+    #     url: http://mcp-flux.ai:8080/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -116,12 +116,18 @@ data:
       #   top_k: 6
       #   similarity_threshold: 0.3
 
-    # MCP servers proxied to clients — populated in Layer 2 (ToolHive endpoints).
-    # mcp_servers:
-    #   kubectl:
-    #     url: http://mcp-kubectl.ai:8080/mcp
-    #   flux:
-    #     url: http://mcp-flux.ai:8080/mcp
+    # MCP tools proxied to any LiteLLM client (ToolHive-managed endpoints, ai ns).
+    # ~30 tools across 4 servers — small enough to expose without the semantic
+    # filter above. Re-enable the filter if this list grows large.
+    mcp_servers:
+      kubectl:
+        url: http://mcp-kubectl.ai.svc.cluster.local:8000/mcp
+      flux:
+        url: http://mcp-flux.ai.svc.cluster.local:8000/mcp
+      talos:
+        url: http://mcp-talos-mcp.ai.svc.cluster.local:8080/mcp
+      searxng:
+        url: http://mcp-searxng.ai.svc.cluster.local:3000/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llmkube
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: llmkube
+      version: 0.8.7
+      sourceRef:
+        kind: HelmRepository
+        name: llmkube
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # No https model sources are served yet, so the shared download cache stays
+    # off. Enable it (and provide an RWX cache PVC) before adding a Model with an
+    # https:// source — see docs/ai-llm-stack.md "Layer 4".
+    modelCache:
+      enabled: false
+    prometheus:
+      inferencePodMonitor:
+        enabled: false

--- a/kubernetes/apps/ai/llmkube/app/helmrepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: llmkube
+spec:
+  interval: 1h
+  url: https://defilantech.github.io/LLMKube/

--- a/kubernetes/apps/ai/llmkube/app/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/llmkube/ks.yaml
+++ b/kubernetes/apps/ai/llmkube/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: llmkube
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: llmkube
+  interval: 1h
+  path: ./kubernetes/apps/ai/llmkube/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/memini/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/memini/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: memini
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: memini
+    template:
+      engineVersion: v2
+      data:
+        api-key: "{{ .MEMINI_API_KEY }}"
+        llm-api-key: "{{ .LITELLM_MASTER_KEY }}"
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: memini

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -1,0 +1,75 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app memini
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    fullnameOverride: memini
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          main:
+            env:
+              MEMINI_BACKEND: sqlite
+              MEMINI_DEFAULT_NAMESPACE: default
+              # Embeddings + rerank served by the CPU llama.cpp pods in this ns.
+              MEMINI_EMBED_BASE_URL: http://llama-embed.ai.svc.cluster.local:8080/v1
+              MEMINI_EMBED_MODEL: sentence-transformers/all-MiniLM-L6-v2
+              MEMINI_EMBED_DIMS: "384"
+              MEMINI_RERANK: http://llama-rerank.ai.svc.cluster.local:8080/v1
+              MEMINI_RERANK_MODEL: qwen3-reranker
+              # Consolidation LLM via LiteLLM's self-hosted group (-> Ollama).
+              MEMINI_LLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000
+              MEMINI_LLM_MODEL: self-hosted
+              MEMINI_LLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini
+                    key: llm-api-key
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini
+                    key: api-key
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+      fsck:
+        enabled: true
+        cronjob:
+          schedule: "0 5 * * *"
+    persistence:
+      data:
+        existingClaim: memini
+    route:
+      internal:
+        enabled: true
+        hostnames:
+          - "memini.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    serviceMonitor:
+      main:
+        enabled: true
+    grafanaDashboards:
+      enabled: true
+      folder: ai

--- a/kubernetes/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.3.1
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: memini-models
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: memini-models
+  interval: 1h
+  path: ./kubernetes/apps/ai/memini/models
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memini
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: litellm
+      namespace: *namespace
+    - name: memini-models
+      namespace: *namespace
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/ai/memini/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/memini/models/kustomization.yaml
+++ b/kubernetes/apps/ai/memini/models/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./llama-embed.yaml
+  - ./llama-rerank.yaml

--- a/kubernetes/apps/ai/memini/models/llama-embed.yaml
+++ b/kubernetes/apps/ai/memini/models/llama-embed.yaml
@@ -1,0 +1,126 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llama-embed
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llama-embed
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: memini-models
+  interval: 1h
+  values:
+    controllers:
+      llama-embed:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # All-MiniLM-L6-v2 is a public GGUF (no HF token needed). Downloaded
+          # once into the RWO model PVC, reused on restart.
+          model-download:
+            image:
+              repository: python
+              tag: 3.14-slim
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                set -euo pipefail
+                if [ ! -s /models/all-MiniLM-L6-v2/all-MiniLM-L6-v2-Q8_0.gguf ]; then
+                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  mkdir -p /models/all-MiniLM-L6-v2
+                  hf download \
+                    second-state/All-MiniLM-L6-v2-Embedding-GGUF \
+                    all-MiniLM-L6-v2-Q8_0.gguf \
+                    --local-dir /models/all-MiniLM-L6-v2
+                  echo "all-MiniLM-L6-v2 download complete"
+                else
+                  echo "all-MiniLM-L6-v2 already present, skipping"
+                fi
+            env:
+              HF_HUB_ENABLE_HF_TRANSFER: "1"
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ggml-org/llama.cpp
+              tag: server
+            args:
+              - --host
+              - 0.0.0.0
+              - --port
+              - "8080"
+              - --alias
+              - sentence-transformers/all-MiniLM-L6-v2
+              - --model
+              - /models/all-MiniLM-L6-v2/all-MiniLM-L6-v2-Q8_0.gguf
+              - --embeddings
+              - --pooling
+              - mean
+              - --ctx-size
+              - "8192"
+              - --parallel
+              - "4"
+              - --cont-batching
+              - --batch-size
+              - "8192"
+              - --ubatch-size
+              - "8192"
+              - --threads
+              - "4"
+              - --metrics
+              - --mmap
+            resources:
+              requests:
+                cpu: 250m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  failureThreshold: 6
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  failureThreshold: 60
+                  periodSeconds: 10
+    persistence:
+      models:
+        existingClaim: llama-embed
+        globalMounts:
+          - path: /models
+    service:
+      app:
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/apps/ai/memini/models/llama-rerank.yaml
+++ b/kubernetes/apps/ai/memini/models/llama-rerank.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llama-rerank
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: ceph-block
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: llama-rerank
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: memini-models
+  interval: 1h
+  values:
+    controllers:
+      llama-rerank:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Qwen3-Reranker-0.6B is a public GGUF (no HF token needed).
+          model-download:
+            image:
+              repository: python
+              tag: 3.14-slim
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                set -euo pipefail
+                if [ ! -s /models/Qwen3-Reranker-0.6B/qwen3-reranker-0.6b-q8_0.gguf ]; then
+                  pip install --no-cache-dir "huggingface_hub[hf_transfer]"
+                  mkdir -p /models/Qwen3-Reranker-0.6B
+                  hf download \
+                    ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF \
+                    qwen3-reranker-0.6b-q8_0.gguf \
+                    --local-dir /models/Qwen3-Reranker-0.6B
+                  echo "Qwen3-Reranker-0.6B download complete"
+                else
+                  echo "Qwen3-Reranker-0.6B already present, skipping"
+                fi
+            env:
+              HF_HUB_ENABLE_HF_TRANSFER: "1"
+            resources:
+              requests:
+                cpu: 250m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+        containers:
+          app:
+            image:
+              repository: ghcr.io/ggml-org/llama.cpp
+              tag: server
+            args:
+              - --host
+              - 0.0.0.0
+              - --port
+              - "8080"
+              - --alias
+              - qwen3-reranker
+              - --model
+              - /models/Qwen3-Reranker-0.6B/qwen3-reranker-0.6b-q8_0.gguf
+              - --rerank
+              - --pooling
+              - rank
+              - --ctx-size
+              - "8192"
+              - --parallel
+              - "4"
+              - --cont-batching
+              - --batch-size
+              - "4096"
+              - --ubatch-size
+              - "4096"
+              - --threads
+              - "4"
+              - --metrics
+              - --mmap
+            resources:
+              requests:
+                cpu: 250m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  failureThreshold: 6
+              readiness: *probe
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  failureThreshold: 60
+                  periodSeconds: 10
+    persistence:
+      models:
+        existingClaim: llama-rerank
+        globalMounts:
+          - path: /models
+    service:
+      app:
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/apps/ai/memini/models/ocirepository.yaml
+++ b/kubernetes/apps/ai/memini/models/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini-models
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/toolhive/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/app/helmrelease.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    operator:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+      gc:
+        gomemlimit: 450MiB
+        gogc: 75

--- a/kubernetes/apps/ai/toolhive/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./mcpgroup.yaml

--- a/kubernetes/apps/ai/toolhive/app/mcpgroup.yaml
+++ b/kubernetes/apps/ai/toolhive/app/mcpgroup.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpgroup_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPGroup
+metadata:
+  name: mcp-tools
+spec:
+  description: MCP tools exposed to AI assistants via LiteLLM

--- a/kubernetes/apps/ai/toolhive/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.29.3
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator

--- a/kubernetes/apps/ai/toolhive/crds/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/helmrelease.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator-crds
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator-crds
+  interval: 1h
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3

--- a/kubernetes/apps/ai/toolhive/crds/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/ai/toolhive/crds/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator-crds
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.29.3
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -1,0 +1,72 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: toolhive-crds
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: toolhive-crds
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/crds
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: toolhive
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: toolhive
+  dependsOn:
+    - name: toolhive-crds
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: toolhive-mcp-servers
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: toolhive-mcp-servers
+  dependsOn:
+    - name: toolhive
+      namespace: *namespace
+  interval: 1h
+  path: ./kubernetes/apps/ai/toolhive/mcp-servers
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux/mcpserver.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: flux
+spec:
+  image: ghcr.io/controlplaneio-fluxcd/flux-operator-mcp:v0.52.0@sha256:50b6b5f346642591e63e7a70a38e60ed5336163d34966bb63e6fbd709ad8a0dd
+  transport: streamable-http
+  proxyMode: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  serviceAccount: flux-mcp
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - serve
+            - --transport=http
+            - --port=8000
+          env:
+            # In-cluster mode: no KUBECONFIG; uses the pod service account.
+            - name: RUNTIME_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: flux-mcp
+  namespace: ai
 ---
 # Read-only: reuses the broad read ClusterRole from kubectl-mcp (secrets
 # excluded) so the flux MCP can inspect Flux state but not mutate it. To grant

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux/rbac.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flux-mcp
+---
+# Read-only: reuses the broad read ClusterRole from kubectl-mcp (secrets
+# excluded) so the flux MCP can inspect Flux state but not mutate it. To grant
+# write access (reconcile/suspend/resume/apply/delete on Flux CRDs), see
+# "Enabling flux-mcp write access" in docs/ai-llm-stack.md.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: flux-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: flux-mcp
+    namespace: ai

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/mcpserver.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubectl
+spec:
+  image: docker.io/rohitghumare64/kubectl-mcp-server:1.24.0@sha256:17134e36a3e1d3a5e457c12d61e8c7f7c52a7927c6ae4250131dfd95a74a2331
+  transport: streamable-http
+  proxyMode: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  serviceAccount: kubectl-mcp-readonly
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - --transport
+            - streamable-http
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --read-only
+          env:
+            - name: MCP_K8S_PROVIDER
+              value: in-cluster
+            - name: PYTHONUNBUFFERED
+              value: "1"
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/rbac.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-mcp-readonly
+---
+# Broad read-only access for the kubectl + flux MCP servers. Kubernetes Secrets
+# (core v1) are deliberately excluded so the LLM can inspect cluster state but
+# never read secret values.
+#
+# - aggregationRule: same selector as the built-in "view" ClusterRole — expands
+#   automatically as operators ship rbac.authorization.k8s.io/aggregate-to-view
+#   ClusterRoles (CRDs, etc.).
+# - Core group "": explicit resource list with `secrets` omitted (and no
+#   exec/attach/proxy subresources).
+# - Non-core API groups: `resources: ["*"]` is safe because Secret objects only
+#   exist in the core group. The list is this cluster's actual API groups
+#   (kubectl api-resources), minus auth/* and onepassword.com.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubectl-mcp-readonly
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - nonResourceURLs:
+      - /api
+      - /api/*
+      - /apis
+      - /apis/*
+      - /healthz
+      - /livez
+      - /openapi
+      - /openapi/*
+      - /readyz
+      - /version
+      - /version/
+    verbs:
+      - get
+  # Core v1 — everything except secrets.
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - componentstatuses
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - namespaces/status
+      - nodes
+      - nodes/status
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - persistentvolumes
+      - persistentvolumes/status
+      - pods
+      - pods/log
+      - pods/status
+      - podtemplates
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+      - serviceaccounts
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - watch
+  # All non-core API groups present on this cluster (Secret objects are not in
+  # these groups). Keep in sync with `kubectl api-resources` after adding CRDs.
+  - apiGroups:
+      - acme.cert-manager.io
+      - actions.github.com
+      - admissionregistration.k8s.io
+      - apiextensions.k8s.io
+      - apiregistration.k8s.io
+      - apps
+      - autoscaling
+      - barmancloud.cnpg.io
+      - batch
+      - ceph.rook.io
+      - cert-manager.io
+      - certificates.k8s.io
+      - cilium.io
+      - config.terraform.padok.cloud
+      - coordination.k8s.io
+      - csi.ceph.io
+      - deuxfleurs.fr
+      - discovery.k8s.io
+      - dragonflydb.io
+      - eventing.keda.sh
+      - events.k8s.io
+      - external-secrets.io
+      - externaldns.k8s.io
+      - flowcontrol.apiserver.k8s.io
+      - fluxcd.controlplane.io
+      - gateway.envoyproxy.io
+      - gateway.networking.k8s.io
+      - gateway.networking.x-k8s.io
+      - generators.external-secrets.io
+      - grafana.integreatly.org
+      - groupsnapshot.storage.k8s.io
+      - helm.toolkit.fluxcd.io
+      - k8s.cni.cncf.io
+      - keda.sh
+      - kguardian.dev
+      - kopiur.home-operations.com
+      - kustomize.toolkit.fluxcd.io
+      - metrics.k8s.io
+      - monitoring.coreos.com
+      - monitoring.giantswarm.io
+      - networking.k8s.io
+      - nfd.k8s-sigs.io
+      - node.k8s.io
+      - notification.toolkit.fluxcd.io
+      - nvidia.com
+      - objectbucket.io
+      - observability.giantswarm.io
+      - policy
+      - postgresql.cnpg.io
+      - rbac.authorization.k8s.io
+      - resource.k8s.io
+      - scheduling.k8s.io
+      - shelly.thirdimpact.io
+      - snapshot.storage.k8s.io
+      - source.toolkit.fluxcd.io
+      - storage.k8s.io
+      - tailscale.com
+      - talos.dev
+      - tuppr.home-operations.com
+      - upgrade.cattle.io
+      - volsync.backube
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubectl-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-mcp-readonly
+    namespace: ai

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/rbac.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kubectl-mcp-readonly
+  namespace: ai
 ---
 # Broad read-only access for the kubectl + flux MCP servers. Kubernetes Secrets
 # (core v1) are deliberately excluded so the LLM can inspect cluster state but

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kubectl
+  - ./flux
+  - ./talos
+  - ./searxng

--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/helmrelease.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mcp-searxng
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: mcp-searxng
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 100
+        fsGroup: 100
+    controllers:
+      mcp-searxng:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/isokoliuk/mcp-searxng
+              tag: 1.5.0@sha256:b467c34f4f0189629cde40abb7d56af0e75c32826777a1baaca27d3c9a2ba289
+            env:
+              SEARXNG_URL: http://searxng.default.svc.cluster.local:8080
+              MCP_HTTP_PORT: &port 3000
+              TZ: ${TIMEZONE}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+    service:
+      app:
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./mcpserverentry.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/mcpserverentry.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/mcpserverentry.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserverentry_v1alpha1.json
+# Registers the externally-deployed mcp-searxng into the mcp-tools group (for a
+# future VirtualMCPServer aggregate). LiteLLM reaches it directly via its
+# mcp_servers config; this entry is harmless without the aggregate.
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: searxng
+spec:
+  remoteUrl: http://mcp-searxng.ai.svc.cluster.local:3000/mcp
+  transport: streamable-http
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mcp-searxng
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./talosserviceaccount.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos/mcpserver.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: talos-mcp
+spec:
+  image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2
+  transport: streamable-http
+  mcpPort: 8080
+  groupRef:
+    name: mcp-tools
+  permissionProfile:
+    type: builtin
+    name: network
+  env:
+    - name: TALOS_MCP_TRANSPORT
+      value: http
+    - name: TALOS_MCP_HTTP_ADDR
+      value: ":8080"
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          volumeMounts:
+            - name: talosconfig
+              mountPath: /var/run/secrets/talos.dev
+              readOnly: true
+      volumes:
+        - name: talosconfig
+          secret:
+            secretName: talos-mcp-talosconfig
+            defaultMode: 0400

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos/talosserviceaccount.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos/talosserviceaccount.yaml
@@ -6,6 +6,7 @@ apiVersion: talos.dev/v1alpha1
 kind: ServiceAccount
 metadata:
   name: talos-mcp-talosconfig
+  namespace: ai
 spec:
   roles:
     - os:reader

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos/talosserviceaccount.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos/talosserviceaccount.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/talos.dev/serviceaccount_v1alpha1.json
+# Mints a read-only talosconfig into Secret `talos-mcp-talosconfig` (mounted by
+# the talos MCP). os:reader = query node/cluster state, no mutating Talos APIs.
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: talos-mcp-talosconfig
+spec:
+  roles:
+    - os:reader


### PR DESCRIPTION
## Summary

Ports most of [joryirving/home-ops `apps/base/llm`](https://github.com/joryirving/home-ops/tree/main/kubernetes/apps/base/llm) into the `ai` namespace, re-targeted to this cluster (**NVIDIA L4 + Ollama**, not his AMD/Mac/llama.cpp gear). Skips `hermes`, `openclaw`, and `agentmemory` per request (agentmemory's only consumers are the first two).

Four staged commits, one per layer. New runbook: `docs/ai-llm-stack.md`.

## Layers

**1. LiteLLM uplift** (`b22cd14`) — config-only. Adds a `self-hosted` model-group, `router_settings.fallbacks` (local → OpenRouter), pre-call checks + cooldowns, and staged commented hooks for MCP / embeddings / cloud providers (MiniMax / Kimi / OpenCode). No behaviour change to existing routing; keeps the `ollama/gemma4` + `openrouter/auto` aliases.

**2. ToolHive + MCP** (`2de9110`) — StackLok ToolHive operator (0.29.3, CRDs + operator) + `MCPGroup` + four MCP servers wired into LiteLLM's `mcp_servers`:
- `kubectl`, `flux` — in-cluster **read-only** (shared ClusterRole built from this cluster's API groups, core `secrets` excluded). Flux **write is opt-in** (documented in the runbook).
- `talos` — `os:reader` via a `talos.dev` ServiceAccount-minted talosconfig.
- `searxng` — `mcp-searxng` fronting `searxng.default`.
- Deferred: the VirtualMCPServer aggregate + EmbeddingServer (needs a Dragonfly the cluster lacks), `github` (PAT), `grafana-mcp`, and the semantic tool filter.

**3. memini** (`67e6338`) — agent long-term memory (sqlite) + two tiny **CPU** llama.cpp servers (`llama-embed` = all-MiniLM, `llama-rerank` = Qwen3-Reranker — Jory's models, GPU/Vulkan bits stripped since the L4s are full and the models are tiny). Consolidation LLM via LiteLLM's `self-hosted` group. A `memini` 1Password item (`MEMINI_API_KEY`) was generated into the Talos vault.

**4. llmkube** (`a5600aa`) — operator (0.8.7) installed as the foundation. **No model runs by default**: a 27B won't fit alongside Ollama on a 24 GB L4 (time-slicing shares compute, not memory), and the cluster has only RWO `ceph-block` (llmkube assumes RWX). A ready CUDA `Model`/`InferenceService` template + the two prerequisites are in the runbook. ComfyUI skipped (GPU-bound, AMD-only upstream).

## Validation

- `kustomize build` + `flate test all --namespace ai --allow-missing-secrets` → all green (local flate 0.1.38; CI runs the pinned 0.4.6).
- Third-party charts confirmed pullable: toolhive `0.29.3`, memini `v0.3.1`, llmkube `0.8.7`.
- No LAN IPs / internal hostnames committed (public repo) — service DNS + `${SECRET_*}` only.

## Verify after merge (runtime — flate can't check these)

- ToolHive operator creates the MCP **proxy services**; confirm LiteLLM's `mcp_servers` URLs resolve (`mcp-kubectl.ai:8000`, `mcp-flux.ai:8000`, `mcp-talos-mcp.ai:8080`, `mcp-searxng.ai:3000`) — these names/ports are mirrored from Jory's working setup, not yet observed here.
- memini reaches embed / rerank / litellm; the CPU llama.cpp servers serve `/v1` after the GGUF init-download.
- `talos-mcp`'s talosconfig Secret mints (`os:reader`).
- LiteLLM reloads and registers the `self-hosted` group + fallbacks (Reloader on the configmap).
