### PR TITLE
fix(certwarden): stop Flux postBuild blanking device-cert deploy scripts

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -6,6 +6,8 @@ misconfigurations:
     paths:
       - "kubernetes/apps/observability/oxidized/app/configmap.yaml"
       - "kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/scripts-configmap.yaml"
+      - "kubernetes/apps/infrastructure/certwarden/cert-deployment/onyx/scripts-configmap.yaml"
+      - "kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml"
     statement: |
       False positive. oxidized/configmap.yaml: the YAML schema requires
       top-level 'username' and 'password' keys; the values here are literal
@@ -13,25 +15,29 @@ misconfigurations:
       oxidized-secret (rendered by the ExternalSecret) into a Secret-mounted
       router.db. The 'token=' is a curl --form-string flag in a Pushover
       hook, not a secret value.
-      certwarden/apc/scripts-configmap.yaml: the ConfigMap holds an embedded
-      Python script that reads APC_PASSWORD / APC_USERNAME from env vars
-      (populated via envFrom from an ExternalSecret-rendered Secret); the
-      literal strings Trivy matches (`export APC_PASSWORD`, `self.password`,
+      certwarden/{apc,onyx,supermicro}/scripts-configmap.yaml: each ConfigMap
+      holds an embedded deploy script that reads the device's *_PASSWORD /
+      *_USERNAME (APC_*, ONYX_*, IPMI_*) from a Secret at runtime (via envFrom
+      or `kubectl get secret`); the literal strings Trivy matches
+      (`export APC_PASSWORD`, `export ONYX_PASSWORD`, `self.password`,
       `password`) are variable / parameter NAMES inside the script, not values.
 
   - id: KSV-01010
     paths:
       - "kubernetes/apps/observability/oxidized/app/configmap.yaml"
       - "kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/scripts-configmap.yaml"
+      - "kubernetes/apps/infrastructure/certwarden/cert-deployment/onyx/scripts-configmap.yaml"
+      - "kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml"
     statement: |-
       False positive. oxidized/configmap.yaml: flagged keys (username, email,
       remote_repo) are config field names, not sensitive content. The git
       commit author email and the public GitHub remote URL for the
       network-configs repo are non-sensitive.
-      certwarden/apc/scripts-configmap.yaml: same pattern as KSV-0109 above
-      — the strings (`echo "APC Username`, `export APC_USERNAME`,
-      `self.username`, `username`) are variable / parameter names inside
-      an embedded Python script, not actual usernames.
+      certwarden/{apc,onyx,supermicro}/scripts-configmap.yaml: same pattern as
+      KSV-0109 above — the strings (`echo "APC Username`, `echo "Onyx Username`,
+      `export APC_USERNAME`, `export ONYX_USERNAME`, `self.username`,
+      `username`) are variable / parameter names inside embedded deploy
+      scripts, not actual usernames.
 
   # The cloudflare-runner Role grants the ARC kubernetes-mode container-hook
   # permissions (manage pods, pods/exec, pods/log, jobs, secrets in

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/scripts-configmap.yaml
@@ -365,6 +365,8 @@ data:
     fi
 kind: ConfigMap
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
   creationTimestamp: null
   name: certwarden-apc-scripts
   namespace: infrastructure

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/brother/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/brother/kustomization.yaml
@@ -10,3 +10,5 @@ configMapGenerator:
       - certwarden-brother-deploy.sh
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/onyx/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/onyx/scripts-configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 data:
   certwarden-onyx-deploy.sh: |
@@ -145,6 +146,8 @@ data:
     fi
 kind: ConfigMap
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
   creationTimestamp: null
   name: certwarden-onyx-scripts
   namespace: infrastructure

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
@@ -168,6 +168,8 @@ data:
     esac
 kind: ConfigMap
 metadata:
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
   creationTimestamp: null
   name: certwarden-supermicro-scripts
   namespace: infrastructure


### PR DESCRIPTION
## Problem

The APC / Brother / Onyx / Supermicro cert-deployment ConfigMaps embed bash scripts that use bare `${VAR}` (`APC_HOST`, `NAMESPACE`, `SECRET_NAME`, cert PEMs, job names, …). The root Kustomization applies `postBuild.substituteFrom` to every child, and none of these are `cluster-secrets` keys — so Flux replaced them all with empty strings.

Verified live before the fix — `kubectl get configmap certwarden-apc-scripts -n infrastructure` rendered:

```
if [[ -z "" ]]; then echo "ERROR: APC_HOST environment variable is required"; exit 1; fi   # guard always fires
SECRET_NAME="apc-"        NAMESPACE=(blank)
kubectl get secret  -n         JOB_NAME="apc-cert-deploy--$(date +%s)"
```

The guard exits immediately on every run, so the entire device cert-push subsystem was non-functional as committed (APC, and identically Brother/Onyx/Supermicro).

## Fix

Add `kustomize.toolkit.fluxcd.io/substitute: disabled` to all four ConfigMaps so Flux skips `postBuild` substitution on them — the same mechanism smokeping and the Grafana dashboards already use. Every `${...}` in these scripts is a **bash runtime variable** (none are `cluster-secrets` vars), so disabling substitution is safe and correct.

## Validation

- `kubectl kustomize kubernetes/apps/infrastructure/certwarden/cert-deployment` builds cleanly (1145 lines); the annotation lands on all four generated ConfigMaps and the scripts are intact.
- Konflate will confirm the rendered diff on this PR (the `${VAR}` tokens should now survive instead of blanking).

Found during the 2026-07-06 cluster review (finding P1-1).