### PR TITLE
fix(ci): render flate diff inside a code fence so GitHub colours it

### DIFF
--- a/.github/workflows/flate.yaml
+++ b/.github/workflows/flate.yaml
@@ -132,18 +132,31 @@ jobs:
             kustomization) KIND=ks ;;
             *) KIND="${RESOURCE}" ;;
           esac
-          : > diff.md
+          : > diff.raw
           rc=0
           flate diff "${KIND}" \
             --path pull/kubernetes/flux/cluster \
             --path-orig default/kubernetes/flux/cluster \
             --strip-attr caBundle \
             --allow-missing-secrets \
-            --output github >> diff.md || rc=1
-          # Cap to stay within GitHub's ~65k-char comment limit
-          if [ "$(wc -c < diff.md)" -gt 60000 ]; then
-            head -c 60000 diff.md > diff.trunc && mv diff.trunc diff.md
-            printf '\n\n_…diff truncated; see workflow logs for the full output._\n' >> diff.md
+            --output github >> diff.raw || rc=1
+          # flate's `github` format emits diff-prefixed lines (@@/#/!/+/-) intended
+          # for GitHub's diff lexer, which only colours them inside a ```diff fence.
+          # Posted raw, GitHub renders them as plain markdown — the `#` line becomes
+          # a heading (auto-linked when it looks like a URL) and `+`/`-` collapse to
+          # a bullet list, losing the diff. Wrap the output in a fence so it renders
+          # as a real diff. Build it AFTER the 60k cap so the closing fence is never
+          # truncated away; the truncation note stays outside the fence.
+          : > diff.md
+          if [ -s diff.raw ]; then
+            {
+              printf '```diff\n'
+              head -c 60000 diff.raw
+              printf '\n```\n'
+            } > diff.md
+            if [ "$(wc -c < diff.raw)" -gt 60000 ]; then
+              printf '\n_…diff truncated; see workflow logs for the full output._\n' >> diff.md
+            fi
           fi
           exit "${rc}"
 


### PR DESCRIPTION
## Problem

The `Flate - Diff` job posts flate's `--output github` result straight into the sticky PR comment with **no code fence**. flate's `github` format emits diff-prefixed lines (`@@ <path> @@`, `#`, `!`, `±`, `+`, `-`) that — per [flate's README](https://github.com/home-operations/flate#:~:text=GitHub's%20diff%20lexer) — *"GitHub's diff lexer renders natively"*, **but that lexer only engages inside a ```` ```diff ```` fence**.

Posted raw, GitHub renders the lines as plain markdown:

- the `# csi.ceph.io/v1/Driver/…` line becomes an `<h1>` heading, and because it looks like a domain GitHub auto-links it → a giant blue link
- `- none` / `+ volumeSnapshot` collapse into a bullet list — the `+`/`-` diff semantics are lost

(See PR #3166's flate comment for the symptom.)

## Fix

Wrap the rendered diff in a ```` ```diff ```` fence. Same output, but now GitHub colours it as a proper red/green monospace diff. The fence is built **after** the 60k truncation cap so the closing fence can never be cut off, and the truncation note stays outside the fence. The empty-diff → no-comment path is unchanged.

## Validation

- `actionlint` (incl. shellcheck of the `run:` block), `yamlfmt`, `zizmor`, `prettier` all pass
- Reproduced the exact PR #3166 change with flate `v0.4.7` locally and ran the new wrapping logic verbatim — confirmed the comment body is a well-formed ```` ```diff ```` block and the empty-diff case still posts no comment