### PR TITLE
fix(kopiur): migrate renamed credentialProjection values key + pause trial

### DIFF
--- a/kubernetes/apps/default/apprise/ks.yaml
+++ b/kubernetes/apps/default/apprise/ks.yaml
@@ -10,7 +10,9 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/kopiur
+    # kopiur trial paused — the operator uninstall removes the CRDs, so the
+    # component's SnapshotPolicy/Schedule would fail this Kustomization's apply.
+    # - ../../../../components/kopiur
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/atuin/ks.yaml
+++ b/kubernetes/apps/default/atuin/ks.yaml
@@ -10,7 +10,9 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   components:
-    - ../../../../components/kopiur
+    # kopiur trial paused — the operator uninstall removes the CRDs, so the
+    # component's SnapshotPolicy/Schedule would fail this Kustomization's apply.
+    # - ../../../../components/kopiur
     - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/default/atuin/app

--- a/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/helmrelease.yaml
@@ -22,8 +22,12 @@ spec:
         enabled: true
       prometheusRule:
         enabled: true
-    secretProjection:
-      enabled: true
+    # Chart ≥0.4.10 renamed secretProjection → features.credentialProjection;
+    # the old key is silently ignored, dropping the operator's secrets
+    # create/patch RBAC that every credentialProjection consumer relies on.
+    features:
+      credentialProjection:
+        enabled: true
     webhook:
       tls:
         mode: self

--- a/kubernetes/apps/kopiur-system/kustomization.yaml
+++ b/kubernetes/apps/kopiur-system/kustomization.yaml
@@ -8,4 +8,9 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
-  - ./kopiur/ks.yaml
+  # Trial paused (mirrors upstream home-ops ea1c153) pending the volsync →
+  # kopiur migration decision. NOTE: pruning the HelmRelease helm-uninstalls
+  # the templated CRDs (installCRDs trade-off), cascading every kopiur CR;
+  # Snapshot finalizers need manual cleanup once the operator is gone. The
+  # NAS repo data is untouched — re-enabling reconnects to the same repo.
+  # - ./kopiur/ks.yaml


### PR DESCRIPTION
## Summary

Two changes from tracking [onedr0p/home-ops](https://github.com/onedr0p/home-ops) upstream:

1. **Values-key migration**: the kopiur chart renamed `secretProjection` → `features.credentialProjection` around 0.4.10 (upstream adopted it in [26a32f7](https://github.com/onedr0p/home-ops/commit/26a32f7)). The old key is silently ignored on newer charts — `features.credentialProjection.enabled` defaults to `false`, so the pending Renovate 0.4.x bumps would strip the operator's secrets create/patch RBAC and break every `credentialProjection` consumer (ClusterRepository, SnapshotPolicy, Restore).
2. **Pause the trial** (mirrors upstream [ea1c153](https://github.com/onedr0p/home-ops/commit/ea1c153)): comment the ks reference out of `kopiur-system` and drop the kopiur component from apprise/atuin. The component removal is required, not optional: `helm uninstall` deletes the **templated** CRDs (`installCRDs` trade-off, per chart docs), so any Kustomization still rendering SnapshotPolicy/SnapshotSchedule would fail to apply.

## Post-merge runbook

Helm's uninstall order removes the operator Deployment **before** the CRDs, so the ~30 `Snapshot` CRs (finalizer `kopiur.home-operations.com/snapshot-cleanup`) will wedge the CRDs in `Terminating` with nobody left to process them. After Flux prunes:

```bash
kubectl get snapshots.kopiur.home-operations.com -A -o name \
  | xargs -I{} kubectl patch {} -n default --type merge -p '{"metadata":{"finalizers":null}}'
kubectl get crd | grep kopiur   # should drain to empty
```

Repo data on the NAS is untouched (nothing runs the kopia cleanup) — re-enabling later reconnects to the same repository.

## Safety
- VolSync continues to back apprise and atuin (both keep the volsync component).
- `kopiur-system` namespace stays (only the ks reference is commented), matching upstream.