### PR TITLE
fix(zigbee2mqtt): Z2M_ONBOARD_NO_SERVER for headless start

### DIFF
--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
               ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.home.svc.cluster.local:1883
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"
               ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack
-              ZIGBEE2MQTT_CONFIG_ONBOARDING: "false"
+              Z2M_ONBOARD_NO_SERVER: "1"
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_STATUS_TOPIC: homeassistant/status
               ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: "false"


### PR DESCRIPTION
ZIGBEE2MQTT_CONFIG_ONBOARDING is a no-op (onboarding is z2m internal state). Z2M_ONBOARD_NO_SERVER=1 is the real headless switch; verified live that z2m then starts and opens the adapter socket. Final config fix in the Phase 1 series (#3296/#3297/#3300).