### PR TITLE
feat(job-ops): add self-hosted job-search automation app

### DIFF
--- a/kubernetes/apps/default/job-ops/app/externalsecret.yaml
+++ b/kubernetes/apps/default/job-ops/app/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: job-ops
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: job-ops-secret
+    template:
+      engineVersion: v2
+      data:
+        JWT_SECRET: "{{ .JWT_SECRET }}"
+        RXRESUME_API_KEY: "{{ .RXRESUME_API_KEY }}"
+        # In-cluster LiteLLM auth — reuse the existing master key rather than
+        # duplicating it into the job-ops item.
+        LLM_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
+  dataFrom:
+    - extract:
+        key: job-ops
+    - extract:
+        key: litellm

--- a/kubernetes/apps/default/job-ops/app/helmrelease.yaml
+++ b/kubernetes/apps/default/job-ops/app/helmrelease.yaml
@@ -35,8 +35,8 @@ spec:
               LLM_PROVIDER: openai_compatible
               LLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
               MODEL: self-hosted
-              # CV generation via the hosted Reactive Resume (no self-hosted instance).
-              RXRESUME_URL: https://rxresu.me
+              # CV generation via the self-hosted Reactive Resume (internal).
+              RXRESUME_URL: https://reactiveresume.${SECRET_DOMAIN}
             envFrom:
               - secretRef:
                   name: job-ops-secret

--- a/kubernetes/apps/default/job-ops/app/helmrelease.yaml
+++ b/kubernetes/apps/default/job-ops/app/helmrelease.yaml
@@ -1,0 +1,113 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: job-ops
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: job-ops
+  values:
+    controllers:
+      job-ops:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # RWO ceph-block PVC: single replica, recreate on rollout to avoid a
+        # multi-attach deadlock (the new pod can't mount until the old releases).
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/dakheera47/job-ops
+              tag: v0.10.0@sha256:fc1be33cce4bf0539164ed244dcc868a943deabf6e2a5eb2365868e24cf98554
+            env:
+              TZ: ${TIMEZONE}
+              PORT: &port "3001"
+              # Self-hosted (not the multi-tenant "hosted" SaaS) mode.
+              JOBOPS_APP_MODE: local
+              JOBOPS_PUBLIC_BASE_URL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"
+              # LLM: OpenAI-compatible endpoint -> in-cluster LiteLLM gateway.
+              # MODEL "self-hosted" routes to llama.cpp (llmkube) with an
+              # automatic openrouter/auto cloud fallback configured in LiteLLM.
+              # Provider/base-URL/model/key are also overridable in the app UI.
+              LLM_PROVIDER: openai_compatible
+              LLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
+              MODEL: self-hosted
+              # CV generation via the hosted Reactive Resume (no self-hosted instance).
+              RXRESUME_URL: https://rxresu.me
+            envFrom:
+              - secretRef:
+                  name: job-ops-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+
+    defaultPodOptions:
+      # Upstream image ships no USER and runs as root; Playwright/Camoufox write
+      # to /root/.cache, /ms-playwright and /tmp on the (writable) rootfs.
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    service:
+      app:
+        controller: job-ops
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          # SQLite DB, generated PDFs, cloudflare-cookies.
+          - path: /app/data
+            subPath: data
+          # LLM auth / session tokens (codex/gemini-cli).
+          - path: /app/codex-home
+            subPath: codex-home

--- a/kubernetes/apps/default/job-ops/app/kustomization.yaml
+++ b/kubernetes/apps/default/job-ops/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/job-ops/app/ocirepository.yaml
+++ b/kubernetes/apps/default/job-ops/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: job-ops
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/job-ops/ks.yaml
+++ b/kubernetes/apps/default/job-ops/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app job-ops
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/job-ops/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_CACHE_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -38,6 +38,7 @@ resources:
   - ./invio/ks.yaml
   - ./invoiceshelf/ks.yaml
   - ./it-tools/ks.yaml
+  - ./job-ops/ks.yaml
   - ./karakeep/ks.yaml
   - ./keeper/ks.yaml
   - ./mail-archiver/ks.yaml


### PR DESCRIPTION
## What

Stands up [**JobOps**](https://github.com/DaKheera47/job-ops) (`ghcr.io/dakheera47/job-ops:v0.10.0`) in the `default` namespace — a self-hosted job-search automation platform that scrapes 15+ job boards (headless Playwright/Camoufox), LLM-scores matches, rewrites CVs, and tracks applications.

Scaffolded with the standard bjw-s `app-template` 4-file pattern.

## Key decisions

| Area | Choice | Why |
|---|---|---|
| **LLM** | In-cluster **LiteLLM** (`openai_compatible`, `MODEL=self-hosted`) | Routes to llama.cpp/llmkube with built-in `openrouter/auto` fallback; all overridable in the app UI. Reuses the existing `litellm` 1Password key. |
| **Security** | **root + RW rootfs** (`runAsNonRoot: false`, `readOnlyRootFilesystem: false`) | Image ships no `USER`; Playwright/Camoufox write to `/root/.cache`, `/ms-playwright`, `/tmp`. Same exception as the s6 images. |
| **Storage** | One **VolSync-backed RWO ceph-block** PVC; `/app/data` + `/app/codex-home` via subPaths | SQLite/PDFs + LLM-auth tokens in one backup. `Recreate` strategy avoids RWO multi-attach on rollout. |
| **Exposure** | `envoy-internal` only | Holds CV + Gmail/LLM tokens — keep it off the public internet. |

## ⚠️ Before merge — create the 1Password item

The `job-ops` ExternalSecret needs a **`job-ops`** item in the **Talos** vault with:

- `JWT_SECRET` (≥32 chars)
- `RXRESUME_API_KEY` (Reactive Resume v5 key; uses hosted rxresu.me)

`LLM_API_KEY` is mapped from the existing `litellm` item's `LITELLM_MASTER_KEY` — no action needed.

## Validation

- `kustomize build kubernetes/apps/default/job-ops/app` :white_check_mark:
- yamlfmt + prettier :white_check_mark:
- No LAN IPs / `.lan` / `.internal` leaked :white_check_mark:
- Full `flate` render left to CI (local run hangs on the offline `dependsOn` graph, per repo guidance)

## Follow-ups (not in this PR)

- Bump memory limit if scraping bursts OOM (browsers are RAM-hungry; currently 2 Gi).
- If headless Chromium fails to launch under dropped caps, add `SYS_ADMIN` or rely on the app's `--no-sandbox`.
- Optional: Gmail OAuth + Adzuna/Apify job-board keys (add to the `job-ops` item + envFrom later).