### PR TITLE
feat(chaski): HTML-formatted notification titles

### DIFF
--- a/kubernetes/apps/default/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/default/chaski/app/helmrelease.yaml
@@ -29,48 +29,52 @@ spec:
       routes:
         radarr-download:
           target: radarr
-          title: "Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
+          title: "<b>Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}</b>"
           message: |-
             {{ .payload.movie.title }} ({{ .payload.movie.year }})
             {{ .payload.movie.overview | ellipsis 300 }}
 
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
+            format: html
             priority: low
             url: "{{ .payload.applicationUrl }}/movie/{{ .payload.movie.tmdbId }}"
             url_title: View Movie
           whenExpr: payload.eventType == "Download"
         radarr-manual:
           target: radarr
-          title: Movie Requires Manual Interaction
+          title: <b>Movie Requires Manual Interaction</b>
           message: |-
             {{ .payload.movie.title }} ({{ .payload.movie.year }})
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
+            format: html
             priority: high
             url: "{{ .payload.applicationUrl }}/activity/queue"
             url_title: View Queue
           whenExpr: payload.eventType == "ManualInteractionRequired"
         sonarr-download:
           target: sonarr
-          title: "Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
+          title: "<b>Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}</b>"
           message: |-
             {{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})
             {{ (index .payload.episodes 0).title }}
 
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
+            format: html
             priority: low
             url: "{{ .payload.applicationUrl }}/series/{{ .payload.series.titleSlug }}"
             url_title: View Series
           whenExpr: payload.eventType == "Download"
         sonarr-manual:
           target: sonarr
-          title: Episode Requires Manual Interaction
+          title: <b>Episode Requires Manual Interaction</b>
           message: |-
             {{ .payload.series.title }}
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
+            format: html
             priority: high
             url: "{{ .payload.applicationUrl }}/activity/queue"
             url_title: View Queue


### PR DESCRIPTION
## What

Bold the notification titles (`<b>…</b>`) and add `params.format: html` to all
four radarr/sonarr chaski routes so Pushover renders the emphasis instead of
showing literal tags.

## Why

Mirrors onedr0p/home-ops [`0e262849e`](https://github.com/onedr0p/home-ops/commit/0e262849e),
picked up during the periodic upstream review. Our chaski route set is identical
(radarr/sonarr × download/manual), so it maps 1:1.

## Validation

- `kustomize build kubernetes/apps/default/chaski/app` renders clean; all four
  `format: html` params and bold titles present.
- Values-only change; no chart/behaviour change beyond the rendered notification.
- Whole-cluster flate render is currently blocked by the unrelated shelly-fleet
  private-GitRepo cascade, so validated via targeted kustomize build.