### PR TITLE
refactor(scaling): detach 9 apps from nfs-scaler ScaledObject (PR B1)

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/kustomization.yaml
@@ -2,21 +2,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./servicemonitor.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: qbittorrent
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name

--- a/kubernetes/apps/downloads/sabnzbd/app/kustomization.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/kustomization.yaml
@@ -2,8 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./configmap.yaml
   - ./externalsecret.yaml
@@ -11,14 +9,3 @@ resources:
   - ./helmrelease.yaml
   - ./servicemonitor.yaml
   - ./cleanup-cronjob.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: sabnzbd
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name

--- a/kubernetes/apps/media/bazarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/bazarr/app/kustomization.yaml
@@ -2,24 +2,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./servicemonitor.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: bazarr
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name
 configMapGenerator:
   - name: bazarr-scripts
     files:

--- a/kubernetes/apps/media/jellyfin/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyfin/app/kustomization.yaml
@@ -2,20 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: jellyfin
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name

--- a/kubernetes/apps/media/pinchflat/app/kustomization.yaml
+++ b/kubernetes/apps/media/pinchflat/app/kustomization.yaml
@@ -2,19 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: pinchflat
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -2,20 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: plex
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name

--- a/kubernetes/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/app/kustomization.yaml
@@ -2,22 +2,9 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
   - ./servicemonitor.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: radarr
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name

--- a/kubernetes/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/app/kustomization.yaml
@@ -2,25 +2,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
   - ./servicemonitor.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: sonarr
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name
 configMapGenerator:
   - name: sonarr-configmap
     files:

--- a/kubernetes/apps/media/wizarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/wizarr/app/kustomization.yaml
@@ -2,20 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization.json
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-components:
-  - ../../../../components/nfs-scaler
 resources:
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
-replacements:
-  - source:
-      kind: HelmRelease
-      name: wizarr
-      fieldPath: metadata.name
-    targets:
-      - select:
-          kind: ScaledObject
-        fieldPaths:
-          - metadata.name
-          - spec.scaleTargetRef.name


### PR DESCRIPTION
**PR B1 of the KEDA→zeroscaler migration.**

Removes the `nfs-scaler` KEDA component reference + its kustomize `replacements:` block from all 9 consumer apps, so Flux prunes the ScaledObjects **while KEDA is still running** (clean finalizer removal). No functional change — apps run at their HelmRelease replica count.

Apps: plex, jellyfin, sonarr, radarr, bazarr, pinchflat, wizarr (media); qbittorrent, sabnzbd (downloads).

Verified: flate renders 0 ScaledObjects for the changed apps.

Follow-ups (staged, APIService singleton): **B2** remove KEDA + nfs-scaler component + RBAC → **C** add prometheus-adapter → **D** add zeroscaler HPA component + convert apps + silence/recipe/docs.