### PR TITLE
feat(agents): port .agents config — sorting instructions, add-app skill, AGENTS.md

### DIFF
--- a/.agents/instructions/sorting.instructions.md
+++ b/.agents/instructions/sorting.instructions.md
@@ -1,0 +1,119 @@
+# Sorting instructions for all yaml files
+
+Whenever asked to sort these files, follow these instructions:
+
+- **Default rule**: All fields and properties should be sorted alphabetically at every level of the YAML structure, regardless of how deeply nested they are, unless a specific override rule is provided below or in other applicable instructions files.
+- All yaml files should start with `---` at the top of the document.
+- All documents should have a `YAML` LSP schema associated with them, if possible, to enable validation and auto-completion features in editors that support it. This is especially important for Kubernetes-related files, which should use the appropriate Kubernetes schema based on their `apiVersion` and `kind` fields. It should be below the `---` at the top of the document.
+
+## Override rules for Kubernetes related file types
+
+- Whenever they are present on the same level of a YAML structure, these fields should be sorted as follows:
+  - `apiVersion`
+  - `kind`
+  - `metadata`
+  - `spec`
+
+- The items within the `metadata` section should be sorted as follows:
+  - `name`
+  - `namespace`
+  - `annotations`
+  - `labels`
+
+## HelmRelease rules for app-template
+
+This section gives instructions specifically for HelmReleases based on the bjw-s `app-template` chart.
+
+In this repository, app-template apps do **not** share a single chart. Each app has its own
+`app/ocirepository.yaml` whose `url` ends in `bjw-s-labs/helm/app-template`, and the HelmRelease
+references it via `spec.chartRef.kind: OCIRepository` with `spec.chartRef.name: <app>` (the app's own
+name). Identify an app-template HelmRelease by that per-app `OCIRepository` source — **not** by a
+shared `chartRef.name: app-template`.
+
+### Sorting rules
+
+Whenever asked to sort these files, follow these instructions:
+
+- Whenever there is an `enabled` field, it should be the first field within its section, unless a more specific rule below dictates otherwise.
+
+- The items within the `spec` section should be sorted as follows (this repo orders `interval` before `chartRef`):
+  - `interval`
+  - `chartRef`
+  - `dependsOn` (if present)
+  - `install` (if present)
+  - `upgrade` (if present)
+  - `values`
+
+- Items within the `spec.values` section should be sorted as follows:
+  - `defaultPodOptions` (if present)
+  - All sibling keys at the `spec.values` level should be sorted alphabetically (e.g., `controllers`, `persistence`, `route`, `service`)
+
+Note: Sibling keys within `persistence.*`, `service.*`, `route.*`, `configMaps.*`, etc. are NOT required to be sorted - only the keys within each individual item. For example, if `persistence` has `config`, `data`, and `tmpfs` as children, they can be in any order. Only the keys within `persistence.config`, `persistence.data`, etc. should be sorted.
+
+**Important:** The sorting rules apply to the HelmRelease structure itself. Do NOT sort arbitrary YAML content embedded within string fields (e.g., `configMap.data.*` values containing YAML configurations).
+
+### General pattern for section keys
+
+Unless a more specific rule applies, keys within any section should be ordered as:
+
+- `annotations` (if present)
+- `labels` (if present)
+- All other keys should be sorted alphabetically
+
+### Detailed sorting rules for nested sections
+
+- Items within the `spec.values.controllers.*` sections should be sorted as follows:
+  - `type` (if present, always first)
+  - `annotations` (if present)
+  - `labels` (if present)
+  - Controller-specific fields such as `cronjob` or `statefulset` (if present)
+  - `pod`
+  - Any other fields should be sorted alphabetically, except the following fields which should come last (and in this order):
+  - `initContainers` (if present)
+  - `containers` (if present)
+
+- Items within `spec.values.controllers.*.containers.*` sections should be sorted as follows:
+  - `image`
+  - Any other fields should be added next in alphabetical order.
+
+- Items within `spec.values.controllers.*.containers.resources` and `spec.values.controllers.*.initContainers.resources` sections should be sorted as follows:
+  - `requests`
+  - `limits`
+
+- Items within `spec.values.service.*` sections should be sorted as follows:
+  - `type` (if present)
+  - `annotations` (if present)
+  - `labels` (if present)
+  - Any other fields should be added next in alphabetical order.
+
+- Items within `persistence.*` sections should be sorted as follows:
+  - `type` (if present)
+  - `annotations` (if present)
+  - `labels` (if present)
+  - Any other fields should be sorted alphabetically, except the following fields which should come last (and in this order):
+  - `globalMounts` (if present)
+  - `advancedMounts` (if present)
+
+### Quick reference
+
+**Before sorting, verify the chart is app-template based:**
+
+1. Check the app's `app/ocirepository.yaml` `url` ends in `bjw-s-labs/helm/app-template` (and the HelmRelease `spec.chartRef` points at that `OCIRepository`).
+2. If not app-template, do not apply these sorting rules.
+
+**Decision tree for sorting HelmRelease fields:**
+
+```
+At spec level?
+  → interval, chartRef, dependsOn, install, upgrade, values
+
+At spec.values level?
+  → defaultPodOptions first (if present), then alphabetical
+
+Within controllers.*.containers.* or .initContainers.*?
+  → image first, then alphabetical
+
+Within persistence.*, service.*, etc. siblings?
+  → No: Do not sort siblings (e.g., persistence.config vs persistence.data order doesn't matter)
+  → Yes: Sort keys within each item (type → annotations → labels → alphabetical)
+```

--- a/.agents/instructions/sorting.instructions.md
+++ b/.agents/instructions/sorting.instructions.md
@@ -1,119 +1,117 @@
-# Sorting instructions for all yaml files
+# Sorting instructions for all YAML files
 
 Whenever asked to sort these files, follow these instructions:
 
 - **Default rule**: All fields and properties should be sorted alphabetically at every level of the YAML structure, regardless of how deeply nested they are, unless a specific override rule is provided below or in other applicable instructions files.
-- All yaml files should start with `---` at the top of the document.
+- All YAML files should start with `---` at the top of the document.
 - All documents should have a `YAML` LSP schema associated with them, if possible, to enable validation and auto-completion features in editors that support it. This is especially important for Kubernetes-related files, which should use the appropriate Kubernetes schema based on their `apiVersion` and `kind` fields. It should be below the `---` at the top of the document.
 
 ## Override rules for Kubernetes related file types
 
-- Whenever they are present on the same level of a YAML structure, these fields should be sorted as follows:
-  - `apiVersion`
-  - `kind`
-  - `metadata`
-  - `spec`
+When these fields are present at the same level of a YAML structure, sort them in this order:
 
-- The items within the `metadata` section should be sorted as follows:
-  - `name`
-  - `namespace`
-  - `annotations`
-  - `labels`
+1. `apiVersion`
+2. `kind`
+3. `metadata`
+4. `spec`
+
+Within the `metadata` section, sort the items in this order:
+
+1. `name`
+2. `namespace`
+3. `annotations`
+4. `labels`
 
 ## HelmRelease rules for app-template
 
 This section gives instructions specifically for HelmReleases based on the bjw-s `app-template` chart.
 
