### PR TITLE
chore(just): modernize justfiles for just 1.55

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,5 +1,7 @@
 #!/usr/bin/env -S just --justfile
 
+set default-list
+set default-script
 set lazy
 set positional-arguments := true
 set quiet := true
@@ -17,10 +19,6 @@ mod kube "kubernetes"
 # Talos Recipes
 [group: 'Talos']
 mod talos "talos"
-
-[private]
-default:
-    just -l
 
 [private]
 log lvl msg *args:

--- a/.mise.toml
+++ b/.mise.toml
@@ -20,7 +20,9 @@ run = "uv pip install -r requirements.txt"
 [tools]
 "aqua:FiloSottile/age" = "1.3.1"
 "aqua:budimanjojo/talhelper" = "3.1.12"
-"aqua:casey/just" = "latest"
+# ≥1.52 required by the justfiles (default-list/default-script settings;
+# recipe_name() needs 1.53). Explicit pin so Renovate manages bumps.
+"aqua:casey/just" = "1.55.1"
 "aqua:charmbracelet/gum" = "latest"
 "aqua:cli/cli" = "2.95.0"
 "aqua:cloudflare/cloudflared" = "2026.6.1"

--- a/bootstrap/mod.just
+++ b/bootstrap/mod.just
@@ -1,3 +1,5 @@
+set default-list
+set default-script
 set lazy
 set positional-arguments := true
 set quiet := true
@@ -5,90 +7,82 @@ set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
 kubernetes_dir := justfile_dir() + '/kubernetes'
-controller := `talosctl config info -o yaml | yq -e '.endpoints[0]'`
-nodes := `talosctl config info -o yaml | yq -e '.nodes | join (" ")'`
+controller := `talosctl config info -o yaml | yq -r -e '.endpoints[0]'`
+nodes := `talosctl config info -o yaml | yq -r -e '.nodes | join (" ")'`
 
 [confirm('Bootstrap cluster? [y|N]')]
-[private]
-default: talos kube (kubeconfig "node") wait namespaces resources crds apps kubeconfig
+[doc('Bootstrap a Talos & Kubernetes cluster end-to-end')]
+cluster: talos kube (kubeconfig "node") wait namespaces resources crds apps kubeconfig
 
 [doc('Install Talos')]
-[script]
 talos:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     for n in {{ nodes }}; do
         if ! op=$(just talos apply-node "$n" --insecure 2>&1); then
             if [[ "$op" == *"certificate required"* ]]; then
-                just log info "Talos already configured, skipping apply of config" "stage" "$0" "node" "$n"
+                just log info "Talos already configured, skipping apply of config" "stage" "{{ recipe_name() }}" "node" "$n"
                 continue
             fi
-            just log fatal "Failed to apply Talos configuration" "stage" "$0" "node" "$n" "output" "$op"
+            just log fatal "Failed to apply Talos configuration" "stage" "{{ recipe_name() }}" "node" "$n" "output" "$op"
         fi
     done
 
 [doc('Install Kubernetes')]
-[script]
 kube:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     until op=$(talosctl -n "{{ controller }}" bootstrap 2>&1 || true) && [[ "$op" == *"AlreadyExists"* ]]; do
-        just log info "Kubernetes bootstrap in progress. Retrying in 5 seconds..." "stage" "$0"
+        just log info "Kubernetes bootstrap in progress. Retrying in 5 seconds..." "stage" "{{ recipe_name() }}"
         sleep 5
     done
 
 [doc('Fetch kubeconfig')]
-[script]
 kubeconfig lb="cilium":
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     if ! talosctl kubeconfig -n "{{ controller }}" -f --force-context-name main {{ justfile_dir() }}; then
-        just log fatal "Failed to fetch kubeconfig" "stage" "$0"
+        just log fatal "Failed to fetch kubeconfig" "stage" "{{ recipe_name() }}"
     fi
     if [[ "{{ lb }}" != "cilium" ]]; then
         if ! kubectl config set-cluster main --server "https://{{ controller }}:6443"; then
-            just log fatal "Failed to set kubectl cluster server address" "stage" "$0"
+            just log fatal "Failed to set kubectl cluster server address" "stage" "{{ recipe_name() }}"
         fi
     fi
 
 [doc('Wait for nodes to be not-ready')]
-[script]
 wait:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     if ! kubectl wait nodes --for=condition=Ready=True --all --timeout=10s &>/dev/null; then
         until kubectl wait nodes --for=condition=Ready=False --all --timeout=10s &>/dev/null; do
