### PR TITLE
feat(downloads): migrate VPN Mullvad -> AirVPN (per-app keys, qBittorrent port forwarding)

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/externalsecret.yaml
@@ -12,21 +12,14 @@ spec:
     name: imgur-proxy-secret
     template:
       data:
-        # WireGuard credentials come from the shared `gluetun` 1Password
-        # item (reused across qbittorrent/sabnzbd/nzbget/prowlarr).
-        # SERVER_CITIES from that item is intentionally NOT templated here
-        # — exit location for this app is set via SERVER_COUNTRIES from
-        # the per-app `imgur-proxy` 1Password item below.
+        # WireGuard creds + exit location come from the per-app
+        # `gluetun-imgur-proxy` 1Password item (its own AirVPN device key
+        # / internal IP, SERVER_COUNTRIES=Netherlands).
         VPN_SERVICE_PROVIDER: "{{ .VPN_SERVICE_PROVIDER }}"
         WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
+        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
         SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
   dataFrom:
     - extract:
-        key: gluetun
-    - extract:
-        # Per-app 1Password item — currently holds a single field
-        # SERVER_COUNTRIES (e.g. "Netherlands"). Add SERVER_CITIES,
-        # SERVER_HOSTNAMES, OWNED_ONLY, etc. here later if you want to
-        # narrow the exit further.
-        key: imgur-proxy
+        key: gluetun-imgur-proxy

--- a/kubernetes/apps/downloads/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/externalsecret.yaml
@@ -13,13 +13,14 @@ spec:
     template:
       data:
         PROWLARR__AUTH__APIKEY: "{{ .PROWLARR_API_KEY }}"
-        SERVER_CITIES: "{{ .SERVER_CITIES }}"
+        SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
         VPN_SERVICE_PROVIDER: "{{ .VPN_SERVICE_PROVIDER }}"
         WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
+        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
   dataFrom:
     - extract:
         key: prowlarr
     - extract:
-        key: gluetun
+        key: gluetun-prowlarr
 ---

--- a/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
@@ -12,9 +12,10 @@ spec:
     name: qbittorrent-secret
     template:
       data:
-        SERVER_CITIES: "{{ .SERVER_CITIES }}"
+        SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
         VPN_SERVICE_PROVIDER: "{{ .VPN_SERVICE_PROVIDER }}"
         WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
+        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
         # qBittorrent WebUI password — consumed by the metrics exporter sidecar
         QBT_WEBUI_PASSWORD: "{{ .QBT_WEBUI_PASSWORD }}"
@@ -26,5 +27,5 @@ spec:
         property: password
   dataFrom:
     - extract:
-        key: gluetun
+        key: gluetun-qbittorrent
 ---

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -26,7 +26,8 @@ spec:
               tag: 5.2.2@sha256:53f4f1a0f3df1b788b496fff41bb0288b66e590bcbe86f32c132287ab302b942
             env:
               QBT_WEBUI_PORT: &port 80
-              QBT_TORRENTING_PORT: &BT-port 51749
+              # Must equal the AirVPN reserved forwarded port (FIREWALL_VPN_INPUT_PORTS below).
+              QBT_TORRENTING_PORT: &BT-port 28812
               # Require WebUI auth even on localhost so the metrics sidecar must present
               # real credentials (from the ExternalSecret) instead of riding an
               # unauthenticated localhost bypass.
@@ -174,6 +175,10 @@ spec:
               FIREWALL: true
               FIREWALL_DEBUG: on
               FIREWALL_INPUT_PORTS: 80,3000,9710,9999
+              # AirVPN static forwarded port (reserved at airvpn.org/ports). Opens
+              # the tunnel for inbound peers so qBittorrent (QBT_TORRENTING_PORT) can
+              # seed. AirVPN ports are account-wide, so no port-forward sync sidecar.
+              FIREWALL_VPN_INPUT_PORTS: 28812
               FIREWALL_OUTBOUND_SUBNETS: '"${CLUSTER_PODS_CIDR},${CLUSTER_SVCS_CIDR},${CR_LAN_CIDR},${GH_LAN_CIDR}"'
               HEALTH_SERVER_ADDRESS: ":9999"
               HEALTH_SERVER_DISABLE_LOOP: on

--- a/kubernetes/apps/downloads/sabnzbd/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/externalsecret.yaml
@@ -14,13 +14,14 @@ spec:
       data:
         SABNZBD__API_KEY: &apiKey "{{ .SABNZBD_API_KEY }}"
         SABNZBD__NZB_KEY: *apiKey
-        SERVER_CITIES: "{{ .SERVER_CITIES }}"
+        SERVER_COUNTRIES: "{{ .SERVER_COUNTRIES }}"
         VPN_SERVICE_PROVIDER: "{{ .VPN_SERVICE_PROVIDER }}"
         WIREGUARD_PRIVATE_KEY: "{{ .WIREGUARD_PRIVATE_KEY }}"
+        WIREGUARD_PRESHARED_KEY: "{{ .WIREGUARD_PRESHARED_KEY }}"
         WIREGUARD_ADDRESSES: "{{ .WIREGUARD_ADDRESSES }}"
   dataFrom:
     - extract:
         key: sabnzbd
     - extract:
-        key: gluetun
+        key: gluetun-sabnzbd
 ---


### PR DESCRIPTION
## What

Move the downloads stack off the shared **Mullvad** WireGuard key onto **per-app AirVPN device keys** (Netherlands).

| App | 1Password item | Internal IP | Port fwd |
|-----|----------------|-------------|----------|
| qbittorrent | `gluetun-qbittorrent` | 10.142.250.80 | **28812** |
| sabnzbd | `gluetun-sabnzbd` | 10.169.30.178 | — |
| prowlarr | `gluetun-prowlarr` | 10.150.198.150 | — |
| imgur-proxy | `gluetun-imgur-proxy` | 10.152.134.90 | — |

Each `externalsecret` now `extract`s its own `gluetun-<app>` item, adds **WIREGUARD_PRESHARED_KEY** (AirVPN requires it; Mullvad didn't), and uses **SERVER_COUNTRIES=Netherlands** instead of `SERVER_CITIES`.

qBittorrent helmrelease: **FIREWALL_VPN_INPUT_PORTS=28812** + **QBT_TORRENTING_PORT=28812** → inbound peers can reach it for seeding.

## Why

AirVPN gives port forwarding (Mullvad removed it in 2023) — needed to seed on ratio-strict trackers. AirVPN can't share one key across simultaneous connections, hence one device key per app.

## Notes

- Distinct internal IPs verified (no collision). AirVPN forwarded ports are account-wide, so **no port-forward sync sidecar** needed (the declarative win vs ProtonVPN/PIA).
- Fits AirVPN's **5-connection limit** with 1 slot free (nzbget archived in #3335).
- Independent of #3335 (no file overlap); merge order doesn't matter. nzbget stays on Mullvad until #3335 prunes it.
- **Post-merge verify:** `flux reconcile` → confirm all 4 gluetun pods get NL exit IPs (distinct, no collision), apps Ready, and port 28812 shows open through the tunnel. Each gluetun is an independent sidecar, so rollback = `git revert` if any fails.
- **Cancel Mullvad** + remove the shared `gluetun` 1Password item only after this is verified.