### PR TITLE
fix(ci): allowlist mosquitto helmrelease (multus static IP + MAC)

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -67,6 +67,7 @@ ALLOWLIST: dict[str, str] = {
     ".github/workflows/image-pull.yaml": "talosctl --nodes in CI",
     "kubernetes/apps/default/shlink/app/helmrelease.yaml": "RFC1918 blocks (DISABLE_TRACKING_FROM)",
     "kubernetes/apps/home/homeassistant/app/helmrelease.yaml": "trusted-proxy IP + multus MAC",
+    "kubernetes/apps/home/mosquitto/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/kube-system/cilium/app/networks.yaml": "LB IP pool / API host",
     "kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml": "etcd-defrag node targets",


### PR DESCRIPTION
## Problem

The VLAN 68 mosquitto macvlan work (#3432) added a static multus IP + MAC to
`kubernetes/apps/home/mosquitto/app/helmrelease.yaml` but **did not add the
matching allowlist entry** to the internal-identifier guard. The guard scans
*all* tracked files, so it now fails on **every** open PR (e.g. #3433, #3434) —
`main` is effectively CI-red.

## Fix

Add the file to `check_internal_identifiers.py`'s `ALLOWLIST` with reason
`multus static IP + MAC`, mirroring the sibling `zigbee2mqtt` and `homeassistant`
entries — the same accepted functional config (a macvlan on-link address must be
a literal IP). One line; guard passes locally (`exit 0`).

Chosen over scrubbing to `${SVC_MOSQUITTO_ADDR}` to stay consistent with the
proven z2m pattern and avoid any risk of Flux substitution misbehaving inside
the multus `k8s.v1.cni.cncf.io/networks` annotation on a live broker.