### PR TITLE
chore(rook-ceph): remove unused CephFS

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -103,52 +103,11 @@ spec:
       deletionPolicy: Delete
     # NOTE: After disabling the filesystem, the filesystem can be removed with the following commands:
     # ceph fs fail ceph-filesystem && ceph fs rm ceph-filesystem --yes-i-really-mean-it
-    cephFileSystems:
-      - name: &cephFileSystemName ceph-filesystem
-        spec:
-          metadataPool:
-            replicated:
-              size: 3
-          dataPools:
-            - failureDomain: host
-              replicated:
-                size: 3
-              name: data0
-          metadataServer:
-            activeCount: 1
-            activeStandby: true
-            priorityClassName: system-cluster-critical
-            placement:
-              topologySpreadConstraints:
-                - maxSkew: 1
-                  topologyKey: kubernetes.io/hostname
-                  whenUnsatisfiable: DoNotSchedule
-                  labelSelector:
-                    matchLabels:
-                      app.kubernetes.io/name: ceph-mds
-                      app.kubernetes.io/part-of: *cephFileSystemName
-            resources:
-              requests:
-                cpu: 100m
-                memory: 1Gi
-              limits:
-                memory: 4Gi
-        storageClass:
-          enabled: true
-          isDefault: false
-          name: ceph-filesystem
-          pool: data0
-          reclaimPolicy: Delete
-          allowVolumeExpansion: true
-          volumeBindingMode: Immediate
-          parameters:
-            csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
-            csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
-            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
-            csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
-            csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
-            csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
-            csi.storage.k8s.io/fstype: ext4
+    # CephFS is unused on this cluster: Talos ships no `ceph` kernel module, so
+    # CephFS can't be kernel-mounted (the llmkube model cache uses RWO ceph-block
+    # instead). Kept empty/disabled. To re-enable you also need the cephfs CSI
+    # driver (csi-drivers helmrelease) + a FUSE mounter or a ceph-module image.
+    cephFileSystems: []
     # cephFileSystemVolumeSnapshotClass:
     #   enabled: true
     #   name: csi-ceph-filesystem

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -11,8 +11,9 @@ spec:
     name: ceph-csi-drivers
   values:
     # Rook v1.20 split CSI driver deployment out of the operator chart into the
-    # ceph-csi-operator-managed ceph-csi-drivers chart. RBD (ceph-block) + CephFS
-    # (ceph-filesystem, backs the llmkube shared model cache). NFS/NVMeoF disabled.
+    # ceph-csi-operator-managed ceph-csi-drivers chart. RBD (ceph-block) only;
+    # CephFS/NFS/NVMeoF disabled (Talos has no `ceph` kernel module, so CephFS
+    # can't be kernel-mounted — llmkube uses RWO ceph-block instead).
     drivers:
       rbd:
         enabled: true
@@ -29,10 +30,7 @@ spec:
         # it for every *-nfs/-r2 ReplicationSource.
         snapshotPolicy: volumeSnapshot
       cephfs:
-        enabled: true
-        # MUST match the ceph-filesystem StorageClass provisioner (rook-prefixed
-        # convention, same as rbd above). Backs the llmkube model cache (RWX).
-        name: rook-ceph.cephfs.csi.ceph.com
+        enabled: false
       nfs:
         enabled: false
       nvmeof:


### PR DESCRIPTION
CephFS was enabled for the llmkube model cache, but Talos ships no `ceph` kernel module so it can't be kernel-mounted; the migration pivoted to RWO ceph-block. No PVCs use `ceph-filesystem`. Removes the CephFilesystem + StorageClass and disables the cephfs CSI driver — tearing down the now-idle MDS + pools.