### PR TITLE
fix(job-ops): unquote PORT so probe/service ports are valid

### DIFF
--- a/kubernetes/apps/default/job-ops/app/helmrelease.yaml
+++ b/kubernetes/apps/default/job-ops/app/helmrelease.yaml
@@ -24,7 +24,9 @@ spec:
               tag: v0.10.0@sha256:fc1be33cce4bf0539164ed244dcc868a943deabf6e2a5eb2365868e24cf98554
             env:
               TZ: ${TIMEZONE}
-              PORT: &port "3001"
+              # Unquoted int so the *port anchor is valid in httpGet/service ports
+              # (a quoted "3001" fails K8s probe validation: "must contain a letter").
+              PORT: &port 3001
               # Self-hosted (not the multi-tenant "hosted" SaaS) mode.
               JOBOPS_APP_MODE: local
               JOBOPS_PUBLIC_BASE_URL: "https://{{ .Release.Name }}.${SECRET_DOMAIN}"


### PR DESCRIPTION
job-ops's Helm install failed on apply:

```
Deployment "job-ops" is invalid: livenessProbe.httpGet.port: Invalid value: "3001": must contain at least one letter
```

The `PORT: &port "3001"` anchor (quoted string) is reused for the probe and service ports. K8s requires `httpGet.port` to be an integer or a *named* port (a string with a letter). Unquoting it to `&port 3001` makes the anchor a valid port number everywhere; the `PORT` env still renders as the string "3001". (Slipped past CI because `kustomize build`/flate validate the HelmRelease CR, not the rendered Deployment's API-level port rules.)