### PR TITLE
chore(lefthook): mirror super-linter's non-Docker linters at pre-commit

### DIFF
--- a/.github/linters/.yaml-lint.yml
+++ b/.github/linters/.yaml-lint.yml
@@ -1,0 +1,67 @@
+---
+# Super-linter yamllint config.
+#
+# Materialized verbatim from super-linter v8's bundled TEMPLATES/.yaml-lint.yml
+# (super-linter@9e863354). Previously this repo had no yamllint config, so CI
+# used super-linter's hidden bundled default. Making it explicit here means:
+#   - CI behaviour is unchanged (super-linter auto-discovers configs in
+#     .github/linters/ and this is byte-identical to its bundled default), and
+#   - the lefthook `lint-yamllint` hook can point at the SAME file with `-c`,
+#     so local pre-commit and CI run identical rules (no local-pass/CI-fail
+#     drift). yamllint is NOT run in strict mode (matching super-linter), so
+#     `level: warning` problems are reported but do not fail — only the
+#     error-level rules (key-duplicates, new-lines) fail a commit.
+#
+# If you bump the super-linter pin in shared-workflows, re-sync this file.
+
+rules:
+  braces:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  brackets:
+    level: warning
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: 1
+    max-spaces-inside-empty: 5
+  colons:
+    level: warning
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    level: warning
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start:
+    level: warning
+    present: true
+  empty-lines:
+    level: warning
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    level: warning
+    max-spaces-after: 1
+  indentation:
+    level: warning
+    spaces: consistent
+    indent-sequences: true
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length:
+    level: warning
+    max: 80
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  new-line-at-end-of-file: disable
+  new-lines:
+    type: unix
+  trailing-spaces: disable

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -36,3 +36,44 @@ stage_fixed = true
 run = "mise x --quiet -- prettier -w --log-level warn {staged_files}"
 glob = ["*.yaml", "*.yml"]
 stage_fixed = true
+
+# ---------------------------------------------------------------------------
+# super-linter parity (report-only — these block the commit, they don't fix).
+#
+# The checks above auto-format; the four below mirror the remaining
+# non-Docker super-linter linters so their findings surface at commit time
+# instead of in CI. Each points at the SAME config super-linter uses under
+# .github/linters/, and is scoped to staged files — matching CI's
+# changed-files-only behaviour on PRs. docs/ is excluded everywhere because
+# the zensical toolchain (canonical root .markdownlint.yml, 2-space indent)
+# owns it and super-linter excludes it too. Tool versions are pinned in
+# .mise.toml to match the super-linter v8 pin in shared-workflows.
+# ---------------------------------------------------------------------------
+
+# yamllint (super-linter YAML). Non-strict to match CI: level:warning rules
+# (line-length, braces, indentation, ...) are reported but only error-level
+# rules (key-duplicates, CRLF line endings) fail the commit.
+[pre-commit.commands.lint-yamllint]
+run = "mise x -- yamllint -c .github/linters/.yaml-lint.yml {staged_files}"
+glob = ["*.yaml", "*.yml"]
+exclude = ["docs/**"]
+
+# codespell (super-linter spell check). No glob — scans every staged file;
+# codespell auto-skips binaries. Honours ignore-words-list from .codespellrc.
+[pre-commit.commands.lint-codespell]
+run = "mise x -- codespell --config .github/linters/.codespellrc {staged_files}"
+exclude = ["docs/**"]
+
+# markdownlint (super-linter MARKDOWN). Uses the indent-4 .markdown-lint.yml;
+# docs/ (indent-2) is excluded to avoid the MD007 indent conflict.
+[pre-commit.commands.lint-markdownlint]
+run = "mise x -- markdownlint --config .github/linters/.markdown-lint.yml {staged_files}"
+glob = ["*.md"]
+exclude = ["docs/**"]
+
+# editorconfig-checker (super-linter EDITORCONFIG). The `ec` binary applies
+# .editorconfig rules + its own .editorconfig-checker.json excludes (Markdown,
+# fixtures, smokeping Targets), so no glob is needed here.
+[pre-commit.commands.lint-editorconfig]
+run = "mise x -- ec -config .github/linters/.editorconfig-checker.json {staged_files}"
+exclude = ["docs/**"]

--- a/.mise.toml
+++ b/.mise.toml
@@ -25,6 +25,11 @@ run = "uv pip install -r requirements.txt"
 "aqua:cli/cli" = "2.95.0"
 "aqua:cloudflare/cloudflared" = "2026.6.1"
 "aqua:cue-lang/cue" = "0.16.1"
+# editorconfig-checker / yamllint / codespell / markdownlint-cli mirror the
+# linters super-linter v8 bundles, so lefthook catches their findings locally
+# before CI. Versions pinned to match super-linter@9e863354 (v8): bumping
+# super-linter may require bumping these in lockstep to avoid local/CI drift.
+"aqua:editorconfig-checker/editorconfig-checker" = "3.6.1"
 "aqua:fluxcd/flux2" = "2.8.8"
 "aqua:google/yamlfmt" = "0.21.0"
 "aqua:helm/helm" = "4.2.2"
@@ -44,4 +49,7 @@ run = "uv pip install -r requirements.txt"
 python = "3.14.6"
 uv = "0.11.23"
 node = "24"
