### PR TITLE
feat(renovate): auto-merge apps by default, guard cluster infra

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -71,6 +71,50 @@
   //     autoMerge → changelogs → grafanaDashboards → groups → labels → overrides) ---
   packageRules: [
     // === Auto-merge (from autoMerge.json5) ===
+    // === App auto-merge (denylist model) ===
+    // Broad enabler: every container image + Helm chart auto-merges for
+    // minor/patch/digest. The protected-infra guard immediately below
+    // re-disables automerge for cluster-critical components (last-match-wins).
+    // `major` is never listed anywhere, so it always stays manual.
+    // platformAutomerge:false => Renovate self-gates on CI (flate, security-scans)
+    // rather than GitHub-native auto-merge, so no branch-protection ruleset is needed.
+    {
+      description: "Auto-merge apps — minor/patch/digest (denylist model; protected guard below)",
+      matchDatasources: ["docker", "helm"],
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      automerge: true,
+      automergeType: "pr",
+      platformAutomerge: false,
+      ignoreTests: false,
+      minimumReleaseAge: "3 days",
+    },
+    {
+      description: "Protected infra — never auto-merge, manual review only",
+      matchDatasources: ["docker", "helm"],
+      matchPackageNames: [
+        "/cilium/",
+        "/cert-manager/",
+        "/coredns/",
+        "/fluxcd\\//", // Flux controllers
+        "/controlplaneio-fluxcd/", // flux-operator + flux-instance
+        "/rook-ceph/",
+        "/rook-ceph-cluster/",
+        "/kube-apiserver/",
+        "/kube-controller-manager/",
+        "/kube-proxy/",
+        "/kube-scheduler/",
+        "/kubelet/",
+        "/siderolabs\\//", // Talos
+        "/external-secrets/",
+        "/spegel/",
+        "/cloudnative-pg/", // CNPG operator + postgresql image + plugin-barman-cloud
+        "/nvidia/", // gpu-operator chart + drivers + dcgm exporter
+        "/dcgm/", // dcgm / dcgm-exporter (no nvidia prefix)
+        "/envoyproxy/", // Envoy Gateway: gateway-helm chart + envoy image
+        "/1password/", // onepassword-connect: connect chart + connect-api + connect-sync
+      ],
+      automerge: false,
+    },
     {
       description: "Auto-merge GitHub Actions",
       matchManagers: ["github-actions"],
@@ -102,24 +146,6 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge OCI Charts",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/kube-prometheus-stack/", "/grafana/"],
-      ignoreTests: false,
-    },
-    {
-      description: "Auto-merge trusted container digests",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["digest", "minor", "patch"],
-      matchPackageNames: ["/home-operations/"],
-      ignoreTests: false,
-    },
-    {
       description: "Auto-merge trusted GitHub Actions",
       matchManagers: ["github-actions"],
       matchPackageNames: ["/^actions\\//", "/^renovatebot\\//"],
@@ -128,42 +154,6 @@
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "1 day",
       ignoreTests: true,
-    },
-    {
-      description: "Auto-merge changedetection.io patch updates",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["patch"],
-      matchPackageNames: ["/changedetection\\.io/"],
-      ignoreTests: false,
-    },
-    {
-      description: "Auto-merge whodb container updates",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/clidey/whodb/"],
-      ignoreTests: false,
-    },
-    {
-      description: "Auto-merge databasus container updates",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/databasus/databasus/"],
-      ignoreTests: false,
-    },
-    {
-      description: "Auto-merge seerr container updates",
-      matchDatasources: ["docker"],
-      automerge: true,
-      automergeType: "pr",
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/seerr-team/seerr/"],
-      ignoreTests: false,
     },
 
     // === Changelogs (from changelogs.json5) ===


### PR DESCRIPTION
## Summary

Flip Renovate's auto-merge policy from an opt-in **allowlist** to a **denylist**:

- A broad catch-all auto-merges **all container images + Helm charts** for `minor`/`patch`/`digest` (`automergeType: pr`, `platformAutomerge: false` so Renovate self-gates on CI, `minimumReleaseAge: "3 days"`). `major` is never listed → always manual.
- A **protected-infra guard** (placed right after the catch-all; Renovate is last-match-wins) keeps cluster-critical components on manual review: Talos, Kubernetes/kubelet, Cilium, Rook-Ceph, cert-manager, Flux (controllers + operator/instance), CoreDNS, external-secrets, spegel, CloudNative-PG (operator + postgresql + barman plugin), NVIDIA gpu-operator + DCGM, Envoy Gateway, onepassword-connect.
- Removes 6 now-redundant per-app/per-source auto-merge rules (OCI charts, home-operations digests, changedetection.io, whodb, databasus, seerr) — all subsumed by the catch-all.

`gateway-api` CRDs continue to auto-merge via the existing `github-releases` rule (separate datasource, additive/low-risk) — intentional.

## Test Plan

- [x] `renovate-config-validator` passes (`Config validated successfully`)
- [x] Independent review: protected patterns don't over-match apps / under-match infra
- [ ] flate / security-scans / lint CI green