### PR TITLE
fix(sentinel-syslog): cap pipeline.workers + direct memory to stop OOM

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -34,8 +34,10 @@ spec:
               tag: 9.1.10
             env:
               TZ: ${TIMEZONE}
-              # Bound the JVM heap for the semi-hyperconverged nodes.
-              LS_JAVA_OPTS: "-Xms512m -Xmx512m"
+              # Bound the JVM heap AND Netty/direct off-heap for the semi-hyperconverged
+              # nodes. Without -XX:MaxDirectMemorySize the syslog input's Netty buffers
+              # creep uncapped past the 1536Mi container limit (OOMKilled ~every 4h).
+              LS_JAVA_OPTS: "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m"
               # Workload identity (federated, NO secret). The plugin's managed_identity mode
               # auto-detects these. Identifiers are sourced from cluster-secrets (1Password) because
               # this repo is public — populate after terraform-entra + -azure-platform apply.
@@ -199,6 +201,12 @@ spec:
             # plain `http.host` was removed and makes Logstash exit on startup.
             api.http.host: 0.0.0.0
             log.level: info
+            # The node has 24 cores and the container sets no CPU limit, so Logstash
+            # defaults pipeline.workers to 24 → 24 worker threads + Netty arenas sized
+            # for 24 cores, pushing RSS past the 1536Mi limit (OOMKilled ~every 4h).
+            # A syslog→Sentinel shipper needs far less; pin it small (raise to 4 if UDP
+            # syslog ever shows drop-off under burst).
+            pipeline.workers: 2
 
     persistence:
       # Projected SA token Azure federates against (no webhook — projected manually).


### PR DESCRIPTION
## Summary

Stops the `sentinel-syslog` Logstash pod from OOMKilling (`exit 137`) ~every 4h.

## Root cause
The container runs on a **24-core node with no CPU limit** (only `cpu: 100m` request), and `logstash.yml` doesn't set `pipeline.workers` — so Logstash sizes itself for 24 cores. Confirmed live via the monitoring API (`:9600/_node/stats`):

- **`pipeline.workers: 24`**, batch_size 125 → up to 3000 events in flight + **145 threads**
- heap is bounded fine (`-Xmx512m`, 494Mi committed), but **off-heap is uncapped**: thread stacks + **Netty direct buffers** (the syslog input is Netty-based; arenas scale with core count) creep over ~3.75h until RSS passes the **1536Mi** limit → `OOMKilled` → restart → repeat.

A syslog→Sentinel shipper needs a fraction of that.

## Changes (`helmrelease.yaml` only)
- **`logstash.yml`: `pipeline.workers: 2`** — the main driver; cuts worker threads + in-flight batch memory (raise to 4 if UDP syslog shows drop-off under burst).
- **`LS_JAVA_OPTS`: add `-XX:MaxDirectMemorySize=256m`** — hard-caps Netty/direct off-heap so it physically can't creep past the container limit.

## Expected result
Steady RSS **~1.1Gi** (heap 512 + direct ≤256 + non-heap ~228 + far fewer thread stacks) — ~400Mi under the **unchanged** 1536Mi limit, so no limit bump needed (keeps the memory-careful posture on the semi-hyperconverged nodes).

## Notes
- Touches only `helmrelease.yaml` — **independent of the in-flight `networkpolicy.yaml` + `kustomization.yaml` WIP** on the sentinel-syslog branch, no conflict.
- Verify after reconcile: `kubectl -n security exec deploy/sentinel-syslog -- curl -s localhost:9600/_node/pipelines` shows `workers: 2`, and `kubectl top pod` plateaus well under 1536Mi.
