### PR TITLE
feat(zigbee2mqtt): switch serial adapter zstack -> ember for SLZB-MR5U

### DIFF
--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -24,7 +24,7 @@ spec:
               ZIGBEE2MQTT_DATA: /data
               ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.home.svc.cluster.local:1883
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"
-              ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: zstack
+              ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: ember
               Z2M_ONBOARD_NO_SERVER: "1"
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant
               ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_STATUS_TOPIC: homeassistant/status


### PR DESCRIPTION
## What

Switch `ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER` from `zstack` to `ember`.

## Why

The Zigbee coordinator hardware was swapped from the SLZB-MRW10 (TI CC2674, Z-Stack/ZNP) to the SLZB-MR5U. The MR5U carries **two Silicon Labs EFR32MG24 radios** running EmberZNet coordinator firmware — verified empirically: both radio sockets answer an ASH reset with a valid RSTACK frame and do not speak ZNP. zigbee2mqtt therefore needs the `ember` adapter.

Radio 1 serves Zigbee; radio 2 is reserved for Thread/OpenThread RCP (Matter, Phase 2).

## Companion change (not in git)

The coordinator host/port is delivered via ExternalSecret from the `zigbee2mqtt` 1Password item (`ZIGBEE_ADAPTER_HOST`), updated separately to point at the new device. Reloader restarts the pod on secret change.

## Notes

- 0 devices were joined on the old coordinator, so a fresh network form under ember is clean; if z2m complains about a stale `coordinator_backup.json` from the TI radio, deleting it from the PVC is safe.
- Do not merge until the 1Password item is updated.