### PR TITLE
fix(seedbox): probe var reference (${SEEDBOX_PUBLIC_IP})

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/probe.yaml
+++ b/kubernetes/apps/observability/seedbox/app/probe.yaml
@@ -10,7 +10,7 @@ spec:
   # when only the tailnet path is flaky (DERP-relay blips) and drops only when the box
   # is genuinely unreachable — letting SeedboxDown mean "box down", not "scrape blip".
   # Port 22 (SSH) is the target: it is reliably open, load-bearing, and firewalled to
-  # stay so. Public IP comes from cluster-secrets (${SECRET_SEEDBOX_PUBLIC_IP}) — never
+  # stay so. Public IP comes from cluster-secrets (${SEEDBOX_PUBLIC_IP}) — never
   # a literal in this public repo.
   jobName: seedbox-public
   interval: 1m
@@ -20,7 +20,7 @@ spec:
   targets:
     staticConfig:
       static:
-        - ${SECRET_SEEDBOX_PUBLIC_IP}:22
+        - ${SEEDBOX_PUBLIC_IP}:22
   metricRelabelings:
     - action: replace
       replacement: seedbox


### PR DESCRIPTION
Follow-up to #3459. The blackbox probe referenced `${SECRET_SEEDBOX_PUBLIC_IP}` but the cluster-secrets key has no `SECRET_` prefix (matching its sibling `SEEDBOX_TAILNET_ADDR`, used in egress.yaml). It substituted to empty → probe target resolved to `:22`. Fixed to `${SEEDBOX_PUBLIC_IP}` so it resolves to the real public IP.