-In this repository, app-template apps do **not** share a single chart. Each app has its own
-`app/ocirepository.yaml` whose `url` ends in `bjw-s-labs/helm/app-template`, and the HelmRelease
-references it via `spec.chartRef.kind: OCIRepository` with `spec.chartRef.name: <app>` (the app's own
-name). Identify an app-template HelmRelease by that per-app `OCIRepository` source — **not** by a
-shared `chartRef.name: app-template`.
+In this repository, app-template apps do **not** share a single chart. Each app has its own `app/ocirepository.yaml` whose `url` ends in `bjw-s-labs/helm/app-template`, and the HelmRelease references it via `spec.chartRef.kind: OCIRepository` with `spec.chartRef.name: <app>` (the app's own name). Identify an app-template HelmRelease by that per-app `OCIRepository` source — **not** by a shared `chartRef.name: app-template`.
 
 ### Sorting rules
 
-Whenever asked to sort these files, follow these instructions:
+Whenever asked to sort these files, follow these instructions.
 
-- Whenever there is an `enabled` field, it should be the first field within its section, unless a more specific rule below dictates otherwise.
+Whenever there is an `enabled` field, it should be the first field within its section, unless a more specific rule below dictates otherwise.
 
-- The items within the `spec` section should be sorted as follows (this repo orders `interval` before `chartRef`):
-  - `interval`
-  - `chartRef`
-  - `dependsOn` (if present)
-  - `install` (if present)
-  - `upgrade` (if present)
-  - `values`
+Within the `spec` section, sort the items in this order (this repository orders `interval` before `chartRef`):
 
-- Items within the `spec.values` section should be sorted as follows:
-  - `defaultPodOptions` (if present)
-  - All sibling keys at the `spec.values` level should be sorted alphabetically (e.g., `controllers`, `persistence`, `route`, `service`)
+1. `interval`
+2. `chartRef`
+3. `dependsOn` (if present)
+4. `install` (if present)
+5. `upgrade` (if present)
+6. `values`
 
-Note: Sibling keys within `persistence.*`, `service.*`, `route.*`, `configMaps.*`, etc. are NOT required to be sorted - only the keys within each individual item. For example, if `persistence` has `config`, `data`, and `tmpfs` as children, they can be in any order. Only the keys within `persistence.config`, `persistence.data`, etc. should be sorted.
+Within the `spec.values` section, place `defaultPodOptions` first (if present), then sort all sibling keys alphabetically (e.g. `controllers`, `persistence`, `route`, `service`).
 
-**Important:** The sorting rules apply to the HelmRelease structure itself. Do NOT sort arbitrary YAML content embedded within string fields (e.g., `configMap.data.*` values containing YAML configurations).
+Note: Sibling keys within `persistence.*`, `service.*`, `route.*`, `configMaps.*`, etc. are NOT required to be sorted — only the keys within each individual item. For example, if `persistence` has `config`, `data`, and `tmpfs` as children, they can be in any order. Only the keys within `persistence.config`, `persistence.data`, etc. should be sorted.
+
+**Important:** The sorting rules apply to the HelmRelease structure itself. Do NOT sort arbitrary YAML content embedded within string fields (e.g. `configMap.data.*` values containing YAML configurations).
 
 ### General pattern for section keys
 
-Unless a more specific rule applies, keys within any section should be ordered as:
+Unless a more specific rule applies, order keys within any section as:
 
-- `annotations` (if present)
-- `labels` (if present)
-- All other keys should be sorted alphabetically
+1. `annotations` (if present)
+2. `labels` (if present)
+3. all other keys, sorted alphabetically
 
 ### Detailed sorting rules for nested sections
 
-- Items within the `spec.values.controllers.*` sections should be sorted as follows:
-  - `type` (if present, always first)
-  - `annotations` (if present)
-  - `labels` (if present)
-  - Controller-specific fields such as `cronjob` or `statefulset` (if present)
-  - `pod`
-  - Any other fields should be sorted alphabetically, except the following fields which should come last (and in this order):
-  - `initContainers` (if present)
-  - `containers` (if present)
+Within `spec.values.controllers.*`, sort keys in this order:
 
-- Items within `spec.values.controllers.*.containers.*` sections should be sorted as follows:
-  - `image`
-  - Any other fields should be added next in alphabetical order.
+1. `type` (if present, always first)
+2. `annotations` (if present)
+3. `labels` (if present)
+4. controller-specific fields such as `cronjob` or `statefulset` (if present)
+5. `pod`
+6. any other fields, alphabetically — except `initContainers` then `containers`, which come last (in that order)
 
-- Items within `spec.values.controllers.*.containers.resources` and `spec.values.controllers.*.initContainers.resources` sections should be sorted as follows:
-  - `requests`
-  - `limits`
+Within `spec.values.controllers.*.containers.*`, sort keys in this order:
 
-- Items within `spec.values.service.*` sections should be sorted as follows:
-  - `type` (if present)
-  - `annotations` (if present)
-  - `labels` (if present)
-  - Any other fields should be added next in alphabetical order.
+1. `image`
+2. any other fields, alphabetically
 
-- Items within `persistence.*` sections should be sorted as follows:
-  - `type` (if present)
-  - `annotations` (if present)
-  - `labels` (if present)
-  - Any other fields should be sorted alphabetically, except the following fields which should come last (and in this order):
-  - `globalMounts` (if present)
-  - `advancedMounts` (if present)
+Within `spec.values.controllers.*.containers.resources` and `spec.values.controllers.*.initContainers.resources`, sort keys in this order:
+
+1. `requests`
+2. `limits`
+
+Within `spec.values.service.*`, sort keys in this order:
+
+1. `type` (if present)
+2. `annotations` (if present)
+3. `labels` (if present)
+4. any other fields, alphabetically
+
+Within `persistence.*`, sort keys in this order:
+
+1. `type` (if present)
+2. `annotations` (if present)
+3. `labels` (if present)
+4. any other fields, alphabetically — except `globalMounts` then `advancedMounts`, which come last (in that order)
 
 ### Quick reference
 
-**Before sorting, verify the chart is app-template based:**
+Before sorting, verify the chart is app-template based:
 
 1. Check the app's `app/ocirepository.yaml` `url` ends in `bjw-s-labs/helm/app-template` (and the HelmRelease `spec.chartRef` points at that `OCIRepository`).
-2. If not app-template, do not apply these sorting rules.
+2. If it is not app-template, do not apply these sorting rules.
 
-**Decision tree for sorting HelmRelease fields:**
+Decision tree for sorting HelmRelease fields:
 
-```
+```text
 At spec level?
-  → interval, chartRef, dependsOn, install, upgrade, values
+  -> interval, chartRef, dependsOn, install, upgrade, values
 
 At spec.values level?
-  → defaultPodOptions first (if present), then alphabetical
+  -> defaultPodOptions first (if present), then alphabetical
 
 Within controllers.*.containers.* or .initContainers.*?
-  → image first, then alphabetical
+  -> image first, then alphabetical
 
 Within persistence.*, service.*, etc. siblings?
-  → No: Do not sort siblings (e.g., persistence.config vs persistence.data order doesn't matter)
-  → Yes: Sort keys within each item (type → annotations → labels → alphabetical)
+  -> No: do not sort siblings (persistence.config vs persistence.data order does not matter)
+  -> Yes: sort keys within each item (type, annotations, labels, then alphabetical)
 ```

--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: add-app
+description: Scaffold a new bjw-s app-template application for the talos-cluster repository
+---
+
+# Add New Application
+
+Scaffold a new application for this repository's **single-cluster** Flux layout.
+
+## Repository-specific assumptions
+
+- App manifests live in `kubernetes/apps/<namespace>/<app>/`: a Flux entrypoint `ks.yaml` plus the
+  rendered resources under `app/`.
+- Each app-template app has its **own** `app/ocirepository.yaml` pointing at
+  `oci://ghcr.io/bjw-s-labs/helm/app-template`; the HelmRelease references it via
+  `spec.chartRef.kind: OCIRepository`, `name: <app>` (the app's own name). There is **no** shared
+  `app-template` OCIRepository — do not create one, and do not use `chartRef.name: app-template`.
+- The app is registered (alphabetically) in `kubernetes/apps/<namespace>/kustomization.yaml`.
+- Secrets use `external-secrets` with the `onepassword-connect` `ClusterSecretStore` (reads the
+  `Talos` 1Password vault). ES-using apps `dependsOn` `onepassword-connect`.
+- Ingress is Envoy Gateway via the app-template `route:` values (preferred) on the
+  `envoy-internal` / `envoy-external` listeners in the `network` namespace.
+- This repo is **PUBLIC** — never write LAN IPs, `.lan`/`.internal` hostnames, or device names.
+  Hosts use `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` (Flux substitutes them at apply time).
+  Any literal `${VAR}` that must survive Flux substitution has to be escaped as `$${VAR}`.
+
+## Workflow
+
+### Step 1: Collect application details
+
+Use the **AskUserQuestion** tool to gather:
+
+1. App name
+2. Namespace (existing dir under `kubernetes/apps/`, e.g. `default`, `media`, `downloads`, `observability`)
+3. Image repository
+4. Image tag
+5. app-template chart version for `ocirepository.yaml` `ref.tag`
+6. Primary service port
+7. Whether the app needs an `ExternalSecret`
+8. Whether the app needs persistence (PVC `existingClaim`, `emptyDir`, NFS, …)
+9. Whether the app needs a route, and if so internal-only (`envoy-internal`) or external (`envoy-external`)
+10. Any Flux `dependsOn` entries, and whether it uses components (`gatus/guarded`, `volsync`, `alerts`, `homepage`)
+
+Always confirm before writing files.
+
+### Step 2: Inspect neighbouring apps
+
+Before generating files:
+
+1. Read 1–2 existing apps in the **same namespace** (`kubernetes/apps/<namespace>/*/`).
+2. Match local patterns for probes, persistence, routes, resources, and secret templates.
+3. Note the namespace's `kustomization.yaml` components (typically `global-vars` + `alerts`).
+
+### Step 3: Create the app directory
+
+Create `kubernetes/apps/<namespace>/<app>/` with `ks.yaml`, `app/kustomization.yaml`,
+`app/ocirepository.yaml`, `app/helmrelease.yaml`. Add `app/externalsecret.yaml` only if secrets are
+needed. Prefer the inline `route:` value over a standalone `app/httproute.yaml` (the latter is the
+rarer case, e.g. catch-all routes).
+
+### Step 4: Generate the Flux Kustomization (`ks.yaml`)
+
+`kubernetes/apps/<namespace>/<app>/ks.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app <app>
+  namespace: &namespace <namespace>
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/<namespace>/<app>/app
+  postBuild: {}
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true
+```
+
+If the app uses an `ExternalSecret`, add a `dependsOn` (alphabetically, after `commonMetadata`):
+
+```yaml
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+```
+
+If the app uses components (gatus/volsync/etc.), add `spec.components` and replace `postBuild: {}`
+with the matching substitutes. Component paths are `../../../../components/...` relative to the app:
+
+```yaml
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+```
+
+The `volsync` component goes in `ks.yaml` `spec.components` **only** — never also in
+`app/kustomization.yaml` (Flux applies ks.yaml components on top of the path build; listing in both
+double-applies). Keep `spec` keys alphabetical (this repo's ks.yaml convention).
+
+### Step 5: Generate `app/kustomization.yaml`
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+```
+
+Add `./externalsecret.yaml` and/or `./httproute.yaml` lines only when those files exist.
+
+### Step 6: Generate `app/ocirepository.yaml`
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: <app>
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: <chart-version>
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+```
+
+### Step 7: Generate `app/helmrelease.yaml`
+
+`spec` order is `interval` → `chartRef` → (`dependsOn`) → `values` (this repo omits `install`/`upgrade`
+on most HRs — the root kustomization injects those defaults):
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: <app>
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: <app>
+  values:
+    controllers:
+      <app>:
+        containers:
+          app:
+            image:
+              repository: <image-repository>
+              tag: <image-tag>
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: <port>
+```
+
+If the app needs a route, add (internal-only default — both hostnames resolve via `envoy-internal`):
+
+```yaml
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+```
+
+For **external** exposure, use `name: envoy-external` instead (and confirm the intent — this repo is
+public). For GPU workloads, set `runtimeClassName: nvidia` under the controller's `pod`.
+
+### Step 8: Generate `app/externalsecret.yaml` (only if needed)
+
+```yaml
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: <app>
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: <app>-secret
+    template:
+      data: {}
+  dataFrom:
+    - extract:
+        key: <app>
+```
+
+Mirror the templated `target.template.data` keys from a similar existing app rather than forcing a
+generic template. The 1Password item must live in the `Talos` vault.
+
+### Step 9: Register the app in the namespace kustomization
+
+Add the app's `ks.yaml` to `kubernetes/apps/<namespace>/kustomization.yaml` `resources`, keeping the
+list alphabetical. Match the exact reference style used by neighbours (e.g. `./<app>/ks.yaml`).
+
+### Step 10: Verify
+
+1. `kubernetes/apps/<namespace>/<app>/` contains `ks.yaml` and `app/` with the expected files.
+2. The namespace `kustomization.yaml` references the new app.
+3. The HelmRelease `chartRef` points at the per-app `OCIRepository`, not a shared `app-template`.
+4. No plain-text secrets, LAN IPs, or internal hostnames were introduced.
+5. Render and validate with flate:
+
+   ```bash
+   flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
+   flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+   ```
+
+## Notes
+
+- Do **not** create a shared `app-template` OCIRepository; each app gets its own `app/ocirepository.yaml`.
+- Prefer minimal scaffolding that matches existing apps in the same namespace.
+- If the workload is not a good fit for `app-template`, stop and ask the user before continuing.

--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -20,7 +20,7 @@ Scaffold a new application for this repository's **single-cluster** Flux layout.
   `Talos` 1Password vault). ES-using apps `dependsOn` `onepassword-connect`.
 - Ingress is Envoy Gateway via the app-template `route:` values (preferred) on the
   `envoy-internal` / `envoy-external` listeners in the `network` namespace.
-- This repo is **PUBLIC** — never write LAN IPs, `.lan`/`.internal` hostnames, or device names.
+- This repository is **PUBLIC** — never write LAN IPs, `.lan`/`.internal` hostnames, or device names.
   Hosts use `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` (Flux substitutes them at apply time).
   Any literal `${VAR}` that must survive Flux substitution has to be escaped as `$${VAR}`.
 
@@ -62,7 +62,7 @@ rarer case, e.g. catch-all routes).
 
 `kubernetes/apps/<namespace>/<app>/ks.yaml`:
 
-```yaml
+```text
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
 apiVersion: kustomize.toolkit.fluxcd.io/v1
@@ -90,7 +90,7 @@ spec:
 
 If the app uses an `ExternalSecret`, add a `dependsOn` (alphabetically, after `commonMetadata`):
 
-```yaml
+```text
   dependsOn:
     - name: onepassword-connect
       namespace: external-secrets
@@ -99,7 +99,7 @@ If the app uses an `ExternalSecret`, add a `dependsOn` (alphabetically, after `c
 If the app uses components (gatus/volsync/etc.), add `spec.components` and replace `postBuild: {}`
 with the matching substitutes. Component paths are `../../../../components/...` relative to the app:
 
-```yaml
+```text
   components:
     - ../../../../components/gatus/guarded
     - ../../../../components/volsync
@@ -111,11 +111,11 @@ with the matching substitutes. Component paths are `../../../../components/...` 
 
 The `volsync` component goes in `ks.yaml` `spec.components` **only** — never also in
 `app/kustomization.yaml` (Flux applies ks.yaml components on top of the path build; listing in both
-double-applies). Keep `spec` keys alphabetical (this repo's ks.yaml convention).
+double-applies). Keep `spec` keys alphabetical (this repository's ks.yaml convention).
 
 ### Step 5: Generate `app/kustomization.yaml`
 
-```yaml
+```text
 ---
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
@@ -129,7 +129,7 @@ Add `./externalsecret.yaml` and/or `./httproute.yaml` lines only when those file
 
 ### Step 6: Generate `app/ocirepository.yaml`
 
-```yaml
+```text
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
@@ -147,10 +147,10 @@ spec:
 
 ### Step 7: Generate `app/helmrelease.yaml`
 
-`spec` order is `interval` → `chartRef` → (`dependsOn`) → `values` (this repo omits `install`/`upgrade`
+`spec` order is `interval` → `chartRef` → (`dependsOn`) → `values` (this repository omits `install`/`upgrade`
 on most HRs — the root kustomization injects those defaults):
 
-```yaml
+```text
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -202,7 +202,7 @@ spec:
 
 If the app needs a route, add (internal-only default — both hostnames resolve via `envoy-internal`):
 
-```yaml
+```text
     route:
       app:
         hostnames:
@@ -212,12 +212,12 @@ If the app needs a route, add (internal-only default — both hostnames resolve 
             namespace: network
 ```
 
-For **external** exposure, use `name: envoy-external` instead (and confirm the intent — this repo is
+For **external** exposure, use `name: envoy-external` instead (and confirm the intent — this repository is
 public). For GPU workloads, set `runtimeClassName: nvidia` under the controller's `pod`.
 
 ### Step 8: Generate `app/externalsecret.yaml` (only if needed)
 
-```yaml
+```text
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
@@ -253,10 +253,10 @@ list alphabetical. Match the exact reference style used by neighbours (e.g. `./<
 4. No plain-text secrets, LAN IPs, or internal hostnames were introduced.
 5. Render and validate with flate:
 
-   ```bash
-   flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
-   flate test all --path kubernetes/flux/cluster --allow-missing-secrets
-   ```
+    ```bash
+    flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
+    flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+    ```
 
 ## Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# talos-cluster — AI Assistant Guide
+
+This is a **home Kubernetes cluster monorepo** managed with GitOps (Talos Linux, Flux, Renovate,
+GitHub Actions). This file is the tool-agnostic conventions guide (read by Codex, Copilot, Cursor,
+etc.). Claude Code loads it via an `@AGENTS.md` import in the repo's local `CLAUDE.md`.
+
+> ⚠️ **This repository is PUBLIC.** Anything committed is world-visible. **Never commit** LAN IPs,
+> `.lan` / `.internal` hostnames, device names, deployment topology, MACs, disk serials, or
+> vendor-specific identifiers that map the home network. Use the `${SECRET_DOMAIN}` /
+> `${SECRET_INTERNAL_DOMAIN}` placeholders (Flux substitutes them from `cluster-secrets` at
+> apply-time). Address/lookup tables that need real device addresses must be templated inside an
+> `ExternalSecret`'s `target.template.data` block and mounted from the rendered Secret — never
+> rendered into a ConfigMap in git.
+
+## Repository structure
+
+```
+kubernetes/
+├── apps/                  # App manifests by namespace
+│   └── <namespace>/
+│       ├── kustomization.yaml   # Lists apps + components for the namespace (alphabetical)
+│       ├── namespace.yaml
+│       └── <app>/
+│           ├── ks.yaml          # Flux Kustomization (entry point)
+│           └── app/
+│               ├── ocirepository.yaml   # Per-app chart source (OCI; preferred)
+│               ├── helmrelease.yaml
+│               ├── externalsecret.yaml  # optional
+│               ├── httproute.yaml       # optional (inline route: in HR values is preferred)
+│               └── kustomization.yaml
+├── components/            # Reusable Kustomize components (global-vars, alerts, volsync, gatus, …)
+└── flux/                  # Core Flux bootstrap config (cluster/ks.yaml = root Kustomization)
+bootstrap/                 # Cluster bootstrap (just tasks + helmfile)
+talos/                     # Talos OS machine configs (talconfig.yaml + patches)
+.agents/                   # Tool-agnostic agent instructions + skills (see "Agent tooling" below)
+```
+
+## Key technologies
+
+| Category   | Tool                          | Purpose                                   |
+| ---------- | ----------------------------- | ----------------------------------------- |
+| OS         | Talos Linux (immutable)       | Node OS; pins kubelet + node together     |
+| GitOps     | Flux                          | Deploys configs from Git to Kubernetes    |
+| CI         | Renovate + GitHub Actions     | Dependency updates, validation            |
+| CNI        | Cilium                        | Pod networking                            |
+| Ingress    | Envoy Gateway (Gateway API)   | L7 routing via `HTTPRoute` (not Ingress)  |
+| DNS        | external-dns + cloudflared    | Internal (OPNsense) + external (Cloudflare)|
+| Secrets    | external-secrets + 1Password  | Secret management                         |
+| Storage    | Rook-Ceph + OpenEBS           | Block + node-local volumes                |
+| Backups    | VolSync (Kopia) → NFS/remote  | PVC snapshots and backups                 |
+| Charts     | bjw-s `app-template`          | The chart most apps use                   |
+
+## GitOps flow
+
+```
+Git push → Flux detects change → reconciles Kustomizations → deploys HelmReleases
+```
+
+The top-level Kustomization (`kubernetes/flux/cluster/ks.yaml`) recursively discovers every app under
+`kubernetes/apps/` and applies default patches to each child Kustomization, including
+`postBuild.substituteFrom` injecting `cluster-secrets` (from 1Password via ExternalSecret) and the
+HelmRelease install/upgrade/rollback strategy defaults.
+
+## App conventions
+
+Every app follows the same shape. The `ks.yaml` is the Flux entry point and uses YAML anchors
+(`&app`, `&namespace`, `*app`) for DRY references; it sets `targetNamespace: *namespace`, and any
+`components` (`gatus/guarded`, `volsync`, `alerts`) plus their `postBuild.substitute` values
+(`APP: *app`, `VOLSYNC_CAPACITY`) live in `ks.yaml` — never duplicated into `app/kustomization.yaml`.
+
+Inside `app/`:
+
+- **Chart source is per-app.** Each app-template app has its own `app/ocirepository.yaml` pointing at
+  `oci://ghcr.io/bjw-s-labs/helm/app-template`; the HelmRelease references it via
+  `spec.chartRef.kind: OCIRepository`, `name: <app>`. There is **no** shared `app-template`
+  OCIRepository. (Non-app-template charts may use a `HelmRepository` source instead.)
+- **HelmRelease `spec` order** is `interval` → `chartRef` → `dependsOn` → `values` (this repo orders
+  `interval` before `chartRef`; most HRs omit `install`/`upgrade` and inherit them from the root
+  Kustomization).
+- **Routing** is usually an inline `route:` in HR values on the `envoy-internal` / `envoy-external`
+  listeners (namespace `network`); a standalone `httproute.yaml` is the rarer case. Hosts are
+  `${APP}.${SECRET_DOMAIN}` (and `${SECRET_INTERNAL_DOMAIN}` for internal).
+
+### Secrets
+
+Flow is **1Password → ExternalSecret → Kubernetes Secret**. Per-app `externalsecret.yaml` files use
+`secretStoreRef.kind: ClusterSecretStore`, `name: onepassword-connect` (reads the `Talos` 1Password
+vault). Apps with an ExternalSecret should `dependsOn` `onepassword-connect` in
+`external-secrets`. Never commit plain-text secrets.
+
+### House rules
+
+- Namespace `kustomization.yaml` lists apps **alphabetically** and references the namespace's
+  components (typically `global-vars` + `alerts`).
+- `ConfigMap` resources must set `metadata.namespace` explicitly (Checkov CKV_K8S_21 fails the
+  `default` namespace).
+- Flux `postBuild` replaces `${VAR}` against `cluster-secrets`; **undefined vars become empty
+  strings**. Any literal `${VAR}` you want preserved (Grafana dashboards, envsubst templates, shell
+  snippets) must be escaped as `$${VAR}`.
+- GPU workloads use `runtimeClassName: nvidia`.
+
+## Validation
+
+CI validates PRs with [flate](https://github.com/home-operations/flate) (HelmRelease + Kustomization
+testing without a live cluster), plus security scans (Checkov/Trivy) and super-linter. Mirror locally
+before pushing:
+
+```bash
+# Render a single app's HelmRelease
+flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
+
+# Test all Kustomizations + HelmReleases
+flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+```
+
+## Agent tooling
+
+Tool-agnostic agent instructions and skills live under `.agents/`:
+
+- **`.agents/instructions/sorting.instructions.md`** — YAML sorting conventions (alphabetical
+  defaults + app-template-specific ordering). Apply when asked to sort YAML.
+- **`.agents/skills/add-app/`** — a skill that scaffolds a new app-template application following the
+  conventions above. (Claude Code discovers it via a local `.claude/skills/add-app` symlink.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is a **home Kubernetes cluster monorepo** managed with GitOps (Talos Linux, Flux, Renovate,
 GitHub Actions). This file is the tool-agnostic conventions guide (read by Codex, Copilot, Cursor,
-etc.). Claude Code loads it via an `@AGENTS.md` import in the repo's local `CLAUDE.md`.
+etc.). Claude Code loads it via an `@AGENTS.md` import in the repository's local `CLAUDE.md`.
 
 > ⚠️ **This repository is PUBLIC.** Anything committed is world-visible. **Never commit** LAN IPs,
 > `.lan` / `.internal` hostnames, device names, deployment topology, MACs, disk serials, or
@@ -14,7 +14,7 @@ etc.). Claude Code loads it via an `@AGENTS.md` import in the repo's local `CLAU
 
 ## Repository structure
 
-```
+```text
 kubernetes/
 ├── apps/                  # App manifests by namespace
 │   └── <namespace>/
@@ -37,22 +37,22 @@ talos/                     # Talos OS machine configs (talconfig.yaml + patches)
 
 ## Key technologies
 
-| Category   | Tool                          | Purpose                                   |
-| ---------- | ----------------------------- | ----------------------------------------- |
-| OS         | Talos Linux (immutable)       | Node OS; pins kubelet + node together     |
-| GitOps     | Flux                          | Deploys configs from Git to Kubernetes    |
-| CI         | Renovate + GitHub Actions     | Dependency updates, validation            |
-| CNI        | Cilium                        | Pod networking                            |
-| Ingress    | Envoy Gateway (Gateway API)   | L7 routing via `HTTPRoute` (not Ingress)  |
-| DNS        | external-dns + cloudflared    | Internal (OPNsense) + external (Cloudflare)|
-| Secrets    | external-secrets + 1Password  | Secret management                         |
-| Storage    | Rook-Ceph + OpenEBS           | Block + node-local volumes                |
-| Backups    | VolSync (Kopia) → NFS/remote  | PVC snapshots and backups                 |
-| Charts     | bjw-s `app-template`          | The chart most apps use                   |
+| Category | Tool                         | Purpose                                     |
+| -------- | ---------------------------- | ------------------------------------------- |
+| OS       | Talos Linux (immutable)      | Node OS; pins kubelet + node together       |
+| GitOps   | Flux                         | Deploys configs from Git to Kubernetes      |
+| CI       | Renovate + GitHub Actions    | Dependency updates, validation              |
+| CNI      | Cilium                       | Pod networking                              |
+| Ingress  | Envoy Gateway (Gateway API)  | L7 routing via `HTTPRoute` (not Ingress)    |
+| DNS      | external-dns + cloudflared   | Internal (OPNsense) + external (Cloudflare) |
+| Secrets  | external-secrets + 1Password | Secret management                           |
+| Storage  | Rook-Ceph + OpenEBS          | Block + node-local volumes                  |
+| Backups  | VolSync (Kopia) → NFS/remote | PVC snapshots and backups                   |
+| Charts   | bjw-s `app-template`         | The chart most apps use                     |
 
 ## GitOps flow
 
-```
+```text
 Git push → Flux detects change → reconciles Kustomizations → deploys HelmReleases
 ```
 
@@ -74,7 +74,7 @@ Inside `app/`:
   `oci://ghcr.io/bjw-s-labs/helm/app-template`; the HelmRelease references it via
   `spec.chartRef.kind: OCIRepository`, `name: <app>`. There is **no** shared `app-template`
   OCIRepository. (Non-app-template charts may use a `HelmRepository` source instead.)
-- **HelmRelease `spec` order** is `interval` → `chartRef` → `dependsOn` → `values` (this repo orders
+- **HelmRelease `spec` order** is `interval` → `chartRef` → `dependsOn` → `values` (this repository orders
   `interval` before `chartRef`; most HRs omit `install`/`upgrade` and inherit them from the root
   Kustomization).
 - **Routing** is usually an inline `route:` in HR values on the `envoy-internal` / `envoy-external`

--- a/docs/superpowers/plans/2026-06-15-agents-config-port.md
+++ b/docs/superpowers/plans/2026-06-15-agents-config-port.md
@@ -1,0 +1,556 @@
+# Agents Config Port Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port joryirving/home-ops `.agents/` (sorting instructions + add-app skill) into this repo, adapted to its single-cluster / per-app-`ocirepository` conventions, with `.claude/` symlinks and an `AGENTS.md → CLAUDE.md` symlink.
+
+**Architecture:** Canonical content under `.agents/`; Claude Code discovers the skill via a relative dir symlink `.claude/skills/add-app -> ../../.agents/skills/add-app`; sorting instructions are reachable via a one-line `CLAUDE.md` pointer; `AGENTS.md` is a root symlink to `CLAUDE.md` for non-Claude tools.
+
+**Tech Stack:** Markdown, git symlinks (mode 120000), lefthook/super-linter, flate (for the *scaffolded apps*, not for these docs).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-agents-config-port-design.md`
+
+**Verification note:** These deliverables are markdown + symlinks — there is no unit-test suite. "Verify" steps mean: file reads back correctly, symlinks resolve, `git ls-files -s` shows mode `120000`, and markdown lints clean.
+
+---
+
+### Task 1: Sorting instructions
+
+**Files:**
+- Create: `.agents/instructions/sorting.instructions.md`
+
+Adapted from joryirving's file. Two substantive changes vs upstream: (a) app-template detection rule rewritten for this repo's per-app `OCIRepository`; (b) HelmRelease `spec` ordering puts `interval` **before** `chartRef` (this repo's actual convention — verified across HRs like `error-pages`, `mosquitto`, `karakeep`).
+
+- [ ] **Step 1: Create the file**
+
+Write `.agents/instructions/sorting.instructions.md` with exactly:
+
+````markdown
+# Sorting instructions for all yaml files
+
+Whenever asked to sort these files, follow these instructions:
+
+- **Default rule**: All fields and properties should be sorted alphabetically at every level of the YAML structure, regardless of how deeply nested they are, unless a specific override rule is provided below or in other applicable instructions files.
+- All yaml files should start with `---` at the top of the document.
+- All documents should have a `YAML` LSP schema associated with them, if possible, to enable validation and auto-completion features in editors that support it. This is especially important for Kubernetes-related files, which should use the appropriate Kubernetes schema based on their `apiVersion` and `kind` fields. It should be below the `---` at the top of the document.
+
+## Override rules for Kubernetes related file types
+
+- Whenever they are present on the same level of a YAML structure, these fields should be sorted as follows:
+  - `apiVersion`
+  - `kind`
+  - `metadata`
+  - `spec`
+
+- The items within the `metadata` section should be sorted as follows:
+  - `name`
+  - `namespace`
+  - `annotations`
+  - `labels`
+
+## HelmRelease rules for app-template
+
+This section gives instructions specifically for HelmReleases based on the bjw-s `app-template` chart.
+
+In this repository, app-template apps do **not** share a single chart. Each app has its own
+`app/ocirepository.yaml` whose `url` ends in `bjw-s-labs/helm/app-template`, and the HelmRelease
+references it via `spec.chartRef.kind: OCIRepository` with `spec.chartRef.name: <app>` (the app's own
+name). Identify an app-template HelmRelease by that per-app `OCIRepository` source — **not** by a
+shared `chartRef.name: app-template`.
+
+### Sorting rules
+
+Whenever asked to sort these files, follow these instructions:
+
+- Whenever there is an `enabled` field, it should be the first field within its section, unless a more specific rule below dictates otherwise.
+
+- The items within the `spec` section should be sorted as follows (this repo orders `interval` before `chartRef`):
+  - `interval`
+  - `chartRef`
+  - `dependsOn` (if present)
+  - `install` (if present)
+  - `upgrade` (if present)
+  - `values`
+
+- Items within the `spec.values` section should be sorted as follows:
+  - `defaultPodOptions` (if present)
+  - All sibling keys at the `spec.values` level should be sorted alphabetically (e.g., `controllers`, `persistence`, `route`, `service`)
+
+Note: Sibling keys within `persistence.*`, `service.*`, `route.*`, `configMaps.*`, etc. are NOT required to be sorted - only the keys within each individual item. For example, if `persistence` has `config`, `data`, and `tmpfs` as children, they can be in any order. Only the keys within `persistence.config`, `persistence.data`, etc. should be sorted.
+
+**Important:** The sorting rules apply to the HelmRelease structure itself. Do NOT sort arbitrary YAML content embedded within string fields (e.g., `configMap.data.*` values containing YAML configurations).
+
+### General pattern for section keys
+
+Unless a more specific rule applies, keys within any section should be ordered as:
+
+- `annotations` (if present)
+- `labels` (if present)
+- All other keys should be sorted alphabetically
+
+### Detailed sorting rules for nested sections
+
+- Items within the `spec.values.controllers.*` sections should be sorted as follows:
+  - `type` (if present, always first)
+  - `annotations` (if present)
+  - `labels` (if present)
+  - Controller-specific fields such as `cronjob` or `statefulset` (if present)
+  - `pod`
+  - Any other fields should be sorted alphabetically, except the following fields which should come last (and in this order):
+  - `initContainers` (if present)
+  - `containers` (if present)
+
+- Items within `spec.values.controllers.*.containers.*` sections should be sorted as follows:
+  - `image`
+  - Any other fields should be added next in alphabetical order.
+
+- Items within `spec.values.controllers.*.containers.resources` and `spec.values.controllers.*.initContainers.resources` sections should be sorted as follows:
+  - `requests`
+  - `limits`
+
+- Items within `spec.values.service.*` sections should be sorted as follows:
+  - `type` (if present)
+  - `annotations` (if present)
+  - `labels` (if present)
+  - Any other fields should be added next in alphabetical order.
+
+- Items within `persistence.*` sections should be sorted as follows:
+  - `type` (if present)
+  - `annotations` (if present)
+  - `labels` (if present)
+  - Any other fields should be sorted alphabetically, except the following fields which should come last (and in this order):
+  - `globalMounts` (if present)
+  - `advancedMounts` (if present)
+
+### Quick reference
+
+**Before sorting, verify the chart is app-template based:**
+
+1. Check the app's `app/ocirepository.yaml` `url` ends in `bjw-s-labs/helm/app-template` (and the HelmRelease `spec.chartRef` points at that `OCIRepository`).
+2. If not app-template, do not apply these sorting rules.
+
+**Decision tree for sorting HelmRelease fields:**
+
+```
+At spec level?
+  → interval, chartRef, dependsOn, install, upgrade, values
+
+At spec.values level?
+  → defaultPodOptions first (if present), then alphabetical
+
+Within controllers.*.containers.* or .initContainers.*?
+  → image first, then alphabetical
+
+Within persistence.*, service.*, etc. siblings?
+  → No: Do not sort siblings (e.g., persistence.config vs persistence.data order doesn't matter)
+  → Yes: Sort keys within each item (type → annotations → labels → alphabetical)
+```
+````
+
+- [ ] **Step 2: Verify it reads back and lints**
+
+Run: `head -5 .agents/instructions/sorting.instructions.md`
+Expected: starts with `# Sorting instructions for all yaml files`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .agents/instructions/sorting.instructions.md
+git commit -m "feat(agents): add adapted yaml sorting instructions"
+```
+
+---
+
+### Task 2: add-app skill
+
+**Files:**
+- Create: `.agents/skills/add-app/SKILL.md`
+
+- [ ] **Step 1: Create the skill file**
+
+Write `.agents/skills/add-app/SKILL.md` with exactly:
+
+````markdown
+---
+name: add-app
+description: Scaffold a new bjw-s app-template application for the talos-cluster repository
+---
+
+# Add New Application
+
+Scaffold a new application for this repository's **single-cluster** Flux layout.
+
+## Repository-specific assumptions
+
+- App manifests live in `kubernetes/apps/<namespace>/<app>/`: a Flux entrypoint `ks.yaml` plus the
+  rendered resources under `app/`.
+- Each app-template app has its **own** `app/ocirepository.yaml` pointing at
+  `oci://ghcr.io/bjw-s-labs/helm/app-template`; the HelmRelease references it via
+  `spec.chartRef.kind: OCIRepository`, `name: <app>` (the app's own name). There is **no** shared
+  `app-template` OCIRepository — do not create one, and do not use `chartRef.name: app-template`.
+- The app is registered (alphabetically) in `kubernetes/apps/<namespace>/kustomization.yaml`.
+- Secrets use `external-secrets` with the `onepassword-connect` `ClusterSecretStore` (reads the
+  `Talos` 1Password vault). ES-using apps `dependsOn` `onepassword-connect`.
+- Ingress is Envoy Gateway via the app-template `route:` values (preferred) on the
+  `envoy-internal` / `envoy-external` listeners in the `network` namespace.
+- This repo is **PUBLIC** — never write LAN IPs, `.lan`/`.internal` hostnames, or device names.
+  Hosts use `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` (Flux substitutes them at apply time).
+  Any literal `${VAR}` that must survive Flux substitution has to be escaped as `$${VAR}`.
+
+## Workflow
+
+### Step 1: Collect application details
+
+Use the **AskUserQuestion** tool to gather:
+
+1. App name
+2. Namespace (existing dir under `kubernetes/apps/`, e.g. `default`, `media`, `downloads`, `observability`)
+3. Image repository
+4. Image tag
+5. app-template chart version for `ocirepository.yaml` `ref.tag`
+6. Primary service port
+7. Whether the app needs an `ExternalSecret`
+8. Whether the app needs persistence (PVC `existingClaim`, `emptyDir`, NFS, …)
+9. Whether the app needs a route, and if so internal-only (`envoy-internal`) or external (`envoy-external`)
+10. Any Flux `dependsOn` entries, and whether it uses components (`gatus/guarded`, `volsync`, `alerts`, `homepage`)
+
+Always confirm before writing files.
+
+### Step 2: Inspect neighbouring apps
+
+Before generating files:
+
+1. Read 1–2 existing apps in the **same namespace** (`kubernetes/apps/<namespace>/*/`).
+2. Match local patterns for probes, persistence, routes, resources, and secret templates.
+3. Note the namespace's `kustomization.yaml` components (typically `global-vars` + `alerts`).
+
+### Step 3: Create the app directory
+
+Create `kubernetes/apps/<namespace>/<app>/` with `ks.yaml`, `app/kustomization.yaml`,
+`app/ocirepository.yaml`, `app/helmrelease.yaml`. Add `app/externalsecret.yaml` only if secrets are
+needed. Prefer the inline `route:` value over a standalone `app/httproute.yaml` (the latter is the
+rarer case, e.g. catch-all routes).
+
+### Step 4: Generate the Flux Kustomization (`ks.yaml`)
+
+`kubernetes/apps/<namespace>/<app>/ks.yaml`:
+
+```yaml
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app <app>
+  namespace: &namespace <namespace>
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/<namespace>/<app>/app
+  postBuild: {}
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true
+```
+
+If the app uses an `ExternalSecret`, add a `dependsOn` (alphabetically, after `commonMetadata`):
+
+```yaml
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+```
+
+If the app uses components (gatus/volsync/etc.), add `spec.components` and replace `postBuild: {}`
+with the matching substitutes. Component paths are `../../../../components/...` relative to the app:
+
+```yaml
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/volsync
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+```
+
+The `volsync` component goes in `ks.yaml` `spec.components` **only** — never also in
+`app/kustomization.yaml` (Flux applies ks.yaml components on top of the path build; listing in both
+double-applies). Keep `spec` keys alphabetical (this repo's ks.yaml convention).
+
+### Step 5: Generate `app/kustomization.yaml`
+
+```yaml
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+```
+
+Add `./externalsecret.yaml` and/or `./httproute.yaml` lines only when those files exist.
+
+### Step 6: Generate `app/ocirepository.yaml`
+
+```yaml
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: <app>
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: <chart-version>
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+```
+
+### Step 7: Generate `app/helmrelease.yaml`
+
+`spec` order is `interval` → `chartRef` → (`dependsOn`) → `values` (this repo omits `install`/`upgrade`
+on most HRs — the root kustomization injects those defaults):
+
+```yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: <app>
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: <app>
+  values:
+    controllers:
+      <app>:
+        containers:
+          app:
+            image:
+              repository: <image-repository>
+              tag: <image-tag>
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: <port>
+```
+
+If the app needs a route, add (internal-only default — both hostnames resolve via `envoy-internal`):
+
+```yaml
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+```
+
+For **external** exposure, use `name: envoy-external` instead (and confirm the intent — this repo is
+public). For GPU workloads, set `runtimeClassName: nvidia` under the controller's `pod`.
+
+### Step 8: Generate `app/externalsecret.yaml` (only if needed)
+
+```yaml
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: <app>
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: <app>-secret
+    template:
+      data: {}
+  dataFrom:
+    - extract:
+        key: <app>
+```
+
+Mirror the templated `target.template.data` keys from a similar existing app rather than forcing a
+generic template. The 1Password item must live in the `Talos` vault.
+
+### Step 9: Register the app in the namespace kustomization
+
+Add the app's `ks.yaml` to `kubernetes/apps/<namespace>/kustomization.yaml` `resources`, keeping the
+list alphabetical. Match the exact reference style used by neighbours (e.g. `./<app>/ks.yaml`).
+
+### Step 10: Verify
+
+1. `kubernetes/apps/<namespace>/<app>/` contains `ks.yaml` and `app/` with the expected files.
+2. The namespace `kustomization.yaml` references the new app.
+3. The HelmRelease `chartRef` points at the per-app `OCIRepository`, not a shared `app-template`.
+4. No plain-text secrets, LAN IPs, or internal hostnames were introduced.
+5. Render and validate with flate:
+
+   ```bash
+   flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
+   flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+   ```
+
+## Notes
+
+- Do **not** create a shared `app-template` OCIRepository; each app gets its own `app/ocirepository.yaml`.
+- Prefer minimal scaffolding that matches existing apps in the same namespace.
+- If the workload is not a good fit for `app-template`, stop and ask the user before continuing.
+````
+
+- [ ] **Step 2: Verify frontmatter + headings**
+
+Run: `head -6 .agents/skills/add-app/SKILL.md`
+Expected: YAML frontmatter with `name: add-app` and `description:`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .agents/skills/add-app/SKILL.md
+git commit -m "feat(agents): add adapted add-app scaffolding skill"
+```
+
+---
+
+### Task 3: Symlinks (.claude discovery + AGENTS.md)
+
+**Files:**
+- Create symlink: `.claude/skills/add-app -> ../../.agents/skills/add-app`
+- Create symlink: `AGENTS.md -> CLAUDE.md`
+
+- [ ] **Step 1: Create the symlinks**
+
+```bash
+mkdir -p .claude/skills
+ln -s ../../.agents/skills/add-app .claude/skills/add-app
+ln -s CLAUDE.md AGENTS.md
+```
+
+- [ ] **Step 2: Verify they resolve and git records them as symlinks**
+
+```bash
+head -3 .claude/skills/add-app/SKILL.md   # resolves through the link
+head -3 AGENTS.md                          # shows CLAUDE.md content
+```
+Expected: skill frontmatter, and CLAUDE.md's first lines, respectively.
+
+```bash
+git add .claude/skills/add-app AGENTS.md
+git ls-files -s .claude/skills/add-app AGENTS.md
+```
+Expected: both lines start with mode `120000` (git symlink), not `100644`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(agents): symlink add-app into .claude and AGENTS.md to CLAUDE.md"
+```
+
+---
+
+### Task 4: CLAUDE.md pointer to sorting instructions
+
+**Files:**
+- Modify: `CLAUDE.md` (add one pointer line referencing the sorting instructions)
+
+- [ ] **Step 1: Add the pointer**
+
+In `CLAUDE.md`, under the existing "Key Conventions" section (which already discusses YAML anchors
+and schema comments), add a bullet:
+
+```markdown
+- YAML sorting conventions (alphabetical defaults + app-template ordering) are documented in `.agents/instructions/sorting.instructions.md`; apply them when asked to sort YAML
+```
+
+Place it adjacent to the existing YAML-anchor / schema-comment bullets so it reads naturally.
+
+- [ ] **Step 2: Verify**
+
+Run: `grep -n "sorting.instructions.md" CLAUDE.md`
+Expected: one match showing the new bullet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: point CLAUDE.md at .agents sorting instructions"
+```
+
+---
+
+### Task 5: Final verification
+
+- [ ] **Step 1: Tree + symlink sanity**
+
+```bash
+find .agents -type f
+ls -l AGENTS.md .claude/skills/add-app
+git ls-files -s | grep '^120000'
+```
+Expected: the two markdown files listed; both symlinks shown; two `120000` entries.
+
+- [ ] **Step 2: Lint the new markdown (mirror CI if convenient)**
+
+The repo's lint is super-linter via `just lint` (amd64 image, slow on Apple Silicon). Optional for a
+docs-only change; if run, expect markdownlint/prettier to pass for the new files. At minimum confirm
+no tabs / trailing-whitespace issues introduced.
+
+- [ ] **Step 3: Confirm clean status**
+
+```bash
+git status --short      # expect empty (all committed)
+git log --oneline -6
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** sorting (Task 1), add-app (Task 2), `.claude` + `AGENTS.md` symlinks (Task 3),
+  CLAUDE.md pointer (Task 4), verification (Task 5) — every spec section maps to a task. `pr-review`
+  is intentionally absent (skipped). The "worth flagging later" items are intentionally not built.
+- **No placeholders:** `<app>` / `<namespace>` / `<image-…>` / `<port>` / `<chart-version>` are the
+  skill's own template tokens (the skill fills them at scaffold time), not plan gaps.
+- **Consistency:** HR `spec` ordering (`interval` → `chartRef` → … → `values`), `onepassword-connect`
+  store name, `target.name: <app>-secret`, and component paths (`../../../../components/...`) are used
+  identically in the sorting file, the skill, and the spec.

--- a/docs/superpowers/specs/2026-06-15-agents-config-port-design.md
+++ b/docs/superpowers/specs/2026-06-15-agents-config-port-design.md
@@ -28,8 +28,10 @@ joryirving's `.agents/` contains exactly three files plus a root `AGENTS.md` it 
 | `pr-review.instructions.md` | **Skip** | It is the literal `system_prompt_file` for `misospace/pr-reviewer-action`, which this repo does not run (this repo uses `renovate-review.yaml` / claude-code-action). Its "documented conventions" are joryirving-specific and partly contradict this repo (we *do* set `metadata.namespace` on ConfigMaps for Checkov CKV_K8S_21; we *do* use per-app `ocirepository.yaml`). |
 | `sorting.instructions.md` | **Port** (light adaptation) | Generic YAML + app-template rules; this repo is an app-template shop. |
 | `add-app/SKILL.md` | **Port** (heavy adaptation) | High value; needs full remap to this repo's single-cluster, per-app `app/` layout. |
-| Root `AGENTS.md` | **Symlink → `CLAUDE.md`** | Tool-agnostic entrypoint with zero duplication / drift. |
+| Root `AGENTS.md` | **Public-safe committed file** (revised — see note) | Originally planned as a `→ CLAUDE.md` symlink, but `CLAUDE.md` is **gitignored/private** and contains LAN IPs, so a symlink would dangle in clones and risk leaking internal data. Instead AGENTS.md is a standalone public-safe conventions guide (scrubbed of IPs/hostnames/device names); Claude Code auto-loads it via an `@AGENTS.md` import in the local private `CLAUDE.md`. |
 | Process | Spec doc → review → plan → build, in a worktree | User preference. |
+
+> **Discovered constraint (during build):** the repo's root `.gitignore` ignores **both `.claude/` and `CLAUDE.md`** — they are local/private (CLAUDE.md holds LAN IPs). Consequences: (a) the `.claude/skills/add-app` symlink is a **local-only** convenience (gitignored, per working tree), not a committed artifact; (b) AGENTS.md is a committed public file rather than a symlink; (c) the "Claude finds it automatically" wiring is a one-line `@AGENTS.md` import the user adds to their local `CLAUDE.md` post-merge. Separately, a **repo-wide exposure** of LAN IPs / node names / device models in tracked manifests and docs was surfaced and **deferred** by the user to a separate effort.
 
 ## Target layout & wiring
 
@@ -40,18 +42,20 @@ joryirving's `.agents/` contains exactly three files plus a root `AGENTS.md` it 
 └── skills/
     └── add-app/
         └── SKILL.md                    # adapted (heavy)
-.claude/skills/add-app  ->  ../../.agents/skills/add-app   # dir symlink (Claude Code discovery)
-AGENTS.md               ->  CLAUDE.md                        # file symlink (tool-agnostic entrypoint)
-CLAUDE.md                                                    # + one pointer line to sorting.instructions.md
+AGENTS.md                                                   # COMMITTED public-safe conventions guide
+.claude/skills/add-app  ->  ../../.agents/skills/add-app   # LOCAL-ONLY symlink (.claude is gitignored)
+CLAUDE.md  (local/private)                                  # + `@AGENTS.md` import line (post-merge, local)
 ```
 
+- `AGENTS.md` is a **committed public file** (not a symlink) — public-safe, scrubbed of IPs/hostnames/device names.
 - The `add-app` skill is an action skill → exposed to Claude Code via a **relative directory
-  symlink** `.claude/skills/add-app -> ../../.agents/skills/add-app`.
-- `sorting.instructions.md` is *reference* material (not an action skill). Claude Code does not
-  auto-load `.agents/instructions/`, so discovery is via a **one-line pointer added to `CLAUDE.md`**
-  rather than a skill symlink.
-- `AGENTS.md -> CLAUDE.md` relative symlink at repo root.
-- Committed relative symlinks are stored by git and survive fresh clones.
+  symlink** `.claude/skills/add-app -> ../../.agents/skills/add-app`. Because `.claude/` is gitignored,
+  this symlink is **local-only** (recreate it per working tree / per clone); it is *not* committed.
+- `sorting.instructions.md` is *reference* material (not an action skill). It is committed under
+  `.agents/instructions/` and referenced from `AGENTS.md`'s "Agent tooling" section.
+- "Claude finds AGENTS.md automatically" is achieved by adding `@AGENTS.md` to the local (private)
+  `CLAUDE.md`; Claude Code has no native AGENTS.md auto-load. This is a **post-merge local step**
+  (CLAUDE.md is gitignored and absent from this worktree).
 
 ## Component 1 — `sorting.instructions.md` (light adaptation)
 
@@ -67,7 +71,9 @@ Everything else maps cleanly and is retained unchanged:
 - Alphabetical-by-default at every level; leading `---`; `yaml-language-server` schema comment.
 - K8s ordering `apiVersion` → `kind` → `metadata` → `spec`.
 - `metadata` ordering `name` → `namespace` → `annotations` → `labels`.
-- app-template `spec` ordering (`chartRef`, `interval`, `dependsOn`, `install`, `upgrade`, `values`),
+- app-template `spec` ordering — **corrected to this repo's actual convention** `interval` →
+  `chartRef` → `dependsOn` → `install` → `upgrade` → `values` (this repo puts `interval` before
+  `chartRef`, the reverse of joryirving; verified across `error-pages`, `mosquitto`, `karakeep`),
   `spec.values` (`defaultPodOptions` first, then alphabetical), and the
   controllers / containers / persistence / service nested ordering rules.
 - The "do not sort YAML embedded inside string fields (e.g. `configMap.data.*`)" caveat.

--- a/docs/superpowers/specs/2026-06-15-agents-config-port-design.md
+++ b/docs/superpowers/specs/2026-06-15-agents-config-port-design.md
@@ -1,0 +1,124 @@
+# Port joryirving/home-ops `.agents/` to talos-cluster
+
+- **Date:** 2026-06-15
+- **Status:** Design approved (brainstorming), pending spec review
+- **Source:** <https://github.com/joryirving/home-ops/tree/main/.agents>
+- **Branch / worktree:** `worktree-feat+agents-port` at `.claude/worktrees/feat+agents-port`
+
+## Goal
+
+Adapt the agent-tooling content from `joryirving/home-ops/.agents` to this cluster's
+conventions, and surface the structural differences so they can be evaluated. This is a
+port + adaptation, not a layout migration — none of joryirving's repo structure (multi-cluster
+base+overlay) is being adopted.
+
+## Source inventory
+
+joryirving's `.agents/` contains exactly three files plus a root `AGENTS.md` it leans on:
+
+1. `.agents/instructions/pr-review.instructions.md` — system prompt for a `misospace/pr-reviewer-action` GitHub workflow.
+2. `.agents/instructions/sorting.instructions.md` — YAML sorting conventions (generic + app-template-specific).
+3. `.agents/skills/add-app/SKILL.md` — scaffold a new app-template application.
+
+## Scope decisions (locked during brainstorming)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Wiring model | Canonical files under `.agents/`, symlinked into `.claude/` | Maximum portability (Copilot/Codex/Cursor) **and** Claude Code auto-discovery. |
+| `pr-review.instructions.md` | **Skip** | It is the literal `system_prompt_file` for `misospace/pr-reviewer-action`, which this repo does not run (this repo uses `renovate-review.yaml` / claude-code-action). Its "documented conventions" are joryirving-specific and partly contradict this repo (we *do* set `metadata.namespace` on ConfigMaps for Checkov CKV_K8S_21; we *do* use per-app `ocirepository.yaml`). |
+| `sorting.instructions.md` | **Port** (light adaptation) | Generic YAML + app-template rules; this repo is an app-template shop. |
+| `add-app/SKILL.md` | **Port** (heavy adaptation) | High value; needs full remap to this repo's single-cluster, per-app `app/` layout. |
+| Root `AGENTS.md` | **Symlink → `CLAUDE.md`** | Tool-agnostic entrypoint with zero duplication / drift. |
+| Process | Spec doc → review → plan → build, in a worktree | User preference. |
+
+## Target layout & wiring
+
+```
+.agents/
+├── instructions/
+│   └── sorting.instructions.md         # adapted (light)
+└── skills/
+    └── add-app/
+        └── SKILL.md                    # adapted (heavy)
+.claude/skills/add-app  ->  ../../.agents/skills/add-app   # dir symlink (Claude Code discovery)
+AGENTS.md               ->  CLAUDE.md                        # file symlink (tool-agnostic entrypoint)
+CLAUDE.md                                                    # + one pointer line to sorting.instructions.md
+```
+
+- The `add-app` skill is an action skill → exposed to Claude Code via a **relative directory
+  symlink** `.claude/skills/add-app -> ../../.agents/skills/add-app`.
+- `sorting.instructions.md` is *reference* material (not an action skill). Claude Code does not
+  auto-load `.agents/instructions/`, so discovery is via a **one-line pointer added to `CLAUDE.md`**
+  rather than a skill symlink.
+- `AGENTS.md -> CLAUDE.md` relative symlink at repo root.
+- Committed relative symlinks are stored by git and survive fresh clones.
+
+## Component 1 — `sorting.instructions.md` (light adaptation)
+
+Ports near-verbatim. The single substantive change:
+
+- **app-template detection rule.** joryirving detects app-template via `spec.chartRef.name: app-template`
+  (one shared chart). Here, `chartRef.name` is the **app's own name** pointing at a **per-app
+  `app/ocirepository.yaml`**. Rewrite the detection to: *"the app's `app/ocirepository.yaml` `url`
+  ends in `bjw-s-labs/helm/app-template`"* (equivalently, `chartRef.kind: OCIRepository` referencing
+  that per-app source).
+
+Everything else maps cleanly and is retained unchanged:
+- Alphabetical-by-default at every level; leading `---`; `yaml-language-server` schema comment.
+- K8s ordering `apiVersion` → `kind` → `metadata` → `spec`.
+- `metadata` ordering `name` → `namespace` → `annotations` → `labels`.
+- app-template `spec` ordering (`chartRef`, `interval`, `dependsOn`, `install`, `upgrade`, `values`),
+  `spec.values` (`defaultPodOptions` first, then alphabetical), and the
+  controllers / containers / persistence / service nested ordering rules.
+- The "do not sort YAML embedded inside string fields (e.g. `configMap.data.*`)" caveat.
+
+## Component 2 — `add-app/SKILL.md` (heavy adaptation)
+
+The skill must emit **this repo's** exact layout. Full remapping from joryirving's assumptions:
+
+| joryirving assumption | this repo (adaptation) |
+|---|---|
+| base + overlay: `apps/base/<ns>/<app>/` + `apps/<cluster>/<ns>/<app>.yaml` | single tree: `apps/<ns>/<app>/ks.yaml` + `apps/<ns>/<app>/app/{ocirepository,helmrelease,kustomization,…}.yaml` |
+| shared `chartRef.name: app-template`, **no** per-app ocirepository | **per-app `app/ocirepository.yaml`** (`oci://ghcr.io/bjw-s-labs/helm/app-template`, own `ref.tag`) + HR `chartRef.kind: OCIRepository, name: <app>` |
+| overlay KS: name-anchor only, `postBuild.substitute {APP, CLUSTER}`, `wait: false`, namespace via `replacements` component | this repo's `ks.yaml`: `&app` + `&namespace` anchors, `commonMetadata.labels.app.kubernetes.io/name: *app`, `targetNamespace: *namespace`, `wait: true`, `retryInterval: 2m`, `timeout: 5m`; components (`gatus/guarded`, `volsync`, `alerts`) and substitutes (`APP: *app`, `VOLSYNC_CAPACITY`) go **in `ks.yaml`**, not a separate overlay file |
+| `ClusterSecretStore name: onepassword` | **`onepassword-connect`** (reads the `Talos` 1Password vault); ES-using apps `dependsOn: { name: onepassword-connect, namespace: external-secrets }` |
+| multi-cluster targeting question | **dropped** (single cluster) |
+| route via inline values only | inline `route:` in HR values is the dominant pattern here (~117 inline vs ~12 separate `httproute.yaml`); skill prefers inline `route:`, offers separate `httproute.yaml` as the rarer option; hosts use `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}`, listeners `envoy-internal` / `envoy-external` |
+| `question` tool to gather inputs | **AskUserQuestion** |
+| (n/a) | register app **alphabetically** in `apps/<ns>/kustomization.yaml`; ConfigMaps need explicit `metadata.namespace` (Checkov CKV_K8S_21); escape Flux-literal vars as `$${VAR}`; GPU workloads use `runtimeClassName: nvidia` |
+| verify via manual file checks | **verify with `flate build hr <app> -n <ns> --path kubernetes/flux/cluster` and `flate test all --path kubernetes/flux/cluster --allow-missing-secrets`** |
+
+Shared, no change needed: the schema host `k8s-schemas.home-operations.com` (this repo already uses it
+in `ks.yaml`), and the bjw-s `app-template` chart itself.
+
+### Files the adapted skill scaffolds
+
+For app `<app>` in namespace `<ns>`:
+
+- `kubernetes/apps/<ns>/<app>/ks.yaml` (Flux Kustomization; anchors, components, substitutes)
+- `kubernetes/apps/<ns>/<app>/app/kustomization.yaml` (lists `ocirepository.yaml`, `helmrelease.yaml`, + optional `externalsecret.yaml` / `httproute.yaml`)
+- `kubernetes/apps/<ns>/<app>/app/ocirepository.yaml` (per-app app-template source)
+- `kubernetes/apps/<ns>/<app>/app/helmrelease.yaml` (app-template HR; inline `route:` when ingress needed)
+- `kubernetes/apps/<ns>/<app>/app/externalsecret.yaml` (only if secrets needed; `onepassword-connect`)
+- update `kubernetes/apps/<ns>/kustomization.yaml` to register the app alphabetically
+
+Skill workflow keeps joryirving's good bones: collect details → **inspect 1-2 neighbouring apps in the
+same namespace and match their patterns** → scaffold → verify. Confirm before writing files.
+
+## Worth flagging (NOT building now)
+
+- **`misospace/pr-reviewer-action` workflow** (the action itself, separate from the skipped
+  instructions file): reviews *all* PRs with a structured JSON verdict, evidence providers, and
+  host-platform compatibility-matrix checks for version bumps — broader than this repo's
+  Renovate-only `renovate-review.yaml`. Candidate future enhancement; flagged, not adopted.
+- joryirving's **base+overlay multi-cluster layout** and **`replacements` component**: *not* worth
+  adopting — single-cluster here; would be a large refactor for zero benefit.
+
+## Verification
+
+1. `.agents/instructions/sorting.instructions.md` and `.agents/skills/add-app/SKILL.md` exist and read correctly.
+2. Symlinks resolve: `.claude/skills/add-app/SKILL.md` and `AGENTS.md` both readable through the link;
+   `git ls-files -s` shows mode `120000` (symlink) for both.
+3. `CLAUDE.md` has the sorting-instructions pointer line.
+4. No secrets / LAN IPs / internal hostnames introduced (repo is public).
+5. `markdownlint` / super-linter pass for the new markdown (mirror with `just lint` if needed).


### PR DESCRIPTION
## Summary

Adapts joryirving/home-ops [`.agents`](https://github.com/joryirving/home-ops/tree/main/.agents) to this repo's conventions.

- **`.agents/instructions/sorting.instructions.md`** — YAML sorting conventions (alphabetical defaults + app-template ordering). Adapted: app-template detection rewritten for this repo's **per-app `OCIRepository`**, and HelmRelease `spec` order corrected to this repo's actual convention (`interval` before `chartRef`).
- **`.agents/skills/add-app/SKILL.md`** — scaffolds a new bjw-s `app-template` app following this repo's single-cluster `ks.yaml`+`app/` layout, per-app `ocirepository.yaml`, `onepassword-connect` ExternalSecrets, inline Envoy Gateway `route:` values, and `flate` validation.
- **`AGENTS.md`** — new tool-agnostic conventions guide (Codex/Copilot/Cursor). Public-safe. Claude Code loads it via an `@AGENTS.md` import in the local `CLAUDE.md`.
- **`docs/superpowers/`** — design spec + implementation plan.

**Skipped:** joryirving's `pr-review.instructions.md` (it's the system prompt for a `misospace/pr-reviewer-action` workflow this repo doesn't run).

## Notes

- `.agents/` is the committed/canonical source. The `add-app` skill is discovered by Claude Code via a **local-only** `.claude/skills/add-app` symlink (`.claude/` is gitignored) — recreate per checkout.
- No Kubernetes manifests change → `flate` unaffected.

## Test plan

- [ ] super-linter passes on the new markdown
- [ ] (post-merge, local) add `@AGENTS.md` to private `CLAUDE.md` + create `.claude/skills/add-app` symlink in the main checkout