### PR TITLE
fix(bazarr): land subcleaner at /opt/subcleaner for post-processing

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -56,7 +56,11 @@ spec:
               GITSYNC_REPO: https://github.com/KBlixt/subcleaner
               GITSYNC_REF: master
               GITSYNC_PERIOD: 24h
-              GITSYNC_ROOT: /subcleaner
+              # Sync into the shared `subcleaner` volume mounted at /opt so the app
+              # container resolves /opt/subcleaner/subcleaner.py (git-sync creates the
+              # `subcleaner` symlink -> current worktree by default).
+              GITSYNC_ROOT: /opt
+              GITSYNC_LINK: subcleaner
             resources:
               requests:
                 cpu: 10m
@@ -118,6 +122,8 @@ spec:
     persistence:
       subcleaner:
         type: emptyDir
+        globalMounts:
+          - path: /opt
       cache:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
## Problem

Bazarr's subtitle post-processing (subcleaner) errors on **every** downloaded subtitle:

```
ERROR (post_processing:31) - BAZARR Post-processing result for file ...:
python3: can't open file '/add-ons/subcleaner/subcleaner.py': [Errno 2] No such file or directory
```

The `subcleaner` git-sync sidecar **does** sync the repo successfully, but into `/subcleaner` — while the post-processing command expects subcleaner at its canonical `/opt/subcleaner/subcleaner.py`. The two never line up, so the cleanup step fails. Subtitles still download/save fine (the error is post-save), but the ad/SDH cleanup never runs.

## Fix

Point git-sync at `/opt` and mount the shared `subcleaner` emptyDir there. git-sync creates its default `subcleaner` symlink → current worktree, so the app container resolves `/opt/subcleaner/subcleaner.py`.

- `GITSYNC_ROOT: /subcleaner` → `/opt` (+ explicit `GITSYNC_LINK: subcleaner`)
- `persistence.subcleaner` now `globalMounts: /opt` (was default `/subcleaner`)

`/opt` is empty in the `ghcr.io/home-operations/bazarr` image, so mounting there is safe. The `subcleaner` emptyDir is already shared into the app container (verified), so the same sharing holds at `/opt`.

## Companion runtime change (not in this repo)

Bazarr's custom post-processing command is a runtime setting (lives on the `/config` PVC, set via API/UI), so it's applied separately:

```
python3 /opt/subcleaner/subcleaner.py "{{subtitles}}" -s
```

## Validation after merge

Once Flux reconciles and the pod restarts, trigger a subtitle re-download and confirm the Bazarr log shows subcleaner running cleanly (no "can't open file"). 