### PR TITLE
fix(qbittorrent): raise memory limit 256Mi -> 2Gi

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -71,9 +71,12 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
+                memory: 512Mi
               limits:
-                memory: 256Mi
+                # qBittorrent (libtorrent v1) spikes well past 256Mi while loading
+                # and rechecking a large torrent session on startup, OOMKilling the
+                # container into a CrashLoop. 2Gi gives headroom for the full library.
+                memory: 2Gi
           metrics:
             dependsOn: app
             image:


### PR DESCRIPTION
## What
Bump the qBittorrent app container memory: limit `256Mi` -> `2Gi`, request `64Mi` -> `512Mi`.

## Why
qBittorrent (libtorrent v1) was **OOMKilled (exit 137) into CrashLoopBackOff** on startup — loading/rechecking a large torrent session spikes memory past 256Mi. The old pod only survived because it had settled at steady state; the pod restart from the AirVPN secret reload (#3337) re-triggered the OOM and it couldn't get past startup.

## Verified
Live-patched to 2Gi → pod came up 4/4, 0 restarts, gluetun tunnel up on AirVPN NL (213.152.161.44). This PR makes that permanent before Flux reverts the live patch.