-            just log info "Nodes not available, waiting for nodes to be available. Retrying in 5 seconds..." "stage" "$0"
+            just log info "Nodes not available, waiting for nodes to be available. Retrying in 5 seconds..." "stage" "{{ recipe_name() }}"
             sleep 5
         done
     fi
 
 [doc('Apply Kubernetes namespaces')]
-[script]
 namespaces:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     find "{{ kubernetes_dir }}/apps" -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do
         if ! kustomize build "$dir" | yq ea -e 'select(.kind == "Namespace")' | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
-            just log fatal "Failed to apply namespace" "stage" "$0" "namespace" "$(basename "$dir")"
+            just log fatal "Failed to apply namespace" "stage" "{{ recipe_name() }}" "namespace" "$(basename "$dir")"
         fi
     done
 
 [doc('Apply Kubernetes resources')]
-[script]
 resources:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     if ! kustomize build "{{ source_directory() }}/kustomize/apps" | just template - | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
-        just log fatal "Failed to apply resources" "stage" "$0"
+        just log fatal "Failed to apply resources" "stage" "{{ recipe_name() }}"
     fi
 
 [doc('Apply Helmfile CRDs')]
-[script]
 crds:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     if ! helmfile -f "{{ source_directory() }}/helmfile.d/00-crds.yaml" template -q | yq ea -e 'select(.kind == "CustomResourceDefinition")' | kubectl apply --server-side --field-manager bootstrap --force-conflicts -f -; then
-        just log fatal "Failed to apply crds" "stage" "$0"
+        just log fatal "Failed to apply crds" "stage" "{{ recipe_name() }}"
     fi
 
 [doc('Apply Helmfile Apps')]
-[script]
 apps:
-    just log info "Running stage..." "stage" "$0"
+    just log info "Running stage..." "stage" "{{ recipe_name() }}"
     if ! helmfile -f "{{ source_directory() }}/helmfile.d/01-apps.yaml" sync --hide-notes; then
-        just log fatal "Failed to sync helmfile" "stage" "$0"
+        just log fatal "Failed to sync helmfile" "stage" "{{ recipe_name() }}"
     fi

--- a/kubernetes/mod.just
+++ b/kubernetes/mod.just
@@ -1,12 +1,10 @@
+set default-list
+set default-script
 set lazy
 set positional-arguments := true
 set quiet := true
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
-
-[private]
-default:
-    just -l kube
 
 [doc('Apply local Flux Kustomization')]
 apply-ks ns ks:
@@ -33,69 +31,59 @@ flate-test:
     flate test all --path "{{ source_directory() }}/flux/cluster" --allow-missing-secrets
 
 [doc('Open a shell on a node')]
-[script]
 node-shell node:
     kubectl debug node/{{ node }} -n default -it --image="mirror.gcr.io/alpine:latest" --profile sysadmin
     kubectl delete pod -n default -l app.kubernetes.io/managed-by=kubectl-debug
 
 [doc('Prune pods in Failed, Pending, or Succeeded state')]
-[script]
 prune-pods:
     for phase in Failed Pending Succeeded; do
         kubectl delete pods -A --field-selector status.phase="$phase" --ignore-not-found=true
     done
 
 [doc('Snapshot VolSync PVCs')]
-[script]
 snapshot:
     kubectl get replicationsources --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" patch replicationsources "$name" --type merge -p '{"spec":{"trigger":{"manual":"$(date +%s)"}}}'
     done
 
 [doc('Suspend or resume Keda ScaledObjects')]
-[script]
 keda state:
     kubectl get scaledobjects --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite so "$name" autoscaling.keda.sh/paused{{ if state != "suspend" { "-" } else { "=true" } }}
     done
 
 [doc('Suspend or resume VolSync')]
-[script]
 volsync state:
     flux -n volsync-system {{ state }} kustomization volsync
     flux -n volsync-system {{ state }} helmrelease volsync
     kubectl -n volsync-system scale deployment volsync --replicas {{ if state != "suspend" { "1" } else { "0" } }}
 
 [doc('Sync ExternalSecrets')]
-[script]
 sync-es:
     kubectl get es --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite es "$name" force-sync="$(date +%s)"
     done
 
 [doc('Sync GitRepositories')]
-[script]
 sync-git:
     kubectl get gitrepo --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite gitrepo "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"
     done
 
 [doc('Sync HelmReleases')]
