### PR TITLE
feat(subspy): bump to 1.6.1

### DIFF
--- a/kubernetes/apps/default/subspy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/subspy/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/subspy
-              tag: 1.6.0
+              tag: 1.6.1
               digest: sha256:01f6a82f1d94ccbb66c53c2666ee39aa6c12e60f38f140546b2bad4ce0f4503c
             env:
               TZ: ${TIMEZONE}


### PR DESCRIPTION
1.6.1 stamps the app version from the release tag at build time (mirrors contracthound 1.7.1), fixing the stale hardcoded `__version__` so /health reports the real version. Functionally identical to 1.6.0.