### PR TITLE
feat(plex-auto-languages): persist /config on a PVC

### DIFF
--- a/kubernetes/apps/media/plex-auto-languages/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex-auto-languages/app/helmrelease.yaml
@@ -52,6 +52,6 @@ spec:
         seccompProfile: { type: RuntimeDefault }
     persistence:
       config:
-        type: emptyDir
+        existingClaim: "{{ .Release.Name }}"
         globalMounts:
           - path: /config

--- a/kubernetes/apps/media/plex-auto-languages/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex-auto-languages/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./externalsecret.yaml
+  - ./pvc.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/plex-auto-languages/app/pvc.yaml
+++ b/kubernetes/apps/media/plex-auto-languages/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plex-auto-languages
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block


### PR DESCRIPTION
## What
Switch the `plex-auto-languages` `/config` volume from `emptyDir` to a 1Gi `ceph-block` PVC (`existingClaim: "{{ .Release.Name }}"`, matching the repo convention used by seerr/sonarr/etc.).

## Why
`plex-auto-languages` keeps a small tracking database of which shows/users it has already processed. With `emptyDir`, that DB was wiped on every pod restart (image bumps, node drains, reschedules), so it had to re-learn each user's per-show audio/subtitle track choices from scratch. Persisting `/config` makes the learned "Japanese audio + English subs" (and per-show dub) preferences survive restarts.

## Changes
- `app/pvc.yaml` (new) — 1Gi RWO `ceph-block` PVC named `plex-auto-languages`
- `app/helmrelease.yaml` — `persistence.config` `emptyDir` → `existingClaim`
- `app/kustomization.yaml` — add `./pvc.yaml`

## Risk
Low. The prior volume was ephemeral, so the new PVC simply starts empty (no data migration) and accumulates state going forward. Pod will roll once on apply.
