### PR TITLE
docs: sweep remaining gatus/guarded + Ollama/RGW staleness

### DIFF
--- a/docs/docs/apps/litellm.md
+++ b/docs/docs/apps/litellm.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-LiteLLM is an OpenAI-compatible LLM gateway in the `ai` namespace. It fronts the local Ollama
-instances and cloud providers behind one API, so in-cluster consumers target a single endpoint and
+LiteLLM is an OpenAI-compatible LLM gateway in the `ai` namespace. It fronts the local llmkube
+(llama.cpp) model-serving tier and cloud providers behind one API, so in-cluster consumers target a single endpoint and
 get virtual keys, per-key budgets, request logging, model-group routing, fallbacks, and an admin UI.
 See the [AI / LLM stack](../architecture/ai-llm-stack.md) page for how it fits the wider stack.
 

--- a/docs/docs/apps/metabase.md
+++ b/docs/docs/apps/metabase.md
@@ -73,5 +73,5 @@ shared `postgres18` CloudNativePG cluster.
 - **First-run setup is manual.** Browse to the internal hostname, complete the wizard to create the
   local admin, then add source databases through the UI.
 - **Health checks:** liveness/readiness hit `GET /api/health` (returns `{"status":"ok"}`); Gatus
-  monitors via the `gatus/guarded` component. Confirm metrics with a port-forward to 9191 and look for
-  `jvm_memory_used_bytes` / `metabase_*` series.
+  monitors it automatically (the gatus-sidecar chart auto-discovers the HTTPRoute). Confirm metrics
+  with a port-forward to 9191 and look for `jvm_memory_used_bytes` / `metabase_*` series.

--- a/docs/docs/apps/netbox.md
+++ b/docs/docs/apps/netbox.md
@@ -22,11 +22,13 @@ and its `existingSecret` contract are already modelled by the upstream chart.
   bundled cache (`valkey.enabled`) is disabled. Separate logical DB indices for the tasks queue
   (`0`) vs the cache (`1`).
 - **Media** — a local `ceph-block` PVC consumed via `persistence.existingClaim` and backed up by the
-  VolSync component (`VOLSYNC_CAPACITY`). Ceph RGW S3 is available but not used here.
+  VolSync component (`VOLSYNC_CAPACITY`). NetBox uses no object storage; the cluster's S3 tier is
+  Garage (`storage` namespace), not Ceph RGW (which was removed).
 - **Auth / exposure** — superuser-only first pass (pocket-id OIDC is a fast-follow); internal-only
   HTTPRoute on `envoy-internal`, never publicly exposed.
-- Health monitored via the `gatus/guarded` component; `reloader.stakater.com/auto` rolls pods on
-  secret/config change; a ServiceMonitor exposes metrics to kube-prometheus-stack.
+- Health monitored automatically by the gatus-sidecar (it auto-discovers the HTTPRoute);
+  `reloader.stakater.com/auto` rolls pods on secret/config change; a ServiceMonitor exposes metrics
+  to kube-prometheus-stack.
 
 ## Deploy gotchas
 

--- a/docs/docs/apps/reclaimerr.md
+++ b/docs/docs/apps/reclaimerr.md
@@ -28,8 +28,9 @@ bjw-s `app-template` deployment mirroring sibling apps (maintainerr, pulsarr).
   `CORS_ORIGINS` includes both the external-domain and internal-domain hostnames
   (`${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}`) so the SPA's API calls are accepted
   regardless of which hostname the user browses to.
