### PR TITLE
docs: fix device-monitoring cluster-secrets recipe + flate/gatus drift

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -25,9 +25,10 @@ Use the `add-app` skill to scaffold, or follow the shape by hand. Every app live
 - **`ks.yaml`** is the Flux entry point:
   - Use YAML anchors (`&app`, `&namespace`, `*app`) for DRY references and set
     `targetNamespace: *namespace`.
-  - Declare any `components` (`gatus/guarded`, `volsync`, `alerts`) here, along with their
+  - Declare any `components` (`volsync`, `alerts`, `homepage`) here, along with their
     `postBuild.substitute` values (`APP: *app`, `VOLSYNC_CAPACITY`). Do not duplicate components into
-    `app/kustomization.yaml`.
+    `app/kustomization.yaml`. (Gatus monitoring is automatic — the gatus-sidecar chart auto-discovers
+    HTTPRoutes, so there is no per-app `gatus/guarded` component anymore.)
   - Add `dependsOn` `onepassword-connect` in `external-secrets` if the app uses an ExternalSecret.
 - **Inside `app/`**:
   - Add a **per-app `ocirepository.yaml`** pointing at `oci://ghcr.io/bjw-s-labs/helm/app-template`;
@@ -54,8 +55,9 @@ Use the `add-app` skill to scaffold, or follow the shape by hand. Every app live
 
 ## Validate before pushing
 
-CI validates pull requests with flate (HelmRelease + Kustomization rendering without a live cluster),
-plus security scans (Checkov/Trivy) and super-linter. Mirror it locally first:
+PR renders and diffs are posted by the in-cluster Konflate as a native commit status plus a PR comment
+(there is no GitHub Actions render workflow). GitHub Actions still run security scans (Checkov/Trivy) and
+super-linter. Mirror the render locally first with flate:
 
 ```bash
 # Render a single app's HelmRelease

--- a/docs/docs/operations/device-monitoring.md
+++ b/docs/docs/operations/device-monitoring.md
@@ -101,7 +101,7 @@ a top-level `params`):
 
 ```yaml
 - name: <short-name>
-  target: ${SOME_ADDR} # a cluster-settings DNS var
+  target: ${SOME_ADDR} # a cluster-secrets DNS var (1Password, not git)
   module: [if_mib] # or [if_mib, entity_sensor] for sensors
   auth: [public_v2] # or a custom auth defined in configmap-entity-sensor
   interval: 60s
@@ -120,8 +120,10 @@ with the image's bundled `snmp.yml` via the two `--config.file` `extraArgs`.
    `/user group add name=prometheus policy=api,read` then
    `/user add name=mktxp group=prometheus password=<from 1Password>`, and enable
    `api-ssl` restricted to the node source IPs.
-2. Add the host as a `cluster-settings` DNS var and append a `[Section]` to the
-   `mktxp.conf` block in `mktxp/app/externalsecret.yaml`.
+2. Add the host as a `cluster-secrets` DNS var (the 1Password item, **not**
+   git-tracked `cluster-settings` — device hostnames stay out of this public
+   repo) and append a `[Section]` to the `mktxp.conf` block in
+   `mktxp/app/externalsecret.yaml`.
 
 ## Validation
 


### PR DESCRIPTION
Docs drift found in the 2026-07-06 review (finding P2-12), focused on the highest-value corrections.

## device-monitoring.md — public-repo correctness (most important)

The "Add a new SNMP device" and "Add a new RouterOS switch" recipes told contributors to add the device address as a **`cluster-settings`** DNS var. But `cluster-settings` is the **git-tracked, public** ConfigMap — device hostnames live in the **`cluster-secrets`** 1Password item (exactly as the same document's section 3 states). Following the recipe verbatim would leak an internal hostname into this public repo — the precise mistake the repo's CI guard and public-repo rules exist to prevent. Corrected both spots.

## contributing.md — stale CI + removed component

- "CI validates pull requests with flate" — that GitHub Actions render workflow was **deleted 2026-07-01** (#3375). PR renders/diffs now come from the in-cluster **Konflate** (native commit status + PR comment); flate is a local-only mirror. Rewritten.
- Dropped the removed **`gatus/guarded`** component from the `ks.yaml` components example and noted that Gatus monitoring is now automatic (the gatus-sidecar chart auto-discovers HTTPRoutes).

## Follow-up (not in this PR)

The remaining `gatus/guarded` mentions in `architecture/overview.md` and the app pages (reclaimerr, scanopy, metabase, netbox), plus the Ollama/RGW staleness in litellm.md/storage.md/secrets.md, are a separate smaller docs pass.