### PR TITLE
feat(llmkube): serve abliterated model at 64k via YaRN for opencode

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -103,8 +103,18 @@ spec:
   replicas: 1
   runtimeClassName: nvidia
   priorityClassName: gpu-preemptible
-  contextSize: 8192
-  parallelSlots: 2
+  # opencode's agent baseline is ~41k tokens (system prompt + tool schemas),
+  # larger than Qwen3-30B-A3B's 32k native context. Serve it at 64k via YaRN
+  # (factor 2.0) so the agent fits with working headroom. Single slot: 64k of
+  # KV (q8_0 K/V ~3.3Gi) fits the L4's ~5.5Gi free after the ~17Gi Q4_K_S
+  # weights; 2 slots would halve the window back to 32k. Static YaRN softens
+  # short-prompt quality slightly, so factor 2 is the smallest that covers opencode.
+  contextSize: 65536
+  parallelSlots: 1
+  ropeScaling:
+    type: yarn
+    factor: "2.0"
+    originalContext: 32768
   flashAttention: true
   jinja: true
   cacheTypeK: q8_0


### PR DESCRIPTION
## Why

Wiring up **opencode** on the operator's Mac to use the local abliterated model (`self-hosted-uncensored` via LiteLLM). opencode's agent baseline — system prompt + built-in tool schemas — measures **~41k tokens before any user input**. The `llama-uncensored` InferenceService is deployed at `contextSize: 8192` with `parallelSlots: 2`, so llama.cpp serves only **4096 usable tokens per request** (`8192 ÷ 2`). Result: every opencode request fails with `request (44418 tokens) exceeds the available context size (4096 tokens)`.

Diagnostics confirmed the bloat is opencode's own payload, **not** LiteLLM injecting MCP tools (a plain request is 18 tokens; a request carrying a tool is 130).

Qwen3-30B-A3B's native context is only 32k — still smaller than opencode's 41k floor — so a plain bump isn't enough. This extends the served window past native via YaRN.

## Change

`spec.ropeScaling` (the validated llmkube field → `--rope-scaling yarn --rope-scale 2.0 --yarn-orig-ctx 32768`):

| field | before | after |
|---|---|---|
| `contextSize` | 8192 | **65536** |
| `parallelSlots` | 2 | **1** |
| `ropeScaling` | — | **yarn, factor 2.0, originalContext 32768** |

Single slot so one request gets the full 64k window (2 slots would halve it back to 32k). opencode's 41k now fits with ~23k of working headroom.

## VRAM

L4 = ~22.5 GiB. Q4_K_S weights ~17 GiB → ~5.5 GiB free. KV cache at 64k with `q8_0` K/V ≈ **3.3 GiB** → fits. (131k/2-slot would need ~6.5 GiB and overflow, hence 64k.)

## Notes / follow-up after merge

- **YaRN context-capping bug**: some llama.cpp server builds cap the served context back to the training length. After Flux reconciles + the pod reloads, verify `/props` reports `n_ctx` 65536 (not 32768).
- Static YaRN slightly softens short-prompt quality — factor 2 is the smallest that covers opencode.
- opencode's client config (`~/.config/opencode/opencode.json`, off-repo) `limit.context` will be set to 65536 once the live window is verified.

## Validation

- `kustomize build kubernetes/apps/ai/llmkube/models` ✅ (renders 65536 / 1 slot / yarn)
- yamlfmt + prettier ✅