### PR TITLE
feat(observability): add prometheus-adapter for external.metrics (PR C)

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -25,6 +25,7 @@ resources:
   - ./oxidized/ks.yaml
   - ./peanut/ks.yaml
   - ./plex-exporter/ks.yaml
+  - ./prometheus-adapter/ks.yaml
   - ./qbittorrent-exporter/ks.yaml
   - ./sabnzbd-dashboard/ks.yaml
   - ./scrutiny/ks.yaml

--- a/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app prometheus-adapter
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: prometheus-adapter
+  values:
+    fullnameOverride: *app
+    prometheus:
+      url: http://prometheus-operated.observability.svc.cluster.local
+      port: 9090
+    rules:
+      default: false
+      external:
+        - seriesQuery: '{__name__="probe_success"}'
+          resources:
+            namespaced: false
+          name:
+            as: probe_success
+          metricsQuery: max_over_time(<<.Series>>{<<.LabelMatchers>>}[3m])
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/kubernetes/apps/observability/prometheus-adapter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/prometheus-adapter/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: prometheus-adapter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.3.0
+  url: oci://ghcr.io/prometheus-community/charts/prometheus-adapter

--- a/kubernetes/apps/observability/prometheus-adapter/ks.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app prometheus-adapter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/prometheus-adapter/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
**PR C of the KEDA→zeroscaler migration.** Depends on #3437 (KEDA removed → external.metrics.k8s.io APIService released).

Adds `prometheus-adapter` (chart 5.3.0, prometheus-community OCI) in `observability`, serving `probe_success` on `external.metrics.k8s.io` with a **`max_over_time(...[3m])`** query — the debounce that fixes the blackbox-reschedule flap (KB 004).

Validated locally via `helm template`: renders the Deployment + the `v1beta1.external.metrics.k8s.io` APIService + the externalRules ConfigMap with the exact rule. (Local flate-build-hr is unusable here due to the known shelly-fleet missing-secret DAG cascade; Konflate renders it in-cluster.)

Next: **D** add zeroscaler HPA component + `nfs_probe` jobName + convert the 9 apps + silence/recipe/docs.