### PR TITLE
feat(ai): add github + grafana MCP servers + semantic tool filter

### DIFF
--- a/docs/ai-llm-stack.md
+++ b/docs/ai-llm-stack.md
@@ -67,21 +67,26 @@ Layer 2 runs the [StackLok ToolHive](https://github.com/stacklok/toolhive) opera
 separate CRDs + operator charts) in `ai`, an `MCPGroup` (`mcp-tools`), and these MCP servers, all
 wired into LiteLLM's `mcp_servers`:
 
-| Server    | Source                          | Access                              |
-| --------- | ------------------------------- | ----------------------------------- |
-| `kubectl` | kubectl-mcp-server              | cluster read-only, secrets excluded |
-| `flux`    | flux-operator-mcp               | Flux read-only (write is opt-in)    |
-| `talos`   | talos-mcp                       | Talos `os:reader` (talosconfig SA)  |
-| `searxng` | mcp-searxng → `searxng.default` | web search                          |
+| Server    | Source                          | Access                                                  |
+| --------- | ------------------------------- | ------------------------------------------------------- |
+| `kubectl` | kubectl-mcp-server              | cluster read-only, secrets excluded                     |
+| `flux`    | flux-operator-mcp               | Flux read-only (write is opt-in)                        |
+| `talos`   | talos-mcp                       | Talos `os:reader` (talosconfig SA)                      |
+| `searxng` | mcp-searxng → `searxng.default` | web search                                              |
+| `github`  | github-mcp-server               | GitHub read-only (`GITHUB_READ_ONLY`, fine-grained PAT) |
+| `grafana` | grafana/mcp-grafana             | Grafana Viewer SA token (read-only)                     |
 
 kubectl + flux share one read-only `ClusterRole` (`kubectl-mcp-readonly`) built from this cluster's
 API groups with core `secrets` omitted — keep it in sync with `kubectl api-resources` as you add
 CRDs. The talos MCP mounts a `talos.dev` `ServiceAccount`-minted `os:reader` talosconfig.
 
