### PR TITLE
feat(oidc-talos): serve JWKS fetched live from the apiserver (bootstrap-clean)

### DIFF
--- a/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
@@ -19,21 +19,101 @@ spec:
       strategy: rollback
   values:
     # Publishes THIS cluster's OIDC discovery doc + JWKS publicly so Entra (and any other cloud) can
-    # federate the cluster's service-account tokens — no apiserver exposure, just two static JSON
-    # files. The apiserver's `service-account-issuer` (talos/patches/controller/cluster.yaml) must
-    # equal https://oidc-talos.${SECRET_DOMAIN}. Only PUBLIC keys are served — the private SA signing
-    # key never leaves the apiserver. Cluster-scoped name (oidc-talos) so other clusters get their own.
+    # federate the cluster's service-account tokens — no apiserver exposure, just two JSON files. The
+    # apiserver's `service-account-issuer` (talos/patches/controller/cluster.yaml) must equal
+    # https://oidc-talos.${SECRET_DOMAIN}. Only PUBLIC keys are served — the private SA signing key
+    # never leaves the apiserver. The JWKS is fetched LIVE from the apiserver's discovery endpoint at
+    # pod start (init container) and refreshed hourly (sidecar), so there is no committed,
+    # cluster-specific key material — this bootstraps clean on any cluster reusing the name. The
+    # discovery doc is static (URLs only). Cluster-scoped name so other clusters get their own.
     defaultPodOptions:
       securityContext:
         runAsUser: 101
         runAsGroup: 101
         runAsNonRoot: true
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
         seccompProfile:
           type: RuntimeDefault
     controllers:
       oidc-talos:
         annotations:
           reloader.stakater.com/auto: "true"
+        # Run as a dedicated SA bound to system:service-account-issuer-discovery (rbac.yaml) so the
+        # fetch/refresh containers can read the apiserver JWKS without the cluster-wide binding.
+        serviceAccount:
+          identifier: oidc-talos
+        initContainers:
+          # Populate the served JWKS from the live apiserver before nginx starts. Authn = the SA's
+          # auto-mounted token; authz = the discovery ClusterRoleBinding. Retries, validates the
+          # payload, writes atomically. KUBERNETES_SERVICE_HOST/_PORT are injected by kubelet, so no
+          # cluster-internal addresses are committed here.
+          fetch-jwks:
+            image: &curlImage
+              repository: docker.io/curlimages/curl
+              tag: 8.11.1@sha256:c1fe1679c34d9784c1b0d1e5f62ac0a79fca01fb6377cdd33e90473c6f9f9a69
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                sa=/var/run/secrets/kubernetes.io/serviceaccount
+                url="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/openid/v1/jwks"
+                i=0
+                while true; do
+                  if curl --fail --silent --show-error --max-time 10 \
+                       --cacert "$sa/ca.crt" \
+                       -H "Authorization: Bearer $(cat "$sa/token")" \
+                       "$url" -o /jwks/jwks.new && grep -q '"keys"' /jwks/jwks.new; then
+                    mv /jwks/jwks.new /jwks/jwks
+                    echo "fetched JWKS ($(wc -c < /jwks/jwks) bytes)"
+                    exit 0
+                  fi
+                  i=$((i + 1))
+                  [ "$i" -ge 30 ] && { echo "giving up after ${i} attempts"; exit 1; }
+                  echo "fetch attempt ${i} failed; retrying in 2s"
+                  sleep 2
+                done
+            securityContext: &hardened
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
+          # Native sidecar: re-fetch hourly so a cluster SA-key rotation is picked up without a pod
+          # restart. Failures are non-fatal — the last good JWKS keeps being served.
+          refresh-jwks:
+            restartPolicy: Always
+            image: *curlImage
+            command:
+              - /bin/sh
+              - -c
+              - |
+                sa=/var/run/secrets/kubernetes.io/serviceaccount
+                url="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/openid/v1/jwks"
+                while true; do
+                  sleep 3600
+                  if curl --fail --silent --show-error --max-time 10 \
+                       --cacert "$sa/ca.crt" \
+                       -H "Authorization: Bearer $(cat "$sa/token")" \
+                       "$url" -o /jwks/jwks.new && grep -q '"keys"' /jwks/jwks.new; then
+                    mv /jwks/jwks.new /jwks/jwks
+                    echo "refreshed JWKS"
+                  else
+                    echo "refresh failed; keeping previous JWKS"
+                  fi
+                done
+            securityContext: *hardened
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
         containers:
           app:
             image:
@@ -64,6 +144,10 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
+    # Create the SA the controller references above; the discovery ClusterRoleBinding (rbac.yaml)
+    # targets this name (network/oidc-talos).
+    serviceAccount:
+      oidc-talos: {}
     service:
       app:
         controller: oidc-talos
@@ -93,22 +177,6 @@ spec:
               "subject_types_supported": ["public"],
               "id_token_signing_alg_values_supported": ["RS256"]
             }
