### PR TITLE
fix(grafana): file cilium/spegel dashboards under kube-system folder

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/grafanadashboard.yaml
@@ -5,6 +5,7 @@ kind: GrafanaDashboard
 metadata:
   name: cilium
 spec:
+  folder: kube-system
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:
@@ -22,6 +23,7 @@ kind: GrafanaDashboard
 metadata:
   name: cilium-operator
 spec:
+  folder: kube-system
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:

--- a/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/grafanadashboard.yaml
@@ -5,6 +5,7 @@ kind: GrafanaDashboard
 metadata:
   name: spegel
 spec:
+  folder: kube-system
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -145,7 +145,6 @@ spec:
               targetLabel: kubernetes_node
     grafana:
       enabled: false
-      forceDeployDashboards: true
     additionalPrometheusRulesMap:
       dockerhub-rules:
         groups:


### PR DESCRIPTION
## Why

Some Grafana dashboards were appearing under the **General** folder (rendered at the bottom, un-nested) instead of a namespace folder. Investigation via the live Grafana API showed two distinct causes; this PR fixes the GitOps-owned half.

### Cilium / Spegel (in this repo, but stuck in General)
The `cilium`, `cilium-operator`, and `spegel` `GrafanaDashboard` CRs deliver their JSON via `configMapRef`, and the embedded dashboard UIDs (`vtuWtdumz`, `1GC0TT4Wz`, `1iY4QMJVk`) collide with leftover copies from a previous dashboard-sidecar Grafana. The operator therefore never relocated them, leaving the `kube-system` folder empty. Adding an explicit `spec.folder: kube-system` makes placement deterministic.

### kube-prometheus-stack `forceDeployDashboards`
Grafana now runs via **grafana-operator** (`grafana.enabled: false`) with **no dashboard sidecar**, so the chart's `forceDeployDashboards: true` only produced orphaned dashboard ConfigMaps that nothing imports. Removed.

## Changes
- `kube-system/cilium`: `spec.folder: kube-system` on both dashboards
- `kube-system/spegel`: `spec.folder: kube-system`
- `observability/kube-prometheus-stack`: drop `grafana.forceDeployDashboards: true`

## Validation
- `kustomize build` passes for all three apps
- `folder: kube-system` confirmed in rendered output

## Follow-up (manual, not in this PR)
~30 stale dashboards remain in the **General** folder — the old kube-prometheus-stack mixin set (Kubernetes/*, Node Exporter/*, Alertmanager, etcd, Prometheus/Overview, CoreDNS, Grafana Overview), already superseded by operator-managed equivalents in the `observability` folder. These are not in Git (DB leftovers on the Grafana PVC) and should be deleted via the Grafana UI (Dashboards → View as list → multi-select → Delete). After this PR reconciles, also delete the old General copies of Cilium/Spegel if duplicates remain.