### PR TITLE
feat(chaski): style notification bodies with HTML (bold title, small meta)

### DIFF
--- a/kubernetes/apps/default/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/default/chaski/app/helmrelease.yaml
@@ -31,11 +31,11 @@ spec:
           target: radarr
           title: "Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
-            {{ .payload.movie.title }} ({{ .payload.movie.year }})
-            {{ .payload.movie.overview | ellipsis 300 }}
-
-            Client: {{ .payload.downloadClient | default "unknown" }}
+            <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
+            <small>{{ .payload.movie.overview | ellipsis 300 }}</small>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
+            format: html
             priority: low
             url: "{{ .payload.applicationUrl }}/movie/{{ .payload.movie.tmdbId }}"
             url_title: View Movie
@@ -44,9 +44,10 @@ spec:
           target: radarr
           title: Movie Requires Manual Interaction
           message: |-
-            {{ .payload.movie.title }} ({{ .payload.movie.year }})
-            Client: {{ .payload.downloadClient | default "unknown" }}
+            <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
+            format: html
             priority: high
             url: "{{ .payload.applicationUrl }}/activity/queue"
             url_title: View Queue
@@ -55,11 +56,11 @@ spec:
           target: sonarr
           title: "Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
-            {{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})
-            {{ (index .payload.episodes 0).title }}
-
-            Client: {{ .payload.downloadClient | default "unknown" }}
+            <b>{{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})</b>
+            <small>{{ (index .payload.episodes 0).title }}</small>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
+            format: html
             priority: low
             url: "{{ .payload.applicationUrl }}/series/{{ .payload.series.titleSlug }}"
             url_title: View Series
@@ -68,9 +69,10 @@ spec:
           target: sonarr
           title: Episode Requires Manual Interaction
           message: |-
-            {{ .payload.series.title }}
-            Client: {{ .payload.downloadClient | default "unknown" }}
+            <b>{{ .payload.series.title }}</b>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
+            format: html
             priority: high
             url: "{{ .payload.applicationUrl }}/activity/queue"
             url_title: View Queue


### PR DESCRIPTION
## What

Re-introduce chaski HTML notification styling — this time **in the message body**, mirroring [onedr0p/home-ops](https://github.com/onedr0p/home-ops/blob/main/kubernetes/apps/default/chaski/app/helmrelease.yaml) exactly.

For all four radarr/sonarr routes:
- **Titles stay plain** (unchanged) — Pushover always renders the notification title as plain text.
- Added `params.format: html`.
- Wrapped message bodies: `<b>{{ title }} ({{ year }})</b>`, `<small>{{ overview }}</small>`, `<small><b>Client:</b> …</small>`.

## Why this is different from #3433 (reverted in #3441)

Pushover's `html=1` styles the **message body only** and shows it **on message-open** (the banner/lock-screen stays plain). The earlier attempt put `<b>` in the *title*, which Pushover ignores — so it rendered literal `<b>` tags and was reverted. This puts the HTML where Pushover actually renders it, matching what onedr0p runs in production.

## Notes

- No new template expressions — only literal `<b>`/`<small>` tags around the existing (already-working) `{{ .payload… }}` expressions, so no new render risk.
- Deliberately **not** adding `| html` escaping: onedr0p runs unescaped against Pushover with no issue (bare `&` renders fine), and it keeps us byte-aligned with a proven config.
- `kustomize build` of the app dir passes; lefthook (yamlfmt/prettier/yamllint) clean (`line-length` is warning-only, pre-existing).