### PR TITLE
fix(prowler): run worker without mingle/gossip; cap prefork pool at 4

### DIFF
--- a/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
@@ -49,6 +49,9 @@ spec:
               # Cap gunicorn workers — defaults to (CPU*2+1) which on a
               # 24-core node was 49 workers * ~80MB each = 4GB just for api.
               DJANGO_WORKERS: "4"
+              # Same story for Celery's prefork pool — defaults to
+              # os.cpu_count() (24 here), and 24 Django children idle at ~4GB.
+              DJANGO_CELERY_WORKER_CONCURRENCY: "4"
             envFrom: *envFrom
             probes:
               # Django enforces ALLOWED_HOSTS on every request. The kubelet
@@ -83,15 +86,29 @@ spec:
                 memory: 2Gi
           worker:
             image: *image
-            # Override the image's hardcoded ENTRYPOINT
-            # `["../docker-entrypoint.sh", "prod"]`. Without `command`,
-            # `args: [worker]` is APPENDED ("prod worker") and the script
-            # still runs in `prod` mode (migrate + gunicorn), causing
-            # port 8080 collision with the api container.
+            # Invoke celery directly instead of `../docker-entrypoint.sh worker`
+            # (which both defaults to `prod` mode without an explicit command
+            # AND hardcodes its flags): Celery 5.6's mingle/gossip startup
+            # steps kill the worker instantly + silently (exit 1, no
+            # traceback) against Dragonfly's pub/sub fanout, and the
+            # entrypoint can't pass `--without-mingle --without-gossip`
+            # through. Both are multi-worker coordination features; this is a
+            # single worker, so dropping them loses nothing. Command otherwise
+            # mirrors the entrypoint's start_worker() (queues, -E,
+            # --max-tasks-per-child); DJANGO_APP_COMPONENT tags pg
+            # application_name as the entrypoint would.
             command:
-              - "../docker-entrypoint.sh"
+              - "/bin/sh"
+              - "-c"
             args:
-              - "worker"
+              - >-
+                DJANGO_APP_COMPONENT=worker exec uv run python -m celery
+                -A config.celery worker
+                -n "worker@$(hostname)"
+                -l "$${DJANGO_LOGGING_LEVEL:-info}"
+                -Q celery,scans,scan-reports,deletion,backfill,overview,integrations,compliance,attack-paths-scans
+                -E --max-tasks-per-child 1
+                --without-mingle --without-gossip
             env: *commonEnv
             envFrom: *envFrom
             securityContext:


### PR DESCRIPTION
## What

Second prowler fix, uncovered by #3390. Fixing broker auth revealed the next failure: the worker now connects to Dragonfly, then exits 1 ~3 seconds after `mingle: searching for neighbors` — no traceback, every restart, at any log level.

## Diagnosis (debug pod against the live broker, same image + secret)

| Configuration | Result |
|---|---|
| defaults, concurrency 24 (2Gi pod) | OOMKilled in 12s |
| concurrency 2, with mingle | exit 1 at mingle |
| concurrency 1, DEBUG, with mingle | exit 1 at mingle, still silent |
| `--without-mingle --without-gossip` | runs cleanly, warm shutdown on SIGTERM |
| final command (concurrency 4, `-E`, all queues, no mingle/gossip) | ran full 90s, 845Mi |

Two independent problems:

1. **Celery 5.6 mingle/gossip are fatally incompatible with Dragonfly's pub/sub fanout** — the worker dies silently at startup. Both features exist only for multi-worker coordination; this deployment runs a single worker, so disabling them loses nothing. The image entrypoint hardcodes its celery flags, so the HelmRelease now invokes celery directly, mirroring the entrypoint's `start_worker()` (same queues, `-E`, `--max-tasks-per-child 1`, `DJANGO_APP_COMPONENT=worker` for pg application_name).
2. **Prefork pool defaults to `os.cpu_count()` = 24** on these nodes — 24 Django children idle at ~4GB, which is why the old worker sat at 98% of its 4Gi limit. Same class as the existing `DJANGO_WORKERS: "4"` gunicorn fix; prowler exposes `DJANGO_CELERY_WORKER_CONCURRENCY` for exactly this.

`$${DJANGO_LOGGING_LEVEL:-info}` is `$$`-escaped so Flux passes the literal through to the shell.

## Verification

- flate test security namespace: 7/7 passed
- Exact production command validated in a debug pod: worker ready, events on, consumed queues, clean warm shutdown, 845Mi footprint