### PR TITLE
fix(ai): wire MEMINI_API_KEY into the memini fsck cronjob

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -56,6 +56,16 @@ spec:
         enabled: true
         cronjob:
           schedule: "0 5 * * *"
+        # The chart's fsck curl uses --variable %MEMINI_API_KEY, so the fsck
+        # container needs the same bearer token as the main container.
+        containers:
+          fsck:
+            env:
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini
+                    key: api-key
     persistence:
       data:
         existingClaim: memini


### PR DESCRIPTION
## Symptom
Netdata alert: `memini-fsck` CronJob last execution failed (14h). Pods exit 2 with `curl: option --variable: variable expansion failure`.

## Root cause
I enabled `controllers.fsck` (Layer 3) but never gave its container `MEMINI_API_KEY`. On the pinned chart **v0.3.1**, the fsck curl is `--variable %MEMINI_API_KEY` — the `%` imports the env var and **errors if unset**, so curl dies before connecting. (The *main* container has the key; the separate fsck container didn't.)

## Fix
Add `MEMINI_API_KEY` (`secretKeyRef: memini/api-key`) to `controllers.fsck.containers.fsck` — exactly what the chart's own values document for enabled fsck.

## Verified
- Throwaway Job with the env set → `POST /v1/fsck` returns **http=200** (`{"expired_purged":0,...}`).
- `helm template` confirms the rendered CronJob now carries the env.

## Why Jory's identical block works
He's on **v0.3.7**, where the curl was changed to `--variable "MEMINI_API_KEY=$MEMINI_API_KEY"` (shell expansion — harmless when unset) and his memini server isn't enforcing auth. Ours enforces auth (I set `MEMINI_API_KEY` on the server), so the token is the correct fix. Renovate can bump v0.3.1→v0.3.7 separately.