### PR TITLE
fix(qbittorrent): switch to libtorrentv1 image

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -19,8 +19,11 @@ spec:
           app:
             nameOverride: qbittorrent
             image:
-              repository: ghcr.io/home-operations/qbittorrent
-              tag: 5.2.2@sha256:58e7ef6ed77f369c484b3066652c9e2e3d2c87bd44fce9883455565145fbd8eb
+              # libtorrent v1.2.x build (vs the default libtorrent v2) — better
+              # private-tracker compatibility and fewer libtorrent-v2 disk/memory
+              # quirks; matches the onedr0p/home-ops reference.
+              repository: ghcr.io/home-operations/qbittorrent-libtorrentv1
+              tag: 5.2.2@sha256:53f4f1a0f3df1b788b496fff41bb0288b66e590bcbe86f32c132287ab302b942
             env:
               QBT_WEBUI_PORT: &port 80
               QBT_TORRENTING_PORT: &BT-port 51749


### PR DESCRIPTION
## What
Swap the qBittorrent container image from the default `ghcr.io/home-operations/qbittorrent` (libtorrent **v2**) to `ghcr.io/home-operations/qbittorrent-libtorrentv1` (libtorrent **1.2.x**). Same qBittorrent `5.2.2`.

## Why
libtorrent v1.2.x has better private-tracker compatibility and avoids known libtorrent-v2 disk/memory quirks. Matches the onedr0p/home-ops reference. Drop-in swap — Gluetun VPN, ports (`51749`), `LocalHostAuth`, save paths, metrics sidecar, and all settings are unchanged.

## Notes
- Digest pinned to the current `5.2.2` (`sha256:53f4f1a0…`); Renovate will track the new repo going forward.
- Readiness probe intentionally left as `tcpSocket` (not onedr0p's `httpGet /api/v2/app/version`) because `LocalHostAuth: true` would make an unauthenticated kubelet httpGet probe 401 and break readiness.
- VPN unchanged (Mullvad/Gluetun, kill-switch); torrent traffic stays VPN'd.
