### PR TITLE
fix(qbittorrent): pin libtorrent-v1 disk cache to 256Mi (stop OOM crashloop)

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -32,6 +32,12 @@ spec:
               # real credentials (from the ExternalSecret) instead of riding an
               # unauthenticated localhost bypass.
               QBT_Preferences__WebUI__LocalHostAuth: true
+              # libtorrent-v1 auto-sizes its disk cache from *detected* host RAM,
+              # which inside a container is the whole node — so the cache (and RSS)
+              # balloon until the cgroup OOMKills it mid-download. Pin the cache to
+              # 256 MiB to keep memory flat (~330Mi steady-state). Set as a QBT_ env
+              # (GitOps) so it survives a PVC recreate, not just the live PVC config.
+              QBT_BitTorrent__Session__DiskCacheSize: 256
             probes:
               liveness:
                 enabled: true
@@ -73,9 +79,10 @@ spec:
                 cpu: 10m
                 memory: 512Mi
               limits:
-                # qBittorrent (libtorrent v1) spikes well past 256Mi while loading
-                # and rechecking a large torrent session on startup, OOMKilling the
-                # container into a CrashLoop. 2Gi gives headroom for the full library.
+                # Disk cache is pinned to 256 MiB (QBT_BitTorrent__Session__DiskCacheSize
+                # above), so RSS stays ~330Mi and 2Gi is ample headroom. (onedr0p runs
+                # this same image at a 32Gi limit only because they leave the cache
+                # uncapped and let it size off host RAM.)
                 memory: 2Gi
           metrics:
             dependsOn: app


### PR DESCRIPTION
## Problem
qBittorrent was `CrashLoopBackOff` / OOMKilled (exit 137). It started fully (port 28812 listening on the VPN IP, external IP detected, WebUI serving) then RSS climbed ~56Mi/s during downloading and was OOMKilled past the limit. Live tests at 4Gi and 8Gi both still OOM'd — so this is not a recheck-size issue (`max_active_checking_torrents` was already 1; only 11 torrents / 12GiB in session).

## Root cause
**libtorrent-v1 auto-sizes its disk cache from *detected* physical RAM.** In a container that isn't cgroup-memory-aware it sees the node's ~192GB, so the cache (and RSS) balloon until the cgroup kills it. `memory_working_set_limit` is a libtorrent **v2** feature and is ignored on this v1 image.

## Fix
Pin the disk cache to **256 MiB** via `QBT_BitTorrent__Session__DiskCacheSize` — set as a `QBT_` env (GitOps, survives PVC recreate), same mechanism as the existing `QBT_Preferences__WebUI__LocalHostAuth`.

## Verification (applied live before this PR)
- Set `disk_cache=256` via the WebUI API → memory went **flat at ~330Mi** (was 1224→2914→OOM), 0 restarts.
- Persisted to PVC config (`Session\\DiskCacheSize=256`).
- `connection_status = connected` (inbound port 28812 reachable; seeding works).

With the cache capped, the existing **2Gi** limit is ample headroom (~6x steady state). onedr0p runs this same image at 32Gi only because they leave the cache uncapped.