### PR TITLE
garage(sync): repoint cluster→NAS sync to s3-nas Traefik endpoint

### DIFF
--- a/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
@@ -47,8 +47,8 @@ spec:
                   export RCLONE_CONFIG_DST_SECRET_ACCESS_KEY=$(cat /secrets/NAS_SECRET_ACCESS_KEY)
                   exec rclone sync --verbose --stats-one-line --stats=5m --fast-list src:cnpg/ dst:cluster-mirror/cnpg/
               env:
-                - name: RCLONE_VERBOSE
-                  value: "1"
+                # No RCLONE_VERBOSE: combined with the --verbose flag it bumps rclone
+                # to DEBUG, which logs the S3 secret access keys in plaintext.
                 # Source: in-cluster Garage
                 - name: RCLONE_CONFIG_SRC_TYPE
                   value: s3

--- a/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
@@ -66,7 +66,8 @@ spec:
                 - name: RCLONE_CONFIG_DST_PROVIDER
                   value: Other
                 - name: RCLONE_CONFIG_DST_ENDPOINT
-                  value: http://${SECRET_STORAGE_SERVER}:3900
+                  # NAS Garage is now bridge+Traefik (s3-nas), not the old host :3900
+                  value: https://s3-nas.${SECRET_INTERNAL_DOMAIN}
                 - name: RCLONE_CONFIG_DST_REGION
                   value: us-east-1
                 - name: RCLONE_CONFIG_DST_ACL


### PR DESCRIPTION
## What
The hourly `garage-cluster-to-nas-sync` CronJob DST endpoint was `http://${SECRET_STORAGE_SERVER}:3900`. The NAS Garage was adopted into doco-cd and moved from `network_mode: host` to bridge + Traefik, so that host port no longer exists:

```diff
- value: http://${SECRET_STORAGE_SERVER}:3900
+ value: https://s3-nas.${SECRET_INTERNAL_DOMAIN}
```

## Why now
Since the adoption the NAS Garage is only reachable via `s3-nas.codelooks.com` / `s3-nas.core.codelooks.com` (NAS Traefik @ 10.32.8.34); the old host port is gone, so this sync is currently failing.

## Verification
From an in-cluster pod, `s3-nas.core.codelooks.com` resolves to **10.32.8.34** and garage answers **HTTP 403** (reached via Traefik, valid LE cert). The DST key (`mirror-key`) and bucket (`cluster-mirror`) are unchanged — only the endpoint moves.