### PR TITLE
fix(nut): stop crashloop + page UPS power alerts at Pushover emergency priority

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -31,6 +31,17 @@ spec:
           - name: alertname
             value: Watchdog
             matchType: =
+      # UPS emergencies — page at Pushover priority 2 (retry/expire) until acknowledged.
+      # Placed before the generic critical route (first match wins) so only alerts
+      # labelled pushover_priority=emergency escalate; every other critical still routes
+      # to the normal pushover receiver unchanged.
+      - receiver: pushover-emergency
+        groupWait: 0s
+        repeatInterval: 30m
+        matchers:
+          - name: pushover_priority
+            value: emergency
+            matchType: =
       - receiver: pushover
         matchers:
           - name: severity
@@ -81,6 +92,48 @@ spec:
             {{ if eq .Status "firing" }}1{{ else }}0{{ end }}
           sendResolved: true
           sound: gamelan
+          title: >-
+            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
+            {{ .CommonLabels.alertname }}
+          ttl: 86400s
+          token:
+            name: *secret
+            key: ALERTMANAGER_PUSHOVER_TOKEN
+          userKey:
+            name: *secret
+            key: PUSHOVER_USER_KEY
+          urlTitle: View in Alertmanager
+    # Emergency channel for UPS power alerts only (routed via pushover_priority=emergency).
+    # Priority 2 = Pushover emergency: re-alerts every `retry` for up to `expire` until
+    # the notification is acknowledged in the Pushover app. Resolved goes out at priority 0.
+    - name: pushover-emergency
+      pushoverConfigs:
+        - html: true
+          message: |-
+            {{- range .Alerts }}
+              {{- if ne .Annotations.description "" }}
+                {{ .Annotations.description }}
+              {{- else if ne .Annotations.summary "" }}
+                {{ .Annotations.summary }}
+              {{- else if ne .Annotations.message "" }}
+                {{ .Annotations.message }}
+              {{- else }}
+                Alert description not available
+              {{- end }}
+              {{- if gt (len .Labels.SortedPairs) 0 }}
+                <small>
+                  {{- range .Labels.SortedPairs }}
+                    <b>{{ .Name }}:</b> {{ .Value }}
+                  {{- end }}
+                </small>
+              {{- end }}
+            {{- end }}
+          priority: |-
+            {{ if eq .Status "firing" }}2{{ else }}0{{ end }}
+          retry: 1m
+          expire: 1h
+          sendResolved: true
+          sound: siren
           title: >-
             [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]
             {{ .CommonLabels.alertname }}

--- a/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
@@ -20,6 +20,14 @@ spec:
             image:
               repository: instantlinux/nut-upsd
               tag: 2.8.3-r3@sha256:edadf0d18b7e240fba0e4073dfcc13f19f93839de0656f4b39752c0cad880cd5
