### PR TITLE
feat(network): move Home Assistant + zigbee2mqtt onto VLAN 68 (IoT-Trusted)

### DIFF
--- a/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
           [{
             "name": "iot",
             "namespace": "kube-system",
-            "ips": ["10.32.8.100/24"],
+            "ips": ["10.32.68.15/23"],
             "mac": "02:00:00:00:00:01"
           }]
       securityContext:

--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
           [{
             "name": "iot",
             "namespace": "kube-system",
-            "ips": ["10.32.8.102/24"],
+            "ips": ["10.32.68.20/23"],
             "mac": "02:00:00:00:00:02"
           }]
       securityContext:

--- a/kubernetes/apps/kube-system/multus/networks/iot.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/iot.yaml
@@ -12,7 +12,7 @@ spec:
       "plugins": [
         {
           "type": "macvlan",
-          "master": "enp1s0np0",
+          "master": "wan.68",
           "mode": "bridge",
           "ipam": {
             "type": "static"

--- a/talos/patches/global/machine-vlans.yaml
+++ b/talos/patches/global/machine-vlans.yaml
@@ -1,0 +1,17 @@
+---
+# Host-side tagged VLAN subinterfaces on the node uplink (wan / enp1s0np0).
+# Each is used as the macvlan `master` for a Multus NAD in
+# kubernetes/apps/kube-system/multus/networks/. Interfaces carry NO host IP —
+# pods get addresses from the NAD's static IPAM. The uplink ports (Eth1/9/1-3)
+# already trunk these VLANs on the core switch (network-ops Gate C).
+#
+# To add a VLAN: append another VLANConfig block below (name: wan.<id>,
+# vlanID: <id>) and add the matching NAD file under multus/networks/.
+#
+# VLAN 68 — IoT-Trusted (10.32.68.0/23): Home Assistant, zigbee2mqtt, mosquitto
+apiVersion: v1alpha1
+kind: VLANConfig
+name: wan.68
+vlanID: 68
+parent: wan
+mtu: 1500

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -170,6 +170,7 @@ patches:
   - "@./patches/global/machine-kernel.yaml"
   - "@./patches/global/machine-kubelet.yaml"
   - "@./patches/global/machine-network.yaml"
+  - "@./patches/global/machine-vlans.yaml"
   - "@./patches/global/machine-sysctls.yaml"
   - "@./patches/global/machine-time.yaml"
 


### PR DESCRIPTION
## What
Moves the smart-home stack onto **VLAN 68 (IoT-Trusted, 10.32.68.0/23)**.

- **Talos** — new `talos/patches/global/machine-vlans.yaml`: a tagged `wan.68` VLAN subinterface on each node's uplink (macvlan parent). **Already applied to all 3 nodes** out-of-band via `talosctl apply-config` (no reboot; etcd/nodes healthy throughout) — merging the files is the source-of-truth record. Structured as the single home for host VLAN interfaces (future VLAN = one more `VLANConfig` block).
- **Multus** — `iot` NAD macvlan `master: enp1s0np0 → wan.68`.
- **Workloads** — HA `10.32.8.100/24 → 10.32.68.15/23`, z2m `10.32.8.102/24 → 10.32.68.20/23` (MACs unchanged).

## Effect on merge
Flux reconciles the NAD + helmreleases → **HA and z2m pods restart onto VLAN 68**. They reach mosquitto via in-cluster DNS (unaffected) and the Zigbee coordinator at its legacy `10.32.8.151` via routing until network-ops Gate D moves it to `10.32.68.5`. 0 Zigbee devices paired today, so no re-pairing.

## Follow-ups (separate)
mosquitto LB IP → VLAN 68 (Cilium pool + L2 + `SVC_MOSQUITTO_ADDR`); then network-ops Gate D + repoint z2m coordinator; Gate E firewall last.

## Structure note
Follows onedr0p's pattern: macvlan on a host VLAN subinterface + per-network NAD files in `multus/networks/`.