### PR TITLE
feat(cilium): add VLAN 68 LoadBalancer IP pool block

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -8,6 +8,9 @@ spec:
   allowFirstLastIPs: "No"
   blocks:
     - cidr: "10.32.8.0/24"
+    # VLAN 68 (IoT-Trusted) LoadBalancer band — inside the static range (.2-.99),
+    # clear of the macvlan pods (.15 HA, .20 z2m). Usable .25-.30. mosquitto = .25.
+    - cidr: "10.32.68.24/29"
 ---
 # yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
 apiVersion: cilium.io/v2alpha1


### PR DESCRIPTION
Adds `10.32.68.24/29` (usable .25-.30) to the Cilium LB IP pool so LoadBalancer services can get VLAN-68 addresses. **Inert** until a service requests one — this just makes the pool available. Next step moves mosquitto's LB IP to `10.32.68.25` (via the `SVC_MOSQUITTO_ADDR` secret) so VLAN-68 devices reach the broker on-link (needed before the Gate E firewall lockdown). L2 policy already announces on all interfaces, so `.68.x` is ARP-answered on `wan.68`.