### PR TITLE
fix(ci): run image-pull post-merge; drop runner cluster-admin binding

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -2,17 +2,20 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: "Image Pull"
 
+# Runs post-merge on push to main (not pull_request): the `pull` job executes
+# on a self-hosted runner that mounts an os:admin talosconfig, so it must only
+# ever run code that has already been reviewed and merged — never untrusted
+# PR-head code on a public repo.
 on:
-  pull_request:
+  push:
     branches:
       - "main"
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -49,16 +52,17 @@ jobs:
       default_images: ${{ steps.set-outputs.outputs.default_images }}
       pull_images: ${{ steps.set-outputs.outputs.pull_images }}
     steps:
-      - name: Checkout Default Branch
+      - name: Checkout Pre-Merge Commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.before }}
           path: default
           persist-credentials: false
 
-      - name: Checkout Pull Request Branch
+      - name: Checkout Merged Commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          ref: ${{ github.sha }}
           path: pull
           persist-credentials: false
 

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/rbac.yaml
@@ -1,22 +1,8 @@
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: talos-cluster-runner
-  namespace: actions-runner-system
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: talos-cluster-runner
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - kind: ServiceAccount
-    name: talos-cluster-runner
-    namespace: actions-runner-system
+# No Kubernetes RBAC: the runner pods use the gha-runner-scale-set chart's
+# auto-created `*-gha-rs-no-permission` ServiceAccount, and the only privileged
+# job (image-pull) calls `talosctl image pull` — no kubectl. The Talos os:admin
+# ServiceAccount below is the sole grant, and image-pull now runs post-merge
+# (push, not pull_request) so untrusted PR code never reaches this runner.
 ---
 apiVersion: talos.dev/v1alpha1
 kind: ServiceAccount


### PR DESCRIPTION
Runner os:admin exposure fix — **Option 1 (post-merge push)**, per discussion.

## Problem

The image-pull `pull` job runs on the self-hosted `talos-cluster-runner`, whose pods mount an **os:admin talosconfig** at `~/.talos/config`. It was triggered by `pull_request`, so on this **public** repo a malicious PR could rewrite that job to read the talosconfig and gain full node-OS admin over all 3 control planes. The talosconfig is a Kubernetes filesystem mount, not a GitHub secret, so fork-PR secret masking does not protect it.

## Fix

**1. Post-merge trigger.** Changed `on: pull_request` → `on: push` (main). The privileged runner now only ever executes code that was already reviewed and merged. The image diff compares `github.event.before` → `github.sha` (the merge range) instead of PR-vs-default-branch. `filter` / `extract` / `diff` still run on `ubuntu-latest` (unprivileged); only `pull` uses the self-hosted runner.

**2. Delete the orphaned cluster-admin binding.** The runner pods actually run as the gha-runner-scale-set chart's `*-gha-rs-no-permission` ServiceAccount (verified live), so the `talos-cluster-runner` → `cluster-admin` ClusterRoleBinding granted the runner nothing — it was pure standing risk. Removed it and the unused k8s ServiceAccount; Flux prunes both. The Talos `os:admin` ServiceAccount stays (`talosctl image pull` needs it).

## Tradeoff (as discussed)

Images now pre-pull just after merge instead of before, so a just-merged deploy can briefly race the pull. Bounded by the 15m HR timeouts on the big-image apps + spegel distribution — worst case is a one-time slow first-start on a giant image, not an outage.

## Note

`talosctl image pull` requires `os:admin`/`os:operator` (both can also reboot/read machine config), so scoping the Talos role down doesn't meaningfully reduce blast radius — removing untrusted PR code from the runner is the effective control.

Finding P1-4.