### PR TITLE
feat(renovate): protect OpenEBS from app auto-merge

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -99,6 +99,7 @@
         "/controlplaneio-fluxcd/", // flux-operator + flux-instance
         "/rook-ceph/",
         "/rook-ceph-cluster/",
+        "/openebs/", // node-local storage provisioner
         "/kube-apiserver/",
         "/kube-controller-manager/",
         "/kube-proxy/",

--- a/docs/docs/operations/renovate-automerge.md
+++ b/docs/docs/operations/renovate-automerge.md
@@ -49,7 +49,7 @@ The protected-infra guard keeps these on manual review for all update types (inc
 | OS / kubelet | `siderolabs/` (Talos), `kubelet` |
 | Control plane | `kube-apiserver`, `kube-controller-manager`, `kube-proxy`, `kube-scheduler` |
 | CNI | `cilium` |
-| Storage | `rook-ceph`, `rook-ceph-cluster` |
+| Storage | `rook-ceph`, `rook-ceph-cluster`, `openebs` |
 | GitOps | `fluxcd/` (controllers), `controlplaneio-fluxcd` (operator + instance) |
 | Certs / DNS / secrets | `cert-manager`, `coredns`, `external-secrets`, `1password` (onepassword-connect) |
 | Image mirror | `spegel` |


### PR DESCRIPTION
## Summary

Follow-up to #3199 / #3201. OpenEBS is the node-local storage provisioner — cluster-critical, but it wasn't in the protected-infra guard, so its updates would auto-merge.

- Add `/openebs/` to the protected guard's `matchPackageNames` in `.renovaterc.json5` (so OpenEBS stays on manual review, like Rook-Ceph).
- Update the Storage row in `docs/docs/operations/renovate-automerge.md` to match.

Effect: the open OpenEBS bump (#3193) will no longer be a candidate for auto-merge.

## Test Plan

- [x] `renovate-config-validator` passes
- [x] `zensical build` clean
- [ ] CI green