### PR TITLE
fix(seedbox): calibrate iowait alert to working band, dashboard polish

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
+++ b/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
@@ -87,7 +87,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "yellow",
@@ -156,7 +157,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -252,7 +254,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -323,13 +326,39 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
           "unit": "none"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "x": 0,
@@ -388,7 +417,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "yellow",
@@ -490,7 +520,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -583,7 +614,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -704,7 +736,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -739,7 +772,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_disk_io_time_seconds_total{job=\"seedbox-node\",device=~\"sd[a-d]\"}[$__rate_interval])",
+          "expr": "rate(node_disk_io_time_seconds_total{job=\"seedbox-node\",device=~\"sd[a-z]\"}[$__rate_interval])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
@@ -797,7 +830,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -890,7 +924,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -29,6 +29,8 @@ spec:
             severity: warning
         # Prometheus retention is 14d → a calendar-month sum is not computable.
         # These are PACE alerts: 7-day in+out volume extrapolated to 30 days.
+        # Under-reads until the series has 7d of history (and after series
+        # churn); vnstat covers the gap.
         # vnstat on the box is the authoritative calendar-month counter
         # (docker exec vnstat vnstat -i eno0 -m). Seedhost counts BOTH directions
         # against the 100 TB/mo cap. 1 TB here = 1e12 bytes (decimal, provider-style).
@@ -56,7 +58,7 @@ spec:
             severity: warning
         - alert: SeedboxRAIDDegraded
           annotations:
-            summary: "Seedbox md4 RAID5 is degraded ({{ $labels.state }} disk count changed)."
+            summary: "Seedbox md4 RAID5 is degraded ({{ $labels.state }}={{ $value }} disks)."
           expr: |-
             node_md_disks{job="seedbox-node",device="md4",state="failed"} > 0
             or node_md_disks{job="seedbox-node",device="md4",state="active"} < 4
@@ -74,11 +76,15 @@ spec:
           for: 30m
           labels:
             severity: warning
+        # Steady-state seeding is iowait-heavy: the observed live working band
+        # is p50≈0.45 / p90≈0.56 / max≈0.66, and Alertmanager routes every
+        # firing alert to Pushover (info is not a quiet tier), so the threshold
+        # sits above the working band rather than at "textbook" 40%.
         - alert: SeedboxIOWaitSustained
           annotations:
-            summary: "Seedbox iowait above 40% for 2h — array saturated."
+            summary: "Seedbox iowait above 75% for 2h — array saturated."
           expr: |-
-            avg(rate(node_cpu_seconds_total{job="seedbox-node",mode="iowait"}[10m])) > 0.4
+            avg(rate(node_cpu_seconds_total{job="seedbox-node",mode="iowait"}[10m])) > 0.75
           for: 2h
           labels:
             severity: info


### PR DESCRIPTION
Follow-up to #3388 code review:

- SeedboxIOWaitSustained: 0.4 → 0.75. Live history shows a steady-state
  working band of p50≈0.45 / p90≈0.56 / max≈0.66 — the old threshold was
  below normal operation, and Alertmanager routes every firing alert to
  Pushover at priority 1, so it would have paged critical-grade every 12h
  for a healthy box. Threshold now sits above the observed band (comment
  records the band); for: 2h unchanged.
- Pace-alert comment: note the 7d-window under-read during bootstrap /
  after series churn; vnstat covers the gap.
- SeedboxRAIDDegraded summary reads correctly for both clauses:
  '{{ $labels.state }}={{ $value }} disks'.
- Dashboard RAID stat panel: 'failed' series renders red when non-zero.
- Disk I/O panel regex sd[a-d] → sd[a-z] (replacement disks can
  enumerate as sde).
- Explicit 'value': null on base threshold steps so a future Grafana UI
  export doesn't produce diff noise.
