### PR TITLE
feat(chaski): migrate chart 0.1.0 → 0.2.0

### DIFF
--- a/kubernetes/apps/default/chaski/app/ocirepository.yaml
+++ b/kubernetes/apps/default/chaski/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.0
+    tag: 0.2.0
   url: oci://ghcr.io/home-operations/charts/chaski


### PR DESCRIPTION
## Summary

Migrates the `chaski` webhook relay from chart **`0.1.0` → `0.2.0`** (tag-only, matching repo convention).

### Why
- `chaski@0.1.0` is the literal first release. One of the two pods **segfaulted once at startup** (`exit 139`, `startedAt`==`finishedAt`), which fired a `KubePodCrashLooping` Alertmanager page. It self-recovered in 1s and has run clean since, so the alert has already resolved — but `0.2.0` rolls up the **`0.1.1` "shutdown drain order" fix** (listener startup/shutdown sequencing), the most likely source of a boot-time SIGSEGV.
- chaski isn't protected-infra, so **Renovate auto-merges its chart minor/patch bumps**. `0.2.0` is a *breaking* minor (webhook routing + `verify` model), and because the chart passes `config:` through verbatim, **flate/CI renders it green and won't catch a runtime config break**. Doing the bump deliberately here defuses that latent auto-merge.

### Changes
- `ocirepository.yaml`: `ref.tag` `0.1.0` → `0.2.0`.
- **No values changes.** The config schema (`targets` / `routes` / `whenExpr` / `params` / `apprise.url`) is identical across `0.1.x`/`0.2.0`; `verify` stays unused (optional). Verified three ways: `helm template` of the `0.2.0` chart with these values renders SA/ConfigMap/Service/Deployment/ServiceMonitor cleanly (exit 0, no warnings); onedr0p runs `0.2.0` on a byte-identical config block; and the `0.2.0` README confirms the field names are unchanged.

### ⚠️ Required manual step after reconcile (out of Git)
`0.2.0` changes the webhook path scheme **`/notify/{route}` → `/hooks/{route}`** (confirmed by probing the live `0.1.0` pod: `/notify/radarr-download` → 500 = route exists; `/hooks/...` → 404). Repoint each *arr's **Settings → Connect** (Radarr/Sonarr live in `media`, so use the cross-namespace FQDN on **port 8080**):

- Radarr → `http://chaski.default.svc.cluster.local:8080/hooks/radarr-download` and `…/hooks/radarr-manual`
- Sonarr → `http://chaski.default.svc.cluster.local:8080/hooks/sonarr-download` and `…/hooks/sonarr-manual`

(These match the `/hooks/...` URLs PR #3255 already documented — that scheme was actually `0.2.0`'s, so this aligns the running path with those instructions.)
