### PR TITLE
observability(seedbox): tame SeedboxDown false pages (tailnet scrape flap)

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -8,12 +8,20 @@ spec:
   groups:
     - name: seedbox.rules
       rules:
+        # This keys on the node-exporter scrape, which traverses the tailnet egress.
+        # That path is DERP-relay-prone and flaps (~12% of the time at baseline,
+        # ~25% during the monthly RAID scrub) while the box is alive and seeding on
+        # its public IP — so up==0 means "not scrapeable over the tailnet", NOT
+        # necessarily "box down". Measured 7d gap distribution: 877 flap-episodes,
+        # 43 exceeded 5m but only 2 exceeded 20m; longest was 36m; none were real
+        # outages. for:20m (paired with scrapeTimeout:30s in scrapeconfig.yaml) rides
+        # out the path blips — a genuine box outage is continuous and still pages in 20m.
         - alert: SeedboxDown
           annotations:
-            summary: "Seedbox node-exporter is not being scraped — box or tailnet path down."
+            summary: "Seedbox node-exporter unscrapeable for 20m — box down OR tailnet scrape path degraded (check public IP / qBit before assuming the box is down)."
           expr: |-
             up{job="seedbox-node"} == 0
-          for: 5m
+          for: 20m
           labels:
             severity: critical
         # The box can be up while the exporter's egress path to the qBittorrent

--- a/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
@@ -11,6 +11,11 @@ spec:
         - seedbox.observability.svc.cluster.local:9100
   metricsPath: /metrics
   scrapeInterval: 60s
+  # The scrape path is the tailnet egress (DERP-relay-prone): scrapes average
+  # ~3.4s and, with the default 10s timeout, spike to the ceiling under torrent
+  # iowait → false up=0 flaps (~12% baseline, ~25% during the monthly RAID scrub).
+  # 30s (≤ interval) absorbs the slow-but-alive scrapes so they stop reading as down.
+  scrapeTimeout: 30s
   relabelings:
     - action: replace
       targetLabel: job
@@ -40,6 +45,7 @@ spec:
         - seedbox.observability.svc.cluster.local:8082
   metricsPath: /metrics
   scrapeInterval: 60s
+  scrapeTimeout: 30s # tailnet-egress scrapes are slow; 30s stops false up=0 (see node job)
   relabelings:
     - action: replace
       targetLabel: job
@@ -60,6 +66,7 @@ spec:
         - seedbox.observability.svc.cluster.local:9074
   metricsPath: /metrics
   scrapeInterval: 60s
+  scrapeTimeout: 30s # tailnet-egress scrapes are slow; 30s stops false up=0 (see node job)
   relabelings:
     - action: replace
       targetLabel: job
@@ -80,6 +87,7 @@ spec:
         - seedbox.observability.svc.cluster.local:9120
   metricsPath: /metrics
   scrapeInterval: 60s
+  scrapeTimeout: 30s # tailnet-egress scrapes are slow; 30s stops false up=0 (see node job)
   relabelings:
     - action: replace
       targetLabel: job


### PR DESCRIPTION
## Problem
Frequent **SeedboxDown (critical)** pages while the box is up and seeding fine on its public IP. Verified independently: public ping 0% loss @ 24 ms, and the cluster's own Prometheus shows \`up{job="seedbox-node"}=1\` at investigation time.

The alert keys on a single tailnet-scraped metric, so it conflates "box down" with "tailnet scrape path degraded."

## Evidence (7 days, from Prometheus)
- \`up{job=seedbox-node}\` == 0 for **18.5% of samples** across **877 flap-episodes**; all 5 seedbox jobs flap together → shared **tailnet egress path**, not any one exporter.
- **43 gaps exceeded 5m** → \`for: 5m\` fired SeedboxDown ~43×/week. Only **2 exceeded 20m**; longest was **36m**; none were real outages.
- Root cause: scrapeconfig had **no \`scrapeTimeout\` (default 10s)** while tailnet scrapes average **3.4s** and spike to the **10.009s** ceiling under RAID-scrub iowait → slow-but-alive scrapes counted as down.
- Per-day: ~12% baseline (pre-scrub) rising to ~26% during the monthly RAID scrub — chronic, not purely transient.

## Changes
- **scrapeconfig.yaml** — add \`scrapeTimeout: 30s\` to all 4 seedbox jobs (≤ 60s interval; avg scrape 3.4s) so slow scrapes stop reading as \`up==0\`.
- **prometheusrule.yaml** — \`SeedboxDown\` \`for: 5m → 20m\` (data: 43 gaps >5m, only 2 >20m) + annotation clarifying \`up==0\` means tailnet-path-or-box, check public IP/qBit first.

## Effect
Projected SeedboxDown firings **43 → ~2 per week**. A genuine box outage (continuous) still pages in 20m. No change to box behavior.

## Follow-up (not in this PR)
Cleanest long-term separation of "box down" vs "monitoring path down" is an independent liveness probe (blackbox-exporter TCP to the box's public IP). Deferred — would add a public-IP literal to this public repo; wanted a design decision first.