### PR TITLE
fix(karakeep): co-locate app+meilisearch in one pod to end RWO multi-attach

### DIFF
--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -24,6 +24,10 @@ spec:
       karakeep:
         annotations:
           reloader.stakater.com/auto: "true"
+        # app + meilisearch share one pod (and the ReadWriteOnce data PVC) so a
+        # rollout can't strand the RWO volume across nodes; Recreate replaces the
+        # pod atomically. meilisearch is reached over localhost within the pod.
+        strategy: Recreate
         containers:
           app:
             image:
@@ -36,7 +40,7 @@ spec:
               CRAWLER_STORE_SCREENSHOT: true
               DATA_DIR: /data
               DISABLE_SIGNUPS: "false"
-              MEILI_ADDR: http://karakeep-meilisearch.default.svc.cluster.local:7700
+              MEILI_ADDR: http://localhost:7700
               DISABLE_NEW_RELEASE_CHECK: true
               COREPACK_INTEGRITY_KEYS: 0
             envFrom:
@@ -52,6 +56,23 @@ spec:
                 cpu: 100m
               limits:
                 memory: 2Gi
+          meilisearch:
+            image:
+              repository: docker.io/getmeili/meilisearch
+              tag: v1.48.3@sha256:c1a52f17c759c2cd6349eede3d5108b8dac07b97e10665b1d64a2d4961c2fd29
+            args:
+              - /bin/meilisearch
+              - --experimental-dumpless-upgrade
+            env:
+              MEILI_NO_ANALYTICS: true
+            envFrom:
+              - secretRef:
+                  name: karakeep-secret
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 4Gi
 
       chrome:
         annotations:
@@ -81,43 +102,6 @@ spec:
               limits:
                 memory: 1Gi
 
-      meilisearch:
-        annotations:
-          reloader.stakater.com/auto: "true"
-        pod:
-          affinity:
-            podAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: app.kubernetes.io/instance
-                        operator: In
-                        values:
-                          - karakeep
-                      - key: app.kubernetes.io/controller
-                        operator: In
-                        values:
-                          - karakeep
-                  topologyKey: kubernetes.io/hostname
-        containers:
-          app:
-            image:
-              repository: docker.io/getmeili/meilisearch
-              tag: v1.48.3@sha256:c1a52f17c759c2cd6349eede3d5108b8dac07b97e10665b1d64a2d4961c2fd29
-            args:
-              - /bin/meilisearch
-              - --experimental-dumpless-upgrade
-            env:
-              MEILI_NO_ANALYTICS: true
-            envFrom:
-              - secretRef:
-                  name: karakeep-secret
-            resources:
-              requests:
-                cpu: 10m
-              limits:
-                memory: 4Gi
-
     service:
       app:
         primary: true
@@ -130,11 +114,6 @@ spec:
         ports:
           http:
             port: 9222
-      meilisearch:
-        controller: meilisearch
-        ports:
-          http:
-            port: 7700
 
     route:
       app:
@@ -157,7 +136,6 @@ spec:
             app:
               - path: /data
                 subPath: karakeep
-          meilisearch:
-            app:
+            meilisearch:
               - path: /meili_data
                 subPath: meilisearch


### PR DESCRIPTION
Finding P2-13 — the report's suggested `strategy: Recreate` was **insufficient**, so this is the proper redesign.

## The deadlock

`karakeep` and `meilisearch` ran as two controllers sharing one **ReadWriteOnce** `data` PVC (via subPaths), with meilisearch pinned to karakeep's node by a `requiredDuringScheduling` / **`IgnoredDuringExecution`** podAffinity. On a karakeep rollout, the new pod could schedule on a different node while meilisearch (whose affinity is ignored during execution) kept the RWO volume attached to the old node → `Multi-Attach` deadlock. Adding `Recreate` to karakeep alone doesn't fix it: after old-karakeep terminates, meilisearch stays put holding the volume, and new-karakeep has no affinity to follow it there.

## Fix

Merge meilisearch into the karakeep controller as a **second container**, so the whole app is one pod — always co-located on one node, rolling **atomically** under `strategy: Recreate`. No cross-node RWO contention is possible.

- karakeep reaches meilisearch over `localhost:7700` now → its `Service` and the podAffinity are removed.
- Same `data` PVC and subPaths (`karakeep`, `meilisearch`) → **no data migration**.
- chrome stays a separate controller (it doesn't share the PVC).

## On merge

Flux prunes the old `meilisearch` Deployment and `Recreate`-rolls the karakeep pod — a brief restart, data preserved. Konflate renders the two-container Deployment.