-- **Components:** `gatus/guarded` (health monitoring), `homepage` (dashboard tile under the
-  `Media` group, `mdi-broom` icon), and `volsync` (PVC backup). `VOLSYNC_CAPACITY: 2Gi` and
+- **Components:** `homepage` (dashboard tile under the
+  `Media` group, `mdi-broom` icon) and `volsync` (PVC backup). (Gatus monitoring is automatic via
+  the gatus-sidecar chart's HTTPRoute auto-discovery — no `gatus/guarded` component.) `VOLSYNC_CAPACITY: 2Gi` and
   `VOLSYNC_CACHE_CAPACITY: 1Gi` are the required substitutes for the volsync component
   (overriding the 5Gi/10Gi defaults).
 - **Deferred (out of scope):** external ingress, pre-seeding `JWT_SECRET`/`ENCRYPTION_KEY` via

--- a/docs/docs/apps/scanopy.md
+++ b/docs/docs/apps/scanopy.md
@@ -40,9 +40,9 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
   credential is then configured in the UI pointing at that file.
 - **Docker-socket scan source dropped.** Talos runs containerd with no Docker socket, so it is
   disabled explicitly with `SCANOPY_ENABLE_LOCAL_DOCKER_SOCKET=false`.
-- **Components** — `gatus/guarded` (DNS check on `${GATUS_SUBDOMAIN}.${SECRET_DOMAIN}`, not an HTTP
-  probe) and `volsync` (`VOLSYNC_CAPACITY: 5Gi`) backing the server `/data` PVC. No PodMonitor:
-  Scanopy exposes no Prometheus metrics.
+- **Components** — `volsync` (`VOLSYNC_CAPACITY: 5Gi`) backing the server `/data` PVC. (Gatus
+  monitoring is automatic via the gatus-sidecar chart, which auto-discovers the HTTPRoute; the old
+  `gatus/guarded` DNS-check component is gone.) No PodMonitor: Scanopy exposes no Prometheus metrics.
 
 ## Deploy gotchas
 

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -20,7 +20,7 @@ install/upgrade/rollback defaults.
 ```text
 kubernetes/
   apps/<namespace>/<app>/      # ks.yaml (Flux entry point) + app/ (HelmRelease, sources, routes)
-  components/                  # reusable Kustomize components (global-vars, alerts, volsync, gatus, …)
+  components/                  # reusable Kustomize components (global-vars, alerts, volsync, homepage, …)
   flux/cluster/                # core Flux bootstrap (root Kustomization with global patches)
 bootstrap/                     # cluster bootstrap (just tasks + helmfile)
 talos/                         # Talos machine config (talconfig.yaml + patches)
@@ -31,8 +31,9 @@ talos/                         # Talos machine config (talconfig.yaml + patches)
 Every app follows the same shape:
 
 - `ks.yaml` is the Flux entry point. It uses YAML anchors (`&app`, `&namespace`, `*app`), sets
-  `targetNamespace`, and lists any `components` (`gatus/guarded`, `volsync`, `alerts`) plus their
-  `postBuild.substitute` values.
+  `targetNamespace`, and lists any `components` (`volsync`, `alerts`, `homepage`) plus their
+  `postBuild.substitute` values. (Gatus monitoring is automatic — the gatus-sidecar chart
+  auto-discovers HTTPRoutes, so there is no per-app `gatus/guarded` component anymore.)
 - Inside `app/`: a per-app chart source (`ocirepository.yaml` pointing at the bjw-s `app-template`
   for most apps), a `helmrelease.yaml`, an optional `externalsecret.yaml`, and usually an inline
   `route:` in the HelmRelease values rather than a standalone `httproute.yaml`.

--- a/docs/docs/architecture/secrets.md
+++ b/docs/docs/architecture/secrets.md
@@ -15,7 +15,7 @@ Secrets never live in Git. They flow:
   app's `postBuild.substituteFrom`. Holds cluster-wide *sensitive* values, including
   `${SECRET_DOMAIN}`, `${SECRET_INTERNAL_DOMAIN}`, and internal device DNS names.
 - **`cluster-settings`** — a git-tracked ConfigMap (`components/global-vars/`) holding cluster-wide
-  *non-sensitive* values (e.g. the default Ollama model).
+  *non-sensitive* `${...}` values (non-secret feature flags and the like; currently empty).
 
 ## Rules for a public repo
 


### PR DESCRIPTION
Follow-up to #3422, clearing the rest of finding P2-12.

- **gatus/guarded → gatus-sidecar** — the `guarded` component was removed; Gatus now auto-discovers HTTPRoutes via the gatus-sidecar chart. Updated `overview.md` (components list ×2), `metabase.md`, `reclaimerr.md`, `scanopy.md`, `netbox.md`.
- **Ollama decommissioned** — `litellm.md` now says LiteLLM fronts the local **llmkube (llama.cpp)** tier, not Ollama; `secrets.md` drops the "default Ollama model" `cluster-settings` example (the ConfigMap is currently empty).
- **Ceph RGW removed** — `netbox.md` points at **Garage** (`storage` namespace) as the S3 tier instead of the removed Ceph RGW.

Prose-only; no manifest impact.