### PR TITLE
fix(gatus): correct garage condition syntax (gatus panic hotfix)

### DIFF
--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -119,7 +119,7 @@ spec:
         annotations:
           # garage S3 API answers anonymous GET with 403 — treat 200/403 as healthy
           gatus.home-operations.com/endpoint: |
-            conditions: ["[STATUS] any of 200, 403"]
+            conditions: ["[STATUS] == any(200, 403)"]
         hostnames:
           - "s3.${SECRET_DOMAIN}"
           - "s3.${SECRET_INTERNAL_DOMAIN}"


### PR DESCRIPTION
Hotfix: `[STATUS] any of 200, 403` (from #3220) is **invalid gatus condition syntax** — gatus **panics on config load**, crashing the whole monitoring pool. Corrected to `[STATUS] == any(200, 403)` (verified against gatus docs).
