### PR TITLE
fix(gatus): deploy the down-alert rule and cover all groups

### DIFF
--- a/kubernetes/apps/default/subspy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/subspy/app/helmrelease.yaml
@@ -78,12 +78,28 @@ spec:
     service:
       app:
         controller: subspy
+        annotations:
+          # Gatus checks the app's health endpoint (returns 200), not the
+          # homepage `/`. Route auto-discovery is disabled below so this is the
+          # single source of truth for subspy's status.
+          gatus.home-operations.com/enabled: "true"
+          gatus.home-operations.com/endpoint: |
+            name: subspy
+            group: internal
+            url: http://subspy.default.svc.cluster.local:8080/api/health
+            interval: 1m
+            conditions:
+              - "[STATUS] == 200"
         ports:
           http:
             port: *port
 
     route:
       app:
+        annotations:
+          # Auto-discovered check would probe `/`; the explicit service check
+          # above owns subspy's status instead.
+          gatus.home-operations.com/enabled: "false"
         hostnames:
           - "subspy.${SECRET_DOMAIN}"
         parentRefs:

--- a/kubernetes/apps/observability/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/observability/gatus/app/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - ./rbac.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
-  # - ./prometheusrule.yaml
+  - ./prometheusrule.yaml
 configMapGenerator:
   - name: gatus-configmap
     files:

--- a/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/gatus/app/prometheusrule.yaml
@@ -9,8 +9,13 @@ spec:
     - name: gatus.rules
       rules:
         - alert: GatusEndpointDown
+          # Denylist, not allowlist: page on any group EXCEPT `connectivity`
+          # (public-DNS ICMP pings, which flap on a single blip). An allowlist
+          # silently drops new groups — `security` (anubis) and `default`
+          # (shlink) were auto-discovered into their own groups and went
+          # unpaged until this was widened.
           expr: |
-            gatus_results_endpoint_success{group=~"internal|external"} == 0
+            gatus_results_endpoint_success{group!="connectivity"} == 0
           for: 5m
           annotations:
             summary: >-


### PR DESCRIPTION
## Problem

`GatusEndpointDown` was scaffolded **commented-out** in `gatus/app/kustomization.yaml` on 2025-03-19 and never enabled. Verified against live Prometheus: **343 alert rules loaded across 67 groups, zero of them gatus.** So no Gatus endpoint going down has ever paged anyone.

Surfaced while comparing our rules to onedr0p's `chore(gatus): migrate to gatus-sidecar chart` (#11077 upstream). His broader alert prompted a look at ours — which turned out to not be running at all.

## Changes

1. **Enable the rule** — uncomment `- ./prometheusrule.yaml` so it's actually applied.
2. **Widen the expr** — `{group=~"internal|external"}` → `{group!="connectivity"}`. The allowlist silently dropped the auto-discovered `security` (anubis) and `default` (shlink) groups, confirmed live:

   | group | series | old expr | new expr |
   |---|---|---|---|
   | internal | 119 | ✅ | ✅ |
   | external | 9 | ✅ | ✅ |
   | security (anubis) | 1 | ❌ | ✅ |
   | default (shlink) | 1 | ❌ | ✅ |
   | connectivity (public DNS ICMP) | 3 | ❌ | ❌ (intentional) |

   A denylist covers any future group automatically, so this can't silently drift again.

3. **subspy** — its auto-discovered check probed `/`, which returns HTTP 500 (a homepage bug), while its health endpoint `/api/health` returns 200 (its k8s readiness probe already uses it). Repointed to an explicit service check on `/api/health` and disabled route auto-discovery, mirroring shlink. Without this, enabling the rule would immediately (and misleadingly) page "subspy down".

## Note — separate follow-up

subspy's homepage 500 is a real app bug (`TypeError: cannot use 'tuple' as a dict key` — jinja2 template render) in `lukeevanstech/subspy:1.6.1`. Not fixed here; lives in the subspy repo.

## Validation

- `kustomize build` confirms the PrometheusRule now renders with the widened expr, and subspy's service (`enabled: true`, `/api/health`) + route (`enabled: false`) annotations are present.
- New expr checked against live Prometheus: evaluates internal/external/security/default, excludes connectivity.