### PR TITLE
fix(observability): lengthen exportarr scrape interval/timeout for sonarr+radarr

### DIFF
--- a/kubernetes/apps/media/radarr/app/servicemonitor.yaml
+++ b/kubernetes/apps/media/radarr/app/servicemonitor.yaml
@@ -13,8 +13,11 @@ spec:
   endpoints:
     - port: metrics
       scheme: http
+      # ENABLE_ADDITIONAL_METRICS iterates every movie; scrape less often and
+      # allow more time (matches sonarr; the standard exportarr pattern).
       path: /metrics
-      interval: 60s
+      interval: 5m
+      scrapeTimeout: 2m
       relabelings:
         - action: replace
           targetLabel: instance

--- a/kubernetes/apps/media/sonarr/app/servicemonitor.yaml
+++ b/kubernetes/apps/media/sonarr/app/servicemonitor.yaml
@@ -13,8 +13,12 @@ spec:
   endpoints:
     - port: metrics
       scheme: http
+      # ENABLE_ADDITIONAL_METRICS iterates every series/episode, so the scrape
+      # runs long (it exceeds the default 10s scrapeTimeout on a large library).
+      # Scrape less often and allow more time — the standard exportarr pattern.
       path: /metrics
-      interval: 60s
+      interval: 5m
+      scrapeTimeout: 2m
       relabelings:
         - action: replace
           targetLabel: instance


### PR DESCRIPTION
## Problem

After #3213 deployed, the exportarr targets came up — but **sonarr was `up=0`** in Prometheus with `context deadline exceeded` at exactly 10.00s (the default `scrapeTimeout`). `ENABLE_ADDITIONAL_METRICS` makes the sonarr exporter iterate every series + episode, so `/metrics` generation runs longer than 10s on a large library.

(radarr currently scrapes in ~1.4s, but runs the same per-item iteration every 60s — this also reduces that API load.)

## Fix

Set the sonarr and radarr ServiceMonitor endpoints to `interval: 5m`, `scrapeTimeout: 2m` — the standard exportarr pattern for additional-metrics exporters. bazarr/prowlarr/sabnzbd are unchanged (they don't use additional metrics and scrape in <4s).

## Validation

`kustomize build` confirms the new `interval`/`scrapeTimeout` on both ServiceMonitors.

Note: prowlarr is separately `up=0` due to an **upstream exportarr bug** (HTTP 500 parsing one indexer's non-padded VIP date `2024-10-7`) — not addressed here as v2.3.0 has no collector toggle for it.
