### PR TITLE
feat(observability): Docker container lifecycle alerts for the NAS

### DIFF
--- a/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
@@ -65,3 +65,63 @@ spec:
             # TrueNAS's own real-time ZFS event detection + system alerts. Revisit if a
             # pool-state metric becomes available (e.g. the netdata.conf swap, declined
             # for its impact on the TrueNAS Reporting UI).
+
+    # ------------------------------------------------------------------
+    # Docker container lifecycle alerts — fed by docker_state_exporter on
+    # the NAS (:9419, scraped as job=truenas-docker-exporter). Container
+    # CPU/mem already come from the graphite bridge's cgroup_* series (by
+    # ID); these add up/down, health, restart and OOM by container NAME.
+    # severity=critical routes to Pushover via the existing AlertmanagerConfig.
+    # ------------------------------------------------------------------
+    - name: truenas-docker.rules
+      rules:
+        - alert: TrueNASDockerStateExporterDown
+          annotations:
+            summary: "TrueNAS docker-state exporter is not being scraped."
+          expr: |-
+            up{job="truenas-docker-exporter"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # "exited|dead" scoped to the doco-cd-managed fleet so intentionally
+        # stopped containers (e.g. the decommissioned minio app) don't page.
+        - alert: TrueNASContainerDown
+          annotations:
+            summary: "TrueNAS container {{ $labels.name }} is not running (state: {{ $labels.status }})."
+          expr: |-
+            container_state_status{job="truenas-docker-exporter", status=~"exited|dead", container_label_cd_doco_metadata_manager="doco-cd"} == 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: TrueNASContainerUnhealthy
+          annotations:
+            summary: "TrueNAS container {{ $labels.name }} healthcheck is failing (unhealthy)."
+          expr: |-
+            container_state_health_status{job="truenas-docker-exporter", health_status="unhealthy"} == 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: TrueNASContainerRestarting
+          annotations:
+            summary: "TrueNAS container {{ $labels.name }} is stuck restarting (crash loop)."
+          expr: |-
+            container_state_status{job="truenas-docker-exporter", status="restarting"} == 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: TrueNASContainerOOMKilled
+          annotations:
+            summary: "TrueNAS container {{ $labels.name }} was OOM-killed."
+          expr: |-
+            container_state_oomkilled{job="truenas-docker-exporter"} == 1
+          for: 0m
+          labels:
+            severity: critical
+        - alert: TrueNASContainerFlapping
+          annotations:
+            summary: "TrueNAS container {{ $labels.name }} restart count changed {{ $value }} times in the last hour."
+          expr: |-
+            changes(container_restartcount{job="truenas-docker-exporter"}[1h]) > 3
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
@@ -16,3 +16,28 @@ spec:
     - action: replace
       targetLabel: job
       replacement: *name
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name truenas-docker-exporter
+spec:
+  # docker_state_exporter on the NAS (truenas-apps apps/monitoring) — per-container
+  # state/health/restartcount/oomkilled keyed by container name on :9419. Drives the
+  # truenas-docker.rules lifecycle alerts (the graphite bridge's cgroup_* series are
+  # keyed by container ID and disappear once a container stops, so they can't).
+  # metricRelabelings drop the ~25 noisy container_label_* values (compose/doco-cd
+  # shas) but keep cd_doco_metadata_manager so "container down" scopes to the
+  # GitOps-managed fleet (auto-excludes the intentionally-stopped minio app).
+  staticConfigs:
+    - targets:
+        - ${SECRET_STORAGE_SERVER}:9419
+  metricsPath: /metrics
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+  metricRelabelings:
+    - action: labelkeep
+      regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager


### PR DESCRIPTION
## What
Adds Docker **container lifecycle alerting** for the TrueNAS box, routed to the existing Alertmanager→Pushover receiver. Requested as an extension of the existing `truenas-exporter` alerts, which already cover disk-temp/SMART/CPU-temp.

## How
- **ScrapeConfig `truenas-docker-exporter`** → `${SECRET_STORAGE_SERVER}:9419` (new `docker_state_exporter` deployed in `truenas-apps` `apps/monitoring`, live + verified). `metricRelabelings` drop the ~25 noisy `container_label_*` values but keep `cd_doco_metadata_manager`.
- **`truenas-docker.rules` group** (6 alerts):
  | alert | expr | sev |
  |---|---|---|
  | TrueNASDockerStateExporterDown | `up == 0` | critical |
  | TrueNASContainerDown | `container_state_status{status=~"exited|dead", …manager="doco-cd"} == 1` | critical |
  | TrueNASContainerUnhealthy | `container_state_health_status{health_status="unhealthy"} == 1` | critical |
  | TrueNASContainerRestarting | `container_state_status{status="restarting"} == 1` | critical |
  | TrueNASContainerOOMKilled | `container_state_oomkilled == 1` | critical |
  | TrueNASContainerFlapping | `changes(container_restartcount[1h]) > 3` | warning |

## Why a new exporter
The graphite bridge's `cgroup_*` series give per-container CPU/mem but are keyed by container **ID** and disappear once a container stops — useless for up/down/health/restart. `docker_state_exporter` reads the Docker API and reports exited/unhealthy/restarting/OOM by **name**.

## Notes
- `Down` is scoped to the doco-cd-managed fleet so the intentionally-stopped **minio** app (being decommissioned) doesn't page.
- Nothing should fire on merge (fleet is healthy; minio excluded).
- Exporter image is `:latest`-only upstream (no version tags) — pinned by digest in truenas-apps.
- Pairs with `truenas-apps@3313b54`.