### PR TITLE
docs(imgur-proxy): correct stale gluetun secret-source comment

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -51,6 +51,7 @@ resources:
   - ./paperless/ks.yaml
   - ./privatebin/ks.yaml
   - ./rackula/ks.yaml
+  - ./reactive-resume/ks.yaml
   - ./reconcilable/ks.yaml
   - ./redditvault/ks.yaml
   - ./searxng/ks.yaml

--- a/kubernetes/apps/default/reactive-resume/app/externalsecret.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/externalsecret.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: reactive-resume
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: reactive-resume-secret
+    template:
+      engineVersion: v2
+      data:
+        # App config
+        DATABASE_URL: "postgresql://{{ .RR_POSTGRES_USER }}:{{ .RR_POSTGRES_PASSWORD }}@postgres18-rw.database.svc.cluster.local:5432/reactive_resume?sslmode=require"
+        REDIS_URL: "redis://default:{{ .DRAGONFLY_PASSWORD }}@dragonfly.database.svc.cluster.local:6379"
+        AUTH_SECRET: "{{ .AUTH_SECRET }}"
+        ENCRYPTION_SECRET: "{{ .ENCRYPTION_SECRET }}"
+        # Garage S3 credentials (reactive-resume bucket)
+        S3_ACCESS_KEY_ID: "{{ .RR_ACCESS_KEY_ID }}"
+        S3_SECRET_ACCESS_KEY: "{{ .RR_SECRET_ACCESS_KEY }}"
+        # Database bootstrap (postgres-init initContainer)
+        INIT_POSTGRES_DBNAME: reactive_resume
+        INIT_POSTGRES_HOST: postgres18-rw.database.svc.cluster.local
+        INIT_POSTGRES_USER: "{{ .RR_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .RR_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_USER: "{{ .POSTGRES_SUPER_USER }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: dragonfly
+    - extract:
+        key: garage
+    - extract:
+        key: reactive-resume

--- a/kubernetes/apps/default/reactive-resume/app/helmrelease.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/helmrelease.yaml
@@ -1,0 +1,116 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: reactive-resume
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: reactive-resume
+  values:
+    controllers:
+      reactive-resume:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # RWO data PVC: avoid multi-attach deadlock on rollout.
+        strategy: Recreate
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: "18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7"
+            envFrom:
+              - secretRef:
+                  name: reactive-resume-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/amruthpillai/reactive-resume
+              tag: v5.1.9@sha256:5ca66890dc8c2f71026b3efe24b3a87b2ad4dcccad7d4eefb5de9052d07094cd
+            env:
+              TZ: ${TIMEZONE}
+              PORT: &port 3000
+              SERVER_PORT: "3001"
+              APP_URL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"
+              # Object storage: in-cluster Garage (S3). Keys come from the Secret.
+              S3_ENDPOINT: http://garage.storage.svc.cluster.local:3900
+              S3_REGION: us-east-1
+              S3_BUCKET: reactive-resume
+              S3_FORCE_PATH_STYLE: "true"
+              # Flip to "true" once the first account is registered.
+              FLAG_DISABLE_SIGNUPS: "false"
+              FLAG_DISABLE_EMAIL_AUTH: "false"
+            envFrom:
+              - secretRef:
+                  name: reactive-resume-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  initialDelaySeconds: 60
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 6
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: reactive-resume
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /app/data
+      # Headless-Chrome PDF rendering needs more than the default 64Mi /dev/shm.
+      dshm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 256Mi
+        globalMounts:
+          - path: /dev/shm

--- a/kubernetes/apps/default/reactive-resume/app/kustomization.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/default/reactive-resume/app/ocirepository.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: reactive-resume
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/reactive-resume/ks.yaml
+++ b/kubernetes/apps/default/reactive-resume/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app reactive-resume
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: database
+    - name: dragonfly-cluster
+      namespace: database
+    - name: garage
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/default/reactive-resume/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 2Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -97,10 +97,10 @@ spec:
               VPN_INTERFACE: wg0
               VPN_IPV6_SERVER: off
               VPN_TYPE: wireguard
-            # WIREGUARD_* + VPN_SERVICE_PROVIDER come from the shared
-            # `gluetun` 1Password item; SERVER_COUNTRIES comes from the
-            # per-app `imgur-proxy` item — both merged into imgur-proxy-secret
-            # by the ExternalSecret.
+            # WireGuard creds + exit location come from the per-app
+            # `gluetun-imgur-proxy` 1Password item (its own AirVPN device key /
+            # internal IP, SERVER_COUNTRIES=Netherlands), merged into
+            # imgur-proxy-secret by the ExternalSecret.
             envFrom:
               - secretRef:
                   name: imgur-proxy-secret


### PR DESCRIPTION
Comment-only fix. The shared `gluetun` 1Password item was deleted after the AirVPN migration (all four VPN'd apps now use per-app `gluetun-<app>` items). imgur-proxy's ExternalSecret already extracts `gluetun-imgur-proxy`; this updates the one remaining helmrelease comment that still referenced the now-removed shared item. No functional change.