### PR TITLE
fix(rook-ceph): enable RBD csi-snapshotter via snapshotPolicy

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -21,6 +21,13 @@ spec:
         # defaults the driver name to the unprefixed "rbd.csi.ceph.com"; Rook's
         # convention (and our ceph-block SC) prefixes the operator namespace.
         name: rook-ceph.rbd.csi.ceph.com
+        # Deploy the csi-snapshotter sidecar. The chart defaults this to "none",
+        # which omits the sidecar entirely -- so the cluster snapshot-controller
+        # creates VolumeSnapshotContents that nothing ever calls CreateSnapshot
+        # on (stuck ReadyToUse=false). The pre-v1.20 rook-managed CSI shipped the
+        # snapshotter by default; VolSync's copyMethod: Snapshot movers depend on
+        # it for every *-nfs/-r2 ReplicationSource.
+        snapshotPolicy: volumeSnapshot
       cephfs:
         enabled: false
       nfs:


### PR DESCRIPTION
## Problem

After the Rook v1.20 CSI split, the `ceph-csi-drivers` chart defaults `drivers.rbd.snapshotPolicy` to `none`, which omits the `csi-snapshotter` sidecar from the RBD ctrlplugin deployment. The cluster `snapshot-controller` still creates `VolumeSnapshotContent` objects, but nothing ever calls `CreateSnapshot` on the driver, so every new `VolumeSnapshot` hangs at `READYTOUSE=false`.

VolSync uses `copyMethod: Snapshot`, so its movers wait on a snapshot that never becomes ready — `data PVC not available (possibly waiting for copy trigger)`. The result was ~88 `VolSyncVolumeOutOfSync` alerts (every `*-nfs` / `*-r2` ReplicationSource) starting ~16:00 the day of the v1.20 cutover. NFS itself was fine — `kopia-maint` jobs kept completing against the same repo.

The pre-v1.20 rook-managed CSI shipped the snapshotter by default, so this regressed silently on migration. This is the snapshot half of the v1.20 CSI hotfix; the driver-`name:` half landed earlier.

## Fix

Set `drivers.rbd.snapshotPolicy: volumeSnapshot` so ceph-csi-operator deploys the `csi-snapshotter` sidecar. Matches the reference home-ops config (`joryirving/home-ops`), which sets the same value.

## Validation

- `helm template` with the new value renders `spec.snapshotPolicy: volumeSnapshot` on the RBD `Driver` CR.
- Render-verified the value path `drivers.rbd.snapshotPolicy` -> `Driver.spec.snapshotPolicy`.

## Rollout

ceph-csi-operator rolls the ctrlplugin deployment to add the sidecar (control-plane only, no impact to mounted volumes), then the pending `VolumeSnapshotContents` get processed and the VolSync movers resume on their next schedule.

Note: the separate `rook-ceph v1.20.0 -> v1.20.1` bump is unrelated and does not fix this — `snapshotPolicy` is a chart value, independent of the operator version.