+            # upsdrvctl aborts with "Duplicate driver instance detected (PID file exists)"
+            # when a prior container left stale driver PID files in /run/nut (the image
+            # entrypoint runs `upsdrvctl start` once and never cleans them). Wipe stale
+            # PIDs before starting, then exec the image entrypoint unchanged.
+            command:
+              - /bin/sh
+              - -c
+              - rm -f /run/nut/*.pid /var/run/nut/*.pid 2>/dev/null; exec /usr/local/bin/entrypoint.sh
             env:
               TZ: ${TIMEZONE:=UTC}
               NAME: cr-ups-main

--- a/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
@@ -8,30 +8,49 @@ spec:
   groups:
     - name: nut-exporter
       rules:
-        - alert: NutExporterAbsent
+        # UPS monitoring is blind — nut-exporter returns no metrics for >3m.
+        # When the NUT server (network-ups-tools) is down/unreachable the exporter
+        # fails its whole scrape, so up == 0 (verified); `absent()` covers the target
+        # vanishing entirely. 3m (not the 15m built-in TargetDown) because the main
+        # UPS battery only lasts ~30m.
+        - alert: UPSUnreachable
           annotations:
-            description: NUT Exporter has disappeared from Prometheus target discovery.
-            summary: NUT Exporter is down.
-          expr: absent(up{job=~".*nut-exporter.*"} == 1)
-          for: 5m
+            description: >-
+              nut-exporter has had no successful scrape for over 3 minutes (up == 0 or
+              target absent). The NUT server (network-ups-tools) is likely down or
+              unreachable, so UPS state is invisible during a power event.
+            summary: UPS monitoring is blind — nut-exporter is not returning UPS metrics.
+          expr: up{job="nut-exporter"} == 0 or absent(up{job="nut-exporter"})
+          for: 3m
           labels:
             severity: critical
-        - alert: UpsOnBattery
+            pushover_priority: emergency
+        # Mains lost — fires within ~1m. `max by (ups)` collapses the ServiceMonitor's
+        # instance cross-product to one alert per real UPS.
+        - alert: UPSOnBattery
           annotations:
-            description: UPS {{ $labels.ups }} has lost power and is running on battery.
-            summary: UPS is running on battery.
-          expr: nut_ups_status{status="OB"} == 1
-          for: 10s
+            description: >-
+              UPS {{ $labels.ups }} switched to battery (status OB). Mains input is lost
+              and battery runtime is finite — investigate immediately.
+            summary: UPS {{ $labels.ups }} is on battery — mains power lost.
+          expr: max by (ups) (nut_ups_status{status="OB"}) == 1
+          for: 30s
           labels:
             severity: critical
-        - alert: UpsLowRuntime
+            pushover_priority: emergency
+        # On battery AND (runtime < 15m OR charge < 50%). by(ups) aggregation also fixes
+        # the old UpsLowRuntime, whose `status`-labelled `and` operand never matched.
+        - alert: UPSBatteryRuntimeLow
           annotations:
-            description: UPS {{ $labels.ups }} battery runtime is {{ $value | humanizeDuration }} which is below 10 minutes.
-            summary: UPS battery runtime is critically low.
-          expr: nut_ups_status{status="OB"} == 1 and nut_battery_runtime_seconds < 600
-          for: 1m
+            description: >-
+              UPS {{ $labels.ups }} is on battery with under 15 minutes runtime remaining
+              or charge below 50%. Shutdown is imminent.
+            summary: UPS {{ $labels.ups }} battery is nearly exhausted.
+          expr: (max by (ups) (nut_ups_status{status="OB"}) == 1) and ((min by (ups) (nut_battery_runtime_seconds) < 900) or (min by (ups) (nut_battery_charge) < 0.5))
+          for: 30s
           labels:
             severity: critical
+            pushover_priority: emergency
         - alert: UpsLowBattery
           annotations:
             description: UPS {{ $labels.ups }} battery charge is {{ $value | humanizePercentage }} which is below 50%.


### PR DESCRIPTION
## Why

On 2026-07-03 the main UPS lost mains power. The only page was a Pushover **priority-1** alert (no ack, no repeat, easy to miss); the sole follow-up was the built-in `TargetDown` at 15m — long after the ~30-minute battery was already dead. This hardens UPS alerting to page **unmissably** and keep escalating while the battery drains, and fixes a live crashloop that had left UPS monitoring blind.

## What

### 1. NUT server crashloop fix (`network-ups-tools`)
`network-ups-tools` was in CrashLoopBackOff. The image entrypoint runs `upsdrvctl start` once and never cleans PID files, so a SIGKILLed prior container leaves `/run/nut/snmp-ups-*.pid` behind and the next start aborts with *"Duplicate driver instance detected (PID file exists)"* → exit 1. While down, `up{job="nut-exporter"}==0` and monitoring is blind. Fix: override the container command to wipe stale PID files, then `exec` the image entrypoint unchanged.

### 2. Emergency UPS alert routing
New **`pushover-emergency`** receiver (Pushover **priority 2**, `retry: 1m` / `expire: 1h`, `siren`) + a route matching **only** `pushover_priority=emergency`, placed before the generic critical route so nothing else's priority changes. Reuses the existing `alertmanager-secret` — no new secret material.

### 3. Rules (upgraded in place, verified against real `nut-exporter` metric names)
| Alert | Condition | `for` | Priority |
|---|---|---|---|
| `UPSUnreachable` | `up{job="nut-exporter"}==0 or absent(up{…})` | 3m | emergency |
| `UPSOnBattery` | `max by(ups)(nut_ups_status{status="OB"})==1` | 30s | emergency |
| `UPSBatteryRuntimeLow` | on battery AND (runtime<15m OR charge<50%) | 30s | emergency |

- `max/min by(ups)` collapses the ServiceMonitor's `instance` cross-product to one alert per real UPS.
- `UPSBatteryRuntimeLow` also fixes the old `UpsLowRuntime`, whose `status`-labelled `and` operand could never match.
- Warnings (`UpsLowBattery`, `UpsHighLoad`, `UpsOverload`, `UpsBatteryReplace`) left untouched.
- **`UPSBatteryDegraded` intentionally skipped**: the exporter exposes no expected-runtime / design-capacity metric to compare against; replace-battery is already covered by `UpsBatteryReplace` (`status=RB`).

## Validation
- `promtool check rules` → 7 rules OK · `amtool check-config` → routes + 4 receivers OK
- `kustomize build` (all 3 app dirs) OK · `helm template` confirms the `command` lands in the Deployment
- No secrets, LAN IPs, or internal hostnames in the diff

## Not included (flagged)
`cr-ups-comms` SNMP throws non-fatal `type error exception` warnings (likely wrong MIB for that device) — separate, out of scope, and needs device-specific config.
