### PR TITLE
fix(sentinel-syslog): $$-escape DCE_URI/DCR_IMMUTABLE_ID from Flux substitution

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -163,8 +163,12 @@ spec:
               # AZURE_* env + projected token (AZURE_FEDERATED_TOKEN_FILE) and does the OIDC exchange.
               microsoft-sentinel-log-analytics-logstash-output-plugin {
                 managed_identity         => true
-                data_collection_endpoint => "${DCE_URI}"
-                dcr_immutable_id         => "${DCR_IMMUTABLE_ID}"
+                # $$ escapes Flux postBuild substitution so these reach Logstash as ${DCE_URI} /
+                # ${DCR_IMMUTABLE_ID} — Logstash then resolves them from the container env (set from
+                # cluster-secrets above). Without the $$, Flux substitutes them to empty (not a
+                # cluster-secrets key) → "data_collection_endpoint cannot be empty".
+                data_collection_endpoint => "$${DCE_URI}"
+                dcr_immutable_id         => "$${DCR_IMMUTABLE_ID}"
                 dcr_stream_name          => "Custom-SyslogStream"
                 create_sample_file       => false
               }


### PR DESCRIPTION
Pipeline `${DCE_URI}`/`${DCR_IMMUTABLE_ID}` are env refs for **Logstash**, but Flux's postBuild substitution ate them (not cluster-secrets keys) → rendered configMap had `data_collection_endpoint => ""` → plugin fatal. `$$` escapes them so Flux passes `${DCE_URI}` through and Logstash resolves it from the container env. Env lines keep single `$` (those are Flux vars).