### PR TITLE
feat(contracthound): bump to 1.7.1

### DIFF
--- a/kubernetes/apps/default/contracthound/app/helmrelease.yaml
+++ b/kubernetes/apps/default/contracthound/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/contracthound
-              tag: 1.7.0
+              tag: 1.7.1
             env:
               TZ: ${TIMEZONE}
               DATABASE_URL: sqlite:///./data/contracthound.db


### PR DESCRIPTION
1.7.1 stamps the app version from the release tag at build time, so /health now reports the correct version (1.7.0's image had a stale hardcoded 1.6.2). Functionally identical to 1.7.0.