### PR TITLE
fix(oidc-talos): automount SA token so JWKS fetch can reach the apiserver

### DIFF
--- a/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
+++ b/kubernetes/apps/network/oidc-talos/app/helmrelease.yaml
@@ -27,6 +27,9 @@ spec:
     # cluster-specific key material — this bootstraps clean on any cluster reusing the name. The
     # discovery doc is static (URLs only). Cluster-scoped name so other clusters get their own.
     defaultPodOptions:
+      # The init/refresh containers authenticate to the apiserver with this token (app-template
+      # disables the automount by default).
+      automountServiceAccountToken: true
       securityContext:
         runAsUser: 101
         runAsGroup: 101


### PR DESCRIPTION
Follow-up to #3263. The fetch/refresh containers crash-looped on deploy:

```
cat: can't open '/var/run/secrets/kubernetes.io/serviceaccount/token': No such file or directory
curl: (77) error setting certificate file: .../ca.crt
```

app-template disables `automountServiceAccountToken` by default, so the curl containers had no in-cluster token/CA. Enable it on the pod (`defaultPodOptions`), matching the repo convention (gatus/garage/barman). The previous pod kept serving the JWKS throughout — the rolling update was held on the not-ready new pod, so **no endpoint downtime**.

Will verify the rollout + served JWKS + sentinel-syslog token exchange after merge.
