### PR TITLE
fix(dispatcharr): authenticate Celery/Redis against Dragonfly

### DIFF
--- a/kubernetes/apps/media/dispatcharr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dispatcharr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: dispatcharr-secret
+    template:
+      engineVersion: v2
+      data:
+        # Dragonfly enforces auth. dispatcharr builds its Celery broker from
+        # REDIS_* (REDIS_PASSWORD), and also honours CELERY_BROKER_URL if set —
+        # provide both, authenticated, so neither code path connects password-less.
+        REDIS_PASSWORD: "{{ .DRAGONFLY_PASSWORD }}"
+        CELERY_BROKER_URL: "redis://default:{{ .DRAGONFLY_PASSWORD }}@dragonfly.database.svc.cluster.local:6379/0"
+  dataFrom:
+    - extract:
+        key: dragonfly

--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -34,11 +34,13 @@ spec:
               tag: 0.27.0@sha256:3eea6de0ca75784f66be7edc1f90a6d5731600aad82d591ce44b284394318752
             env:
               TZ: ${TIMEZONE}
-              CELERY_BROKER_URL: redis://dragonfly.database.svc.cluster.local:6379/0
               DISPATCHARR_ENV: aio
               DISPATCHARR_LOG_LEVEL: info
               DISPATCHARR_PORT: &port 9191
               REDIS_HOST: dragonfly.database.svc.cluster.local
+            envFrom:
+              - secretRef:
+                  name: dispatcharr-secret
             resources:
               requests:
                 cpu: 50m

--- a/kubernetes/apps/media/dispatcharr/app/kustomization.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/media/dispatcharr/ks.yaml
+++ b/kubernetes/apps/media/dispatcharr/ks.yaml
@@ -15,6 +15,8 @@ spec:
   dependsOn:
     - name: gpu-operator
       namespace: gpu-operator
+    - name: onepassword-connect
+      namespace: external-secrets
     - name: rook-ceph-cluster
       namespace: rook-ceph
   interval: 1h


### PR DESCRIPTION
## Problem

dispatcharr pointed `CELERY_BROKER_URL` and `REDIS_HOST` at Dragonfly **with no password**, but Dragonfly enforces auth. Its worker/beat has been spamming `Cannot connect to redis://…:6379/0: Authentication required.` / `celery.beat Connection error` at runtime — Celery has been non-functional since deploy (previously tracked known-open item).

## Fix

Add an ExternalSecret (`dispatcharr-secret`) that sources `DRAGONFLY_PASSWORD` from the `dragonfly` 1Password item and templates both authentication paths:

- **`REDIS_PASSWORD`** — dispatcharr's documented Redis auth var; it builds its broker/cache URLs from `REDIS_*`.
- **`CELERY_BROKER_URL`** with `redis://default:<pass>@…:6379/0` — belt-and-suspenders in case the app honours an explicit broker URL instead.

Plus:
- Remove the inline password-less `CELERY_BROKER_URL` from the HelmRelease (an inline `env` value would override the authenticated one delivered via `envFrom`).
- Consume the secret via `envFrom: [{secretRef: {name: dispatcharr-secret}}]`.
- Register `externalsecret.yaml` in the app kustomization.
- Add `dependsOn: onepassword-connect` (external-secrets).

`REDIS_HOST` stays inline (non-secret); the broker keeps db 0 to match the existing config (Dragonfly `cluster_mode=emulated` exposes only db 0).

## Notes

The `dragonfly` item / `DRAGONFLY_PASSWORD` field is the same one paperless, prowler, and netbox already consume. dispatcharr's `REDIS_PASSWORD` support confirmed from its upstream docker-compose env contract.

Found during the 2026-07-06 cluster review (finding P1-6 / previously tracked known-open item).