### PR TITLE
fix(flux-operator): scrape metrics via named port (resolves FluxInstanceAbsent)

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
@@ -1,6 +1,10 @@
 ---
+# The chart's ServiceMonitor scrapes via `targetPort: 8080`, which prometheus-operator can't
+# resolve on k8s 1.33+ (it relies on the deprecated v1 Endpoints API) — the scrape target silently
+# drops on pod churn, breaking flux_instance_info (→ FluxInstanceAbsent). We ship our own named-port
+# ServiceMonitor (servicemonitor.yaml) instead.
 serviceMonitor:
-  create: true
+  create: false
 web:
   enabled: true
   config:

--- a/kubernetes/apps/flux-system/flux-operator/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./clusterrolebinding.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./servicemonitor.yaml
 configMapGenerator:
   - name: flux-operator-values
     files:

--- a/kubernetes/apps/flux-system/flux-operator/app/servicemonitor.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/servicemonitor.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app flux-operator
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *app
+      app.kubernetes.io/instance: *app
+  endpoints:
+    # Scrape via the named service port (http = 8080) rather than the chart default `targetPort: 8080`.
+    # prometheus-operator resolves an integer targetPort through the deprecated v1 Endpoints API,
+    # which is degraded on k8s 1.33+ — so on pod churn the target silently drops and flux_instance_info
+    # disappears (FluxInstanceAbsent). A named port doesn't need that resolution path. See README/PR.
+    - port: http
+      interval: 60s
+      path: /metrics


### PR DESCRIPTION
## Symptom
`FluxInstanceAbsent` (critical) firing since 2026-06-22 ~20:52. **Flux itself is healthy** — it's a metrics scrape gap: `flux_instance_info` has 0 series in Prometheus.

## Root cause
The flux-operator chart's ServiceMonitor scrapes via **`targetPort: 8080`** (integer). prometheus-operator resolves an integer `targetPort` through the **v1 `Endpoints` API, deprecated/degraded on k8s 1.33+** (this cluster is **1.36**; the operator logs spam `Warning: v1 Endpoints is deprecated in v1.33+`). While the pod sat stable the previously-resolved target kept working; the **2026-06-22 apiserver incident replaced the flux-operator pod (21:06)**, forcing a re-resolution that fails — the target dropped and never returned. Confirmed: `flux_instance_info` present at 20:45, absent from 21:30 on, and a **prometheus-operator restart did not recover it**.

Working ServiceMonitors in the cluster (konflate, shelly-exporter) use a **named `port:`**, which doesn't need targetPort resolution.

## Fix
- `serviceMonitor.create: false` on the chart.
- Add our own ServiceMonitor scraping the named service port **`http`** (8080).

## Verification (post-merge)
Expect `flux_instance_info{exported_namespace="flux-system",name="flux"}` to return and `FluxInstanceAbsent` to resolve.

## Note / sweep
Cluster sweep for the at-risk `targetPort` form found only one other: `cert-manager/cert-manager` (uses the **string** `targetPort: http-metrics`, currently scraping fine on a stable pod). Not changed here — flagged as at-risk on its next pod restart.