### PR TITLE
fix(shlink): persist SQLite DB on a backed-up PVC instead of emptyDir

### DIFF
--- a/kubernetes/apps/default/shlink/app/helmrelease.yaml
+++ b/kubernetes/apps/default/shlink/app/helmrelease.yaml
@@ -91,7 +91,7 @@ spec:
             namespace: network
     persistence:
       data:
-        type: emptyDir
+        existingClaim: "{{ .Release.Name }}"
         globalMounts:
           - path: /etc/shlink/data
       tmp:

--- a/kubernetes/apps/default/shlink/ks.yaml
+++ b/kubernetes/apps/default/shlink/ks.yaml
@@ -11,11 +11,13 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/homepage
+    - ../../../../components/volsync
   interval: 1h
   path: ./kubernetes/apps/default/shlink/app
   postBuild:
     substitute:
       APP: *app
+      VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Shlink
       HOMEPAGE_GROUP: Tools
       HOMEPAGE_ICON: shlink.svg


### PR DESCRIPTION
## Problem

shlink stored its SQLite database (all short URLs + the `INITIAL_API_KEY` state) on `persistence.data: {type: emptyDir}` mounted at `/etc/shlink/data`, with no volsync component. Every pod restart — a routine Renovate image bump, node drain, or OOM — wiped every short link and API key. The route is live at `s.${SECRET_DOMAIN}`, so this is guaranteed data loss on the next restart.

## Fix

- Add the `volsync` component to `ks.yaml` with `VOLSYNC_CAPACITY: 1Gi` (the component creates the `shlink` PVC + nfs/remote ReplicationSource/Destination).
- Point `persistence.data` at `existingClaim: "{{ .Release.Name }}"` (resolves to the `shlink` release name, matching the volsync-created PVC). `tmp` stays `emptyDir`.

Mirrors the established pattern in `reconcilable` / `redditvault`.

## Migration

None needed. The `emptyDir` contents were already destroyed on every restart, so there is nothing to preserve. On first apply the volsync component provisions a fresh empty PVC and shlink re-seeds `INITIAL_API_KEY` on the new DB.

Found during the 2026-07-06 cluster review (finding P1-5).