### PR TITLE
fix(chaski): drop <small> tags (Pushover renders them literally)

### DIFF
--- a/kubernetes/apps/default/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/default/chaski/app/helmrelease.yaml
@@ -32,8 +32,8 @@ spec:
           title: "Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
             <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
-            <small>{{ .payload.movie.overview | ellipsis 300 }}</small>
-            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+            {{ .payload.movie.overview | ellipsis 300 }}
+            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
           params:
             format: html
             priority: low
@@ -45,7 +45,7 @@ spec:
           title: Movie Requires Manual Interaction
           message: |-
             <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
-            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
           params:
             format: html
             priority: high
@@ -57,8 +57,8 @@ spec:
           title: "Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
             <b>{{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})</b>
-            <small>{{ (index .payload.episodes 0).title }}</small>
-            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+            {{ (index .payload.episodes 0).title }}
+            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
           params:
             format: html
             priority: low
@@ -70,7 +70,7 @@ spec:
           title: Episode Requires Manual Interaction
           message: |-
             <b>{{ .payload.series.title }}</b>
-            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
+            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
           params:
             format: html
             priority: high


### PR DESCRIPTION
## Problem

Body styling from #3449 garbled the Pushover message description: `<small>` is **not** a Pushover-supported HTML tag, so it rendered as literal `<small>…</small>` text.

Pushover's `html=1` supports **only** `<b>`, `<i>`, `<u>`, `<font color>`, `<a href>` ([API docs](https://pushover.net/api#html)). onedr0p ships `<small>` too, but their notifier tolerates it; ours is `pover://` and does not.

## Fix

Drop `<small>` from all four routes; keep the Pushover-supported `<b>` (bold title line + bold **Client:** label). `format: html` stays for the `<b>` tags.

Result per notification: **bold title**, plain overview/episode line, **bold "Client:"** label + plain value — all Pushover-valid.

## Validation

- `kustomize build` of the app dir passes; lefthook clean.
- Will fire a live test through `POST /hooks/radarr-download` after merge/reconcile to confirm the render is clean this time.