### PR TITLE
fix(llmkube): stop Flux re-applying immutable staging Jobs

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -16,6 +16,10 @@ kind: Job
 metadata:
   name: stage-qwen3-30b-abliterated
   annotations:
+    # One-shot staging Job (downloads the GGUF to the RWO PVC once). Flux must not
+    # re-apply it: a Job's spec.template is immutable, so Renovate bumping the curl
+    # image would fail the Kustomization. Created once, then left alone.
+    kustomize.toolkit.fluxcd.io/reconcile: disabled
     # CKV_K8S_21: namespace is applied by the Flux Kustomization targetNamespace,
     # not the raw manifest. CKV_K8S_40: UID 1000 is the cluster convention and a
     # host-UID collision is not a concern on single-tenant Talos nodes.

--- a/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
@@ -16,6 +16,10 @@ kind: Job
 metadata:
   name: stage-qwen3-6-35b-a3b
   annotations:
+    # One-shot staging Job (downloads the GGUF to the RWO PVC once). Flux must not
+    # re-apply it: a Job's spec.template is immutable, so Renovate bumping the curl
+    # image would fail the Kustomization. Created once, then left alone.
+    kustomize.toolkit.fluxcd.io/reconcile: disabled
     # CKV_K8S_21: namespace is applied by the Flux Kustomization targetNamespace,
     # not the raw manifest. CKV_K8S_40: UID 1000 is the cluster convention and a
     # host-UID collision is not a concern on single-tenant Talos nodes.


### PR DESCRIPTION
The one-shot model-staging Jobs are completed + immutable; Renovate bumping the curl image makes Flux fail to re-apply them (`spec.template field is immutable`), failing the `llmkube-models` Kustomization (FluxKustomizationReconciliationFailed on ai). Models are unaffected/serving. Annotate the Jobs `kustomize.toolkit.fluxcd.io/reconcile: disabled` so Flux creates them once and leaves them alone.