### PR TITLE
feat(sentinel-syslog): in-cluster Logstash syslog→Sentinel shipper + Talos OIDC issuer

### DIFF
--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway/ks.yaml
   - ./error-pages/ks.yaml
+  - ./oidc-talos/ks.yaml
   - ./opnsense-dns/ks.yaml
   - ./scanopy/ks.yaml
   - ./tailscale-operator/ks.yaml

--- a/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
@@ -1,0 +1,157 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app oidc-talos
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: oidc-talos
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    # Publishes THIS cluster's OIDC discovery doc + JWKS publicly so Entra (and any other cloud) can
+    # federate the cluster's service-account tokens — no apiserver exposure, just two static JSON
+    # files. The apiserver's `service-account-issuer` (talos/patches/controller/cluster.yaml) must
+    # equal https://oidc-talos.${SECRET_DOMAIN}. Only PUBLIC keys are served — the private SA signing
+    # key never leaves the apiserver. Cluster-scoped name (oidc-talos) so other clusters get their own.
+    defaultPodOptions:
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      oidc-talos:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/nginxinc/nginx-unprivileged
+              tag: 1.31-alpine@sha256:cc300bd2e8776708a8c2c8686a74f06eadf221c5ce01e85d0e821955d7a730ab
+            env:
+              TZ: ${TIMEZONE}
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 5
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 64Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+    service:
+      app:
+        controller: oidc-talos
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          external-dns.alpha.kubernetes.io/target: "external.${SECRET_DOMAIN}"
+          gatus.home-operations.com/enabled: "false"
+        hostnames:
+          - "oidc-talos.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+    configMaps:
+      content:
+        data:
+          # OIDC discovery document. `issuer` + `jwks_uri` MUST match the apiserver
+          # service-account-issuer and terraform-entra var.sentinel_syslog_oidc_issuer.
+          openid-configuration: |-
+            {
+              "issuer": "https://oidc-talos.${SECRET_DOMAIN}",
+              "jwks_uri": "https://oidc-talos.${SECRET_DOMAIN}/openid/v1/jwks",
+              "response_types_supported": ["id_token"],
+              "subject_types_supported": ["public"],
+              "id_token_signing_alg_values_supported": ["RS256"]
+            }
+          # Live cluster JWKS (public SA-signing keys, from `kubectl get --raw /openid/v1/jwks`,
+          # 2026-06-18). Safe to commit — public keys only. If the cluster SA signing key ever
+          # rotates, re-fetch and re-commit this block.
+          jwks: |-
+            {
+              "keys": [
+                {
+                  "use": "sig",
+                  "kty": "RSA",
+                  "kid": "G2IhcVbYVTxL8-5ftqOqebOSA1NEPuIuWi8Zi9yZxHw",
+                  "alg": "RS256",
+                  "n": "60hvAuCcvdRTAlJkSkor4Q46nzuP-41o0A7k9G8qTJC4xDYlyybASxa4zOotkLPHZ9pXIl1xUsPsE2skwXRV8nGkI1tEV2XsRBFZc7hwdstNy103RxKWhfWkX_7Qo0g3N563LzTelux2BfZwa_ENlyHV1QgXueap0Ubcir4myv4XlNCvtX26FB8z7PNOJGuxYMBugMJWgb-6KCKDycT-hr_hmbiahxPd7ZyfYp4vO4Vd_weRQ3hVTE7HBAXDvHiELpU5QcdVFsDIdFoPXqk-pdnNCf79ZkKKYWCWiCEObOldFsCX8m0qTHtwNUD3lS0hYqgkVbm-gD5V_fSVuulLL1YrIcpNDcijF_SkKcy6sAb8gUQDsLf-UXx05-mAA8Dw0hdNSeuliFtUqIYK97HOJvKUGx7R3AGC5RS6hgmoS00ndJVxwFqCOrBuGozeub1u6iDPl8M7UdTHfF9bBM-SYFj7Sl7q3QiinwRiwVcngiLIZQ-YKKAiWNZAnjajU1cxlE2Ztb7IlE28FT9V4O3E8Lra_1FAFFumq7P9P4fjjbuXJukKUkmIK21zGbNpysioSzle_cFeKHjTMcsz4GjQP-n3O6V4tua-0EdqecU6i3L7PbpnAFICNriqsiHFHf0OKBfT1kjzzhzLJa2xv9b4k-4LQToSTGjFHo8gamc0Pcs",
+                  "e": "AQAB"
+                }
+              ]
+            }
+      nginx:
+        data:
+          default.conf: |-
+            server {
+              listen 8080;
+              server_name _;
+              location = /.well-known/openid-configuration {
+                default_type application/json;
+                alias /config/openid-configuration;
+              }
+              location = /openid/v1/jwks {
+                default_type application/json;
+                alias /config/jwks;
+              }
+              location = /healthz {
+                default_type text/plain;
+                return 200 "ok";
+              }
+              location / { return 404; }
+            }
+    persistence:
+      content:
+        type: configMap
+        identifier: content
+        globalMounts:
+          - path: /config
+            readOnly: true
+      nginx-conf:
+        type: configMap
+        identifier: nginx
+        globalMounts:
+          - path: /etc/nginx/conf.d/default.conf
+            subPath: default.conf
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+      cache:
+        type: emptyDir
+        globalMounts:
+          - path: /var/cache/nginx
+      run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run

