### PR TITLE
fix(qbittorrent): track qBit 5.2.x WebUI cookie in exporter

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -85,6 +85,10 @@ spec:
                   secretKeyRef:
                     name: qbittorrent-secret
                     key: QBT_WEBUI_PASSWORD
+              # qBittorrent >= 5.2.0 names the WebUI session cookie QBT_SID_<port>
+              # (here QBT_SID_80); the exporter must track it or it loops re-auth
+              # once the localhost-auth bypass is off.
+              QBITTORRENT_COOKIE_NAME: QBT_SID_80
               EXPORTER_PORT: &metricsPort 9710
               # Per-torrent series (qbittorrent_torrent_info / qbittorrent_tracker_info)
               ENABLE_HIGH_CARDINALITY: "true"


### PR DESCRIPTION
## What

Follow-up to #3217. qBittorrent 5.2.2 names the WebUI session cookie **`QBT_SID_80`** (SID + WebUI port). The martabal exporter v2.0.1 doesn't track that cookie automatically, so with the localhost-auth bypass disabled it loops `Cookie changed, trying to reconnect` and stops producing metrics (verified live).

Setting **`QBITTORRENT_COOKIE_NAME=QBT_SID_80`** makes the exporter follow the session, which lets us turn off the localhost-auth bypass.

## After merge

`WebUI\LocalHostAuth` is qBit conf state that ignores the `QBT_*` env on an existing install (conf wins), so the bypass is flipped off at runtime via the WebUI API (`setPreferences bypass_local_auth=false`) once this is deployed — then verify the exporter maintains its session under enforcement and the Prometheus target stays `up`.
