### PR TITLE
fix(observability): tautulli panel refIds + vmware "All" var defaults

### DIFF
--- a/kubernetes/apps/observability/tautulli-exporter/app/dashboards/tautulli.json
+++ b/kubernetes/apps/observability/tautulli-exporter/app/dashboards/tautulli.json
@@ -782,7 +782,7 @@
           "editorMode": "code",
           "expr": "plex_active_streams_total{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Tot",
+          "refId": "A",
           "legendFormat": "Total"
         },
         {
@@ -793,7 +793,7 @@
           "editorMode": "code",
           "expr": "plex_active_streams_direct_play{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Dir",
+          "refId": "B",
           "legendFormat": "Direct Play"
         },
         {
@@ -804,7 +804,7 @@
           "editorMode": "code",
           "expr": "plex_active_streams_direct_stream{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Dir",
+          "refId": "C",
           "legendFormat": "Direct Stream"
         },
         {
@@ -815,7 +815,7 @@
           "editorMode": "code",
           "expr": "plex_active_streams_transcode{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Tra",
+          "refId": "D",
           "legendFormat": "Transcode"
         }
       ]
@@ -1109,7 +1109,7 @@
           "editorMode": "code",
           "expr": "plex_transcode_video_sessions{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Vid",
+          "refId": "A",
           "legendFormat": "Video"
         },
         {
@@ -1120,7 +1120,7 @@
           "editorMode": "code",
           "expr": "plex_transcode_audio_sessions{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Aud",
+          "refId": "B",
           "legendFormat": "Audio"
         },
         {
@@ -1131,7 +1131,7 @@
           "editorMode": "code",
           "expr": "plex_transcode_container_sessions{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Con",
+          "refId": "C",
           "legendFormat": "Container"
         }
       ]
@@ -1417,7 +1417,7 @@
           "editorMode": "code",
           "expr": "plex_bandwidth_total_kbps{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "Tot",
+          "refId": "A",
           "legendFormat": "Total"
         },
         {
@@ -1428,7 +1428,7 @@
           "editorMode": "code",
           "expr": "plex_bandwidth_lan_kbps{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "LAN",
+          "refId": "B",
           "legendFormat": "LAN"
         },
         {
@@ -1439,7 +1439,7 @@
           "editorMode": "code",
           "expr": "plex_bandwidth_wan_kbps{job=\"tautulli-exporter\"}",
           "range": true,
-          "refId": "WAN",
+          "refId": "C",
           "legendFormat": "WAN"
         }
       ]

--- a/kubernetes/apps/observability/vmware-exporter/app/dashboards/cluster.json
+++ b/kubernetes/apps/observability/vmware-exporter/app/dashboards/cluster.json
@@ -1933,11 +1933,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
         "datasource": "$datasource",
         "definition": "label_values(cluster_name)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "cluster",
         "multi": true,
         "name": "cluster",

--- a/kubernetes/apps/observability/vmware-exporter/app/dashboards/esxi.json
+++ b/kubernetes/apps/observability/vmware-exporter/app/dashboards/esxi.json
@@ -1681,11 +1681,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
         "datasource": "$datasource",
         "definition": "",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "esxhost",
         "multi": true,
         "name": "esxhost",

--- a/kubernetes/apps/observability/vmware-exporter/app/dashboards/virtualmachine.json
+++ b/kubernetes/apps/observability/vmware-exporter/app/dashboards/virtualmachine.json
@@ -1876,11 +1876,15 @@
       },
       {
         "allValue": null,
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": ["All"],
+          "value": ["$__all"]
+        },
         "datasource": "$datasource",
         "definition": "label_values(vm_name)",
         "hide": 0,
-        "includeAll": false,
+        "includeAll": true,
         "label": "vm",
         "multi": true,
         "name": "vm",


### PR DESCRIPTION
Follow-ups to #3233, both caught via Playwright verification of the live dashboards.

- **Tautulli** — the hand-built "Active Streams" timeseries had two targets sharing a refId (`Direct Play`/`Direct Stream` both → `Dir`), which broke that panel ("No data"). Every target now gets a unique refId. (Stat panels were unaffected and already showed data.)
- **vmware** — after the datasource fix the dashboards resolved, but the `cluster`/`esxhost`/`vm` template vars defaulted to the first value alphabetically — **"Standalone Cluster"**, which has 1 host and no performance metrics → cluster panels showed N/A. The real data lives in **"vSAN Cluster"** (3 hosts, 36 CPUs). Vars are `multi:true` (panels use `=~` regex match), so enabling `includeAll` + defaulting to **All** makes the landing view aggregate across all clusters/hosts/VMs.

Validated: `kustomize build` passes; metrics confirmed present per cluster.