--- a/kubernetes/apps/network/oidc-talos/app/kustomization.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/oidc-talos/app/ocirepository.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: oidc-talos
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/oidc-talos/ks.yaml
+++ b/kubernetes/apps/network/oidc-talos/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app oidc-talos
+  namespace: &namespace network
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/network/oidc-talos/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./anubis/ks.yaml
   - ./pocket-id/ks.yaml
   - ./prowler/ks.yaml
+  - ./sentinel-syslog/ks.yaml

--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -1,0 +1,209 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app sentinel-syslog
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: sentinel-syslog
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      sentinel-syslog:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # Run as the SA whose token the Entra federated credential trusts
+        # (subject = system:serviceaccount:security:sentinel-syslog).
+        serviceAccount:
+          identifier: sentinel-syslog
+        containers:
+          app:
+            image:
+              # Custom image: Logstash + microsoft-sentinel output plugin (LukeEvansTech/containers).
+              repository: ghcr.io/lukeevanstech/logstash-sentinel
+              tag: 9.1.10
+            env:
+              TZ: ${TIMEZONE}
+              # Bound the JVM heap for the semi-hyperconverged nodes.
+              LS_JAVA_OPTS: "-Xms512m -Xmx512m"
+              # Workload identity (federated, NO secret). The plugin's managed_identity mode
+              # auto-detects these. Identifiers are sourced from cluster-secrets (1Password) because
+              # this repo is public — populate after terraform-entra + -azure-platform apply.
+              AZURE_CLIENT_ID: "${SECRET_SENTINEL_SYSLOG_CLIENT_ID}"
+              AZURE_TENANT_ID: "${SECRET_AZURE_TENANT_ID}"
+              AZURE_AUTHORITY_HOST: "https://login.microsoftonline.com/"
+              AZURE_FEDERATED_TOKEN_FILE: "/var/run/secrets/azure/tokens/azure-identity-token"
+              # Non-secret DCE/DCR coordinates (also via cluster-secrets for public-repo hygiene).
+              DCE_URI: "${SECRET_SYSLOG_DCE_URI}"
+              DCR_IMMUTABLE_ID: "${SECRET_SYSLOG_DCR_ID}"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &monitor 9600
+                  initialDelaySeconds: 90
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *monitor
+                  initialDelaySeconds: 90
+                  periodSeconds: 30
+                  failureThreshold: 5
+            securityContext:
+              allowPrivilegeEscalation: false
+              # TODO(hardening): set true once data/logs/tmp are all emptyDir-mounted.
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 768Mi
+              limits:
+                memory: 1536Mi
+
+    serviceAccount:
+      sentinel-syslog: {}
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    service:
+      app:
+        controller: sentinel-syslog
+        type: LoadBalancer
+        annotations:
+          # The shared LAN syslog endpoint — any source ships here. CONFIRM .90 is free in the
+          # 10.32.8.0/24 pool (existing statics: .87/.88/.89); ideally register SVC_SYSLOG_ADDR.
+          lbipam.cilium.io/ips: ${SVC_SYSLOG_ADDR:=10.32.8.90}
+        externalTrafficPolicy: Local
+        ports:
+          syslog-udp:
+            port: 514
+            protocol: UDP
+          syslog-tcp:
+            port: 514
+            protocol: TCP
+          monitor:
+            port: *monitor
+
+    configMaps:
+      pipeline:
+        data:
+          logstash.conf: |-
+            input {
+              # Logstash syslog input listens on TCP+UDP 514. Senders should use RFC3164.
+              # This is the generic ingestion point — any syslog source can target it.
+              syslog {
+                port => 514
+              }
+            }
+
+            filter {
+              # ---- FILTER HARD (cost control; deliberate per design) ----
+              # Per-source rules below. Sources with no rule pass through to the Syslog table as-is.
+
+              # --- Source: OPNsense firewall (filterlog) ---
+              # Keep block/reject; drop routine "pass" (allow) noise. First 7 CSV fields are stable
+              # across IP versions: rule,subrule,anchor,tracker,iface,reason,action
+              if [program] == "filterlog" {
+                dissect {
+                  mapping => {
+                    "message" => "%{?rule},%{?subrule},%{?anchor},%{?tracker},%{?iface},%{?reason},%{fw_action},%{}"
+                  }
+                }
+                if [fw_action] == "pass" {
+                  drop {}
+                }
+                mutate { remove_field => ["fw_action"] }
+              }
+
+              # --- Source: OPNsense Unbound DNS resolver ---
+              # Very high volume — sample to ~10% to protect the budget. Promote to keep-all later
+              # if DNS threat-hunting needs full fidelity.
+              if [program] == "unbound" {
+                drop { percentage => 90 }
+              }
+
+              # --- Source: OPNsense Suricata/IDS ---
+              # Kept whole (security-relevant, low volume) — no rule needed.
+
+              # --- Future sources (Mikrotik, switches, Linux hosts) ---
+              # Add per-source filter blocks here; otherwise they ingest verbatim.
+            }
+
+            output {
+              # Federated workload identity — no secret. The plugin auto-detects the AKS-style
+              # AZURE_* env + projected token (AZURE_FEDERATED_TOKEN_FILE) and does the OIDC exchange.
+              microsoft-sentinel-log-analytics-logstash-output-plugin {
+                managed_identity         => true
+                data_collection_endpoint => "${DCE_URI}"
+                dcr_immutable_id         => "${DCR_IMMUTABLE_ID}"
+                dcr_stream_name          => "Custom-SyslogStream"
+                create_sample_file       => false
+              }
+            }
+      settings:
+        data:
+          logstash.yml: |-
+            http.host: 0.0.0.0
+            log.level: info
+
+    persistence:
+      # Projected SA token Azure federates against (no webhook — projected manually).
+      # audience api://AzureADTokenExchange is what Entra expects for the client assertion.
+      azure-token:
+        type: custom
+        volumeSpec:
+          projected:
+            defaultMode: 0644
+            sources:
+              - serviceAccountToken:
+                  path: azure-identity-token
+                  expirationSeconds: 3600
+                  audience: api://AzureADTokenExchange
+        globalMounts:
+          - path: /var/run/secrets/azure/tokens
+            readOnly: true
+      pipeline-file:
+        type: configMap
+        identifier: pipeline
+        globalMounts:
+          - path: /usr/share/logstash/pipeline/logstash.conf
+            subPath: logstash.conf
+      settings-file:
+        type: configMap
+        identifier: settings
+        globalMounts:
+          - path: /usr/share/logstash/config/logstash.yml
+            subPath: logstash.yml
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /usr/share/logstash/data

