### PR TITLE
fix(downloads): use ip2location for gluetun public-IP check (avoid ipinfo 429)

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -86,6 +86,11 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: info
+              # Public IP check provider. gluetun only accepts "ipinfo" or
+              # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
+              # tier, so use ip2location for the (cosmetic) public-IP display.
+              # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
+              PUBLICIP_API: ip2location
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h
               VERSION_INFORMATION: off

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -37,9 +37,11 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # Public IP check provider. gluetun only accepts "ipinfo" or
+              # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
+              # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
-              PUBLICIP_API: ipinfo
+              PUBLICIP_API: ip2location
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -194,9 +194,11 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # Public IP check provider. gluetun only accepts "ipinfo" or
+              # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
+              # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
-              PUBLICIP_API: ipinfo
+              PUBLICIP_API: ip2location
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -163,9 +163,11 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
-              # Public IP check provider — gluetun only accepts "ipinfo" or "ip2location" (not "cloudflare").
+              # Public IP check provider. gluetun only accepts "ipinfo" or
+              # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
+              # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
-              PUBLICIP_API: ipinfo
+              PUBLICIP_API: ip2location
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h


### PR DESCRIPTION
## What
Switch gluetun's `PUBLICIP_API` from `ipinfo` to `ip2location` across all four VPN'd apps (qbittorrent, prowlarr, sabnzbd, imgur-proxy).

## Why
ipinfo rate-limits with HTTP 429 on its free monthly tier, which breaks gluetun's public-IP display (cosmetic — the tunnel itself is unaffected). ip2location has no such monthly cap. imgur-proxy previously set no `PUBLICIP_API` and so defaulted to ipinfo; it's now explicit and consistent.

## Risk
Cosmetic only — affects the displayed public IP, not VPN connectivity, firewall, or port forwarding.