### PR TITLE
feat(gatus): alert on auto-discovered routes (close monitoring gap)

### DIFF
--- a/kubernetes/apps/flux-system/konflate/app/httproute-webhook.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/httproute-webhook.yaml
@@ -8,6 +8,8 @@ metadata:
   name: konflate-webhook
   annotations:
     external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+    # POST-only webhook (GET / → 404); not health-checkable via gatus. UI route is monitored.
+    gatus.home-operations.com/enabled: "false"
 spec:
   hostnames:
     - konflate-webhook.${SECRET_DOMAIN}

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -54,6 +54,9 @@ metadata:
     type: external
   annotations:
     external-dns.alpha.kubernetes.io/target: &hostname external.${SECRET_DOMAIN}
+    # Default gatus group for routes on this gateway; the sidecar inherits it to attached HTTPRoutes
+    gatus.home-operations.com/endpoint: |
+      group: external
 spec:
   gatewayClassName: envoy
   infrastructure:
@@ -89,6 +92,9 @@ metadata:
     external-dns.alpha.kubernetes.io/record-type: A
     external-dns.alpha.kubernetes.io/target: ${ENVOY_INTERNAL_IP}
     external-dns.alpha.kubernetes.io/hostname: &internalHost internal.${SECRET_DOMAIN}
+    # Default gatus group for routes on this gateway; the sidecar inherits it to attached HTTPRoutes
+    gatus.home-operations.com/endpoint: |
+      group: internal
 spec:
   gatewayClassName: envoy
   infrastructure:

--- a/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
@@ -10,7 +10,7 @@ spec:
       rules:
         - alert: GatusEndpointDown
           expr: |
-            gatus_results_endpoint_success{group="external"} == 0
+            gatus_results_endpoint_success{group=~"internal|external"} == 0
           for: 5m
           annotations:
             summary: >-
@@ -18,6 +18,9 @@ spec:
           labels:
             severity: critical
 
+        # NOTE: the "guarded" exposure-detection group has no live endpoints since the
+        # move to sidecar auto-discovery — this alert is currently inactive (restoring
+        # exposure-detection is a separate decision; see the gatus migration).
         - alert: GatusEndpointExposed
           expr: |
             gatus_results_endpoint_success{group="guarded"} == 0

--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -116,6 +116,10 @@ spec:
             port: 3903
     route:
       app:
+        annotations:
+          # garage S3 API answers anonymous GET with 403 — treat 200/403 as healthy
+          gatus.home-operations.com/endpoint: |
+            conditions: ["[STATUS] any of 200, 403"]
         hostnames:
           - "s3.${SECRET_DOMAIN}"
           - "s3.${SECRET_INTERNAL_DOMAIN}"


### PR DESCRIPTION
## What

Closes a monitoring gap found while reviewing the onedr0p gatus-sidecar pattern.

Our gatus already runs `gatus-sidecar --auto-httproute`, so every HTTPRoute is auto-discovered — but auto-discovered endpoints get **no group**, and the alert rule only fired on `group="external"` (6 apps) + `group="guarded"` (0 live endpoints). So **117 auto-discovered apps were monitored but had no alert that could fire**.

This PR groups the auto-discovered routes and alerts on their liveness:

- **Gateways** (`envoy-internal` / `envoy-external`): add `gatus.home-operations.com/endpoint: { group: internal|external }` — the sidecar inherits the group to every attached HTTPRoute. The 9 already-annotated routes keep their explicit group (child wins).
- **False-positive fixes:** `garage` s3 API answers anonymous GET with 403 → tolerant condition `[STATUS] any of 200, 403`; `konflate-webhook` is POST-only (GET → 404) → opted out of monitoring.
- **prometheusrule** `GatusEndpointDown`: `group="external"` → `group=~"internal|external"`.

## Notes / follow-ups

- **`guarded` was an exposure-detection security check** (alert if an internal app gets a *public* DNS record), not liveness — and it's been silently **inactive** since the auto-discovery migration. Its (dead) alert is left in place with a note; **restoring exposure-detection is a separate decision** and gates the dead-component cleanup (PR B).
- Liveness alerting now covers all internal apps, so any intentionally-down app (e.g. KEDA-scaled) should be opted out via `gatus.home-operations.com/enabled: "false"` — only `garage`/`konflate-webhook` needed it today.
