### PR TITLE
fix(prowler): authenticate Celery to Dragonfly; raise fetcharr memory limit

### DIFF
--- a/kubernetes/apps/media/fetcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/fetcharr/app/helmrelease.yaml
@@ -40,7 +40,7 @@ spec:
               requests:
                 cpu: 10m
               limits:
-                memory: 512Mi
+                memory: 1Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true

--- a/kubernetes/apps/security/prowler/app/externalsecret.yaml
+++ b/kubernetes/apps/security/prowler/app/externalsecret.yaml
@@ -33,6 +33,10 @@ spec:
         VALKEY_HOST: dragonfly.database.svc.cluster.local
         VALKEY_PORT: "6379"
         VALKEY_DB: "0"
+        # Dragonfly requires auth; without these the Celery worker/beat retry
+        # "Authentication required" 100x (~1h) then exit 1, forever.
+        VALKEY_USERNAME: default
+        VALKEY_PASSWORD: "{{ .DRAGONFLY_PASSWORD }}"
         # ---- Neo4j / DozerDB -------------------------------------------------
         NEO4J_HOST: dozerdb.database.svc.cluster.local
         NEO4J_PORT: "7687"
@@ -45,6 +49,8 @@ spec:
   dataFrom:
     - extract:
         key: cloudnative-pg
+    - extract:
+        key: dragonfly
     - extract:
         key: prowler
     - extract:


### PR DESCRIPTION
## What

Follow-ups from the OOM investigation in #3383.

### prowler: worker + beat have never connected to their broker

`prowler-api` worker and `prowler-beat` are at 107 restarts each, looping on:

```text
consumer: Cannot connect to redis://dragonfly.database.svc.cluster.local:6379/0: Authentication required..
Trying again in 32.00 seconds... (100/100)
```

Dragonfly has required auth since it was deployed, but prowler's ExternalSecret only set `VALKEY_HOST/PORT/DB` — no credentials — so Celery retries 100× (~1h) and exits 1, forever. The api container serves fine, which is why this went unnoticed; scheduled scans have never dispatched.

Fix: add `VALKEY_USERNAME: default` + `VALKEY_PASSWORD` templated from the `dragonfly` 1Password item (same pattern as paperless/netbox/keeper). Verified prowler 5.31.1 builds its Celery broker URL from these env vars (`api/src/backend/config/settings/celery.py`). Both deployments carry `reloader.stakater.com/auto`, so the secret change rolls the pods.

### fetcharr: next OOM candidate

Working set peaked at 434–500Mi against a 512Mi limit across all pod generations this week (93–98%). Raise limit to 1Gi before it joins the OOMKilled list.

## Verification

- `flate test all` — security 7/7, media 65/65 passed