### PR TITLE
fix(bazarr): correct subcleaner post-processing script paths

### DIFF
--- a/kubernetes/apps/media/bazarr/app/resources/subcleaner.sh
+++ b/kubernetes/apps/media/bazarr/app/resources/subcleaner.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 printf "Cleaning subtitles for '%s' ...\n" "$1"
-python3 /add-ons/subcleaner/subcleaner.py "$1" -s
+python3 /opt/subcleaner/subcleaner.py "$1" -s
 
 case $1 in
-*movies*) section="1" ;;
-*shows*) section="2" ;;
+*/movies/*) section="1" ;;
+*/tv/*) section="2" ;;
 esac
 
 if [[ -n "$section" ]]; then


### PR DESCRIPTION
## What

The Bazarr `subcleaner.sh` post-processing wrapper had two bugs that made it non-functional:

1. **Wrong interpreter path** — it called `python3 /add-ons/subcleaner/subcleaner.py`, but the git-sync sidecar (`GITSYNC_ROOT: /subcleaner`) makes the code available at `/opt/subcleaner/`. `/add-ons` is an empty `emptyDir`, so the hook failed with `No such file or directory`.
2. **TV never matched** — the Plex section refresh matched `*shows*`, but TV media lives under `/media/tv`, so the `section=2` branch never fired (only movie refreshes worked).

## Fix

- Point `python3` at `/opt/subcleaner/subcleaner.py` (the git-sync target).
- Match `*/movies/*` and `*/tv/*` so both Plex section refreshes trigger.

## Validation (in-cluster, against real subtitles)

| Test | subcleaner | Plex section | Refresh |
|---|---|---|---|
| Movie | ran OK | 1 | HTTP 200 |
| TV | ran OK | 2 | HTTP 200 |

## Follow-up (runtime/PVC, not GitOps — done after this deploys)

Bazarr's `postprocessing_cmd` currently calls the direct command (`python3 /opt/subcleaner/subcleaner.py "{{subtitles}}" -s`), which cleans subs but does **not** refresh Plex. To activate this wrapper, `postprocessing_cmd` must be set to `/scripts/subcleaner.sh "{{subtitles}}"` in Bazarr → Settings → Subtitles → Custom Post-Processing **after this merges/deploys**.
