### PR TITLE
fix(resources): raise memory limits for OOMKilled bazarr and ceph-mgr

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -42,12 +42,12 @@ spec:
             securityContext: &securityContext
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: [ALL] }
+              capabilities: {drop: [ALL]}
             resources:
               requests:
                 cpu: 500m
               limits:
-                memory: 1Gi
+                memory: 2Gi
           subcleaner:
             image:
               repository: registry.k8s.io/git-sync/git-sync
@@ -85,7 +85,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
@@ -102,7 +102,7 @@ spec:
         supplementalGroups:
           - 44
           - 10000
-        seccompProfile: { type: RuntimeDefault }
+        seccompProfile: {type: RuntimeDefault}
     service:
       app:
         controller: bazarr

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -42,7 +42,7 @@ spec:
             securityContext: &securityContext
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: {drop: [ALL]}
+              capabilities: { drop: [ALL] }
             resources:
               requests:
                 cpu: 500m
@@ -85,7 +85,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
+              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m
@@ -102,7 +102,7 @@ spec:
         supplementalGroups:
           - 44
           - 10000
-        seccompProfile: {type: RuntimeDefault}
+        seccompProfile: { type: RuntimeDefault }
     service:
       app:
         controller: bazarr

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -21,6 +21,15 @@ spec:
       enabled: true
     cephClusterSpec:
       resources:
+        # NOTE: mgr resources must live here (spec.resources.mgr) — the CephCluster
+        # CRD has no spec.mgr.resources field, so a block there is silently pruned
+        # and the chart default (1Gi limit) applies instead.
+        mgr:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+          limits:
+            memory: 2Gi
         mon:
           requests:
             cpu: 100m
@@ -44,12 +53,6 @@ spec:
         ssl: false
         prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
       mgr:
-        resources:
-          requests:
-            cpu: 100m
-            memory: 1Gi
-          limits:
-            memory: 2Gi
         modules:
           - name: diskprediction_local
             enabled: true


### PR DESCRIPTION
## What

Two containers were OOMKilled in the last 72h (both had `OomKilled` alerts firing):

| Container | OOMKilled at | Limit | Peak working set (72h) |
|---|---|---|---|
| `rook-ceph` mgr (`rook-ceph-mgr-b`) | 2026-07-02 13:41 UTC | 1Gi (chart default) | 1021Mi |
| `media` bazarr `app` | 2026-07-01 18:38 UTC | 1Gi | ~378Mi recorded (sub-scrape-interval spike) |

## Why

- **ceph-mgr**: the 2Gi limit intended by #3145 was placed under `cephClusterSpec.mgr.resources` — a field that doesn't exist in the CephCluster CRD, so it was silently pruned and the chart default (`resources.mgr` = 1Gi) applied. The mgr's working set grew into the limit and it was killed. This PR moves the block to `cephClusterSpec.resources.mgr` (alongside the existing `mon` override) where it actually takes effect, with a comment so it doesn't regress.
- **bazarr**: OOMKilled at 1Gi by a spike faster than the 30s scrape interval (subtitle sync work). Limit raised 1Gi → 2Gi; requests untouched.

## Verification

- `flate test all` — rook-ceph 6/6, media 65/65 passed
- `helm template rook-ceph-cluster v1.20.1` with the new values renders the CephCluster with `spec.resources.mgr.limits.memory: 2Gi` and no stray `spec.mgr.resources`
- Node memory is healthy (11–31% on all three nodes) — these were pure container-limit OOMs, not node pressure. The firing `NodeMemoryHighUtilization` is the storage box's ZFS ARC, unrelated.