-[script]
 sync-hr:
     kubectl get hr --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite hr "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)" reconcile.fluxcd.io/forceAt="$(date +%s)"
     done
 
 [doc('Sync Kustomizations')]
-[script]
 sync-ks:
     kubectl get ks --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite ks "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"
     done
 
 [doc('Sync OCIRepositories')]
-[script]
 sync-oci:
     kubectl get ocirepo --no-headers -A | while read -r ns name _; do
         kubectl -n "$ns" annotate --field-manager flux-client-side-apply --overwrite ocirepo "$name" reconcile.fluxcd.io/requestedAt="$(date +%s)"

--- a/mise.lock
+++ b/mise.lock
@@ -24,20 +24,20 @@ version = "3.1.12"
 backend = "aqua:budimanjojo/talhelper"
 
 [[tools."aqua:casey/just"]]
-version = "1.47.1"
+version = "1.55.1"
 backend = "aqua:casey/just"
 
 [tools."aqua:casey/just"."platforms.linux-arm64"]
-checksum = "sha256:e6321ac6d0499bfe849cf28869e34bffbee246b8d450ffbb9a6792aea3084f72"
-url = "https://github.com/casey/just/releases/download/1.47.1/just-1.47.1-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:b0ee814c9656427408e339893541e30d9027828686839499b2a2a34dd61ad173"
+url = "https://github.com/casey/just/releases/download/1.55.1/just-1.55.1-aarch64-unknown-linux-musl.tar.gz"
 
 [tools."aqua:casey/just"."platforms.linux-x64"]
-checksum = "sha256:3cb931ae25860f261ee373f32ede3b772ac91f14f588e4071576d3ffcf1a16fd"
-url = "https://github.com/casey/just/releases/download/1.47.1/just-1.47.1-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:b0ef600f0df20d5ae91ae931627c499fc52b477ffe5f5ea7b7b3ec616b16c778"
+url = "https://github.com/casey/just/releases/download/1.55.1/just-1.55.1-x86_64-unknown-linux-musl.tar.gz"
 
 [tools."aqua:casey/just"."platforms.macos-arm64"]
-checksum = "sha256:630390f3cfe131f5153c336cb5d5e9714c49ff27bee38d090da0a5901fd660e5"
-url = "https://github.com/casey/just/releases/download/1.47.1/just-1.47.1-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:0225e3899b1b555bc3f4122d0402ba931a6ee697d188c68e4d971468064c78f4"
+url = "https://github.com/casey/just/releases/download/1.55.1/just-1.55.1-aarch64-apple-darwin.tar.gz"
 
 [[tools."aqua:charmbracelet/gum"]]
 version = "0.17.0"

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -1,55 +1,47 @@
+set default-list
+set default-script
 set lazy
 set positional-arguments := true
 set quiet := true
 set script-interpreter := ['bash', '-euo', 'pipefail']
 set shell := ['bash', '-euo', 'pipefail', '-c']
 
-[private]
-default:
-    just -l talos
-
 [doc('Generate Talos configuration with talhelper')]
-[script]
 gen-config:
-    just log info "Generating Talos configuration..." "stage" "$0"
+    just log info "Generating Talos configuration..." "stage" "{{ recipe_name() }}"
     talhelper genconfig --config-file "{{ source_directory() }}/talconfig.yaml" --secret-file "{{ source_directory() }}/talsecret.sops.yaml" --out-dir "{{ source_directory() }}/clusterconfig"
 
 [doc('Generate secret if missing')]
-[script]
 gen-secret:
     if [ ! -f "{{ source_directory() }}/talsecret.sops.yaml" ]; then
-        just log info "Generating Talos secret..." "stage" "$0"
+        just log info "Generating Talos secret..." "stage" "{{ recipe_name() }}"
         talhelper gensecret | sops --filename-override talos/talsecret.sops.yaml --encrypt - > "{{ source_directory() }}/talsecret.sops.yaml"
     else
-        just log info "Talos secret already exists" "stage" "$0"
+        just log info "Talos secret already exists" "stage" "{{ recipe_name() }}"
     fi
 
 [doc('Apply Talos config to a specific node')]
-[script]
 apply-node node *args:
-    just log info "Applying Talos config to node..." "stage" "$0" "node" "{{ node }}"
+    just log info "Applying Talos config to node..." "stage" "{{ recipe_name() }}" "node" "{{ node }}"
     talhelper gencommand apply --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --node {{ node }} --extra-flags "{{ args }}" | bash
 
 [confirm('Upgrade Talos on node? [y|N]')]
 [doc('Upgrade Talos on a specific node')]
