### PR TITLE
feat(arc): R2 creds for terraform-vsphere runner

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/externalsecret.yaml
@@ -44,8 +44,13 @@ spec:
         TF_VAR_vsphere_unverified_ssl: "true"
         TF_VAR_vm_domain_admin: "{{ .DOMAIN_ADMIN_USER }}"
         TF_VAR_vm_domain_admin_password: "{{ .DOMAIN_ADMIN_PASSWORD }}"
-        # NOTE: Cloudflare R2 keys (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
-        # are ADDED to this block in Plan 2, once the R2 bucket exists.
+        # Cloudflare R2 backend creds (S3-compatible) for the OpenTofu state.
+        AWS_ACCESS_KEY_ID: "{{ .R2_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2_SECRET_ACCESS_KEY }}"
+        AWS_ENDPOINT_URL_S3: "{{ .R2_S3_ENDPOINT }}"
+        AWS_REGION: "auto"
   dataFrom:
     - extract:
         key: vsphere-terraform
+    - extract:
+        key: cloudflare-r2-tfstate


### PR DESCRIPTION
Adds R2 backend creds (from `cloudflare-r2-tfstate`) to the `terraform-vsphere-creds` ExternalSecret. Enables the on-prem ARC runner to use the R2 OpenTofu state backend (terraform-vsphere TFC→R2 migration).