### PR TITLE
fix(alerts): scope github-status to cluster-apps so cross-repo shelly-fleet-sync stops 422ing

### DIFF
--- a/kubernetes/components/alerts/github-status/alert.yaml
+++ b/kubernetes/components/alerts/github-status/alert.yaml
@@ -8,5 +8,13 @@ spec:
   providerRef:
     name: github-status
   eventSources:
+    # Only post commit statuses for Kustomizations reconciled from THIS repo.
+    # Every app Kustomization is a child of the `cluster-apps` root, so it
+    # carries this label. Cross-repo syncs (e.g. home/shelly-fleet-sync, applied
+    # by the `shelly-fleet` Kustomization from a separate private GitRepository)
+    # do not — their revision SHAs don't exist in talos-cluster, so the commit
+    # status POST would 422 forever. Scoping here stops that noise at the source.
     - kind: Kustomization
       name: "*"
+      matchLabels:
+        kustomize.toolkit.fluxcd.io/name: cluster-apps


### PR DESCRIPTION
## Problem

\`home/shelly-fleet-sync\` is the only Kustomization (of ~232) synced from a **different repo** — the private \`shelly-fleet\` GitRepository (\`ssh://git@github.com/LukeEvansTech/shelly-fleet.git\`) — rather than talos-cluster. Its applied revision SHA is a shelly-fleet commit that never exists in talos-cluster.

The \`github-status\` Provider posts Flux commit statuses to \`github.com/LukeEvansTech/talos-cluster\`, so every shelly-fleet-sync reconcile POSTs a status for a non-existent SHA:

\`\`\`
NotificationDispatchFailed: failed to send notification for Kustomization/home/shelly-fleet-sync:
could not create commit status: POST .../statuses/<sha>: 422 No commit found for SHA
\`\`\`

Harmless to reconciliation, but recurs hourly + on every shelly-fleet push.

## Fix

Scope the shared \`github-status\` Alert to Kustomizations applied by the \`cluster-apps\` root via \`matchLabels\`. Every app Kustomization carries \`kustomize.toolkit.fluxcd.io/name: cluster-apps\`; the cross-repo \`shelly-fleet-sync\` (applier=\`shelly-fleet\`) does not, so it's excluded — stopping the 422 at the source.

- Keeps commit statuses for all 230 app Kustomizations
- Drops the 2 flux-system root Kustomizations' (non-required, post-merge) statuses — cosmetic
- Auto-excludes any future cross-repo sync in any namespace

notification-controller has no eventSource negation / exclude-by-name, so applier-label scoping is the clean lever. \`matchLabels\` is supported in the Alert CRD (v1beta2/v1beta3, nc v1.8.4).