-[script]
 upgrade-node node:
-    just log info "Upgrading Talos on node..." "stage" "$0" "node" "{{ node }}"
-    TALOS_IMAGE=$(yq '.nodes[] | select(.ipAddress == "{{ node }}") | .talosImageURL' "{{ source_directory() }}/talconfig.yaml")
-    TALOS_VERSION=$(yq '.talosVersion' "{{ source_directory() }}/talenv.yaml")
+    just log info "Upgrading Talos on node..." "stage" "{{ recipe_name() }}" "node" "{{ node }}"
+    TALOS_IMAGE=$(yq -r -e '.nodes[] | select(.ipAddress == "{{ node }}") | .talosImageURL' "{{ source_directory() }}/talconfig.yaml")
+    TALOS_VERSION=$(yq -r -e '.talosVersion' "{{ source_directory() }}/talenv.yaml")
     talhelper gencommand upgrade --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --node {{ node }} --extra-flags "--image=${TALOS_IMAGE}:${TALOS_VERSION} --timeout=10m" | bash
 
 [confirm('Upgrade Kubernetes on the cluster? [y|N]')]
 [doc('Upgrade Kubernetes version')]
-[script]
 upgrade-k8s:
-    just log info "Upgrading Kubernetes..." "stage" "$0"
-    K8S_VERSION=$(yq '.kubernetesVersion' "{{ source_directory() }}/talenv.yaml")
+    just log info "Upgrading Kubernetes..." "stage" "{{ recipe_name() }}"
+    K8S_VERSION=$(yq -r -e '.kubernetesVersion' "{{ source_directory() }}/talenv.yaml")
     talhelper gencommand upgrade-k8s --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --extra-flags "--to ${K8S_VERSION}" | bash
 
 [doc('Reset cluster nodes to maintenance mode')]
-[script]
 reset:
     gum confirm "This will destroy your cluster and reset the nodes back to maintenance mode. Continue?" --default=false || exit 0
-    just log warn "Resetting cluster..." "stage" "$0"
+    just log warn "Resetting cluster..." "stage" "{{ recipe_name() }}"
     talhelper gencommand reset --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --extra-flags "--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash


### PR DESCRIPTION
## Summary

Adopts the upstream home-ops justfile modernization ([b4dcdc2](https://github.com/onedr0p/home-ops/commit/b4dcdc2), [1d5f9a7](https://github.com/onedr0p/home-ops/commit/1d5f9a7), [eae39f4](https://github.com/onedr0p/home-ops/commit/eae39f4), [f47d235](https://github.com/onedr0p/home-ops/commit/f47d235)) across `.justfile` + the three module files.

- **`set default-list`** — drops the four `[private] default: just -l …` recipes
- **`set default-script`** — drops all 24 `[script]` attributes. Audited first: every multi-line recipe already ran in script mode and the rest are single-line/backslash-continued, so semantics are unchanged
- **`recipe_name()`** replaces `"$0"` in ~20 log lines — in script mode `$0` is the temp-script *path*, so stage names in `gum log` output were garbage; now they render correctly (verified via `--dry-run`: `"stage" "kube"`)
- **`yq -r -e`** on all scalar lookups (bootstrap `controller`/`nodes`, talos `TALOS_IMAGE`/`TALOS_VERSION`/`K8S_VERSION`) — raw output guaranteed, missing keys fail loudly instead of yielding `null`
- **Bootstrap chain renamed `default` → `cluster`** (⚠️ behavior change): bare `just bootstrap` now lists recipes; the full end-to-end bootstrap is `just bootstrap cluster` (still confirm-gated). Matches upstream and removes the footgun of a bare module invocation arming a cluster bootstrap
- **`.mise.toml`: just pinned `latest` → `1.55.1`** (+ lockfile) — `default-list`/`default-script` need ≥1.52, `recipe_name()` ≥1.53; the explicit pin hands future bumps to Renovate like the rest of the toolchain

## Validation (just 1.55.1)

- Bare `just`, `just --list bootstrap|kube|talos` all parse and list, `cluster` shows with its doc
- `just log info …` executes under default-script
- `--dry-run bootstrap kube` shows correct `recipe_name()` interpolation and the `yq -r -e` lookups

**Note for other checkouts**: run `mise install` after pulling — older just errors with `Unknown setting default-list` on every invocation.