### PR TITLE
feat(echo): add home-operations echo debug endpoint

### DIFF
--- a/kubernetes/apps/network/echo/app/helmrelease.yaml
+++ b/kubernetes/apps/network/echo/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: echo
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: echo
+  values:
+    replicaCount: 1
+    config:
+      kubernetes: true
+      # Trust the in-cluster Envoy Gateway proxy so echo reports the real client IP
+      trustedProxies:
+        - ${CLUSTER_PODS_CIDR}
+    httpRoute:
+      enabled: true
+      hostnames:
+        - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+      parentRefs:
+        - name: envoy-internal
+          namespace: network
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi

--- a/kubernetes/apps/network/echo/app/kustomization.yaml
+++ b/kubernetes/apps/network/echo/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/network/echo/app/ocirepository.yaml
+++ b/kubernetes/apps/network/echo/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: echo
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.2
+  url: oci://ghcr.io/home-operations/charts/echo

--- a/kubernetes/apps/network/echo/ks.yaml
+++ b/kubernetes/apps/network/echo/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app echo
+  namespace: &namespace network
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/network/echo/app
+  postBuild: {}
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ./certificates/ks.yaml
   - ./cloudflare-dns/ks.yaml
   - ./cloudflare-tunnel/ks.yaml
+  - ./echo/ks.yaml
   - ./envoy-gateway/ks.yaml
   - ./error-pages/ks.yaml
   - ./opnsense-dns/ks.yaml


### PR DESCRIPTION
## What

Adds the `echo` debug app (home-operations/echo chart) on **envoy-internal**, adopted from the onedr0p/home-ops review.

- Reports request headers and the **real client IP** — `config.trustedProxies: [${CLUSTER_PODS_CIDR}]` trusts the in-cluster Envoy Gateway proxy so `X-Forwarded-For` resolves correctly.
- **Internal-only** (`{{ .Release.Name }}.${SECRET_DOMAIN}` + `${SECRET_INTERNAL_DOMAIN}` on `envoy-internal`).
- Useful for gateway debugging — e.g. seeing exactly what client IP / headers reach an app behind Envoy / cloudflared.

## Notes

Part of the June onedr0p review. The other two candidates from that review:
- `justfile set default-script` — **dropped**: unsupported on our `just` 1.47.1 (`Unknown setting`).
- `gatus-sidecar` migration — **separate, larger effort** (touches ~50 apps); being planned out independently.
