### PR TITLE
feat(qbittorrent): exporter WebUI auth + per-torrent metrics

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
@@ -16,6 +16,8 @@ spec:
         VPN_SERVICE_PROVIDER: "{{ .VPN_SERVICE_PROVIDER }}"
         WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
+        # qBittorrent WebUI password — consumed by the metrics exporter sidecar
+        QBT_WEBUI_PASSWORD: "{{ .QBT_WEBUI_PASSWORD }}"
   dataFrom:
     - extract:
         key: gluetun

--- a/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
@@ -18,6 +18,12 @@ spec:
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
         # qBittorrent WebUI password — consumed by the metrics exporter sidecar
         QBT_WEBUI_PASSWORD: "{{ .QBT_WEBUI_PASSWORD }}"
+  data:
+    # WebUI password lives in its own "qbittorrent" 1Password item (not gluetun)
+    - secretKey: QBT_WEBUI_PASSWORD
+      remoteRef:
+        key: qbittorrent
+        property: password
   dataFrom:
     - extract:
         key: gluetun

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -24,7 +24,10 @@ spec:
             env:
               QBT_WEBUI_PORT: &port 80
               QBT_TORRENTING_PORT: &BT-port 51749
-              QBT_Preferences__WebUI__LocalHostAuth: false
+              # Require WebUI auth even on localhost so the metrics sidecar must present
+              # real credentials (from the ExternalSecret) instead of riding an
+              # unauthenticated localhost bypass.
+              QBT_Preferences__WebUI__LocalHostAuth: true
             probes:
               liveness:
                 enabled: true
@@ -73,10 +76,18 @@ spec:
               repository: ghcr.io/martabal/qbittorrent-exporter
               tag: v2.0.1@sha256:ddf2bff9b357e50be4ddb699b6489ac5a49e4fac8c7dc5d4ca2abe1e5855f4dd
             env:
-              # qbittorrent has WebUI LocalHostAuth bypass (QBT_…__LocalHostAuth: false),
-              # so this localhost sidecar reaches the API unauthenticated — no creds needed.
+              # Authenticate to the qBittorrent WebUI with real credentials from the
+              # ExternalSecret (the localhost-auth bypass is disabled on the app container).
               QBITTORRENT_BASE_URL: "http://localhost:80"
+              QBITTORRENT_USERNAME: admin
+              QBITTORRENT_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: qbittorrent-secret
+                    key: QBT_WEBUI_PASSWORD
               EXPORTER_PORT: &metricsPort 9710
+              # Per-torrent series (qbittorrent_torrent_info / qbittorrent_tracker_info)
+              ENABLE_HIGH_CARDINALITY: "true"
             securityContext:
               runAsNonRoot: true
               runAsUser: 1000


### PR DESCRIPTION
## What

Harden the qBittorrent Prometheus exporter (added in #3215) and enable per-torrent metrics.

- **Auth instead of localhost bypass** — flip `QBT_…__WebUI__LocalHostAuth` to `true` and give the `metrics` sidecar real WebUI credentials (`QBITTORRENT_USERNAME` / `QBITTORRENT_PASSWORD`) sourced from `qbittorrent-secret` via `secretKeyRef`, mirroring the `*arr` exportarr pattern.
- **Per-torrent metrics** — `ENABLE_HIGH_CARDINALITY=true` adds `qbittorrent_torrent_info` / `qbittorrent_tracker_info`, which the vendored martabal dashboard's per-torrent panels consume.
- **ExternalSecret** — pulls `QBT_WEBUI_PASSWORD` from a **dedicated `qbittorrent` 1Password item** (explicit `data`/`remoteRef`, `property: password`), kept separate from the `gluetun` (VPN) item.

No password rotation: this reuses qBittorrent's existing WebUI password (the one the `*arr` download clients already use), so those clients are unaffected.

## ⚠️ Merge prerequisite

Create a `qbittorrent` item in the **Talos** vault with the **current** qBit WebUI password **before** this merges — otherwise the now-auth-enforced exporter cannot log in:

```bash
op item create --category login --title qbittorrent --vault Talos \
  username=admin 'password=<current-qbit-webui-password>'
```

## Verify after deploy

- `kubectl logs -n downloads deploy/qbittorrent -c metrics` should show it authenticating with the provided creds (not the "username not set, using default" warning).
- The `serviceMonitor/downloads/qbittorrent/0` Prometheus target should stay `up`.
- qBittorrent 5.2.x changed WebUI cookie/SID handling; if the exporter cannot auth with username/password alone, the fallback is to revert `LocalHostAuth` to `false` (keeping the creds) — the bypass is localhost / same-pod only.
