### PR TITLE
fix(memini): co-locate fsck cronjob with main pod (RWO PVC)

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -56,6 +56,19 @@ spec:
         enabled: true
         cronjob:
           schedule: "0 5 * * *"
+        pod:
+          # The data PVC is ReadWriteOnce (ceph-block), shared with the main
+          # StatefulSet pod. Pin the fsck job to the node running main so both
+          # can mount the RWO volume; otherwise the fsck pod Multi-Attach-stalls
+          # in ContainerCreating until it happens to land on the right node.
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: memini
+                      app.kubernetes.io/controller: main
+                  topologyKey: kubernetes.io/hostname
         # The chart's fsck curl uses --variable %MEMINI_API_KEY, so the fsck
         # container needs the same bearer token as the main container.
         containers:


### PR DESCRIPTION
## Problem

The memini `fsck` cronjob shares the **ReadWriteOnce** `memini` data PVC (ceph-block) with the `main` StatefulSet pod. With no affinity, the fsck pod can land on a different node than `main`, where it Multi-Attach-stalls in `ContainerCreating` until it happens to be scheduled on the node holding the volume (observed ~6h stuck before self-resolving).

## Fix

Add a hard `podAffinity` (`requiredDuringSchedulingIgnoredDuringExecution`, topologyKey `kubernetes.io/hostname`) pinning the fsck pod to the node running `main` (selector `app.kubernetes.io/controller: main`). RWO allows multiple pods on the same node, so co-location lets the fsck job mount the volume reliably. Same pattern used for other RWO co-located workloads in this cluster.

## Validation

`helm template` (chart v0.4.4) renders the CronJob with the podAffinity block on the job pod template.