### PR TITLE
fix(observability): repair OPNsense gateway + Unbound alerts (dead metrics)

### DIFF
--- a/kubernetes/apps/observability/opnsense-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/prometheusrule.yaml
@@ -16,24 +16,27 @@ spec:
           for: 5m
           labels:
             severity: critical
-        # NOTE: confirm the gateway metric name/label encoding against live /metrics.
-        # AthennaMind exposes opnsense_gateways_status with a status label
-        # (e.g. "online"/"down"); adjust the matcher if your version differs.
+        # Gateway RTT monitoring is disabled on this OPNsense, so the loss/RTT
+        # value on opnsense_gateways_monitor_info isn't populated. The reliable
+        # down signal is the no_route label (set from the routing table when a
+        # gateway loses its default route), which is independent of monitoring.
+        # Enable gateway monitoring on the firewall to unlock loss/RTT alerting.
         - alert: OPNsenseGatewayDown
           annotations:
-            summary: "OPNsense gateway {{ $labels.name }} is not online (status {{ $labels.status }})."
+            summary: "OPNsense gateway {{ $labels.name }} has no route (down)."
           expr: |-
-            opnsense_gateways_status{job="opnsense-exporter", status!="online"} == 1
+            opnsense_gateways_monitor_info{job="opnsense-exporter", no_route="true"}
           for: 5m
           labels:
             severity: critical
         # Unbound (the resolver behind opnsense-dns / split-horizon) being down
-        # breaks internal name resolution cluster-wide.
+        # breaks internal name resolution cluster-wide. The exporter has no
+        # unbound-specific metric, so it surfaces via opnsense_services_status.
         - alert: OPNsenseUnboundDown
           annotations:
             summary: "OPNsense Unbound DNS service is not running."
           expr: |-
-            opnsense_unbound_uptime_seconds{job="opnsense-exporter"} == 0
+            opnsense_services_status{job="opnsense-exporter", name="unbound"} == 0
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
## Problem

Both OPNsense alert rules queried metrics this exporter build never emits, so a firewall gateway drop or DNS-resolver outage **paged nobody**. Verified against live Prometheus:

- `count(opnsense_gateways_status)` → 0 series
- `count(opnsense_unbound_uptime_seconds)` → 0 series

The in-file comment even assumed an "AthennaMind" exporter variant with an `opnsense_gateways_status` `status` label that this build doesn't have.

## Fix

- **`OPNsenseUnboundDown`** → `opnsense_services_status{name="unbound"} == 0`. The exporter has no Unbound-specific metric; Unbound surfaces via the per-service status metric (confirmed: the `unbound` series exists and reads `1` when running).
- **`OPNsenseGatewayDown`** → `opnsense_gateways_monitor_info{no_route="true"}`. Gateway RTT monitoring is **disabled** on this OPNsense (`enabled="false"` on both WAN gateways), so the loss/RTT value isn't populated. The `no_route` label is routing-table based and independent of monitoring, making it the reliable down signal. (Enabling gateway monitoring on the firewall would unlock richer loss/RTT alerting — noted in a code comment.)

## Validation

Both new expressions were run against live Prometheus: valid PromQL, **0 results while healthy** (no false positives), and the `unbound` series is confirmed present so the alert can actually fire when the service stops.

Found during the 2026-07-06 cluster review (finding P1-2).