+"npm:markdownlint-cli" = "0.48.0"
 "npm:prettier" = "3"
+"pipx:codespell" = "2.4.2"
+"pipx:yamllint" = "1.38.0"

--- a/mise.lock
+++ b/mise.lock
@@ -118,6 +118,22 @@ url = "https://github.com/cue-lang/cue/releases/download/v0.16.1/cue_v0.16.1_lin
 checksum = "sha256:a72b0cddb377c52d1b003bed9a335d893b70cd75a182cd5e3fee8bae30ddb6d6"
 url = "https://github.com/cue-lang/cue/releases/download/v0.16.1/cue_v0.16.1_darwin_arm64.tar.gz"
 
+[[tools."aqua:editorconfig-checker/editorconfig-checker"]]
+version = "3.6.1"
+backend = "aqua:editorconfig-checker/editorconfig-checker"
+
+[tools."aqua:editorconfig-checker/editorconfig-checker"."platforms.linux-arm64"]
+checksum = "sha256:a471181b0741982afa4f3dbc1e433b6caa0c5e6daad580572841884fd9957220"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.6.1/ec-linux-arm64.tar.gz"
+
+[tools."aqua:editorconfig-checker/editorconfig-checker"."platforms.linux-x64"]
+checksum = "sha256:cd32084fce5f3d49ba49697f362ac3a114989715c98819303247dd54c1f368b0"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.6.1/ec-linux-amd64.tar.gz"
+
+[tools."aqua:editorconfig-checker/editorconfig-checker"."platforms.macos-arm64"]
+checksum = "sha256:64f6006e4ae880ef140ac175f30b5b4cab72fa92b3708d9104006441fb7ed723"
+url = "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.6.1/ec-darwin-arm64.tar.gz"
+
 [[tools."aqua:fluxcd/flux2"]]
 version = "2.8.8"
 backend = "aqua:fluxcd/flux2"
@@ -408,9 +424,21 @@ url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-linux-x64.tar.gz"
 checksum = "sha256:a1a54f46a750d2523d628d924aab61758a51c9dad3e0238beb14141be9615dd3"
 url = "https://nodejs.org/dist/v24.14.0/node-v24.14.0-darwin-arm64.tar.gz"
 
+[[tools."npm:markdownlint-cli"]]
+version = "0.48.0"
+backend = "npm:markdownlint-cli"
+
 [[tools."npm:prettier"]]
 version = "3.8.1"
 backend = "npm:prettier"
+
+[[tools."pipx:codespell"]]
+version = "2.4.2"
+backend = "pipx:codespell"
+
+[[tools."pipx:yamllint"]]
+version = "1.38.0"
+backend = "pipx:yamllint"
 
 [[tools.python]]
 version = "3.14.6"


### PR DESCRIPTION
## What

Adds **yamllint, codespell, markdownlint and editorconfig-checker** as native `pre-commit` hooks so their findings surface at commit time instead of in CI — cutting the local-pass / CI-fail churn that the `Lint` (super-linter) workflow currently catches only after pushing.

This continues the existing pattern in `.lefthook.toml` of porting super-linter rules into fast native hooks (yamlfmt, prettier, shellcheck, actionlint, zizmor). The deliberately-avoided alternative is calling `just lint` from a hook — that's the super-linter **Docker** image (`slim-v8`, amd64-only → Rosetta on Apple Silicon, whole-tree scan), far too slow for per-commit use.

## How

- **Pin the four tools in `.mise.toml`** to the exact versions super-linter v8 bundles at the shared-workflows pin (`super-linter@9e863354`):
  - `yamllint 1.38.0`, `codespell 2.4.2`, `markdownlint-cli 0.48.0`, `editorconfig-checker 3.6.1`
  - checksums locked across all 3 platforms in `mise.lock` (npm/pipx pin version-only, same as the existing `prettier` entry).
- **Materialize super-linter's bundled yamllint config** to `.github/linters/.yaml-lint.yml` — byte-identical to what super-linter was using invisibly, so **CI behaviour is unchanged**, but now the hook and CI read the same rules (no drift). yamllint runs **non-strict** to match CI: `level: warning` rules report but don't fail; only `key-duplicates` / CRLF block.
- **Four new report-only hooks**, each reusing its existing `.github/linters/` config, scoped to `{staged_files}` (mirroring CI's changed-files-only behaviour on PRs), and excluding `docs/` (owned by the zensical toolchain / canonical root `.markdownlint.yml`).

## Validation

- Full hook run on the staged changes: green in **~0.5s**.
- Negative test: each hook correctly **fails** on planted defects (yamllint dup-key, ec trailing-whitespace, codespell `typpo`/`recieve`, markdownlint MD007) → pre-commit exits non-zero.
- This very commit was made through the hooks (they passed).

## Notes

- **Version coupling:** when the super-linter pin bumps in `shared-workflows`, re-sync these 4 versions + `.yaml-lint.yml`. Documented in the `.mise.toml` comment.
- **Changed-files parity:** editing an already-non-conforming file (e.g. a README with 2-space lists) will now surface its pre-existing issues at commit — accurate, since CI lints the full changed file too. `git commit --no-verify` remains the escape hatch.