### PR TITLE
fix(mosquitto): VLAN 68 via macvlan instead of Cilium LB

### DIFF
--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -43,6 +43,18 @@ spec:
               globalMounts:
                 - path: /mosquitto/data
     defaultPodOptions:
+      annotations:
+        # macvlan on VLAN 68 (IoT-Trusted) so external VLAN-68 clients (Shellys)
+        # reach the broker on-link at 10.32.68.25 (${SVC_MOSQUITTO_ADDR}).
+        # In-cluster clients (HA/z2m) use the ClusterIP/DNS. Matches the
+        # HA (.15) / z2m (.20) macvlan pattern; broker = .25.
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": ["10.32.68.25/23"],
+            "mac": "02:00:00:00:00:03"
+          }]
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -54,10 +66,10 @@ spec:
     service:
       app:
         controller: mosquitto
-        type: LoadBalancer
-        annotations:
-          lbipam.cilium.io/ips: ${SVC_MOSQUITTO_ADDR}
-        externalTrafficPolicy: Cluster
+        # ClusterIP for in-cluster clients (mosquitto.home.svc.cluster.local).
+        # External VLAN-68 clients reach the broker via the pod's macvlan IP
+        # (10.32.68.25), configured in defaultPodOptions above.
+        type: ClusterIP
         ports:
           mqtt:
             port: 1883

--- a/kubernetes/apps/kube-system/cilium/app/networks.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/networks.yaml
@@ -8,9 +8,6 @@ spec:
   allowFirstLastIPs: "No"
   blocks:
     - cidr: "10.32.8.0/24"
-    # VLAN 68 (IoT-Trusted) LoadBalancer band — inside the static range (.2-.99),
-    # clear of the macvlan pods (.15 HA, .20 z2m). Usable .25-.30. mosquitto = .25.
-    - cidr: "10.32.68.24/29"
 ---
 # yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/cilium.io/ciliuml2announcementpolicy_v2alpha1.json
 apiVersion: cilium.io/v2alpha1


### PR DESCRIPTION
## Why
Moving mosquitto's Cilium LoadBalancer IP to `10.32.68.25` didn't make it reachable on VLAN 68: Cilium's L2 announcement only runs on interfaces matching its device filter (`enp+`), and the VLAN interface is `wan.68` — no match. Bringing the VLAN under Cilium (rename to `enp1s0np0.68` or widen `devices`) would also put the **HA/z2m macvlan parent** under Cilium's BPF (risky).

## Fix
Expose mosquitto exactly like HA/z2m already are — a **static macvlan IP on the `iot` NAD** (`10.32.68.25`, MAC `…:03`), Service back to **ClusterIP** for in-cluster clients. Cilium-independent, consistent with the other two. External VLAN-68 clients (Shellys) reach the broker on-link; `mosquitto.home.svc.cluster.local` unchanged for HA/z2m. Reverts the now-unused VLAN-68 LB pool block.

(onedr0p uses LB+BGP with a `bond+` device filter that covers his VLAN — a different architecture; macvlan is the right fit for this L2-announcement + macvlan repo.)