--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -100,7 +100,7 @@ spec:
         type: LoadBalancer
         annotations:
           # The shared LAN syslog endpoint — any source ships here. CONFIRM .90 is free in the
-          # 10.32.8.0/24 pool (existing statics: .87/.88/.89); ideally register SVC_SYSLOG_ADDR.
+          # 10.32.8.0/24 pool (existing static IPs: .87/.88/.89); ideally register SVC_SYSLOG_ADDR.
           lbipam.cilium.io/ips: ${SVC_SYSLOG_ADDR:=10.32.8.90}
         externalTrafficPolicy: Local
         ports:

--- a/kubernetes/apps/security/sentinel-syslog/app/kustomization.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/security/sentinel-syslog/app/ocirepository.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: sentinel-syslog
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/security/sentinel-syslog/ks.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app sentinel-syslog
+  namespace: &namespace security
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/security/sentinel-syslog/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -7,6 +7,13 @@ cluster:
     extraArgs:
       # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
       enable-aggregator-routing: true
+      # Public OIDC issuer so Entra (and other clouds) can federate the cluster's service-account
+      # tokens — backs the sentinel-syslog workload identity (no secrets). Served as static OIDC
+      # discovery + JWKS by the `network/oidc-talos` app at this exact URL. MUST match byte-for-byte:
+      # the oidc-talos openid-configuration `issuer` + terraform-entra var.sentinel_syslog_oidc_issuer.
+      # ── OPS: control-plane change (rolling apiserver restart). Apply in a maintenance window;
+      #     existing pods re-auth as their projected SA tokens rotate (self-healing, brief).
+      service-account-issuer: https://oidc-talos.codelooks.com
     resources:
       requests:
         memory: 2Gi


### PR DESCRIPTION
GitOps for the OPNsense→Sentinel ingestion path (Phase D). Cross-repo siblings: `terraform-azure-platform` (DCE/DCR/role — live), `terraform-entra` (federated app reg — live), `containers` (logstash-sentinel image — building in #35).

**Deploys (Flux, on merge):**
- `security/sentinel-syslog` — Logstash (`ghcr.io/lukeevanstech/logstash-sentinel:9.1.10`) on a Cilium LoadBalancer (UDP/TCP 514, `10.32.8.90`), **federated workload identity** (projected SA token, audience `api://AzureADTokenExchange`, no secret); `AZURE_*` + DCE/DCR coords from `cluster-secrets` (1Password — **populated**); OPNsense filter rules (drop `pass`, sample `unbound` 90%, keep Suricata).
- `network/oidc-talos` — nginx serving cluster OIDC discovery + JWKS at `https://oidc-talos.codelooks.com` so Azure can validate the SA token.

**⚠️ Not deployed by Flux — needs a separate `talosctl` apply:** `talos/patches/controller/cluster.yaml` sets `service-account-issuer: https://oidc-talos.codelooks.com` on the apiserver (control-plane change — restarts apiserver). Apply this **before/with** merge so the projected tokens carry the right issuer.

**Deploy order:** image built (#35) → apiserver patch applied (`talosctl`) → merge this → verify pod authenticates + Syslog table fills.