### PR TITLE
fix(talos): HPAScaleToZero on apiServer for zeroscaler HPAs

### DIFF
--- a/docs/docs/troubleshooting/kb/024-zeroscaler-nfs-hpa.md
+++ b/docs/docs/troubleshooting/kb/024-zeroscaler-nfs-hpa.md
@@ -28,11 +28,15 @@ The chain is:
 
 ## Gotchas
 
-- **`HPAScaleToZero` feature gate is required.** `minReplicas: 0` is silently clamped to 1 without
-  it. It is enabled on kube-controller-manager in
-  `talos/patches/controller/cluster.yaml`
-  (`cluster.controllerManager.extraArgs.feature-gates: HPAScaleToZero=true`). flate/CI pass either
-  way — this only surfaces as "apps never scale to zero" at runtime.
+- **`HPAScaleToZero` feature gate is required on BOTH the apiserver and the controller-manager.**
+  Set `feature-gates: HPAScaleToZero=true` under **both** `cluster.apiServer.extraArgs` and
+  `cluster.controllerManager.extraArgs` in `talos/patches/controller/cluster.yaml`. The apiserver
+  **validates** `minReplicas` — without the gate there it **rejects** the HPA at apply
+  (`spec.minReplicas: Invalid value: 0: must be greater than or equal to 1`), leaving the app's
+  Flux Kustomization `Ready=False`; the controller-manager does the actual scale-to-0. flate/CI
+  pass either way — it only surfaces when Flux applies the HPA. Changing either arg is a
+  control-plane change (rolling restart); regenerate with `just talos gen-config` and
+  `just talos apply-node` on each control-plane node.
 - **`external.metrics.k8s.io` is a cluster singleton.** Only one APIService can back it. KEDA's
   metrics server and `prometheus-adapter` both claim it, so they **cannot coexist** — this is why
   the migration removed KEDA before adding the adapter.

--- a/talos/patches/controller/cluster.yaml
+++ b/talos/patches/controller/cluster.yaml
@@ -7,6 +7,11 @@ cluster:
     extraArgs:
       # https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/
       enable-aggregator-routing: true
+      # Required here AND under controllerManager below for the zeroscaler HPAs to use
+      # minReplicas=0: the apiserver validates the field (rejects 0 without the gate), the
+      # controller-manager does the scaling. Control-plane change (rolling apiserver restart).
+      # See KB-024.
+      feature-gates: HPAScaleToZero=true
       # Public OIDC issuer so Entra (and other clouds) can federate the cluster's service-account
       # tokens — backs the sentinel-syslog workload identity (no secrets). Served as static OIDC
       # discovery + JWKS by the `network/oidc-talos` app at this exact URL. MUST match byte-for-byte:


### PR DESCRIPTION
The 9 zeroscaler HPAs from #3439 fail to apply (`spec.minReplicas: Invalid value: 0: must be greater than or equal to 1`) because `HPAScaleToZero` was set on `controllerManager` but **not** `apiServer` — and the apiserver validates `minReplicas`. Add it to `apiServer.extraArgs` too (matches onedr0p, which sets it in both). Correct KB-024 accordingly.

**Control-plane change:** rolling kube-apiserver restart via `just talos gen-config` + `just talos apply-node` on each CP node. No workload impact (apps already run at 1). After apply, the failing app kustomizations reconcile and the HPAs come up.