### PR TITLE
fix(grafana): file external-secrets dashboard under lowercase namespace folder

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/grafanadashboard.yaml
@@ -5,6 +5,10 @@ kind: GrafanaDashboard
 metadata:
   name: external-secrets
 spec:
+  # Override the chart configMap's `grafana_folder: External-Secrets` annotation so this
+  # dashboard files under the lowercase namespace folder like every other app (folderless
+  # CRs default to their namespace; this one is the exception only because of that annotation).
+  folder: external-secrets
   allowCrossNamespaceImport: true
   instanceSelector:
     matchLabels:


### PR DESCRIPTION
The external-secrets Helm chart ships its dashboard ConfigMap with an
annotation grafana_folder: External-Secrets, which the operator honors when
the GrafanaDashboard CR has no spec.folder. That capitalized name mismatched
every other folder (lowercase namespace) and, under a case-sensitive sort,
floated to the top of the dashboards list. Pin spec.folder: external-secrets
to match the cilium/spegel convention (#3159 follow-up).
