### PR TITLE
docs(known-issues): CKV_K8S_21 + Trivy KSV0046 scanner gotchas

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -664,7 +664,25 @@ target hostnames needs investigation — likely a `dnsPolicy` /
 resolv.conf issue post-Cilium-identity-shuffle. 3. KEDA-on-Plex pause annotations get reverted by Flux; would be cleaner
 to set them through chart values so they survive reconcile.
 
+## Checkov CKV_K8S_21 Flags Namespaced Resources Without an Explicit Namespace
+
+### Issue
+
+The `security-scans` workflow (Checkov) fails a PR with **CKV_K8S_21** — _"The default namespace should not be used"_ — on namespaced resources under `app/` (ConfigMaps, ServiceAccounts, PVCs, …), even though they deploy into the correct namespace at runtime.
+
+### Root Cause
+
+Checkov scans the **raw committed manifests**, _before_ Flux applies the Kustomization's `targetNamespace` (or the parent-dir `kustomization.yaml` `namespace:`). A resource with no explicit `metadata.namespace` looks like it lives in `default` to the scanner, so it gets flagged — even though `targetNamespace` sets it correctly at apply-time.
+
+It bites namespaced **core** kinds (ConfigMaps, ServiceAccounts, PVCs, Services). Cluster-scoped kinds (ClusterRole / ClusterRoleBinding) are not flagged, and CRD instances (ExternalSecret, ToolHive `MCPServer`, …) are typically skipped — so it mainly surfaces on the core kinds.
+
+### Fix
+
+Set `metadata.namespace: <ns>` explicitly on every namespaced resource you author, matching the Kustomization's `targetNamespace`. It is redundant with `targetNamespace` at apply-time (and harmless), but it satisfies the raw-YAML scanner.
+
+> Trivy's `KSV0046` (wildcard RBAC) is a sibling gotcha: for a deliberate read-only `resources: ["*"]` ClusterRole, suppress it path-scoped in `.trivyignore.yaml` with a justification rather than narrowing the role.
+
 ---
 
-**Last Updated**: 2026-05-13
+**Last Updated**: 2026-06-16
 **Cluster**: talos-cluster


### PR DESCRIPTION
Documents two raw-manifest security-scanner gotchas (previously only in the git-ignored local CLAUDE.md):

- **Checkov CKV_K8S_21** flags namespaced resources (ConfigMaps, ServiceAccounts, PVCs, …) that lack an explicit `metadata.namespace` — it scans the raw committed YAML *before* Flux applies `targetNamespace`. Fix: set `metadata.namespace` explicitly.
- **Trivy KSV0046** (wildcard RBAC): suppress path-scoped in `.trivyignore.yaml` for deliberate read-only `resources: ["*"]` ClusterRoles rather than narrowing the role.

Both surfaced while building the ai LLM stack (the ToolHive MCP ServiceAccounts + the kubectl-mcp read-only role).