### PR TITLE
fix(llmkube): override context_length so abliterated YaRN 64k isn't capped

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -104,11 +104,14 @@ spec:
   runtimeClassName: nvidia
   priorityClassName: gpu-preemptible
   # opencode's agent baseline is ~41k tokens (system prompt + tool schemas),
-  # larger than Qwen3-30B-A3B's 32k native context. Serve it at 64k via YaRN
-  # (factor 2.0) so the agent fits with working headroom. Single slot: 64k of
-  # KV (q8_0 K/V ~3.3Gi) fits the L4's ~5.5Gi free after the ~17Gi Q4_K_S
-  # weights; 2 slots would halve the window back to 32k. Static YaRN softens
-  # short-prompt quality slightly, so factor 2 is the smallest that covers opencode.
+  # just over this GGUF's 40960 native train context. Serve it at 64k via YaRN
+  # so the agent fits with working headroom. NOTE: the pinned llama.cpp server
+  # hard-caps a slot to n_ctx_train (40960) even with correct YaRN args, so the
+  # --override-kv in extraArgs below raises the reported context_length to 65536
+  # to defeat that cap; the rope interpolation still comes from ropeScaling.
+  # Single slot: 64k of KV (q8_0 K/V ~3.3Gi) fits the L4's ~5.5Gi free after the
+  # ~17Gi Q4_K_S weights; 2 slots would halve the window. Static YaRN softens
+  # short prompts slightly, so factor 2 is the smallest that covers opencode.
   contextSize: 65536
   parallelSlots: 1
   ropeScaling:
@@ -153,6 +156,11 @@ spec:
   extraArgs:
     - --alias
     - self-hosted-uncensored
+    # Defeat the llama.cpp server's hard cap of n_ctx to the model's trained
+    # length (40960): raise the reported context_length so the YaRN-extended 64k
+    # window is actually served. Arch key is qwen3moe (Qwen3-30B-A3B is MoE).
+    - --override-kv
+    - qwen3moe.context_length=int:65536
     - --no-mmap
     - --temp
     - "0.6"


### PR DESCRIPTION
## Follow-up to #3368

After #3368 merged, the model pod reloaded with the correct YaRN args (`--ctx-size 65536 --rope-scaling yarn --rope-scale 2.0 --yarn-orig-ctx 32768 --parallel 1`) — verified in the live container spec. **But the served window capped at 40960**, not 65536:

```
W llama_context: n_ctx_seq (65536) > n_ctx_train (40960) -- possible training context overflow
W srv  load_model: the slot context (65536) exceeds the training context of the model (40960) - capping
I slot load_model: id 0 | new slot, n_ctx = 40960
```

Two findings:
1. This GGUF's **native train context is 40960**, not the 32768 I assumed (mradermacher's quant). That's basically dead-even with opencode's ~41k baseline — so even an uncapped-to-native serve wouldn't fit.
2. The pinned `llama.cpp:server-cuda` build **hard-caps each slot to `n_ctx_train` even with valid YaRN args** (known llama.cpp server behaviour, issue ggml-org/llama.cpp#22140).

## Fix

Add the escape hatch the llmkube CRD documents — `--override-kv` to raise the `context_length` the server caps against:

```yaml
extraArgs:
  - --override-kv
  - qwen3moe.context_length=int:65536
```

The YaRN rope interpolation (`spec.ropeScaling`) is unchanged; this only stops the cap, so the full 64k window is actually served. Arch key `qwen3moe` = Qwen3-30B-A3B (MoE).

## After merge

Verify `/props` reports `n_ctx = 65536` (no "capping" log line), then opencode's 41k fits with ~24k headroom.

## Validation
- `kustomize build kubernetes/apps/ai/llmkube/models` ✅
- yamlfmt + prettier ✅