### PR TITLE
feat(victoria-logs): expose server Service to tailnet for seedbox Vector

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -22,6 +22,12 @@ spec:
         enabled: true
         storageClass: ceph-block
         size: 100Gi
+      service:
+        annotations:
+          # tailscale-operator publishes this Service as a tailnet device so the
+          # seedbox's Vector can push logs (pods/LAN unaffected; ClusterIP stays).
+          tailscale.com/expose: "true"
+          tailscale.com/hostname: victoria-logs
       retentionPeriod: 28d
       route:
         enabled: true


### PR DESCRIPTION
Annotate the victoria-logs server Service with tailscale.com/expose so the
tailscale-operator publishes it as a tailnet device (hostname: victoria-logs).
The seedbox's Vector will push docker+journald logs to it over the tailnet.
ClusterIP behaviour for in-cluster/LAN consumers is unchanged.
