### PR TITLE
fix(observability): stop ceph-mixin node alerts flapping on the seedbox

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
@@ -18,6 +18,15 @@ spec:
     - action: replace
       targetLabel: instance
       replacement: seedbox
+  # The ceph-mixin node alerts (CephNodeDiskspaceWarning et al) join every
+  # node-exporter target via node_uname_info, so the seedbox's spiky torrent
+  # disk flaps them. Dropping the metric here breaks that join; nothing else
+  # (dashboard, seedbox.rules) reads it.
+  metricRelabelings:
+    - action: drop
+      sourceLabels:
+        - __name__
+      regex: node_uname_info
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
 apiVersion: monitoring.coreos.com/v1alpha1


### PR DESCRIPTION
## Problem

`CephNodeDiskspaceWarning` has been paging Pushover multiple times a day for `instance=seedbox` / nodename `ds112978` — a host that has nothing to do with Ceph.

The rook-ceph-cluster chart (`monitoring.createPrometheusRules: true`) ships the upstream ceph-mixin rules, and the node alerts assume every node-exporter Prometheus scrapes is a Ceph host:

```promql
predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600*24*5)
  * on(cluster, instance) group_left(nodename) node_uname_info < 0
```

The seedbox scrape (`job=seedbox-node`) matches. Its torrent working disk constantly fills and clears, so the 48h linear projection keeps crossing "full within 5 days" and back — the upstream rule has no `for:` duration, and with `sendResolved: true` each flap is two notifications. Measured **234 alert-state changes in 3 days**.

## Fix

Drop `node_uname_info` from the `seedbox-node` ScrapeConfig via `metricRelabelings`. The ceph-mixin node alerts join on that metric, so without it the expressions return nothing for the seedbox and structurally cannot fire — no Alertmanager muting, no patching of the chart-managed PrometheusRule (which wouldn't survive chart upgrades).

Nothing else consumes the metric: the seedbox Grafana dashboard and `seedbox.rules` don't reference `node_uname_info`, and deliberate disk coverage for the box already exists (`SeedboxDiskFillHigh` >85% for 30m, `SeedboxRAIDDegraded`).

No other `ceph_default` alert has fired for the seedbox in the last 14 days, so this closes the only active false-positive path.

## Validation

- `kustomize build kubernetes/apps/observability/seedbox/app` renders the new block correctly
- `kubectl explain scrapeconfig.spec.metricRelabelings` confirms the field on the live CRD
