### PR TITLE
fix: pin MCP images, rename shelly OCIRepository, drop sonarr dead mount

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/github/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github/mcpserver.yaml
@@ -5,7 +5,7 @@ kind: MCPServer
 metadata:
   name: github
 spec:
-  image: ghcr.io/github/github-mcp-server
+  image: ghcr.io/github/github-mcp-server:latest@sha256:e25564dccc9110a70a77b9df560cbde11aa392fcb5f08b9abe5c4ebc6d146ea4
   transport: stdio
   proxyMode: streamable-http
   proxyPort: 8080

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana/mcpserver.yaml
@@ -5,7 +5,7 @@ kind: MCPServer
 metadata:
   name: grafana
 spec:
-  image: docker.io/grafana/mcp-grafana
+  image: docker.io/grafana/mcp-grafana:0.17.0@sha256:da49d967b72ebb4d08617295ef196b53b3294a9c1d484775dd3315190a166c55
   transport: stdio
   proxyMode: streamable-http
   proxyPort: 8080

--- a/kubernetes/apps/home/shelly-prometheus-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-prometheus-exporter/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 1h
   chartRef:
     kind: OCIRepository
-    name: app-template
+    name: shelly-prometheus-exporter
   values:
     controllers:
       shelly-prometheus-exporter:

--- a/kubernetes/apps/home/shelly-prometheus-exporter/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-prometheus-exporter/app/ocirepository.yaml
@@ -3,7 +3,7 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
-  name: app-template
+  name: shelly-prometheus-exporter
 spec:
   interval: 15m
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -116,9 +116,6 @@ spec:
           - path: /scripts/refresh-series.sh
             subPath: refresh-series.sh
             readOnly: true
-          - path: /scripts/tag-codecs.sh
-            subPath: tag-codecs.sh
-            readOnly: true
       tmp:
         type: emptyDir
       media:


### PR DESCRIPTION
Three small P3 fixes.

- **P3-4 — pin the MCP server images.** The `github` and `grafana` MCPServer images were **untagged** (floated to `:latest`), so Renovate couldn't track them and a restart could silently pull a different image — and both mount credentials (a GitHub PAT, a Grafana SA token). Pinned to `tag@digest`:
  - `github` → `latest@sha256:e25564…` (no clean semver tags published upstream; the digest locks the current image and Renovate still tracks the digest)
  - `grafana` → `0.17.0@sha256:da49d9…`
- **P3-5 — rename shelly-prometheus-exporter's OCIRepository.** It was named the generic `app-template` (with `chartRef` pointing at it). Harmless today, but a landmine if another `home` app copied the name (two Kustomizations fighting over one object). Renamed the OCIRepository and `chartRef.name` to the app.
- **P3-7 — drop sonarr's dead ConfigMap mount.** sonarr mounted `/scripts/tag-codecs.sh` via `subPath`, but that key was removed from `sonarr-configmap` 5 months ago (only `refresh-series.sh` remains). Removed the dead mount.

> Deferred: the etcd-defrag `${VAR}` log-escaping (P3-6) — it needs verifying Flux's bare-`$VAR` substitution behavior in that mixed ConfigMap and is only cosmetic, so I left it rather than risk an incomplete escape.