### PR TITLE
observability(seedbox): true availability model (public-IP probe + tiered alerts)

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
+++ b/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
@@ -979,6 +979,124 @@
       ],
       "title": "qBittorrent up/down rate",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Overall availability. 'Box reachable' is the independent blackbox TCP probe to the public IP (true box-up, does not use the tailnet). 'Scrape path health' is the fraction of the 5 tailnet sensors up (seedbox:up:ratio). 'qBittorrent WebUI' is the qBit exporter scrape. Box reachable staying at 1 while the others dip = tailnet/qBit degradation, not an outage.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1.05,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 7
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "probe_success{job=\"seedbox-public\"}",
+          "legendFormat": "Box reachable (public IP)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "seedbox:up:ratio",
+          "legendFormat": "Scrape path health",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"seedbox-qbittorrent\"}",
+          "legendFormat": "qBittorrent WebUI",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Seedbox availability — box vs scrape path vs qBit",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/kubernetes/apps/observability/seedbox/app/kustomization.yaml
+++ b/kubernetes/apps/observability/seedbox/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./probe.yaml
   - ./prometheusrule.yaml
   - ./scrapeconfig.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/seedbox/app/probe.yaml
+++ b/kubernetes/apps/observability/seedbox/app/probe.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: seedbox-public
+spec:
+  # True box-liveness: TCP-connect to the seedbox's PUBLIC datacenter IP, which does
+  # NOT traverse the tailnet egress the metric scrapes use. So probe_success stays up
+  # when only the tailnet path is flaky (DERP-relay blips) and drops only when the box
+  # is genuinely unreachable — letting SeedboxDown mean "box down", not "scrape blip".
+  # Port 22 (SSH) is the target: it is reliably open, load-bearing, and firewalled to
+  # stay so. Public IP comes from cluster-secrets (${SECRET_SEEDBOX_PUBLIC_IP}) — never
+  # a literal in this public repo.
+  jobName: seedbox-public
+  interval: 1m
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter-lan.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - ${SECRET_SEEDBOX_PUBLIC_IP}:22
+  metricRelabelings:
+    - action: replace
+      replacement: seedbox
+      targetLabel: service

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -6,24 +6,46 @@ metadata:
   name: seedbox.rules
 spec:
   groups:
+    # Combined availability reading. seedbox:up:ratio = fraction of the 5 tailnet
+    # scrape sensors currently reachable (0..1). NB all 5 ride the same tailnet
+    # egress, so this measures MONITORING-PATH health, not true box-up — the
+    # independent public-IP blackbox probe (probe_success{job="seedbox-public"})
+    # is the box-up anchor. Dashboards graph both for the overall picture.
+    - name: seedbox.recording
+      rules:
+        - record: seedbox:up:ratio
+          expr: avg(up{instance="seedbox"})
     - name: seedbox.rules
       rules:
-        # This keys on the node-exporter scrape, which traverses the tailnet egress.
-        # That path is DERP-relay-prone and flaps (~12% of the time at baseline,
-        # ~25% during the monthly RAID scrub) while the box is alive and seeding on
-        # its public IP — so up==0 means "not scrapeable over the tailnet", NOT
-        # necessarily "box down". Measured 7d gap distribution: 877 flap-episodes,
-        # 43 exceeded 5m but only 2 exceeded 20m; longest was 36m; none were real
-        # outages. for:20m (paired with scrapeTimeout:30s in scrapeconfig.yaml) rides
-        # out the path blips — a genuine box outage is continuous and still pages in 20m.
+        # TRUE box-down: the blackbox TCP probe to the box's PUBLIC IP (probe.yaml),
+        # which does NOT traverse the tailnet. It stays up through DERP-relay scrape
+        # blips and drops only when the box is genuinely unreachable — so this finally
+        # means "box down", not "scrape path flapped" (the old up{seedbox-node}==0 keyed
+        # on the tailnet scrape and false-paged ~43x/week; that failure mode is now the
+        # SeedboxScrapePathDegraded warning below).
         - alert: SeedboxDown
           annotations:
