### PR TITLE
observability(seedbox): stop SeedboxQbittorrentExporterDown false pages

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/seedbox/app/helmrelease.yaml
@@ -24,7 +24,13 @@ spec:
               QBITTORRENT_BASE_URL: http://seedbox.observability.svc.cluster.local:8080
               QBITTORRENT_COOKIE_NAME: QBT_SID_8080
               EXPORTER_PORT: &port 9710
-              ENABLE_HIGH_CARDINALITY: "true"
+              # OFF (2026-07-08): high-cardinality adds only qbittorrent_torrent_info +
+              # qbittorrent_tracker_info — neither used by any dashboard — but forces a
+              # per-torrent tracker fetch across ~500 torrents that exceeds QBITTORRENT_TIMEOUT
+              # (30s) while the box's qBit API is slow under RAID-scrub iowait → the exporter
+              # logged "qBittorrent is timing out" every scrape, up=0, and exited (21 restarts),
+              # firing SeedboxQbittorrentExporterDown. Cheap query without it clears the timeouts.
+              ENABLE_HIGH_CARDINALITY: "false"
             envFrom:
               - secretRef:
                   name: seedbox-qbittorrent-exporter-secret

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -27,12 +27,17 @@ spec:
         # The box can be up while the exporter's egress path to the qBittorrent
         # WebUI is broken; the existing QbittorrentExporterDown alert keys on
         # instance="qbittorrent" so it does not cover this scrape.
+        # The in-cluster exporter reaches the box's qBit WebUI over the same tailnet
+        # egress, so up==0 also flaps when qBit's API is slow (RAID-scrub iowait) or the
+        # path blips — not only when the exporter is truly down. for:20m rides that out
+        # (matches SeedboxDown); high-cardinality is off (helmrelease.yaml) so the qBit
+        # query no longer times out.
         - alert: SeedboxQbittorrentExporterDown
           annotations:
-            summary: "Seedbox qBittorrent exporter scrape is failing — exporter or its egress path to the WebUI is down."
+            summary: "Seedbox qBittorrent exporter unscrapeable for 20m — exporter down, qBit API slow, or tailnet path to the WebUI degraded."
           expr: |-
             up{job="seedbox-qbittorrent"} == 0
-          for: 10m
+          for: 20m
           labels:
             severity: warning
         # Prometheus retention is 14d → a calendar-month sum is not computable.


### PR DESCRIPTION
## Problem
Recurring **SeedboxQbittorrentExporterDown (warning)** pages while the box is up and seeding. The `seedbox-qbittorrent-exporter` pod logs **"qBittorrent is timing out"** every scrape and has **restarted 21×** (exit 2); \`up{job="seedbox-qbittorrent"}=0\` and the alert is firing.

## Root cause
The exporter reaches the box's qBit WebUI over the tailnet egress with **`ENABLE_HIGH_CARDINALITY: true`**, which forces a **per-torrent tracker fetch across ~500 torrents**. That exceeds the exporter's **`QBITTORRENT_TIMEOUT` (30s)** while qBit's API is slow under the monthly RAID-scrub iowait → timeout → `up=0` (and the process exits → the 21 restarts).

Per the exporter docs, `ENABLE_HIGH_CARDINALITY` toggles only `qbittorrent_torrent_info` + `qbittorrent_tracker_info` — **neither is used by any dashboard** (verified: dashboards use `qbittorrent_torrent_states/seeders/leechers/ratio/*_speed_bytes` + `qbittorrent_global_*`, all exposed regardless).

## Changes
- **helmrelease.yaml** — `ENABLE_HIGH_CARDINALITY: "true" → "false"`. Drops the expensive tracker fetch (and two unused metrics); the remaining qBit query is cheap and completes well under 30s even under load.
- **prometheusrule.yaml** — `SeedboxQbittorrentExporterDown` `for: 10m → 20m` + clarified annotation (mirrors the SeedboxDown tailnet-scrape tuning in #3455).

## Effect
Exporter stops timing out / restarting; alert stops false-firing. Box behaviour unchanged. If a real exporter/qBit outage occurs it still pages, at 20m.