### PR TITLE
fix(rook-ceph): pin ceph-csi rbd driver name to rook-ceph.rbd.csi.ceph.com

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -16,6 +16,11 @@ spec:
     drivers:
       rbd:
         enabled: true
+        # MUST match the existing StorageClass provisioner and all in-use PVs.
+        # This mirror packages the upstream ceph-csi-operator chart, which
+        # defaults the driver name to the unprefixed "rbd.csi.ceph.com"; Rook's
+        # convention (and our ceph-block SC) prefixes the operator namespace.
+        name: rook-ceph.rbd.csi.ceph.com
       cephfs:
         enabled: false
       nfs:


### PR DESCRIPTION
Hotfix for #3145 rollout. The mirror packages the upstream ceph-csi-operator chart whose default RBD driver name is the unprefixed `rbd.csi.ceph.com`; our `ceph-block` StorageClass + 124 in-use PVs use `rook-ceph.rbd.csi.ceph.com`. Without the override the new operator wound down the in-use driver (nodeplugin `FailedCreate`: missing `rbd-nodeplugin-sa`). Pins `drivers.rbd.name` to match the provisioner (what rook's own chart defaults to). Existing Driver CR is already annotated for this release → adopts in place; the spurious `rbd.csi.ceph.com` driver is pruned.

Ceph 19→20 upgrade itself completed cleanly (HEALTH_OK) and RGW teardown was clean — this is purely the CSI driver-name correction.