### PR TITLE
feat(external-secrets): enable metrics + ServiceMonitor for the ESO dashboard

### DIFF
--- a/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/external-secrets/app/helmrelease.yaml
@@ -13,6 +13,14 @@ spec:
   values:
     installCRDs: true
     leaderElect: true
+    # Expose controller/webhook/cert-controller metrics (:8080) and scrape them —
+    # the bundled Grafana dashboard (grafanaDashboard below) is blank without this.
+    serviceMonitor:
+      enabled: true
+      interval: 1m
+    metrics:
+      service:
+        enabled: true
     resources:
       requests:
         cpu: 10m
@@ -20,6 +28,9 @@ spec:
       limits:
         memory: 256Mi
     certController:
+      metrics:
+        service:
+          enabled: true
       resources:
         requests:
           cpu: 10m
@@ -32,6 +43,9 @@ spec:
         grafana_folder: External-Secrets
     webhook:
       replicaCount: 2
+      metrics:
+        service:
+          enabled: true
       resources:
         requests:
           cpu: 10m


### PR DESCRIPTION
## Why

The External-Secrets Grafana dashboard was blank. Unlike the #3233 dashboards, the cause here was **not** the datasource (it already uses lowercase `prometheus`) — it's that **ESO metrics were never scraped**:

- `grafanaDashboard.enabled: true` installs the dashboard configMap ✅
- but there was **no ServiceMonitor and no metrics Service** → `count({__name__=~"externalsecret_.*"})` = **0 series**

## Fix

Enable metrics exposure + scraping in the chart values:
- `serviceMonitor.enabled: true` (interval 1m)
- `metrics.service.enabled: true` (controller)
- `webhook.metrics.service.enabled: true`
- `certController.metrics.service.enabled: true`

Rendered output (release name `external-secrets`, `renderMode=alwaysRender`): **3 ServiceMonitors + 3 metrics Services** (controller / webhook / cert-controller), each SM selecting its service on port `metrics` (8080).

## Validation
- `kustomize build` passes
- chart render confirms the SM/Service pairs + matching selectors
- will verify panels populate post-reconcile (Playwright)