### PR TITLE
fix(chaski): bump chart 0.2.0 → 0.2.5 (apprise input-format fix)

### DIFF
--- a/kubernetes/apps/default/chaski/app/ocirepository.yaml
+++ b/kubernetes/apps/default/chaski/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.0
+    tag: 0.2.5
   url: oci://ghcr.io/home-operations/charts/chaski


### PR DESCRIPTION
## Root cause (the real one)

The garbled Pushover bodies (`&lt;b&gt;Zootopia&nbsp;2&nbsp;(2025)&lt;/b&gt;<br/>…`) were **not** a config problem. Our deployed chaski is chart **0.2.0**, which predates:

- **#43 (0.2.3)** — `fix(sink): pass params format as the apprise input format` → calls `apprise.WithInputFormat(f)`. Without it, apprise-go's default **text** input format HTML-escapes the body when the target format is `html`, so `<b>` → `&lt;b&gt;`, spaces → `&nbsp;`, newlines → `<br/>` — all rendered literally.
- **#42 (0.2.3)** — `pushover format applies to the message only, never the title`.
- **apprise-go v0.2.7 (0.2.2)** — the `format` param support itself.

So the `<b>` body styling from #3449/#3451 was already correct — the running binary was just too old to honor `format: html`.

## Fix

Bump the OCIRepository chart tag **0.2.0 → 0.2.5** (highest 0.2.x). Gets the full fix and **avoids the 0.3.0 breaking change** (health moves to the main port, metrics port becomes optional) — so no HR/probe changes needed. HR doesn't override `image.tag`, so the chart appVersion bump moves the binary too.

## Validation

- `kustomize build` passes.
- **Konflate renders the actual 0.2.5 chart with our values** — holding merge on it (local flate is slow behind the shelly-fleet GitRepo cascade).
- Post-merge: reconcile, confirm pods roll onto the 0.2.5 image, fire a live test and verify the body renders **bold** (not `&lt;b&gt;`).

A later, deliberate 0.3.x bump (with the health-port change) can follow via Renovate.