-          # Live cluster JWKS (public SA-signing keys, from `kubectl get --raw /openid/v1/jwks`,
-          # 2026-06-18). Safe to commit — public keys only. If the cluster SA signing key ever
-          # rotates, re-fetch and re-commit this block.
-          jwks: |-
-            {
-              "keys": [
-                {
-                  "use": "sig",
-                  "kty": "RSA",
-                  "kid": "G2IhcVbYVTxL8-5ftqOqebOSA1NEPuIuWi8Zi9yZxHw",
-                  "alg": "RS256",
-                  "n": "60hvAuCcvdRTAlJkSkor4Q46nzuP-41o0A7k9G8qTJC4xDYlyybASxa4zOotkLPHZ9pXIl1xUsPsE2skwXRV8nGkI1tEV2XsRBFZc7hwdstNy103RxKWhfWkX_7Qo0g3N563LzTelux2BfZwa_ENlyHV1QgXueap0Ubcir4myv4XlNCvtX26FB8z7PNOJGuxYMBugMJWgb-6KCKDycT-hr_hmbiahxPd7ZyfYp4vO4Vd_weRQ3hVTE7HBAXDvHiELpU5QcdVFsDIdFoPXqk-pdnNCf79ZkKKYWCWiCEObOldFsCX8m0qTHtwNUD3lS0hYqgkVbm-gD5V_fSVuulLL1YrIcpNDcijF_SkKcy6sAb8gUQDsLf-UXx05-mAA8Dw0hdNSeuliFtUqIYK97HOJvKUGx7R3AGC5RS6hgmoS00ndJVxwFqCOrBuGozeub1u6iDPl8M7UdTHfF9bBM-SYFj7Sl7q3QiinwRiwVcngiLIZQ-YKKAiWNZAnjajU1cxlE2Ztb7IlE28FT9V4O3E8Lra_1FAFFumq7P9P4fjjbuXJukKUkmIK21zGbNpysioSzle_cFeKHjTMcsz4GjQP-n3O6V4tua-0EdqecU6i3L7PbpnAFICNriqsiHFHf0OKBfT1kjzzhzLJa2xv9b4k-4LQToSTGjFHo8gamc0Pcs",
-                  "e": "AQAB"
-                }
-              ]
-            }
       nginx:
         data:
           default.conf: |-
@@ -121,7 +189,8 @@ spec:
               }
               location = /openid/v1/jwks {
                 default_type application/json;
-                alias /config/jwks;
+                # Served from the emptyDir the init/refresh containers populate from the live apiserver.
+                alias /jwks/jwks;
               }
               location = /healthz {
                 default_type text/plain;
@@ -130,28 +199,43 @@ spec:
               location / { return 404; }
             }
     persistence:
+      # Live JWKS, fetched from the apiserver by the init/refresh containers (rw) and served by nginx (ro).
+      jwks:
+        type: emptyDir
+        globalMounts:
+          - path: /jwks
       content:
         type: configMap
         identifier: content
-        globalMounts:
-          - path: /config
-            readOnly: true
+        advancedMounts:
+          oidc-talos:
+            app:
+              - path: /config
+                readOnly: true
       nginx-conf:
         type: configMap
         identifier: nginx
-        globalMounts:
-          - path: /etc/nginx/conf.d/default.conf
-            subPath: default.conf
-            readOnly: true
+        advancedMounts:
+          oidc-talos:
+            app:
+              - path: /etc/nginx/conf.d/default.conf
+                subPath: default.conf
+                readOnly: true
       tmp:
         type: emptyDir
-        globalMounts:
-          - path: /tmp
+        advancedMounts:
+          oidc-talos:
+            app:
+              - path: /tmp
       cache:
         type: emptyDir
-        globalMounts:
-          - path: /var/cache/nginx
+        advancedMounts:
+          oidc-talos:
+            app:
+              - path: /var/cache/nginx
       run:
         type: emptyDir
-        globalMounts:
-          - path: /var/run
+        advancedMounts:
+          oidc-talos:
+            app:
+              - path: /var/run

--- a/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
@@ -55,25 +55,18 @@ spec:
             command:
               - /bin/sh
               - -c
+              # NB: $$ escapes Flux postBuild substitution so $(cat ...) reaches the shell intact;
+              # the URL uses kubernetes.default.svc (no ${KUBERNETES_SERVICE_*}, which Flux would eat).
+              # curl does the retries; set -e + the grep make a bad/empty payload fail the init.
               - |
                 set -eu
