### PR TITLE
ci(renovate): protect tuppr/volsync/snapshot-controller; drop dead Flate watch

### DIFF
--- a/.github/workflows/renovate-assign-on-failure.yaml
+++ b/.github/workflows/renovate-assign-on-failure.yaml
@@ -18,7 +18,6 @@ on:
   # flags does not apply.
   workflow_run:
     workflows:
-      - "Flate"
       - "security-scans"
       - "Lint"
     types:

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -130,6 +130,9 @@
         "/dcgm/", // dcgm / dcgm-exporter (no nvidia prefix)
         "/envoyproxy/", // Envoy Gateway: gateway-helm chart + envoy image
         "/1password/", // onepassword-connect: connect chart + connect-api + connect-sync
+        "/tuppr/", // drives Talos + Kubernetes node upgrades (system-upgrade)
+        "/volsync/", // backup mover (charts-mirror/volsync-perfectra1n)
+        "/snapshot-controller/", // CSI VolumeSnapshot controller (backup path)
       ],
       automerge: false,
     },


### PR DESCRIPTION
Two Renovate / CI-automation gaps found in the 2026-07-06 review.

## P2-8 — protected-infra guard omits backup/upgrade-critical components

`.renovaterc.json5`'s protected-infra `matchPackageNames` didn't cover:

| Component | Package | Why it matters |
|-----------|---------|----------------|
| **tuppr** | `ghcr.io/home-operations/charts/tuppr` | Drives Talos + Kubernetes node upgrades |
| **volsync** | `ghcr.io/home-operations/charts-mirror/volsync-perfectra1n` | Backup mover |
| **snapshot-controller** | `ghcr.io/piraeusdatastore/helm-charts/snapshot-controller` | CSI VolumeSnapshot controller (backup path) |

All three auto-merged minor/patch/digest after only the 3-day cooldown, and all three have prior-incident history in this repo (`project_talos_patch_rollout_tuppr_stuck`, `project_volsync_snapshotter_rook_v120`). Added `/tuppr/`, `/volsync/`, `/snapshot-controller/` so they require manual review like the other cluster-critical charts. Regexes verified against the actual OCIRepository URLs.

## P2-7 — renovate-assign-on-failure watched a deleted workflow

`renovate-assign-on-failure.yaml` still listed `"Flate"` in its `workflow_run.workflows`. That workflow was deleted 2026-07-01 (#3375) when render validation moved to the in-cluster Konflate (which posts a **commit status**, not a `workflow_run`), so the entry can never fire. Dropped it.

> Note: Konflate/render failures are no longer caught by this `workflow_run` mechanism at all. A follow-up could add a commit-status-based trigger so a failed Konflate render on a Renovate PR still assigns you — out of scope here.

Findings P2-7 and P2-8.