### PR TITLE
fix(certwarden): mount SA token so post-process kubectl can auth

### DIFF
--- a/kubernetes/apps/infrastructure/certwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/app/helmrelease.yaml
@@ -55,6 +55,11 @@ spec:
                 memory: 2Gi
               limits:
                 memory: 2Gi
+    defaultPodOptions:
+      # The device cert-deploy post-process scripts run kubectl in-pod (create Secret +
+      # spawn deploy Job) with the certwarden SA's RBAC. app-template disables the token
+      # automount by default, which strands kubectl on localhost:8080 — mount it back.
+      automountServiceAccountToken: true
     service:
       app:
         controller: certwarden

--- a/mise.lock
+++ b/mise.lock
@@ -360,23 +360,23 @@ url = "https://github.com/zizmorcore/zizmor/releases/download/v1.26.1/zizmor-aar
 provenance = "github-attestations"
 
 [[tools."github:home-operations/flate"]]
-version = "0.1.38"
+version = "0.4.10"
 backend = "github:home-operations/flate"
 
 [tools."github:home-operations/flate"."platforms.linux-arm64"]
-checksum = "sha256:5322bd561822d72a807ab350bc59492dce639837e872fc7bfffbd25b4f4ea1e2"
-url = "https://github.com/home-operations/flate/releases/download/0.1.38/flate_0.1.38_linux_arm64.tar.gz"
-url_api = "https://api.github.com/repos/home-operations/flate/releases/assets/435788809"
+checksum = "sha256:c2b1e8587b9a7fef53e3b16879e3b860f87797b5623916bfbf196c6aca79cae2"
+url = "https://github.com/home-operations/flate/releases/download/v0.4.10/flate_0.4.10_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/home-operations/flate/releases/assets/459865882"
 
 [tools."github:home-operations/flate"."platforms.linux-x64"]
-checksum = "sha256:036592af8650033f0273ddcd3290d4bf262fec9888183f26fccd2be3b383a911"
-url = "https://github.com/home-operations/flate/releases/download/0.1.38/flate_0.1.38_linux_amd64.tar.gz"
-url_api = "https://api.github.com/repos/home-operations/flate/releases/assets/435788810"
+checksum = "sha256:f76f67949ed55637658faf54c17dd04babefb3cc2e7cad1ddd6c4d2c58fa107b"
+url = "https://github.com/home-operations/flate/releases/download/v0.4.10/flate_0.4.10_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/home-operations/flate/releases/assets/459865881"
 
 [tools."github:home-operations/flate"."platforms.macos-arm64"]
-checksum = "sha256:b7c62c9339a263ddbf5ac0499509e4414576c8bc1eb76dcdd508c2a238dd1d3b"
-url = "https://github.com/home-operations/flate/releases/download/0.1.38/flate_0.1.38_darwin_arm64.tar.gz"
-url_api = "https://api.github.com/repos/home-operations/flate/releases/assets/435788811"
+checksum = "sha256:4e08cdf96c0812fba1eba50bc6357f1905b9d6eed2268a0ae0e168d206e741ba"
+url = "https://github.com/home-operations/flate/releases/download/v0.4.10/flate_0.4.10_darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/home-operations/flate/releases/assets/459865879"
 
 [[tools."github:home-operations/yayamlls"]]
 version = "0.1.10"


### PR DESCRIPTION
## Problem

The device cert-deploy post-process scripts run `kubectl` **inside the certwarden pod** (create the cert Secret + spawn the deploy Job) under the `certwarden` ServiceAccount's RBAC (`certwarden-supermicro-deployer` Role, in place since 2025-11). But app-template disables `automountServiceAccountToken` by default, so no token is mounted and kubectl falls back to `localhost:8080`:

```text
error: failed to create secret Post "http://localhost:8080/api/v1/namespaces/infrastructure/secrets...":
dial tcp [::1]:8080: connect: connection refused
```

**Why this was never seen before:** until #3413 the scripts were blanked by Flux postBuild substitution and exited at their env guard — the kubectl step was unreachable. The first real post-process since (re-issuing the node-07 IPMI cert for #2324) surfaced this immediately-next failure in the chain.

## Fix

`defaultPodOptions.automountServiceAccountToken: true` — same fix and comment rationale as oidc-talos.

Also bumps the stale `mise.lock` flate pin 0.1.38 → 0.4.10 to match what CI installs (separate commit).

## Validation

- `flate build hr certwarden -n infrastructure` (0.4.10): rendered Deployment pod spec carries `automountServiceAccountToken: true`
- RBAC already exists and is unchanged; this only mounts the token the scripts were always meant to use
- Post-merge: will re-run Post Process for the pending node-07 IPMI order and confirm the Supermicro deploy Job runs

Closes nothing by itself — #2324 closes once the re-issued cert actually deploys.
