### PR TITLE
feat(renovate): rebaseWhen conflicted to stop the CI re-run storm

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -17,6 +17,13 @@
   // too — clean auto-merges stay silent.
   assignees: ["LukeEvansTech"],
   assignAutomerge: false,
+  // Only rebase a PR when it actually conflicts — NOT every time it falls behind
+  // main (the default with automerge enabled). With high auto-merge volume every
+  // merge would otherwise re-rebase all open PRs and re-run the full CI suite on
+  // each (PRs accumulated ~55 redundant runs). Behind-base PRs still auto-merge
+  // when green: platformAutomerge:false self-merges and there is no ruleset
+  // requiring up-to-date branches.
+  rebaseWhen: "conflicted",
   // ---------------------------------------------------------------------------
   // Repo-specific config previously split across .renovate/*.json5 and pulled in
   // via self-referencing `github>LukeEvansTech/talos-cluster//.renovate/*` extends.


### PR DESCRIPTION
## Problem

`rebaseWhen` wasn't set, so it was inherited as **"behind-base-branch"** (the default when `automerge` is on — confirmed from PR bodies: *"♻ Rebasing: Whenever PR is behind base branch"*). With high auto-merge volume, **every merge to `main` re-rebases every open PR and re-runs the entire CI suite on each one**.

The receipt: PR #3191 had **56 comments — 55 per-re-run `github-actions` comments** + 1 sticky konflate. The nginx/python PRs sat at 53 each. Those PRs ran full CI ~55 times while just waiting.

## Fix

```json5
rebaseWhen: "conflicted",
```

Rebase only on a **real merge conflict**. A PR runs CI once at creation, then only re-runs if it actually conflicts.

**Safe here:** behind-base PRs still auto-merge when green — `platformAutomerge: false` self-merges and there's **no branch-protection ruleset requiring up-to-date branches**. The only change is merging against a slightly stale (but CI-validated) base, which for independent image/chart bumps is a non-issue; a genuine textual conflict still triggers a rebase.

## Impact

~80–95% fewer Renovate CI runs (e.g. #3191: ~55 runs → ~1), and the per-run comment spam disappears as a side effect. No workflows removed — the per-PR suite (flate, security-scans, lint, konflate, image-pull, …) is each still justified; this only stops them from re-running needlessly.