### PR TITLE
feat(renovate): email only on actionable PRs (assign manual + on CI failure)

### DIFF
--- a/.github/workflows/renovate-assign-on-failure.yaml
+++ b/.github/workflows/renovate-assign-on-failure.yaml
@@ -1,0 +1,67 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "Renovate Assign On Failure"
+
+# Renovate self-gates on CI (platformAutomerge:false), so a failed check means the
+# auto-merge PR stays open and needs a human. Auto-merge PRs are intentionally NOT
+# assigned (assignAutomerge:false in .renovaterc.json5), so they don't reach my
+# "Participating" notifications on a quiet watch level. This workflow closes that
+# gap: when a CI workflow fails on a Renovate PR, assign me — assignment notifies
+# regardless of repo Watch level, so a broken bump emails me while clean ones stay
+# silent. (Manual PRs — protected-infra + major — are already assigned at creation.)
+
+on:
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run runs in the base-repo context with a write token, but this
+  # workflow never checks out PR code or runs PR-supplied commands — it only
+  # calls gh to assign the repo owner, so the code-injection risk this audit
+  # flags does not apply.
+  workflow_run:
+    workflows:
+      - "Flate"
+      - "security-scans"
+      - "Lint"
+    types:
+      - completed
+
+# Top-level read-only (zizmor excessive-permissions / CKV2_GHA_1).
+permissions:
+  contents: read
+
+jobs:
+  assign:
+    name: Assign owner on CI failure
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Only act on failed runs that originated from a pull request.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    # Per-job write scope: add the assignee that triggers the e-mail.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Assign repo owner to failed Renovate PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |-
+          # Resolve the open PR for this run's head branch, and only act if it is a
+          # Renovate PR. gh reports the bot author as "app/renovate" (the webhook
+          # payload calls it "renovate[bot]" — see renovate-review.yaml).
+          pr=$(gh pr list --head "$HEAD_BRANCH" --state open \
+            --json number,author \
+            --jq '.[] | select(.author.login == "app/renovate") | .number' | head -n1)
+
+          if [[ -z "$pr" ]]; then
+            echo "No open Renovate PR for branch ${HEAD_BRANCH} — nothing to do."
+            exit 0
+          fi
+
+          echo "CI failed on ${HEAD_SHA}; assigning owner to Renovate PR #${pr}."
+          # Idempotent: re-adding an existing assignee is a no-op and does not
+          # re-notify, so repeated failures across the 3 CI workflows e-mail once.
+          gh pr edit "$pr" --add-assignee LukeEvansTech

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -7,6 +7,16 @@
   // dependencies/security labels, and vulnerabilityAlerts — single source of
   // truth, so they are no longer duplicated here.
   extends: ["github>LukeEvansTech/renovate-config"],
+  // Assign manual PRs to me so they reach my GitHub "Participating" notifications.
+  // assignAutomerge:false (the Renovate default, pinned here for clarity) means
+  // auto-merge PRs are NOT assigned — so with the repo Watch set to
+  // "Participating and @mentions" (not "All Activity"), only PRs that need a human
+  // (protected-infra guard + any `major`) email me. Auto-merge PRs that FAIL CI
+  // won't merge (platformAutomerge:false self-gates on CI) and get me assigned by
+  // .github/workflows/renovate-assign-on-failure.yaml, so a broken bump emails me
+  // too — clean auto-merges stay silent.
+  assignees: ["LukeEvansTech"],
+  assignAutomerge: false,
   // ---------------------------------------------------------------------------
   // Repo-specific config previously split across .renovate/*.json5 and pulled in
   // via self-referencing `github>LukeEvansTech/talos-cluster//.renovate/*` extends.


### PR DESCRIPTION
## What

Cuts the GitHub e-mail firehose from auto-merging Renovate PRs down to **just the PRs that need a human**. Notifications are routed through **assignment**, which lands in the *Participating* stream regardless of repo Watch level.

| PR type | Auto-merges? | E-mails me? | How |
|---|---|---|---|
| App/chart bump, CI green | ✅ silently | ❌ | not assigned (`assignAutomerge: false`) |
| App/chart bump, **CI fails** | ❌ stays open | ✅ | new workflow assigns me on failure |
| Protected-infra / `major` | ❌ manual | ✅ | assigned at creation (`assignees`) |

## Changes

- **`.renovaterc.json5`** — `assignees: ["LukeEvansTech"]` + `assignAutomerge: false` (the Renovate default, pinned for clarity). Auto-merge PRs stay unassigned; manual ones (protected-infra guard + any `major`) get me assigned at creation.
- **`.github/workflows/renovate-assign-on-failure.yaml`** — `workflow_run` on `Flate` / `security-scans` / `Lint`; when one fails on a Renovate PR, `gh pr edit --add-assignee`. A failed check means Renovate won't merge (`platformAutomerge: false` self-gates on CI), so the PR sits open = needs a human. Idempotent, so a bump that trips all three checks e-mails me once. No checkout / no PR code executed (zizmor `dangerous-triggers` suppressed with justification, matching `labeler.yaml`).

## ⚠️ Manual step after merge

Set the repo **Watch** level to **"Participating and @mentions"** (or Custom without Pull requests) to silence the all-activity stream. Assignment is what gets *through* the quiet setting; the quiet setting is what stops everything else. Activates only once merged to `main` (Renovate config + `workflow_run` are read from the default branch).

## Caveats

- **Transient CI failures will e-mail me too** (source-controller OOM, GHCR timeouts, quay 504 cascades). Just unassign — Renovate retries and merges when green. Can scope the trigger to `Flate` only if it gets noisy.
- **One gap:** the *"Trivy" code-scanning* check can block auto-merge while the `security-scans` *workflow* still succeeds, so that specific case won't trip this workflow — Dependency Dashboard remains the backstop.