-                sa=/var/run/secrets/kubernetes.io/serviceaccount
-                url="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/openid/v1/jwks"
-                i=0
-                while true; do
-                  if curl --fail --silent --show-error --max-time 10 \
-                       --cacert "$sa/ca.crt" \
-                       -H "Authorization: Bearer $(cat "$sa/token")" \
-                       "$url" -o /jwks/jwks.new && grep -q '"keys"' /jwks/jwks.new; then
-                    mv /jwks/jwks.new /jwks/jwks
-                    echo "fetched JWKS ($(wc -c < /jwks/jwks) bytes)"
-                    exit 0
-                  fi
-                  i=$((i + 1))
-                  [ "$i" -ge 30 ] && { echo "giving up after ${i} attempts"; exit 1; }
-                  echo "fetch attempt ${i} failed; retrying in 2s"
-                  sleep 2
-                done
+                curl --fail --silent --show-error --max-time 10 --retry 5 --retry-delay 2 --retry-all-errors \
+                  --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                  -H "Authorization: Bearer $$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                  https://kubernetes.default.svc/openid/v1/jwks -o /jwks/jwks.new
+                grep -q '"keys"' /jwks/jwks.new
+                mv /jwks/jwks.new /jwks/jwks
+                echo "fetched JWKS ($$(wc -c < /jwks/jwks) bytes)"
             securityContext: &hardened
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
@@ -92,15 +85,16 @@ spec:
             command:
               - /bin/sh
               - -c
+              # $$ escapes Flux postBuild substitution (see fetch-jwks). Failures are non-fatal:
+              # the previously written /jwks/jwks keeps being served.
               - |
-                sa=/var/run/secrets/kubernetes.io/serviceaccount
-                url="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/openid/v1/jwks"
                 while true; do
                   sleep 3600
-                  if curl --fail --silent --show-error --max-time 10 \
-                       --cacert "$sa/ca.crt" \
-                       -H "Authorization: Bearer $(cat "$sa/token")" \
-                       "$url" -o /jwks/jwks.new && grep -q '"keys"' /jwks/jwks.new; then
+                  if curl --fail --silent --show-error --max-time 10 --retry 3 --retry-delay 5 --retry-all-errors \
+                       --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                       -H "Authorization: Bearer $$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                       https://kubernetes.default.svc/openid/v1/jwks -o /jwks/jwks.new \
+                     && grep -q '"keys"' /jwks/jwks.new; then
                     mv /jwks/jwks.new /jwks/jwks
                     echo "refreshed JWKS"
                   else

--- a/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
@@ -91,10 +91,10 @@ spec:
                 while true; do
                   sleep 3600
                   if curl --fail --silent --show-error --max-time 10 --retry 3 --retry-delay 5 --retry-all-errors \
-                       --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
-                       -H "Authorization: Bearer $$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
-                       https://kubernetes.default.svc/openid/v1/jwks -o /jwks/jwks.new \
-                     && grep -q '"keys"' /jwks/jwks.new; then
+                    --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+                    -H "Authorization: Bearer $$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
+                    https://kubernetes.default.svc/openid/v1/jwks -o /jwks/jwks.new \
+                    && grep -q '"keys"' /jwks/jwks.new; then
                     mv /jwks/jwks.new /jwks/jwks
                     echo "refreshed JWKS"
                   else

--- a/kubernetes/apps/network/oidc-talos/app/kustomization.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/network/oidc-talos/app/rbac.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/rbac.yaml
@@ -1,0 +1,17 @@
+---
+# Lets the oidc-talos ServiceAccount read the apiserver's OIDC discovery endpoints
+# (/.well-known/openid-configuration + /openid/v1/jwks) so the init/refresh containers can
+# fetch the live JWKS. Bound explicitly to this SA (not relying on the cluster-wide
+# system:serviceaccounts binding) so the app bootstraps clean on a fresh cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-talos-issuer-discovery
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:service-account-issuer-discovery
+subjects:
+  - kind: ServiceAccount
+    name: oidc-talos
+    namespace: network


### PR DESCRIPTION
## Why
The oidc-talos OIDC endpoint published the cluster's JWKS from a **static, committed key block** — cluster-specific material that wouldn't be correct on a fresh bootstrap reusing the name, and that drifts if the cluster's SA signing key ever rotates.

## What
Serve the JWKS fetched **live from the apiserver's discovery endpoint** instead:

- **init container `fetch-jwks`** — populates an emptyDir from `/openid/v1/jwks` *before* nginx starts (retries + validates payload, atomic write).
- **native sidecar `refresh-jwks`** (`restartPolicy: Always`) — re-fetches hourly so an SA-key rotation is picked up without a pod restart; failures are non-fatal (last-good JWKS keeps serving).
- **dedicated ServiceAccount** bound to the built-in `system:service-account-issuer-discovery` ClusterRole (`rbac.yaml`) — so it does **not** rely on the cluster-wide `system:serviceaccounts` discovery binding → bootstraps clean.
- nginx now serves `/openid/v1/jwks` from the emptyDir; the **discovery document stays static** (URLs only). No public/private key material is committed anymore.
- curl image pinned by digest; no cluster-internal addresses committed (uses `KUBERNETES_SERVICE_HOST/_PORT`).

## Safety
- Federation is unchanged in effect: the live endpoint already serves exactly the key (`kid` `G2Ihc…`) this would fetch — **verified in-cluster** (curl + SA token returns the live JWKS).
- Will deploy + verify the public endpoint + the sentinel-syslog token-exchange after merge.
