### PR TITLE
feat(downloads): deploy autobrr (torrent automation)

### DIFF
--- a/kubernetes/apps/downloads/autobrr/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: autobrr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: autobrr-secret
+    template:
+      data:
+        AUTOBRR__SESSION_SECRET: "{{ .AUTOBRR_SESSION_SECRET }}"
+  dataFrom:
+    - extract:
+        key: autobrr

--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: autobrr
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: autobrr
+  values:
+    controllers:
+      autobrr:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/autobrr/autobrr
+              tag: v1.80.0@sha256:944b1c438302ed10bef810a49f2eb7f334b5abf578db473bcb8d997db3978227
+            env:
+              AUTOBRR__HOST: 0.0.0.0
+              AUTOBRR__PORT: &port 80
+              AUTOBRR__METRICS_ENABLED: true
+              AUTOBRR__METRICS_HOST: 0.0.0.0
+              AUTOBRR__METRICS_PORT: &metricsPort 9094
+              AUTOBRR__CHECK_FOR_UPDATES: false
+              AUTOBRR__LOG_LEVEL: INFO
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz/readiness
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+          metrics:
+            port: *metricsPort
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: metrics
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/downloads/autobrr/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/downloads/autobrr/app/ocirepository.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: autobrr
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/downloads/autobrr/app/prometheusrule.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/prometheusrule.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: autobrr
+spec:
+  groups:
+    - name: autobrr.rules
+      rules:
+        - alert: AutobrrNetworkUnmonitored
+          expr: |-
+            autobrr_irc_channel_enabled_total != autobrr_irc_channel_monitored_total
+          for: 1h
+          annotations:
+            summary: >-
+              {{ $labels.network }} is not being monitored by Autobrr
+          labels:
+            severity: critical

--- a/kubernetes/apps/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/downloads/autobrr/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app autobrr
+  namespace: &namespace downloads
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/homepage
+    - ../../../../components/volsync
+  dependsOn:
+    - name: qbittorrent
+      namespace: downloads
+  interval: 1h
+  path: ./kubernetes/apps/downloads/autobrr/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      HOMEPAGE_NAME: Autobrr
+      HOMEPAGE_GROUP: Downloads
+      HOMEPAGE_ICON: autobrr
+      HOMEPAGE_DESCRIPTION: Torrent automation
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/downloads/kustomization.yaml
+++ b/kubernetes/apps/downloads/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./netpol.yaml
+  - ./autobrr/ks.yaml
   - ./qbittorrent/ks.yaml
   - ./qui/ks.yaml
   - ./prowlarr/ks.yaml


### PR DESCRIPTION
## What
Deploy [autobrr](https://autobrr.com) into the `downloads` namespace, adapted from the onedr0p/home-ops reference.

- app-template 5.0.1 via OCIRepository (matches qui)
- `homepage` + `volsync` components (1Gi config PVC, R2 + NFS backups)
- internal-only HTTPRoute on `SECRET_DOMAIN` / `SECRET_INTERNAL_DOMAIN` (envoy-internal)
- `serviceMonitor` + `PrometheusRule` (monitoring CRDs present in-cluster)
- session secret from the 1Password `autobrr` item via ExternalSecret

## Why
autobrr automates torrent grabs (IRC/RSS announce → filter → qBittorrent), complementing the Prowlarr search path. Pairs with the just-deployed qui (qBittorrent UI) — both from the autobrr project.

## ⚠️ Merge prerequisite
Requires a 1Password `autobrr` item (vault Talos) with field `AUTOBRR_SESSION_SECRET` to exist first, or the ExternalSecret won't sync and the pod won't start. Creating that item is the gating step before merge.