-            summary: "Seedbox node-exporter unscrapeable for 20m — box down OR tailnet scrape path degraded (check public IP / qBit before assuming the box is down)."
+            summary: "Seedbox unreachable on its public IP for 5m — box is genuinely down (independent of the tailnet scrape path)."
           expr: |-
-            up{job="seedbox-node"} == 0
-          for: 20m
+            probe_success{job="seedbox-public"} == 0
+          for: 5m
           labels:
             severity: critical
+        # Box IS reachable on its public IP, but some/all tailnet metric scrapes are
+        # failing — a monitoring blind spot (DERP-relay flakiness / box I/O starving
+        # tailscaled), NOT an outage. This is what used to page as SeedboxDown; it is a
+        # warning now. `and on()` gates it on the box being up so it does not double-fire
+        # with SeedboxDown during a real outage.
+        - alert: SeedboxScrapePathDegraded
+          annotations:
+            summary: "Seedbox reachable on public IP but only {{ $value | humanizePercentage }} of tailnet scrapes are up for 20m — monitoring path degraded, not an outage."
+          expr: |-
+            (avg(up{instance="seedbox"}) < 1)
+            and on()
+            (probe_success{job="seedbox-public"} == 1)
+          for: 20m
+          labels:
+            severity: warning
         # The box can be up while the exporter's egress path to the qBittorrent
         # WebUI is broken; the existing QbittorrentExporterDown alert keys on
         # instance="qbittorrent" so it does not cover this scrape.

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -46,3 +46,8 @@ stringData:
   # in-cluster before the ExternalSecret overwrites it, so a routable value
   # here could be scraped silently. A dead one fails loudly instead.
   SEEDBOX_TAILNET_ADDR: "100.127.255.254"
+  # Public datacenter IP of the seedbox, probed by blackbox for true box-liveness
+  # (independent of the tailnet scrape path). Same fail-loud rationale: TEST-NET-1
+  # (RFC 5737) is unroutable, so if the ExternalSecret ever fails to overwrite it
+  # the probe hits a dead address rather than silently succeeding on a real host.
+  SEEDBOX_PUBLIC_IP: "192.0.2.1"


### PR DESCRIPTION
## Why
Every seedbox sensor scrapes over the same tailnet egress, so they flap together — `SeedboxDown` (keyed on the tailnet node scrape) couldn't tell "box down" from "tailnet blip" and false-paged ~43×/week. This adds the one signal that *can* tell them apart: an **independent probe to the box's public IP**.

## What
- **`probe.yaml`** — blackbox `tcp_connect` to `${SECRET_SEEDBOX_PUBLIC_IP}:22` (does NOT use the tailnet). Public IP comes from the `cluster-secrets` 1Password item via `dataFrom` — no literal in this public repo (mirrors `SEEDBOX_TAILNET_ADDR`). Verified a cluster pod reaches the box `:22` in ~49ms.
- **`cluster-secrets.yaml`** — `SEEDBOX_PUBLIC_IP` CI placeholder (TEST-NET-1, fail-loud).
- **`prometheusrule.yaml`**:
  - `seedbox:up:ratio` recording rule = `avg(up{instance="seedbox"})` — the **combined availability reading** (fraction of the 5 sensors up).
  - **`SeedboxDown`** retiered onto the public probe → `probe_success{job="seedbox-public"} == 0 for 5m` (true box-down, critical).
  - new **`SeedboxScrapePathDegraded`** (warning, 20m) — box reachable but scrapes flaky; `and on()`-gated by the probe so it can't double-fire with SeedboxDown.
- **`seedbox.json`** — "Seedbox availability" panel (box reachable / scrape-path health / qBit).

## Load monitoring
The dashboard already has a **Load / RAM** panel, so spike visibility is covered. Deliberately **no paging load alert** — the box runs `load15 ≈ 14` normally, so a load alert would just add noise (the opposite of the goal).

## Deploy order
The real `SEEDBOX_PUBLIC_IP` is added to the `cluster-secrets` 1Password item **before** this merges, so the probe resolves on first apply.