### PR TITLE
observability(seedbox): fix qbit-exporter crashloop (disable tracker fetch)

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/seedbox/app/helmrelease.yaml
@@ -24,21 +24,43 @@ spec:
               QBITTORRENT_BASE_URL: http://seedbox.observability.svc.cluster.local:8080
               QBITTORRENT_COOKIE_NAME: QBT_SID_8080
               EXPORTER_PORT: &port 9710
-              # OFF (2026-07-08): high-cardinality adds only qbittorrent_torrent_info +
-              # qbittorrent_tracker_info — neither used by any dashboard — but forces a
-              # per-torrent tracker fetch across ~500 torrents that exceeds QBITTORRENT_TIMEOUT
-              # (30s) while the box's qBit API is slow under RAID-scrub iowait → the exporter
-              # logged "qBittorrent is timing out" every scrape, up=0, and exited (21 restarts),
-              # firing SeedboxQbittorrentExporterDown. Cheap query without it clears the timeouts.
+              # 2026-07-08: the exporter did a PER-TORRENT tracker fetch (~500 qBit API calls,
+              # one per torrent). Under RAID-scrub iowait qBit is too slow to serve that, so the
+              # exporter blocked BEFORE opening :9710 → the (1s) liveness probe saw connection
+              # refused and killed it → crashloop, up=0, SeedboxQbittorrentExporterDown. Disabling
+              # the tracker features (no dashboard uses tracker metrics/labels) leaves one cheap
+              # bulk torrents/info call, so it binds and serves fast even while the box is busy.
+              ENABLE_TRACKER: "false"
+              ENABLE_LABEL_WITH_TRACKER: "false"
+              # high-cardinality (qbittorrent_torrent_info + qbittorrent_tracker_info) also unused.
               ENABLE_HIGH_CARDINALITY: "false"
             envFrom:
               - secretRef:
                   name: seedbox-qbittorrent-exporter-secret
+            # Default app-template probe (tcp :9710, timeout 1s, no delay, 3 failures) is too
+            # tight for this box: the exporter's startup qBit fetch can lag under torrent iowait,
+            # tripping liveness before it binds. Give it startup room so it isn't killed mid-fetch.
             probes:
               liveness:
                 enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 5
               readiness:
                 enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                  failureThreshold: 5
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Problem (follow-up to #3456)
Disabling `ENABLE_HIGH_CARDINALITY` (#3456) wasn't enough — the exporter still logged **"Features enabled: [Trackers]"** and kept **crashlooping** (`0/1`, restarts climbing). Probe events show `dial tcp :9710 connect: connection refused` → the exporter blocks on its startup qBit fetch and never opens its port, so the **1s liveness probe (no delay, 3 failures)** kills it at ~30s. `up=0`, alert firing.

## Root cause
`ENABLE_TRACKER` (default **true**, a *separate* flag from high-cardinality) drives a **per-torrent tracker fetch — ~500 qBit API calls, one per torrent**. Under the monthly RAID-scrub iowait, qBit is too slow to serve that in time, so the exporter blocks before binding `:9710`.

## Changes (helmrelease.yaml)
- `ENABLE_TRACKER: "false"` + `ENABLE_LABEL_WITH_TRACKER: "false"` — **no dashboard uses tracker metrics or a tracker label** (verified). Leaves one cheap bulk `torrents/info` call, so the exporter binds and serves fast even while the box is busy.
- Loosen liveness/readiness (custom: `initialDelaySeconds` 30/15, `timeoutSeconds` 5, `failureThreshold` 5) so a slow startup fetch under torrent iowait can't kill the pod. The default (1s / no delay / 3 failures) is too tight for this I/O-heavy host.

## Expected result
Exporter reaches Ready, stops restarting, `up=1`; `SeedboxQbittorrentExporterDown` (now `for: 20m` from #3456) stops firing. No dashboard panels lost.