### PR TITLE
fix(reactive-resume): skip Node TLS verification for CNPG connection

### DIFF
--- a/kubernetes/apps/default/reactive-resume/app/helmrelease.yaml
+++ b/kubernetes/apps/default/reactive-resume/app/helmrelease.yaml
@@ -34,6 +34,14 @@ spec:
               PORT: &port 3000
               SERVER_PORT: "3001"
               APP_URL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"
+              # RR v5 bundles pg-connection-string v2, which forces sslmode=require
+              # to verify-full and ignores the URL's ssl params. CNPG's server cert
+              # is signed by the in-cluster cert-manager CA that Node doesn't trust,
+              # so DB TLS fails with DEPTH_ZERO_SELF_SIGNED_CERT. The CA isn't
+              # reachable from this namespace, so skip Node TLS verification. The DB
+              # hop stays TLS-encrypted (just unverified) and is in-cluster only;
+              # S3 (Garage) and Redis (Dragonfly) are non-TLS.
+              NODE_TLS_REJECT_UNAUTHORIZED: "0"
               # Object storage: in-cluster Garage (S3). Keys come from the Secret.
               S3_ENDPOINT: http://garage.storage.svc.cluster.local:3900
               S3_REGION: us-east-1


### PR DESCRIPTION
## What

Adds `NODE_TLS_REJECT_UNAUTHORIZED=0` to the Reactive Resume container so it can connect to CNPG Postgres.

## Why

The `reactive-resume` app landed on `main` via #3342 (it got bundled into that PR by accident during concurrent work). The manifests are correct, but the app crash-loops at startup:

```
DrizzleQueryError: CREATE SCHEMA IF NOT EXISTS "drizzle"
cause: self-signed certificate (DEPTH_ZERO_SELF_SIGNED_CERT)
```

RR v5 bundles `pg-connection-string` v2, which treats `sslmode=require` as **verify-full** and **ignores the connection string's ssl params** (verified live: `require`, `no-verify`, `disable`, and `uselibpqcompat=true&sslmode=require` all still failed). CNPG's server cert is signed by the in-cluster cert-manager CA that Node doesn't trust, and that CA isn't reachable from the `default` namespace.

## Trade-off

The DB hop stays **TLS-encrypted** (just unverified) and never leaves the cluster pod network — strictly stronger than the 3 existing apps that use `sslmode=disable` (plaintext). S3 (Garage) and Redis (Dragonfly) are non-TLS, so this flag only affects the DB connection in practice.

## Verified

With this flag live, the pod reaches `1/1 Running`: migrations complete and `🚀 Up and running on http://localhost:3000`.