### PR TITLE
docs(agents): update for gatus-sidecar, Konflate-native CI, and component drift

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -39,7 +39,7 @@ Use the **AskUserQuestion** tool to gather:
 7. Whether the app needs an `ExternalSecret`
 8. Whether the app needs persistence (PVC `existingClaim`, `emptyDir`, NFS, …)
 9. Whether the app needs a route, and if so internal-only (`envoy-internal`) or external (`envoy-external`)
-10. Any Flux `dependsOn` entries, and whether it uses components (`gatus/guarded`, `volsync`, `alerts`, `homepage`)
+10. Any Flux `dependsOn` entries, and whether it uses components (`volsync`, `alerts`, `homepage`, `kopiur`)
 
 Always confirm before writing files.
 
@@ -96,12 +96,11 @@ If the app uses an `ExternalSecret`, add a `dependsOn` (alphabetically, after `c
       namespace: external-secrets
 ```
 
-If the app uses components (gatus/volsync/etc.), add `spec.components` and replace `postBuild: {}`
+If the app uses components (volsync/alerts/etc.), add `spec.components` and replace `postBuild: {}`
 with the matching substitutes. Component paths are `../../../../components/...` relative to the app:
 
 ```text
   components:
-    - ../../../../components/gatus/guarded
     - ../../../../components/volsync
   postBuild:
     substitute:
@@ -215,6 +214,9 @@ If the app needs a route, add (internal-only default — both hostnames resolve 
 For **external** exposure, use `name: envoy-external` instead (and confirm the intent — this repository is
 public). For GPU workloads, set `runtimeClassName: nvidia` under the controller's `pod`.
 
+The route is auto-monitored by the gatus-sidecar (no component needed). To opt out, annotate the
+route: `route.app.annotations` → `gatus.home-operations.com/enabled: "false"`.
+
 ### Step 8: Generate `app/externalsecret.yaml` (only if needed)
 
 ```text
@@ -251,11 +253,11 @@ list alphabetical. Match the exact reference style used by neighbours (e.g. `./<
 2. The namespace `kustomization.yaml` references the new app.
 3. The HelmRelease `chartRef` points at the per-app `OCIRepository`, not a shared `app-template`.
 4. No plain-text secrets, LAN IPs, or internal hostnames were introduced.
-5. Render and validate with flate:
+5. Render and validate with flate (just wrappers add `--allow-missing-secrets`):
 
    ```bash
-   flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
-   flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+   just kube flate-build-hr <namespace> <app>
+   just kube flate-test
    ```
 
 ## Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ kubernetes/
 │               ├── externalsecret.yaml  # optional
 │               ├── httproute.yaml       # optional (inline route: in HR values is preferred)
 │               └── kustomization.yaml
-├── components/            # Reusable Kustomize components (global-vars, alerts, volsync, gatus, …)
+├── components/            # Reusable Kustomize components (global-vars, alerts, volsync, homepage, kopiur, …)
 └── flux/                  # Core Flux bootstrap config (cluster/ks.yaml = root Kustomization)
 bootstrap/                 # Cluster bootstrap (just tasks + helmfile)
 talos/                     # Talos OS machine configs (talconfig.yaml + patches)
@@ -65,7 +65,7 @@ HelmRelease install/upgrade/rollback strategy defaults.
 
 Every app follows the same shape. The `ks.yaml` is the Flux entry point and uses YAML anchors
 (`&app`, `&namespace`, `*app`) for DRY references; it sets `targetNamespace: *namespace`, and any
-`components` (`gatus/guarded`, `volsync`, `alerts`) plus their `postBuild.substitute` values
+`components` (`volsync`, `alerts`, `homepage`, `kopiur`) plus their `postBuild.substitute` values
 (`APP: *app`, `VOLSYNC_CAPACITY`) live in `ks.yaml` — never duplicated into `app/kustomization.yaml`.
 
 Inside `app/`:
@@ -104,6 +104,11 @@ vault). Apps with an ExternalSecret should `dependsOn` `onepassword-connect` in
 - Flux `postBuild` replaces `${VAR}` against `cluster-secrets`; **undefined vars become empty
   strings**. Any literal `${VAR}` you want preserved (Grafana dashboards, envsubst templates, shell
   snippets) must be escaped as `$${VAR}`.
+- **Gatus monitoring is automatic** — the gatus-sidecar chart watches HTTPRoutes cluster-wide, so a
+  new app's route gets an uptime check with no per-app config (the old `gatus/guarded` component is
+  gone). Opt a route out with a `gatus.home-operations.com/enabled: "false"` annotation; opt a
+  Service in with `"true"` plus an optional `gatus.home-operations.com/endpoint:` YAML block for
+  name/group overrides.
 - GPU workloads use `runtimeClassName: nvidia`.
 
 ## Provisioning a new app
@@ -151,16 +156,19 @@ Either way Flux **prunes the PVC** — take a VolSync snapshot or copy the data 
 
 ## Validation
 
-CI validates PRs with [flate](https://github.com/home-operations/flate) (HelmRelease + Kustomization
-testing without a live cluster), plus security scans (Checkov/Trivy) and super-linter. Mirror locally
-before pushing:
+PR renders and diffs are posted by the in-cluster **Konflate** as a native `Konflate` commit status
+plus a PR comment — there is no GitHub Actions render workflow. GitHub Actions still run security
+scans (Checkov/Trivy → Code Scanning) and super-linter. Mirror the render locally before pushing
+with [flate](https://github.com/home-operations/flate) (in the mise toolchain), via the just
+wrappers:
 
 ```bash
-# Render a single app's HelmRelease
-flate build hr <app> -n <namespace> --path kubernetes/flux/cluster
+# Render a single app's HelmRelease / Kustomization
+just kube flate-build-hr <namespace> <app>
+just kube flate-build-ks <namespace> <app>
 
-# Test all Kustomizations + HelmReleases
-flate test all --path kubernetes/flux/cluster --allow-missing-secrets
+# Test all Kustomizations + HelmReleases (the full CI-equivalent check)
+just kube flate-test
 ```
 
 ## Agent tooling


### PR DESCRIPTION
## Summary

Refreshes the agent-facing docs (`AGENTS.md` + `.agents/skills/add-app`) for changes that landed since they were last updated:

- **Gatus**: the `gatus/guarded` component was removed in #3221 and Gatus moved to the [gatus-sidecar](https://github.com/home-operations/gatus-sidecar) chart in #3376, but the docs still told agents to wire `components/gatus/guarded` into new apps. They now describe the auto-discovery model: every HTTPRoute is monitored automatically, opt out with a `gatus.home-operations.com/enabled: "false"` route annotation, Services opt in with `"true"` + an optional `gatus.home-operations.com/endpoint:` block.
- **Components list** corrected to `global-vars`, `alerts`, `volsync`, `homepage`, `kopiur` (gatus gone).
- **Validation**: the flate GitHub Actions workflow was dropped in #3375 — renders/diffs are posted by the in-cluster Konflate as a native commit status + PR comment. Local validation now points at the `just kube flate-build-hr/-ks/-test` wrappers (which add `--allow-missing-secrets`, matching `kubernetes/mod.just`).
- **add-app skill**: same component/validation updates, plus a note that a new app's route is auto-monitored (and how to opt out).

Docs-only — no manifests changed. markdownlint (repo config) passes on both files.