### PR TITLE
fix(sentinel-syslog): cap glibc malloc arenas (MALLOC_ARENA_MAX=2) to stop OOM

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -38,6 +38,12 @@ spec:
               # nodes. Without -XX:MaxDirectMemorySize the syslog input's Netty buffers
               # creep uncapped past the 1536Mi container limit (OOMKilled ~every 4h).
               LS_JAVA_OPTS: "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=256m"
+              # Cap glibc malloc arenas. On a 24-core node glibc defaults to up to
+              # 8*ncpu per-thread arenas (~64MB each) for native allocs (JRuby, the
+              # Azure SDK's token churn, Netty native) and never returns them to the OS
+              # — smaps showed 6x ~64MB arenas creeping ~138Mi/h past the 1536Mi limit,
+              # which Xmx/MaxDirectMemorySize don't bound. Pin to 2.
+              MALLOC_ARENA_MAX: "2"
               # Workload identity (federated, NO secret). The plugin's managed_identity mode
               # auto-detects these. Identifiers are sourced from cluster-secrets (1Password) because
               # this repo is public — populate after terraform-entra + -azure-platform apply.


### PR DESCRIPTION
## Summary
Stops `sentinel-syslog` from OOMKilling by capping glibc malloc arenas. Follow-up to #3277 — that fix (`pipeline.workers: 2` + `-XX:MaxDirectMemorySize=256m`) cut threads and Netty direct memory but **didn't bound the OOM**; the pod still climbed to ~1420Mi and OOMKilled overnight (node logged 4 OOM-kills/14h).

## Root cause (proven via smaps on the live pod)
RSS is dominated by **glibc per-thread malloc arenas**, not heap/direct:
- `[heap]` 0.1Mi, file-backed libs 43Mi, **ANON 1029Mi**
- top anon regions: one ~302Mi (JVM heap) + **six ~64Mi arenas (~380Mi and growing)**
- heap `167/494` and non-heap `184/206` stay **flat**; the **~138 Mi/h creep is all native malloc**

On the 24-core nodes glibc defaults to up to `8*ncpu` 64Mi arenas for native allocations (JRuby, the Azure SDK's constant token exchange, Netty native) and never returns them to the OS. Neither `-Xmx` nor `-XX:MaxDirectMemorySize` bounds that region. `MALLOC_ARENA_MAX` was unset.

## Fix
`MALLOC_ARENA_MAX: "2"` — glibc keeps at most 2 arenas. The standard Java-in-container fix; directly bounds the region smaps shows is growing.

**Expected:** the 138 Mi/h creep flattens, RSS plateaus ~1.1–1.2Gi under the **unchanged** 1536Mi limit.

## Verification (post-merge)
Watch `deriv(container_memory_working_set_bytes{namespace="security",pod=~"sentinel-syslog.*"}[1h])` drop from ~138 Mi/h toward 0 and RSS plateau, over ~1–2h, before calling it fixed. If it still creeps it's a true native leak (escalate to jemalloc / plugin investigation).
