### PR TITLE
revert(chaski): drop HTML notification titles (Pushover renders them literally)

### DIFF
--- a/kubernetes/apps/default/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/default/chaski/app/helmrelease.yaml
@@ -29,52 +29,48 @@ spec:
       routes:
         radarr-download:
           target: radarr
-          title: "<b>Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}</b>"
+          title: "Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
             {{ .payload.movie.title }} ({{ .payload.movie.year }})
             {{ .payload.movie.overview | ellipsis 300 }}
 
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
-            format: html
             priority: low
             url: "{{ .payload.applicationUrl }}/movie/{{ .payload.movie.tmdbId }}"
             url_title: View Movie
           whenExpr: payload.eventType == "Download"
         radarr-manual:
           target: radarr
-          title: <b>Movie Requires Manual Interaction</b>
+          title: Movie Requires Manual Interaction
           message: |-
             {{ .payload.movie.title }} ({{ .payload.movie.year }})
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
-            format: html
             priority: high
             url: "{{ .payload.applicationUrl }}/activity/queue"
             url_title: View Queue
           whenExpr: payload.eventType == "ManualInteractionRequired"
         sonarr-download:
           target: sonarr
-          title: "<b>Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}</b>"
+          title: "Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
             {{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})
             {{ (index .payload.episodes 0).title }}
 
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
-            format: html
             priority: low
             url: "{{ .payload.applicationUrl }}/series/{{ .payload.series.titleSlug }}"
             url_title: View Series
           whenExpr: payload.eventType == "Download"
         sonarr-manual:
           target: sonarr
-          title: <b>Episode Requires Manual Interaction</b>
+          title: Episode Requires Manual Interaction
           message: |-
             {{ .payload.series.title }}
             Client: {{ .payload.downloadClient | default "unknown" }}
           params:
-            format: html
             priority: high
             url: "{{ .payload.applicationUrl }}/activity/queue"
             url_title: View Queue


### PR DESCRIPTION
## Why

PR #3433 added `<b>…</b>` to the chaski route **titles** plus `params.format: html`.
On device the titles render as **literal `<b>…</b>` text**.

Per [Pushover's docs](https://pushover.net/api#html): `html=1` applies to the
`message` body **only** — the **title is always plain text**. (Pushover also
strips HTML from the notification banner, showing it only when the message is
opened.) onedr0p's change targets a notifier that styles titles; our target is
Pushover, which doesn't — so the tags leak through as text.

## Fix

Revert to plain titles (restores the pre-#3433 known-good state). If we want
emphasis on Pushover later, it has to live in the **message body** (not the
title), and would need dynamic values HTML-escaped — but since Pushover only
shows it on message-open, it's marginal.

Reverts `5569165f9`.