### PR TITLE
feat(scrutiny): SMART disk-health UI with per-node collectors

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -24,6 +24,8 @@ resources:
   - ./oxidized/ks.yaml
   - ./peanut/ks.yaml
   - ./plex-exporter/ks.yaml
+  - ./scrutiny/ks.yaml
+  - ./scrutiny-collector/ks.yaml
   - ./silence-operator/ks.yaml
   - ./smartctl-exporter/ks.yaml
   - ./snmp-exporter/ks.yaml

--- a/kubernetes/apps/observability/scrutiny-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/scrutiny-collector/app/helmrelease.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app scrutiny-collector
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      scrutiny-collector:
+        type: daemonset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/starosdev/scrutiny
+              tag: 1.64.0-collector@sha256:0bff11c2f29758c76474867fe9270ec72c7e5bca8e8cfaa621d7b1dbb9fd5747
+            env:
+              TZ: ${TIMEZONE:=UTC}
+              COLLECTOR_API_ENDPOINT: http://scrutiny.observability.svc.cluster.local:8080
+              COLLECTOR_CRON_SCHEDULE: "0 * * * *"
+              COLLECTOR_RUN_STARTUP: "true"
+              COLLECTOR_HOST_ID:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+            securityContext:
+              # Privileged + root is required for raw device I/O (smartctl ioctls);
+              # privileged also exposes the host's /dev to the container.
+              privileged: true
+              readOnlyRootFilesystem: false
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+    persistence:
+      udev:
+        type: hostPath
+        hostPath: /run/udev
+        hostPathType: Directory
+        globalMounts:
+          - path: /run/udev
+            readOnly: true

--- a/kubernetes/apps/observability/scrutiny-collector/app/kustomization.yaml
+++ b/kubernetes/apps/observability/scrutiny-collector/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/scrutiny-collector/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/scrutiny-collector/app/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1

--- a/kubernetes/apps/observability/scrutiny-collector/ks.yaml
+++ b/kubernetes/apps/observability/scrutiny-collector/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app scrutiny-collector
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: scrutiny
+      namespace: observability
+  interval: 1h
+  path: ./kubernetes/apps/observability/scrutiny-collector/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/observability/scrutiny/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/scrutiny/app/helmrelease.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app scrutiny
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    controllers:
+      scrutiny:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/starosdev/scrutiny
+              tag: 1.64.0-omnibus@sha256:d027f018648b1d89552d051a10a3603abf1e2bd52357b1517d0fac1086094b15
+            env:
+              TZ: ${TIMEZONE:=UTC}
+              # In-pod collector disabled: collection is handled uniformly by the
+              # scrutiny-collector DaemonSet, keeping this server unprivileged.
+              COLLECTOR_RUN_STARTUP: "false"
+              COLLECTOR_CRON_SCHEDULE: "0 0 30 2 *" # 30 February — never fires
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        # Omnibus uses s6-overlay + an embedded InfluxDB and must run as root.
+        runAsNonRoot: false
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: 8080
+    route:
+      app:
+        hostnames:
+          - scrutiny.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /opt/scrutiny/config
+            subPath: config
+          - path: /opt/scrutiny/influxdb
+            subPath: influxdb

--- a/kubernetes/apps/observability/scrutiny/app/kustomization.yaml
+++ b/kubernetes/apps/observability/scrutiny/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/scrutiny/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/scrutiny/app/ocirepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 15m
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+  ref:
+    tag: 5.0.1

--- a/kubernetes/apps/observability/scrutiny/ks.yaml
+++ b/kubernetes/apps/observability/scrutiny/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app scrutiny
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/gatus/guarded
+    - ../../../../components/homepage
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/observability/scrutiny/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_CACHE_CAPACITY: 2Gi
+      HOMEPAGE_GROUP: Tools
+      HOMEPAGE_ICON: scrutiny.svg
+      HOMEPAGE_DESCRIPTION: Disk S.M.A.R.T. health
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## What

Stands up [Scrutiny](https://github.com/Starosdev/scrutiny) — a S.M.A.R.T. disk-health web UI with historical trends and real-world failure prediction — in the `observability` namespace, hub-and-spoke.

Inspired by jfroy's `flatops` `observability-agents` layout, adapted to this repo's conventions.

## Components

| | `scrutiny` (server) | `scrutiny-collector` |
|---|---|---|
| Workload | Deployment, omnibus image (web + embedded InfluxDB) | DaemonSet on all nodes |
| Privilege | **Unprivileged** (no host access; runs container-root for s6/InfluxDB) | `privileged: true`, hostPath `/run/udev` |
| Storage | one `ceph-block` PVC via `volsync`, `config`+`influxdb` subPaths | none |
| Network | Service `:8080`, internal route `scrutiny.${SECRET_DOMAIN}` | reaches server over the cluster Service |
| Extras | `gatus/guarded`, `homepage` (group `Tools`) | per-node `COLLECTOR_HOST_ID`, hourly scan |

The omnibus pod's **in-pod collector is disabled** (never-fires cron + `RUN_STARTUP=false`) so collection is uniform via the DaemonSet and the server stays unprivileged.

## Decisions
- **Fork:** actively-maintained `starosdev/scrutiny` v1.64.0 (digest-pinned), not the dormant `analogj` original.
- **Existing `smartctl-exporter` is kept** — it still feeds the Grafana dashboard + PrometheusRule alerts; Scrutiny is the human-facing view.
- **Out of scope (YAGNI):** ZFS/Btrfs/MDADM/perf collectors (Talos nodes run plain disks for Ceph; TrueNAS ZFS is external + already monitored), web auth (internal DNS only), ExternalSecret (omnibus embeds InfluxDB).

## Validation
- `kustomize build` clean (both app dirs + the observability tree).
- `helm template` against the real **app-template 5.0.1** chart renders the expected resources (server → Deployment/HTTPRoute/Service/SA; collector → DaemonSet/SA); image digests, security contexts, env, mounts and route verified in the rendered output.
- `yamlfmt` → `prettier` clean.
- Both image digests resolve on GHCR (collector digest matches a known-good upstream pin).

The Flate-Diff check will render this in full cluster context.