### PR TITLE
fix(sentinel-syslog): Logstash 9.x api.http.host

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -172,7 +172,9 @@ spec:
       settings:
         data:
           logstash.yml: |-
-            http.host: 0.0.0.0
+            # Logstash 9.x: the monitoring API bind settings moved under api.* —
+            # plain `http.host` was removed and makes Logstash exit on startup.
+            api.http.host: 0.0.0.0
             log.level: info
 
     persistence:


### PR DESCRIPTION
Logstash 9.x removed the bare `http.host` setting (moved under `api.*`), so the container exited at startup (`Setting "http.host" doesn't exist`). Rename `http.host` → `api.http.host` so the monitoring API (port 9600, used by liveness/readiness probes) binds. The pod was crashing *before* reaching Azure auth — this unblocks it.