+The `mcp_semantic_tool_filter` is **on** (top_k 8, embeddings via the `all-minilm` model on the
+CPU `llama-embed` pod): with ~110 tools across 6 servers it trims each request to the most
+relevant tools. `github` + `grafana` are read-only — a fine-grained PAT (`toolhive-github`) and a
+Grafana Viewer service-account token (`toolhive-grafana`).
+
 Deferred (add later): the `VirtualMCPServer` aggregate + `EmbeddingServer` (a single
-`mcp.<domain>` endpoint for non-LiteLLM clients — it's what pulls in a Dragonfly + embedder),
-`github` (needs a PAT in 1Password), `grafana-mcp` (needs a grafana MCP server), and LiteLLM's
-`mcp_semantic_tool_filter` (only worth enabling past ~50 tools).
+`mcp.<domain>` endpoint for non-LiteLLM clients — it's what pulls in a Dragonfly + embedder).
 
 ### Enabling flux-mcp write access
 

--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -43,17 +43,16 @@ data:
           api_key: os.environ/OPENROUTER_API_KEY
 
       # ------------------------------------------------------------------
-      # Embedding — enabled in Layer 2 (semantic tool filter + memory).
-      # Needs an embedding model present on EVERY Ollama replica first (the
-      # StatefulSet has 3 separate RWO PVCs); Layer 2 stages it. Commented so
-      # the proxy doesn't health-check an absent model.
+      # Embedding — served by the CPU llama-embed pod (all-MiniLM-L6-v2, 384-dim,
+      # OpenAI /v1). Powers the MCP semantic tool filter below.
       # ------------------------------------------------------------------
-      # - model_name: nomic-embed-text
-      #   model_info:
-      #     mode: embedding
-      #   litellm_params:
-      #     model: ollama/nomic-embed-text
-      #     api_base: ${OLLAMA_BASE_URL}
+      - model_name: all-minilm
+        model_info:
+          mode: embedding
+        litellm_params:
+          model: openai/sentence-transformers/all-MiniLM-L6-v2
+          api_base: http://llama-embed.ai.svc.cluster.local:8080/v1
+          api_key: llama-embed
 
       # ------------------------------------------------------------------
       # Optional cloud providers (Jory's set). To enable one: add its key to the
@@ -108,17 +107,17 @@ data:
       drop_params: true
       num_retries: 2
       request_timeout: 600
-      # Enabled in Layer 2: surfaces only the top-k relevant MCP tools per request
-      # (needs the embedding model above + ToolHive MCP servers).
-      # mcp_semantic_tool_filter:
-      #   enabled: true
-      #   embedding_model: nomic-embed-text
-      #   top_k: 6
-      #   similarity_threshold: 0.3
+      # Surfaces only the top-k relevant MCP tools per request (6 servers, ~110
+      # tools) using the all-minilm embedding model above.
+      mcp_semantic_tool_filter:
+        enabled: true
+        embedding_model: all-minilm
+        top_k: 8
+        similarity_threshold: 0.3
 
     # MCP tools proxied to any LiteLLM client (ToolHive-managed endpoints, ai ns).
-    # ~30 tools across 4 servers — small enough to expose without the semantic
-    # filter above. Re-enable the filter if this list grows large.
+    # ~110 tools across 6 servers — the semantic filter above trims each request
+    # to the top-k relevant tools.
     mcp_servers:
       kubectl:
         url: http://mcp-kubectl.ai.svc.cluster.local:8000/mcp
@@ -128,6 +127,10 @@ data:
         url: http://mcp-talos-mcp.ai.svc.cluster.local:8080/mcp
       searxng:
         url: http://mcp-searxng.ai.svc.cluster.local:3000/mcp
+      github:
+        url: http://mcp-github-proxy.ai.svc.cluster.local:8080/mcp
+      grafana:
+        url: http://mcp-grafana-proxy.ai.svc.cluster.local:8080/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/toolhive/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/ks.yaml
@@ -59,6 +59,8 @@ spec:
   dependsOn:
     - name: toolhive
       namespace: *namespace
+    - name: onepassword-connect
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/ai/toolhive/mcp-servers
   prune: true

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-github
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-github
+    template:
+      data:
+        token: "{{ .token }}"
+  dataFrom:
+    - extract:
+        key: toolhive-github

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github/kustomization.yaml
@@ -3,9 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kubectl
-  - ./flux
-  - ./talos
-  - ./searxng
-  - ./github
-  - ./grafana
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github/mcpserver.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: github
+spec:
+  image: ghcr.io/github/github-mcp-server
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: GITHUB_API_URL
+      value: https://api.github.com
+    # Read-only: write tools are skipped even if the PAT would permit them.
+    - name: GITHUB_READ_ONLY
+      value: "1"
+    - name: LOG_LEVEL
+      value: info
+  secrets:
+    - name: toolhive-github
+      key: token
+      targetEnvName: GITHUB_PERSONAL_ACCESS_TOKEN
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-grafana
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-grafana
+    template:
+      data:
+        token: "{{ .token }}"
+  dataFrom:
+    - extract:
+        key: toolhive-grafana

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana/kustomization.yaml
@@ -3,9 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kubectl
-  - ./flux
-  - ./talos
-  - ./searxng
-  - ./github
-  - ./grafana
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana/mcpserver.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: grafana
+spec:
+  image: docker.io/grafana/mcp-grafana
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  # The image defaults to streamable-http; force stdio so ToolHive proxies it.
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - -t
+            - stdio
+  env:
+    - name: GRAFANA_URL
+      value: http://grafana-service.observability.svc.cluster.local:3000
+  secrets:
+    - name: toolhive-grafana
+      key: token
+      targetEnvName: GRAFANA_SERVICE_ACCOUNT_TOKEN
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools


### PR DESCRIPTION
Adds the two deferred ToolHive MCP servers (both **read-only**) and turns on the MCP semantic tool filter now that the fleet is large enough to need it. Follow-up to #3116.

## Servers
- **github** — `ghcr.io/github/github-mcp-server`, `GITHUB_READ_ONLY=1`, PAT from the `toolhive-github` 1Password item (fine-grained, read-only). Service `mcp-github-proxy:8080`.
- **grafana** — `grafana/mcp-grafana` against `grafana-service.observability:3000` with a Grafana **Viewer** service-account token (`toolhive-grafana`, created via the admin API). Service `mcp-grafana-proxy:8080`.

## Semantic tool filter
6 servers ≈ 110 tools is too many to expose per request, so `litellm_settings.mcp_semantic_tool_filter` is enabled (top_k 8), backed by a new `all-minilm` embedding model served by the existing CPU `llama-embed` pod (Layer 3).

`toolhive-mcp-servers` now `dependsOn` onepassword-connect (the two new ExternalSecrets).

## Credentials — both already in the Talos 1Password vault
- `toolhive-grafana` (Viewer SA token) and `toolhive-github` (your fine-grained read-only PAT).

## Validation
`kustomize build` + `flate test --namespace ai` → **18/18 PASSED**.