### PR TITLE
style(markdown): fix list indentation broken by de-identify rewrite

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -253,10 +253,10 @@ list alphabetical. Match the exact reference style used by neighbours (e.g. `./<
 4. No plain-text secrets, LAN IPs, or internal hostnames were introduced.
 5. Render and validate with flate:
 
-    ```bash
-    flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
-    flate test all --path kubernetes/flux/cluster --allow-missing-secrets
-    ```
+   ```bash
+   flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
+   flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+   ```
 
 ## Notes
 

--- a/kubernetes/apps/flux-system/konflate/README.md
+++ b/kubernetes/apps/flux-system/konflate/README.md
@@ -22,34 +22,34 @@ webhook secret (mirrors onedr0p/home-ops):
    (a random string).
 2. Add `app/externalsecret.yaml`:
 
-    ```yaml
-    ---
-    # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
-    apiVersion: external-secrets.io/v1
-    kind: ExternalSecret
-    metadata:
-        name: konflate-webhook-token
-    spec:
-        secretStoreRef:
-            kind: ClusterSecretStore
-            name: onepassword-connect
-        target:
-            name: konflate-webhook-token-secret
-            template:
-                data:
-                    KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
-        dataFrom:
-            - extract:
-                  key: konflate
-    ```
+   ```yaml
+   ---
+   # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+   apiVersion: external-secrets.io/v1
+   kind: ExternalSecret
+   metadata:
+     name: konflate-webhook-token
+   spec:
+     secretStoreRef:
+       kind: ClusterSecretStore
+       name: onepassword-connect
+     target:
+       name: konflate-webhook-token-secret
+       template:
+         data:
+           KONFLATE_WEBHOOK_SECRET: "{{ .KONFLATE_WEBHOOK_SECRET }}"
+     dataFrom:
+       - extract:
+           key: konflate
+   ```
 
 3. Add `./externalsecret.yaml` to `app/kustomization.yaml` and set in the
    HelmRelease values:
 
-    ```yaml
-    secret:
-        existingSecret: konflate-webhook-token-secret
-    ```
+   ```yaml
+   secret:
+     existingSecret: konflate-webhook-token-secret
+   ```
 
 4. In GitHub repository settings → Webhooks, POST `https://konflate.${SECRET_DOMAIN}/hooks`
    (content-type `application/json`, secret = the same value, events =

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/CONTAINERIZED-README.md
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/CONTAINERIZED-README.md
@@ -7,10 +7,10 @@ This deployment now uses a **pre-built container** for faster and more reliable 
 - **Container**: `ghcr.io/lukeevanstech/supermicro-ipmi-cert:latest`
 - **Script**: `certwarden-supermicro-deploy.sh`
 - **Benefits**:
-    - Faster execution (no runtime dependency installation)
-    - Consistent environment across deployments
-    - Reduced job execution time by ~30-60 seconds
-    - Better security (minimal container, no runtime downloads)
+  - Faster execution (no runtime dependency installation)
+  - Consistent environment across deployments
+  - Reduced job execution time by ~30-60 seconds
+  - Better security (minimal container, no runtime downloads)
 
 ## Files
 
@@ -23,9 +23,9 @@ This deployment now uses a **pre-built container** for faster and more reliable 
 1. Certwarden calls `certwarden-supermicro-deploy.sh` after certificate renewal
 2. Script creates a Kubernetes Job using the pre-built container
 3. Container has all dependencies pre-installed:
-    - kubectl v1.32.0
-    - Python 3.12 + requests + pyOpenSSL
-    - supermicro_ipmi_cert.py script
+   - kubectl v1.32.0
+   - Python 3.12 + requests + pyOpenSSL
+   - supermicro_ipmi_cert.py script
 4. Job deploys certificate via Redfish API
 5. Job auto-cleans up after 5 minutes
 
@@ -45,25 +45,25 @@ If you need to rollback to the old runtime-installation method:
 
 1. Edit `kustomization.yaml`:
 
-    ```yaml
-    # Comment out containerized approach:
-    # - name: certwarden-supermicro-scripts
-    #   files:
-    #     - certwarden-supermicro-deploy.sh
+   ```yaml
+   # Comment out containerized approach:
+   # - name: certwarden-supermicro-scripts
+   #   files:
+   #     - certwarden-supermicro-deploy.sh
 
-    # Uncomment old approach:
-    - name: certwarden-supermicro-scripts
-      files:
-          - supermicro_updater.py
-          - certwarden-supermicro-deploy.sh.OLD
-    ```
+   # Uncomment old approach:
+   - name: certwarden-supermicro-scripts
+     files:
+       - supermicro_updater.py
+       - certwarden-supermicro-deploy.sh.OLD
+   ```
 
 2. Apply changes:
 
-    ```bash
-    kubectl delete configmap certwarden-supermicro-scripts -n infrastructure
-    kubectl apply -k .
-    ```
+   ```bash
+   kubectl delete configmap certwarden-supermicro-scripts -n infrastructure
+   kubectl apply -k .
+   ```
 
 3. Restart Certwarden to pick up the new ConfigMap
 

--- a/kubernetes/components/nfs-scaler/README.md
+++ b/kubernetes/components/nfs-scaler/README.md
@@ -27,20 +27,20 @@ Add the component to your application's kustomization.yaml:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
-    - ../../../../components/nfs-scaler
+  - ../../../../components/nfs-scaler
 resources:
-    - ./helmrelease.yaml
+  - ./helmrelease.yaml
 replacements:
-    - source:
-          kind: HelmRelease
-          name: your-app-name
-          fieldPath: metadata.name
-      targets:
-          - select:
-                kind: ScaledObject
-            fieldPaths:
-                - metadata.name
-                - spec.scaleTargetRef.name
+  - source:
+      kind: HelmRelease
+      name: your-app-name
+      fieldPath: metadata.name
+    targets:
+      - select:
+          kind: ScaledObject
+        fieldPaths:
+          - metadata.name
+          - spec.scaleTargetRef.name
 ```
 
 The replacements section automatically configures the ScaledObject to target your deployment using the HelmRelease name.


### PR DESCRIPTION
## What
Fixes the **markdown-lint failure on `main`** (both `MARKDOWN` and `MARKDOWN_PRETTIER` super-linter checks).

## Cause
The #3151 de-identify history rewrite inflated nested list / fenced-code-block indentation from **2 → 4 spaces** in 4 non-docs markdown files. That trips:
- **MARKDOWN_PRETTIER** — prettier's canonical nested-list indent is 2
- **MARKDOWN** — markdownlint `MD007/ul-indent` (default 2) via the repo `.markdownlint.yml`

Both passed before the rewrite, so this just restores them.

## Fix
`prettier --write` on the 4 files (**whitespace-only** — `git diff -w` is empty, no content changed):
- `.agents/skills/add-app/SKILL.md`
- `kubernetes/apps/flux-system/konflate/README.md`
- `kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/CONTAINERIZED-README.md`
- `kubernetes/components/nfs-scaler/README.md`

## Verified locally
- `prettier --check` across the whole non-docs markdown set → clean
- `markdownlint-cli2 --config .markdownlint.yml` on all 4 → **0 errors**