### PR TITLE
feat(homeassistant): install HACS via built-in image flag

### DIFF
--- a/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
@@ -21,6 +21,10 @@ spec:
               tag: 2026.6.3@sha256:82db7a297c96a0288559c5f2849878168c14a06557edc114084d874268c92a9a
             env:
               TZ: ${TIMEZONE}
+              # Install HACS at startup (built-in to the home-operations image).
+              # Custom components (Rako, MG/SAIC, etc.) are added via the HACS UI
+              # - the standard home-ops pattern for this image.
+              HOME_ASSISTANT__HACS_INSTALL: "true"
               # Trust proxy from pod network and management network
               HASS_HTTP_TRUSTED_PROXY_1: 10.42.0.0/16
               HASS_HTTP_TRUSTED_PROXY_2: 10.32.8.0/24


### PR DESCRIPTION
## What

Enable HACS on Home Assistant by setting `HOME_ASSISTANT__HACS_INSTALL: "true"` on the app container. The `ghcr.io/home-operations/home-assistant` image installs HACS into `/config` at startup when this flag is set.

## Why

This is the **standard home-ops pattern** for this image — it's used across many community clusters (m00nwtchr, the-homelab-00, rwade628, qlonik, siggerzz, Nospamas, …). It lets custom components be installed and updated through the HACS UI instead of a bespoke mechanism.

Immediate driver: the **Rako** lighting integration (no core HA integration exists) and, later, the **MG/SAIC** car integration — both HACS-distributed.

## Rollout effect

- HA pod restarts; on boot HACS is installed into the (VolSync-backed) `/config` volume. Idempotent on subsequent restarts.
- Pod has outbound egress for the one-time download.
- No secrets/identifiers added to git. Device/hub addresses (e.g. the Rako hub) are entered in the HA UI config flow, not committed.

## Verify after merge

- `kubectl -n home rollout status deploy/homeassistant`
- HACS appears under Settings → Devices & Services → Add Integration.