### PR TITLE
fix(volsync): add kopia cache config to the nfs ReplicationDestination

### DIFF
--- a/kubernetes/components/volsync/nfs/replicationdestination.yaml
+++ b/kubernetes/components/volsync/nfs/replicationdestination.yaml
@@ -12,6 +12,10 @@ spec:
   kopia:
     accessModes:
       - ${VOLSYNC_ACCESSMODES:=ReadWriteOnce}
+    cacheAccessModes:
+      - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
+    cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=10Gi}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
     capacity: ${VOLSYNC_CAPACITY:=5Gi}
     cleanupCachePVC: true
     cleanupTempPVC: true


### PR DESCRIPTION
## Problem

The nfs `ReplicationDestination` was the **only** one of the four volsync mover resources without `cache*` fields — its nfs source sibling and both remote (restic) resources have them. Without `cacheCapacity`, VolSync provisions the default **1Gi** cache PVC, which causes `no space left on device` failures when restoring large volumes.

This is the exact bug commit `131c1d7ae` fixed for the R2/restic path ("VolSync still creates 1Gi PVCs which caused backup failures for larger volumes like Plex"); the nfs *source* got the same fix in `7ac6f014c9`, but the nfs *destination* was missed.

## Fix

Add `cacheAccessModes` / `cacheCapacity` (`${VOLSYNC_CACHE_CAPACITY:=10Gi}`) / `cacheStorageClassName`, mirroring the nfs source's fully-parameterized kopia cache block, so a manual restore of a large PVC (e.g. Plex with `VOLSYNC_CACHE_CAPACITY: 100Gi`) from the nfs/kopia repo doesn't hit the 1Gi-cache failure.

## Impact

Restore-only and non-disruptive: the destination is `manual: restore-once` triggered, so nothing reconciles until an actual restore is initiated. Konflate will show the change re-rendered across every volsync-nfs app's destination (shared component).

Found during the 2026-07-06 cluster review (finding P2-2).