### PR TITLE
fix(mosquitto): externalTrafficPolicy Local->Cluster (fix L2 black-hole)

### DIFF
--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -57,7 +57,7 @@ spec:
         type: LoadBalancer
         annotations:
           lbipam.cilium.io/ips: ${SVC_MOSQUITTO_ADDR}
-        externalTrafficPolicy: Local
+        externalTrafficPolicy: Cluster
         ports:
           mqtt:
             port: 1883


### PR DESCRIPTION
## What
`externalTrafficPolicy: Local` -> `Cluster` on the mosquitto LoadBalancer service.

## Why
mosquitto's LB IP (`${SVC_MOSQUITTO_ADDR}`) is ARP-announced by Cilium L2. The announcement lease can be held by **any** linux node (the `l2-policy` selects all), while the single mosquitto pod is hostpath-pinned to **cr-talos-03**. Under `etp=Local`, if the lease lands on a node without the local endpoint (observed: lease on **cr-talos-02**, pod on **cr-talos-03**), external MQTT clients are **black-holed**. In-cluster clients (z2m/HA via ClusterIP) are unaffected.

`etp=Cluster` lets any lease-holder node forward to the pod (one extra hop). Source-IP preservation is immaterial here (`allow_anonymous true`).

## Context
First step of the **VLAN 68 (IoT-Trusted) migration** — must be fixed before external IoT devices (Shelly fleet, etc.) point at the broker, and de-risks the later move of the LB IP onto VLAN 68 (`10.32.68.25`).

## Risk
Low, single-line. No IP literals (CI identifier gate unaffected). Reversible by revert.