### PR TITLE
docs(readme): link the documentation / knowledge-base site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 _... managed with Flux, Renovate, and GitHub Actions_ 🤖
 
+📖 **[Documentation &amp; Knowledge Base →](https://lukeevanstech.github.io/talos-cluster/)**
+
 </div>
 
 <div align="center">
@@ -25,6 +27,8 @@ This is a monorepository is for my home kubernetes clusters.
 I try to adhere to Infrastructure as Code (IaC) and GitOps practices using tools like [Kubernetes](https://kubernetes.io/), [Flux](https://github.com/fluxcd/flux2), [Renovate](https://github.com/renovatebot/renovate), and [GitHub Actions](https://github.com/features/actions).
 
 The purpose here is to learn k8s, while practicing Gitops.
+
+📖 Architecture, operations runbooks, and troubleshooting notes live in the **[documentation site](https://lukeevanstech.github.io/talos-cluster/)** (built from `docs/` with [Zensical](https://zensical.org/) and published to GitHub Pages).
 
 ---
 


### PR DESCRIPTION
## Summary

Surface the published Zensical KB site (https://lukeevanstech.github.io/talos-cluster/) from the repo front door:

- README header: prominent **Documentation & Knowledge Base →** link.
- README Overview: a sentence pointing to the docs site (built from `docs/`, published to GitHub Pages).
- Repo **About → Website** (right sidebar) set to the same URL via `gh repo edit --homepage` (settings change, already applied — not part of this diff).

Docs-only; site verified live (HTTP 200). markdownlint + prettier clean locally.

## Test Plan

- [ ] super-linter (markdown) + CI green