### PR TITLE
fix: escape etcd-defrag log vars, drop dead smartctl rule, sort kustomizations

### DIFF
--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -11,13 +11,13 @@ resources:
   - ./netpol.yaml
   - ./esphome/ks.yaml
   - ./go2rtc/ks.yaml
-  - ./homeassistanttimemachine/ks.yaml
   - ./homeassistant/ks.yaml
+  - ./homeassistanttimemachine/ks.yaml
   - ./homebridge/ks.yaml
   - ./mosquitto/ks.yaml
   - ./node-red/ks.yaml
-  - ./shelly-prometheus-exporter/ks.yaml
   - ./shelly-fleet/ks.yaml
   - ./shelly-operator/ks.yaml
+  - ./shelly-prometheus-exporter/ks.yaml
   - ./zigbee2mqtt/ks.yaml
   - ./zwave/ks.yaml

--- a/kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml
@@ -19,7 +19,7 @@ data:
     echo "etcd Fragmentation Check & Defrag Script"
     echo "=========================================="
     echo "Start time: $(date)"
-    echo "Fragmentation threshold: ${FRAG_THRESHOLD}%"
+    echo "Fragmentation threshold: $${FRAG_THRESHOLD}%"
     echo ""
 
     # Control plane nodes
@@ -121,7 +121,7 @@ data:
         NODE_NAME=$(echo "$NODE_INFO" | cut -d: -f2)
 
         FRAG=$(get_fragmentation "$NODE")
-        echo "$NODE_NAME ($NODE): ${FRAG}% fragmentation"
+        echo "$NODE_NAME ($NODE): $${FRAG}% fragmentation"
 
         if [ "$FRAG" -gt "$MAX_FRAG" ] 2>/dev/null; then
             MAX_FRAG="$FRAG"
@@ -133,8 +133,8 @@ data:
     done
 
     echo ""
-    echo "Maximum fragmentation: ${MAX_FRAG}%"
-    echo "Threshold: ${FRAG_THRESHOLD}%"
+    echo "Maximum fragmentation: $${MAX_FRAG}%"
+    echo "Threshold: $${FRAG_THRESHOLD}%"
     echo ""
 
     if [ "$NEEDS_DEFRAG" = "true" ]; then

--- a/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/smartctl-exporter/app/prometheusrule.yaml
@@ -50,11 +50,3 @@ spec:
           for: 5m
           labels:
             severity: critical
-        - alert: SmartDeviceInterfaceSlow
-          annotations:
-            summary: "Device {{ $labels.device }} on instance {{ $labels.instance }} interface is slow."
-          expr: |-
-            smartctl_device_interface_speed{speed_type="current"} != on(device, instance, namespace, pod) smartctl_device_interface_speed{speed_type="max"}
-          for: 5m
-          labels:
-            severity: critical

--- a/kubernetes/apps/volsync-system/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kustomization.yaml
@@ -8,6 +8,6 @@ components:
   - ../../components/alerts
 resources:
   - ./namespace.yaml
-  - ./volsync/ks.yaml
-  - ./kopia/ks.yaml
   - ./backrest/ks.yaml
+  - ./kopia/ks.yaml
+  - ./volsync/ks.yaml


### PR DESCRIPTION
The remaining P3 nits.

- **P3-6 — etcd-defrag log escaping.** The defrag script's log lines used braced `${FRAG}` / `${MAX_FRAG}` / `${FRAG_THRESHOLD}`, which Flux postBuild blanked (`"Threshold: %"`). Verified empirically against the **live** ConfigMap that Flux substitutes **only braced `${VAR}`, not bare `$VAR`** — so the defrag *logic* (bare `$FRAG` comparisons) was always correct; only the log output was broken. Escaped the four braced log vars as `$${...}`. Cosmetic, logs-only.
- **P3-10 — drop the dead smartctl rule.** `SmartDeviceInterfaceSlow` queried `smartctl_device_interface_speed`, which this **all-NVMe** fleet never emits (that metric is SATA/SAS only), so it could never fire. Removed it (the 5 real SMART rules stay).
- **P3-9 — alphabetical ordering.** Sorted the `home` and `volsync-system` namespace kustomization app lists. List order doesn't affect Flux apply order (`dependsOn` does), so this is convention-only.