### PR TITLE
feat(home): enable zigbee2mqtt against SLZB-MR1

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -61,6 +61,7 @@ ALLOWLIST: dict[str, str] = {
     ".github/workflows/image-pull.yaml": "talosctl --nodes in CI",
     "kubernetes/apps/default/shlink/app/helmrelease.yaml": "RFC1918 blocks (DISABLE_TRACKING_FROM)",
     "kubernetes/apps/home/homeassistant/app/helmrelease.yaml": "trusted-proxy IP + multus MAC",
+    "kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/kube-system/cilium/app/networks.yaml": "LB IP pool / API host",
     "kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml": "etcd-defrag node targets",
     "kubernetes/apps/network/envoy-gateway/app/envoy.yaml": "Envoy LB listener IPs",

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -19,6 +19,5 @@ resources:
   - ./shelly-exporter/ks.yaml
   - ./shelly-fleet/ks.yaml
   - ./shelly-operator/ks.yaml
-  # TODO: Update externalsecret with ZIGBEE_ADAPTER_HOST before enabling
-  # - ./zigbee2mqtt/ks.yaml
+  - ./zigbee2mqtt/ks.yaml
   - ./zwave/ks.yaml

--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -24,6 +24,7 @@ spec:
               ZIGBEE2MQTT_DATA: /data
               ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.default.svc.cluster.local:1883
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"
+              ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_STATUS_TOPIC: homeassistant/status
               ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: "false"
@@ -48,6 +49,14 @@ spec:
               limits:
                 memory: 384Mi
     defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": ["10.32.8.102/24"],
+            "mac": "02:00:00:00:00:02"
+          }]
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
             env:
               TZ: ${TIMEZONE}
               ZIGBEE2MQTT_DATA: /data
-              ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.default.svc.cluster.local:1883
+              ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.home.svc.cluster.local:1883
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"
               ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant

--- a/kubernetes/apps/home/zigbee2mqtt/ks.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/ks.yaml
@@ -16,7 +16,7 @@ spec:
     - name: rook-ceph-cluster
       namespace: rook-ceph
     - name: mosquitto
-      namespace: default
+      namespace: home
   interval: 1h
   path: ./kubernetes/apps/home/zigbee2mqtt/app
   postBuild:


### PR DESCRIPTION
## What

Enables the already-scaffolded `zigbee2mqtt` app in the `home` namespace.

- Uncomments `./zigbee2mqtt/ks.yaml` in `kubernetes/apps/home/kustomization.yaml`.
- Adds an `iot` Multus (macvlan) interface to the z2m pod (`10.32.8.102/24`, MAC `02:00:00:00:00:02`) so it can reach the coordinator intra-VLAN — mirrors the Home Assistant pattern.
- Pins `ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack` (coordinator chip is CC2652P7).

## Coordinator

SMLIGHT **SLZB-MR1**, networked, Zigbee serial-over-IP at `tcp://10.32.8.180:6638` (probed reachable 2026-06-25). Runs on the current `10.32.8.0/24` IoT VLAN; will re-home to VLAN 68 in a later phase.

## ⚠️ Prerequisite before merge

The 1Password item `zigbee2mqtt` must have field **`ZIGBEE_ADAPTER_HOST = tcp://10.32.8.180:6638`** (the ExternalSecret maps it to `ZIGBEE2MQTT_CONFIG_SERIAL_PORT`). Without it the deploy will fail to resolve the secret.

## Post-merge verify

- `kubectl -n home get pods -l app.kubernetes.io/name=zigbee2mqtt` → Running
- z2m logs show coordinator connected (no connect-refused loop to `10.32.8.180:6638`)
- HA shows the **Zigbee2MQTT Bridge** device (MQTT discovery)

Plan: Phase 1 of the Home Assistant buildout roadmap. `permit_join` stays `false` in git; devices onboarded via the z2m UI.