### PR TITLE
feat(seedbox): add PrometheusRule alerts and hand-built Grafana dashboard

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
+++ b/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
@@ -1,0 +1,977 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "7-day in+out volume on eno0 extrapolated to 30 days. Prometheus retention is 14d so a calendar-month sum is not computable; vnstat on the box is the authoritative monthly counter. Seedhost counts BOTH directions against the 100 TB/mo cap (1 TB = 1e12 bytes, provider-style).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100000000000000,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 80000000000000
+              },
+              {
+                "color": "red",
+                "value": 95000000000000
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 6,
+        "h": 8
+      },
+      "id": 1,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "(increase(node_network_receive_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[7d]) + increase(node_network_transmit_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[7d])) * 30 / 7",
+          "legendFormat": "30-day pace",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Month pace vs 100 TB cap",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total in+out traffic on eno0 over the last 14 days (full Prometheus retention window).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 0,
+        "w": 4,
+        "h": 8
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "increase(node_network_receive_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[14d]) + increase(node_network_transmit_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[14d])",
+          "legendFormat": "14d in+out",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "14d cumulative traffic",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 10,
+        "y": 0,
+        "w": 14,
+        "h": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_network_receive_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[$__rate_interval])",
+          "legendFormat": "receive",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_network_transmit_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[$__rate_interval])",
+          "legendFormat": "transmit",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "eno0 throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "md4 is the RAID5 data array — healthy is active=4, failed=0, spare=0.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 6,
+        "h": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_md_disks{job=\"seedbox-node\",device=\"md4\"}",
+          "legendFormat": "{{state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RAID md4 disks by state",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "yellow",
+                "value": 0.75
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 6,
+        "y": 8,
+        "w": 4,
+        "h": 8
+      },
+      "id": 5,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "1 - (node_filesystem_avail_bytes{job=\"seedbox-node\",mountpoint=\"/\"} / node_filesystem_size_bytes{job=\"seedbox-node\",mountpoint=\"/\"})",
+          "legendFormat": "rootfs used",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Rootfs usage",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 10,
+        "y": 8,
+        "w": 7,
+        "h": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (mode) (rate(node_cpu_seconds_total{job=\"seedbox-node\",mode!=\"idle\"}[$__rate_interval]))",
+          "legendFormat": "{{mode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU by mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RAM available"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "x": 17,
+        "y": 8,
+        "w": 7,
+        "h": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_load5{job=\"seedbox-node\"}",
+          "legendFormat": "load5",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemAvailable_bytes{job=\"seedbox-node\"}",
+          "legendFormat": "RAM available",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Load / RAM",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Fraction of each second the disk spent doing I/O — 1.0 means saturated.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_disk_io_time_seconds_total{job=\"seedbox-node\",device=~\"sd[a-d]\"}[$__rate_interval])",
+          "legendFormat": "{{device}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Disk I/O per device",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "qbittorrent_torrent_states{job=\"seedbox-qbittorrent\"}",
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "qBittorrent torrents by state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Instantaneous transfer speeds reported by qBittorrent (already gauges — no rate()).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 16,
+        "w": 8,
+        "h": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "qbittorrent_global_download_speed_bytes{job=\"seedbox-qbittorrent\"}",
+          "legendFormat": "download",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "qbittorrent_global_upload_speed_bytes{job=\"seedbox-qbittorrent\"}",
+          "legendFormat": "upload",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "qBittorrent up/down rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 40,
+  "tags": ["seedbox"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Seedbox",
+  "uid": "seedbox",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/apps/observability/seedbox/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/seedbox/app/externalsecret.yaml
@@ -12,7 +12,8 @@ spec:
     name: seedbox-qbittorrent-exporter-secret
     template:
       data:
-        # seedbox-monitoring mirrors op://seedbox/qbittorrent (Connect serves only Talos).
+        # seedbox-monitoring MANUALLY mirrors op://seedbox/qbittorrent (Connect
+        # serves only Talos) — update BOTH on password rotation.
         QBITTORRENT_USERNAME: "{{ .username }}"
         QBITTORRENT_PASSWORD: "{{ .password }}"
   dataFrom:

--- a/kubernetes/apps/observability/seedbox/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/seedbox/app/grafanadashboard.yaml
@@ -1,0 +1,20 @@
+---
+# Hand-built: no public dashboard matches this mixed node/qbittorrent/seedbox
+# schema. DS_PROMETHEUS mapped via spec.datasources (house pattern).
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: seedbox
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  resyncPeriod: 1h
+  configMapRef:
+    name: seedbox-dashboard
+    key: seedbox.json

--- a/kubernetes/apps/observability/seedbox/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/seedbox/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
               repository: ghcr.io/martabal/qbittorrent-exporter
               tag: v2.0.1@sha256:ddf2bff9b357e50be4ddb699b6489ac5a49e4fac8c7dc5d4ca2abe1e5855f4dd
             env:
-              # Seedbox qBittorrent WebUI via the tailscale egress Service (Task 4).
+              # Seedbox qBittorrent WebUI via the tailscale egress Service (see ./egress.yaml).
               QBITTORRENT_BASE_URL: http://seedbox.observability.svc.cluster.local:8080
               QBITTORRENT_COOKIE_NAME: QBT_SID_8080
               EXPORTER_PORT: &port 9710
@@ -28,6 +28,11 @@ spec:
             envFrom:
               - secretRef:
                   name: seedbox-qbittorrent-exporter-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
             resources:
               requests:
                 cpu: 10m

--- a/kubernetes/apps/observability/seedbox/app/kustomization.yaml
+++ b/kubernetes/apps/observability/seedbox/app/kustomization.yaml
@@ -5,7 +5,19 @@ kind: Kustomization
 resources:
   - ./egress.yaml
   - ./externalsecret.yaml
+  - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml
   - ./scrapeconfig.yaml
   - ./servicemonitor.yaml
+configMapGenerator:
+  - name: seedbox-dashboard
+    files:
+      - seedbox.json=./dashboards/seedbox.json
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    # Dashboard JSON uses Grafana ${DS_PROMETHEUS}/$__rate_interval macros;
+    # disable Flux postBuild substitution so they are not clobbered to empty.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -1,0 +1,84 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: seedbox.rules
+spec:
+  groups:
+    - name: seedbox.rules
+      rules:
+        - alert: SeedboxDown
+          annotations:
+            summary: "Seedbox node-exporter is not being scraped — box or tailnet path down."
+          expr: |-
+            up{job="seedbox-node"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        # The box can be up while the exporter's egress path to the qBittorrent
+        # WebUI is broken; the existing QbittorrentExporterDown alert keys on
+        # instance="qbittorrent" so it does not cover this scrape.
+        - alert: SeedboxQbittorrentExporterDown
+          annotations:
+            summary: "Seedbox qBittorrent exporter scrape is failing — exporter or its egress path to the WebUI is down."
+          expr: |-
+            up{job="seedbox-qbittorrent"} == 0
+          for: 10m
+          labels:
+            severity: warning
+        # Prometheus retention is 14d → a calendar-month sum is not computable.
+        # These are PACE alerts: 7-day in+out volume extrapolated to 30 days.
+        # vnstat on the box is the authoritative calendar-month counter
+        # (docker exec vnstat vnstat -i eno0 -m). Seedhost counts BOTH directions
+        # against the 100 TB/mo cap. 1 TB here = 1e12 bytes (decimal, provider-style).
+        - alert: SeedboxTrafficPaceCritical
+          annotations:
+            summary: "Seedbox on pace for {{ $value | humanize }}B/mo — 100 TB cap at risk."
+          expr: |-
+            (
+              increase(node_network_receive_bytes_total{job="seedbox-node",device="eno0"}[7d])
+              + increase(node_network_transmit_bytes_total{job="seedbox-node",device="eno0"}[7d])
+            ) * 30 / 7 > 95e12
+          for: 6h
+          labels:
+            severity: critical
+        - alert: SeedboxTrafficPaceHigh
+          annotations:
+            summary: "Seedbox on pace for {{ $value | humanize }}B/mo (warn at 80 TB/mo pace)."
+          expr: |-
+            (
+              increase(node_network_receive_bytes_total{job="seedbox-node",device="eno0"}[7d])
+              + increase(node_network_transmit_bytes_total{job="seedbox-node",device="eno0"}[7d])
+            ) * 30 / 7 > 80e12
+          for: 6h
+          labels:
+            severity: warning
+        - alert: SeedboxRAIDDegraded
+          annotations:
+            summary: "Seedbox md4 RAID5 is degraded ({{ $labels.state }} disk count changed)."
+          expr: |-
+            node_md_disks{job="seedbox-node",device="md4",state="failed"} > 0
+            or node_md_disks{job="seedbox-node",device="md4",state="active"} < 4
+          for: 5m
+          labels:
+            severity: critical
+        - alert: SeedboxDiskFillHigh
+          annotations:
+            summary: "Seedbox rootfs above 85% ({{ $value | humanizePercentage }} used)."
+          expr: |-
+            1 - (
+              node_filesystem_avail_bytes{job="seedbox-node",mountpoint="/"}
+              / node_filesystem_size_bytes{job="seedbox-node",mountpoint="/"}
+            ) > 0.85
+          for: 30m
+          labels:
+            severity: warning
+        - alert: SeedboxIOWaitSustained
+          annotations:
+            summary: "Seedbox iowait above 40% for 2h — array saturated."
+          expr: |-
+            avg(rate(node_cpu_seconds_total{job="seedbox-node",mode="iowait"}[10m])) > 0.4
+          for: 2h
+          labels:
+            severity: info


### PR DESCRIPTION
Task 7 of the seedbox observability plan:

- prometheusrule.yaml: 7 alerts — SeedboxDown, SeedboxQbittorrentExporterDown
  (review-mandated: existing QbittorrentExporterDown keys on
  instance="qbittorrent" and misses this scrape), traffic pace warn/crit
  (7d in+out extrapolated to 30d; 14d retention makes calendar-month sums
  impossible, vnstat on the box is authoritative), RAID md4 degraded,
  rootfs >85%, sustained iowait.
- dashboards/seedbox.json: hand-built 10-panel dashboard (traffic pace
  gauge, 14d cumulative, eno0 throughput, RAID state, rootfs, CPU by mode,
  load/RAM, per-disk I/O, qBittorrent states and transfer rate). Every
  panel expression validated against live Prometheus before inclusion.
  Log-volume panel omitted: no VictoriaLogs Grafana datasource exists.
- grafanadashboard.yaml + configMapGenerator wiring per the
  sabnzbd-dashboard house pattern (substitute: disabled so Flux postBuild
  leaves ${DS_PROMETHEUS}/$__rate_interval macros alone).
- helmrelease.yaml: default TCP probes on the exporter (plex-exporter
  pattern) and comment now points at ./egress.yaml instead of a planning
  task number.
- externalsecret.yaml: make the manual 1Password mirror explicit — update
  both items on password rotation.
