### PR TITLE
fix(sentinel-syslog): allow world→514 ingress + classic syslog parsing + UTC

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -124,10 +124,26 @@ spec:
               # This is the generic ingestion point — any syslog source can target it.
               syslog {
                 port => 514
+                # Emit CLASSIC flat fields (program, logsource, facility_label, severity_label,
+                # host, timestamp) that the DCR's Custom-SyslogStream + transformKql expect and
+                # that the per-source filters below key on. Logstash 8/9 default this input to
+                # ECS v8, which nests them ([log][syslog][appname] ...) and leaves [program]
+                # empty — so the filters never matched and Computer/Facility/ProcessName/Severity
+                # landed blank in the Syslog table. Verified against real OPNsense data 2026-06-23.
+                ecs_compatibility => "disabled"
               }
             }
 
             filter {
+              # OPNsense (cr-fw) keeps its clock in UTC and sends RFC3164 timestamps with no zone.
+              # The syslog input otherwise reads them in the container's local zone (Europe/London
+              # => BST in summer), shifting TimeGenerated ~1h behind ingestion. Re-parse as UTC so
+              # TimeGenerated (= the plugin's ls_timestamp = @timestamp) is correct.
+              date {
+                match    => ["timestamp", "MMM dd HH:mm:ss", "MMM  d HH:mm:ss"]
+                timezone => "UTC"
+              }
+
               # ---- FILTER HARD (cost control; deliberate per design) ----
               # Per-source rules below. Sources with no rule pass through to the Syslog table as-is.
 

--- a/kubernetes/apps/security/sentinel-syslog/app/kustomization.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./helmrelease.yaml
+  - ./networkpolicy.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/security/sentinel-syslog/app/networkpolicy.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: sentinel-syslog-allow-external-syslog
+spec:
+  # The cluster runs default-deny ingress (see kube-system cilium-policies). External
+  # syslog senders are seen by Cilium as the `world` identity, so without this rule the
+  # LoadBalancer'd syslog ports are dropped at pod ingress ("Policy denied", bpf_lxc).
+  # Scoped tightly (least privilege): only the sentinel-syslog pod, only the syslog
+  # ports — NOT the :9600 Logstash monitoring API (that stays cluster-internal /
+  # prometheus-scraped). The LB IP is RFC1918 (LAN/VPN-reachable only), so `world` here
+  # is effectively the on-prem LAN; using the entity keeps LAN CIDRs out of this public repo.
+  description: "Allow external (LAN) syslog senders to reach the sentinel-syslog collector on 514/udp+tcp"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: sentinel-syslog
+  ingress:
+    - fromEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "514"
+              protocol: UDP
+            - port: "514"
+              protocol: TCP


### PR DESCRIPTION
## Context
Verifying the OPNsense → Microsoft Sentinel ingestion end-to-end (task #5 of the
syslog-to-Sentinel work). OPNsense's remote-syslog target was pointed at the
LB (`network-ops`), but **no data was reaching the mgmt LAW `Syslog` table** even
though Logstash reported `out == in` and the DCR showed `RowsDropped = 0`.

Two distinct bugs, found via `cilium monitor`, DCR metrics, and KQL:

### 1. NetworkPolicy — external syslog dropped at pod ingress
The cluster runs **default-deny ingress**. External (LAN) syslog senders are the
Cilium `world` identity, and there was no allow for them — so every packet was
dropped (`xx drop (Policy denied) … world->… :514 udp`, `bpf_lxc.c`). The
in-cluster test passed only because that source had a *same-namespace* identity.

Fix: an **app-scoped** `CiliumNetworkPolicy` allowing `world → 514/udp+tcp`
**only** (not the `:9600` Logstash API; not the other `security` pods). The LB IP
is RFC1918, so `world` is effectively the on-prem LAN — and the entity keeps LAN
CIDRs out of this public repo.

### 2. Pipeline — ECS v8 broke parsing + a 1h timezone skew
The `syslog` input defaulted to **ECS v8**, which nests fields and leaves
`[program]` empty — so the per-source filters never matched: no cost-control drop
of routine `pass` filterlog, and `Computer`/`Facility`/`ProcessName`/`Severity`
landed **blank** in the table (only `SyslogMessage` + `HostIP` populated).

- `ecs_compatibility => "disabled"` → emit the classic flat fields
  (`program`, `logsource`, `facility_label`, `severity_label`, `host`,
  `timestamp`) that the DCR's `Custom-SyslogStream` transform expects.
- `date { … timezone => "UTC" }` → OPNsense logs in UTC and sends RFC3164
  timestamps with no zone; the container's `Europe/London` (BST) zone shifted
  `TimeGenerated` ~1h behind ingestion.

## Verification
- NetworkPolicy fix **verified live**: applying it flipped Logstash from `in=8`
  (stuck) to `in=501` in 15s; data now lands in the `Syslog` table (14.5k rows
  ingested in 20m via `ingestion_time()`).
- Pipeline fix: `flate test all` green (645 passed); reasoned against the DCR
  schema. Post-merge check: confirm `ProcessName=filterlog`, `pass` rows dropped,
  `TimeGenerated == ingestion_time`.
