### PR TITLE
feat(talos): allow ai namespace + os:reader for Talos API access

### DIFF
--- a/talos/patches/controller/machine-features.yaml
+++ b/talos/patches/controller/machine-features.yaml
@@ -9,6 +9,8 @@ machine:
       enabled: true
       allowedRoles:
         - os:admin
+        - os:reader
       allowedKubernetesNamespaces:
         - actions-runner-system
         - system-upgrade
+        - ai


### PR DESCRIPTION
Enables the talos MCP server (ToolHive, `ai` ns) to mint a read-only talosconfig via a `talos.dev` ServiceAccount — adds `os:reader` to allowedRoles and `ai` to allowedKubernetesNamespaces.

Already applied live to cr-talos-01/02/03 via `talosctl patch machineconfig --mode=no-reboot` (no reboot; `just talos gen-config` needs the SOPS age key, which wasn't available in-session). This commit keeps `talconfig.yaml` aligned so a future gen-config reproduces the same machine config.

Follow-up to #3116 — talos-mcp was the one MCP server needing this OS-level grant.