### PR TITLE
feat(ollama): num_ctx 8192 for abliterated model + reconciler converges Modelfiles

### DIFF
--- a/docs/docs/architecture/ai-llm-stack.md
+++ b/docs/docs/architecture/ai-llm-stack.md
@@ -48,7 +48,12 @@ abliterated (Q4_K_S ≈ 17.5Gi), exposed via LiteLLM as `self-hosted-uncensored`
 fallback (a cloud model would reintroduce refusals). Two ~17Gi models can't co-reside on one 24Gi
 card, so alternating between the default and the uncensored model triggers a model swap
 (~seconds) — fine for ad-hoc use. (The exact huihui-ai 3.6-35B-A3B abliterated GGUF is avoided —
-its bare `Q3_K`/`Q4_K` file tags aren't valid Ollama quant schemes.)
+its bare `Q3_K`/`Q4_K` file tags aren't valid Ollama quant schemes.) The abliterated model sets
+`PARAMETER num_ctx 8192` (2× Ollama's 4096 default) so it's usable from opencode/agents; it loads
+~20Gi 100% on-GPU, preserving headroom for the time-sliced Plex/Jellyfin transcodes on the same
+L4. The reconciler **always** re-runs `ollama create` for Modelfiles so such `PARAMETER` changes
+converge (the change applies on the next model load — keep-alive expiry, eviction, or
+`ollama stop`).
 
 To add a model: drop a `<name>.Modelfile` (or a `models.list` line) under `app/resources/`, add
 it to the `configMapGenerator` in `app/kustomization.yaml`, and commit — Reloader restarts the

--- a/kubernetes/apps/ai/ollama/app/resources/README.md
+++ b/kubernetes/apps/ai/ollama/app/resources/README.md
@@ -39,9 +39,16 @@ on the 35B and guarantees valid typed objects.
 
 ## Notes
 
-- The reconciler is idempotent and resilient: it only pulls/creates what's missing, swallows
-  transient failures, and loops every ~30m (`RECONCILE_INTERVAL`). It never exits, so it can't
-  flip the pod to NotReady and drop the server from the Service.
+- The reconciler is idempotent and resilient: it pulls missing library models and **always
+  re-runs `ollama create`** for each Modelfile (so `PARAMETER` changes like `num_ctx` converge on
+  existing replicas — create is cheap when the blob is local). It swallows transient failures and
+  loops every ~30m (`RECONCILE_INTERVAL`). It never exits, so it can't flip the pod to NotReady
+  and drop the server from the Service. A changed `PARAMETER` takes effect on the next model load
+  (keep-alive expiry, eviction, or a manual `ollama stop <name>` on each replica).
+- `num_ctx`: Ollama defaults to 4096, which is too small for agent/coding use. The abliterated
+  model sets `num_ctx 8192` in its Modelfile (verified to load ~20Gi 100% on-GPU, leaving headroom
+  for the time-sliced Plex/Jellyfin transcodes sharing the L4). Raising it further squeezes that
+  shared VRAM — 16384 fits at ~21.4/23Gi but leaves only ~1.6Gi.
 - The exact 3.6-35B-A3B abliterated sibling (huihui-ai's `...-MTP-GGUF`) is intentionally not
   used: its files carry bare `Q3_K`/`Q4_K` quant tags that Ollama's HF puller rejects ("not a
   valid quantization scheme"), and only its `Q2_K` fits VRAM. mradermacher's imatrix GGUF of

--- a/kubernetes/apps/ai/ollama/app/resources/qwen3-30b-a3b-abliterated.Modelfile
+++ b/kubernetes/apps/ai/ollama/app/resources/qwen3-30b-a3b-abliterated.Modelfile
@@ -13,8 +13,14 @@
 #
 # Provisioned automatically on every replica by the reconciler sidecar — see
 # resources/reconcile.sh and app/kustomization.yaml (no manual `ollama create`).
+#
+# num_ctx 8192 (2x Ollama's 4096 default) — usable context for opencode/agents.
+# Verified fit: this model loads ~20Gi 100% on-GPU at 8192, leaving headroom for
+# the time-sliced Plex/Jellyfin transcode workloads on the same L4. 16384 also
+# fits (~21.4/23Gi) but would starve those — raise only if you accept that.
 FROM hf.co/mradermacher/Qwen3-30B-A3B-abliterated-i1-GGUF:Q4_K_S
 PARAMETER temperature 0.6
 PARAMETER top_p 0.95
 PARAMETER stop "<|im_start|>"
 PARAMETER stop "<|im_end|>"
+PARAMETER num_ctx 8192

--- a/kubernetes/apps/ai/ollama/app/resources/reconcile.sh
+++ b/kubernetes/apps/ai/ollama/app/resources/reconcile.sh
@@ -45,16 +45,17 @@ while true; do
         done <"${CONFIG_DIR}/models.list"
     fi
 
-    # 2. Modelfile creates (<name>.Modelfile -> model <name>:latest).
+    # 2. Modelfile (re)creates (<name>.Modelfile -> model <name>:latest).
+    # Always run create so PARAMETER changes (e.g. num_ctx) converge on existing
+    # replicas — `ollama create` is cheap when the FROM blob is already local (it
+    # just rewrites the manifest) and does not unload a running model. A changed
+    # parameter takes effect on the next model load (keep-alive expiry, eviction,
+    # or a manual `ollama stop`).
     for mf in "${CONFIG_DIR}"/*.Modelfile; do
         [ -e "${mf}" ] || continue
         name="$(basename "${mf}" .Modelfile)"
-        if have_model "${name}:latest"; then
-            log "present: ${name}"
-        else
-            log "creating: ${name}"
-            ollama create "${name}" -f "${mf}" || log "WARN create failed: ${name}"
-        fi
+        log "ensuring: ${name}"
+        ollama create "${name}" -f "${mf}" || log "WARN create failed: ${name}"
     done
 
     log "reconcile pass complete; sleeping ${INTERVAL}s"


### PR DESCRIPTION
## What

Raises the abliterated model's context window so it's actually usable from opencode / agents, and makes the reconciler converge Modelfile `PARAMETER` changes.

- **`PARAMETER num_ctx 8192`** on `qwen3-30b-a3b-abliterated` (2× Ollama's 4096 default). Verified live: loads **~19–20Gi, 100% on-GPU** at 8192 on all 3 replicas, preserving VRAM headroom for the **time-sliced Plex/Jellyfin transcodes** sharing each L4. (16384 also fits at ~21.4/23Gi but leaves only ~1.6Gi — would starve transcodes, so not chosen.)
- **Reconciler now always re-runs `ollama create`** for Modelfiles (was skip-if-present) so `PARAMETER` changes converge on existing replicas. `ollama create` is cheap when the FROM blob is local and doesn't unload a running model; the new param applies on the next load (keep-alive expiry / eviction / `ollama stop`).

Context: this backs the opencode wire-in (local `oc` → LiteLLM `self-hosted-uncensored`); 4096 was too small for coding sessions.

## Applied live

Already re-created at `num_ctx 8192` + `ollama stop` on `ollama-0/1/2`, so it's serving 8192 now; this PR makes git match and keeps it converged.

## Validation

shellcheck + editorconfig + prettier + markdownlint clean; `kustomize build` regenerates the `ollama-models` ConfigMap with the new param.
