### PR TITLE
fix(plex): expand config PVC 200Gi → 300Gi (filling up)

### DIFF
--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -22,7 +22,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 200Gi
+      VOLSYNC_CAPACITY: 300Gi
       VOLSYNC_CACHE_CAPACITY: 100Gi
       HOMEPAGE_NAME: Plex
       HOMEPAGE_GROUP: Media


### PR DESCRIPTION
## Problem

Alertmanager firing `KubePersistentVolumeFillingUp` for `media/plex` — the Plex **config** PVC (`/config`, `ceph-block`) is at **193G / 196G = 99% full**.

## Diagnosis

`df` inside the Plex pod + `du` of the config dir:

| Path | Usage | |
|------|-------|--|
| `/config` (plex PVC, 200Gi) | **99%** | ← alerting |
| ↳ `Media/` (preview thumbnails / bundles) | 149G | |
| ↳ `Metadata/` | 35G | |
| ↳ `Plug-in Support/` (DB) | 9.7G | |
| `Cache/` (separate `plex-cache` PVC) | 2.1G / 100Gi (3%) | healthy |
| `/media` (NFS) | 51% | healthy |
| `/transcode` (emptyDir) | 19% | healthy |

It's legitimate config growth (metadata + video-preview thumbnails), not runaway logs — the volume has simply outgrown 200Gi. Cache is already offloaded to its own non-backed-up PVC.

## Fix

Bump `VOLSYNC_CAPACITY` `200Gi → 300Gi` in `plex/ks.yaml`. This sizes the `plex` config PVC via `components/volsync/pvc.yaml` (and keeps the VolSync restore target in sync). `ceph-block` has `allowVolumeExpansion: true`, so Flux expands it online — no recreate.

- New headroom: ~64% used, ~107G free.
- Ceph capacity is fine: `ceph-blockpool` MAX AVAIL **2.2 TiB**, cluster 13% used.
- Deliberately a git-driven expansion (not `kubectl patch`) to avoid PVC drift from desired state.