### PR TITLE
fix(paperless): prefix Redis keys so prowler's worker stops eating its tasks

### DIFF
--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -51,6 +51,13 @@ spec:
               PAPERLESS_TASK_WORKERS: "2"
               PAPERLESS_WEBSERVER_WORKERS: "2"
               PAPERLESS_URL: "https://paperless.${SECRET_DOMAIN}"
+              # Namespace every broker/cache key (kombu global_keyprefix).
+              # Dragonfly runs cluster_mode=emulated (db 0 only), and prowler's
+              # Celery worker also consumes the default "celery" queue there —
+              # without a prefix it steals paperless tasks (observed as
+              # KeyError: paperless_mail.tasks.process_mail_accounts in the
+              # prowler worker once it finally started consuming).
+              PAPERLESS_REDIS_PREFIX: "paperless:"
               PAPERLESS_DBENGINE: postgresql
               PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
               PAPERLESS_ACCOUNT_ALLOW_SIGNUPS: "false"


### PR DESCRIPTION
## What

Direct consequence of #3391: once prowler's Celery worker started consuming, it began stealing paperless's tasks. Both apps use Celery's default `celery` queue on Dragonfly db 0, and Dragonfly's `cluster_mode=emulated` forbids `SELECT`, so separate Redis dbs aren't an option. Observed in the prowler worker log:

```text
KeyError: 'paperless_mail.tasks.process_mail_accounts'
```

Every paperless mail-check/consume task dispatched since the prowler worker came alive (~18:00 UTC yesterday) was grabbed and discarded as an unregistered task.

## Fix

`PAPERLESS_REDIS_PREFIX: "paperless:"` — paperless's upstream knob for shared Redis servers. It sets kombu's `global_keyprefix` plus the channels/cache prefixes, so every paperless broker key (including its `celery` queue) is namespaced away from other consumers.

Recovery is automatic: mail checks are periodic, and documents pending consumption stay in the consume dir until successfully processed.

## Notes

- dispatcharr is the third Celery app on db 0, currently harmless because its broker URL lacks credentials (same auth bug prowler had — its background tasks have never run). Needs its own follow-up: creds via ExternalSecret + queue isolation.

## Verification

- flate test default namespace: 120/120 passed