### PR TITLE
fix(zigbee2mqtt): literal secret name

### DIFF
--- a/kubernetes/apps/home/zigbee2mqtt/app/externalsecret.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/externalsecret.yaml
@@ -3,14 +3,14 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: "{{ .Release.Name }}-secret"
+  name: zigbee2mqtt-secret
 spec:
   refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: "{{ .Release.Name }}-secret"
+    name: zigbee2mqtt-secret
     template:
       engineVersion: v2
       data:

--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -35,7 +35,7 @@ spec:
               ZIGBEE2MQTT_CONFIG_AVAILABILITY_PASSIVE_TIMEOUT: 2000
             envFrom:
               - secretRef:
-                  name: "{{ .Release.Name }}-secret"
+                  name: zigbee2mqtt-secret
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
The zigbee2mqtt ExternalSecret used {{ .Release.Name }}-secret, but it's applied by kustomize/Flux (not Helm) so the template never renders -> invalid k8s name, ks apply fails. Switch to the literal zigbee2mqtt-secret (matches shelly-fleet / homeassistanttimemachine convention) and align the HelmRelease envFrom secretRef. Found during live deploy of #3296.