### PR TITLE
docs: image verification page + talsecret-in-1Password section

### DIFF
--- a/docs/docs/architecture/image-verification.md
+++ b/docs/docs/architecture/image-verification.md
@@ -1,0 +1,78 @@
+# Image signature verification
+
+Every node cryptographically verifies Sidero-published container images at pull time using
+[Talos `ImageVerificationConfig`](https://www.talos.dev/latest/reference/configuration/security/imageverificationconfig/)
+with cosign keyless (sigstore) signatures. Live since 2026-07 (issue #2340, PR #3462); the config
+lives in `talos/patches/global/machine-image-verification.yaml` and is applied to all nodes as a
+global talconfig patch.
+
+## What is verified
+
+| Image pattern | OIDC issuer | Signing identity |
+| --- | --- | --- |
+| `ghcr.io/siderolabs/*` | `https://accounts.google.com` | regex: `@siderolabs.com` emails **or** `releasemgr-svc@talos-production.iam.gserviceaccount.com` |
+| `factory.talos.dev/*` | `https://accounts.google.com` | `image-factory-signing@talos-production.iam.gserviceaccount.com` |
+
+Rule semantics (Talos v1.13):
+
+- Rules are evaluated in order; **first matching rule applies**. Matching is on registry +
+  repository only, never tag or digest.
+- An image matching **no** rule is pulled unverified, exactly as before this config existed. There
+  are no `deny` rules, so this setup cannot block third-party images.
+- The `subjectRegex` on the `ghcr.io/siderolabs/*` rule keeps the legacy personal-email identities
+  as a fallback: images published before Sidero's cutover to service-account signing (including
+  some tags still referenced by older Talos versions) were signed by individual
+  `@siderolabs.com` engineers.
+
+## Design decisions
+
+- **Sidero-only scope.** Talos's verifier chokes on the newer OCI-referrers/bundle-tag signature
+  format (siderolabs/talos#13639), which registries like `quay.io/cilium` use. Sidero's own images
+  use the legacy `.sig`-tag scheme, which works. Third-party rules stay out until upstream settles.
+- **The factory boot path is the point.** The nodes boot from
+  `factory.talos.dev/installer-secureboot/<schematic>` (the schematic is pinned in
+  `talos/talconfig.yaml`). Since Talos v1.14 drops `ghcr.io/siderolabs/installer` from releases
+  entirely, the factory path is the sole installer route — its signing coverage is what makes this
+  config worthwhile.
+- **History.** A first attempt (PR #2315/#2337) was rolled back (#2339) in April 2026 because
+  Sidero then signed only three images, with rotating personal-email identities, and did not sign
+  the factory images at all. Issue #2340 tracked the revisit triggers; by 2026-07 all of them had
+  flipped (image-factory#417, talos#13178) and the config was re-landed in #3462.
+
+## Verifying / testing
+
+Check a signature manually (cosign is not in the mise toolchain; run it ad hoc):
+
+```bash
+mise exec "aqua:sigstore/cosign@latest" -- cosign verify \
+  --certificate-oidc-issuer=https://accounts.google.com \
+  --certificate-identity=image-factory-signing@talos-production.iam.gserviceaccount.com \
+  "factory.talos.dev/installer-secureboot/<schematic>:<talos-version>"
+```
+
+On-node pull-test matrix (run against any node with `talosctl image pull -n <node>`):
+
+| Test image | Expected |
+| --- | --- |
+| `ghcr.io/siderolabs/installer:<current-version>` | pulled — signature verifies |
+| `docker.io/library/busybox:<tag>` | pulled — no matching rule, unaffected |
+| `ghcr.io/siderolabs/installer:v1.0.0` | **rejected** — pre-dates signing, proves enforcement |
+
+The rejection looks like:
+
+```text
+image verification failed: no valid signature found: bundle tag not found
+legacy signature tag not found
+```
+
+## Operational notes
+
+- Applying the config is a **no-reboot** machine-config change (`just talos apply-node <ip>`;
+  `--dry-run` first shows the document diff and confirms no reboot).
+- If a Talos upgrade or image pull fails with `image verification failed`, see the
+  [upgrade troubleshooting page](../operations/talos-upgrades.md#image-verification-failures) —
+  diagnose whether Sidero's signing identity changed before suspecting anything else.
+- **Emergency bypass:** remove
+  `"@./patches/global/machine-image-verification.yaml"` from the `patches` list in
+  `talos/talconfig.yaml`, regenerate (`just talos gen-config`), and apply to the affected node.
+  Restore it once the upstream identity question is resolved.

--- a/docs/docs/architecture/secrets.md
+++ b/docs/docs/architecture/secrets.md
@@ -32,3 +32,28 @@ Secrets never live in Git. They flow:
   (`cr-*` / `sw-*`), MAC address, or internal hostname (`.lan` / `.internal`) outside a small
   allowlist of accepted functional configs. Device models are intentionally not enumerated in the
   script to avoid self-disclosure in this public repository.
+
+## Talos machine secrets (talsecret)
+
+The talhelper secrets bundle (cluster CA/PKI, etcd certs, bootstrap tokens) follows the same
+"1Password owns it" rule as everything else. There is **no SOPS anywhere in this repository** —
+the historical `talos/talsecret.sops.yaml` was removed in PR #3463 (2026-07) after the age key for
+it was lost; the encrypted blob left in git history is dead ciphertext.
+
+- The bundle is stored as the **`talsecret` document** in the `Talos` 1Password vault.
+- `just talos gen-config` fetches it (`op document get talsecret --vault Talos`) to a temp file,
+  runs `talhelper genconfig`, and cleans up. Node configs land in the gitignored
+  `talos/clusterconfig/`.
+- `just talos gen-secret` creates the 1Password document (from `talhelper gensecret`) only if it
+  does not already exist.
+- **Recovery without 1Password:** any previously generated node config contains the full secret
+  material, so the bundle can be reconstructed offline from the gitignored output of a prior run:
+
+  ```bash
+  talosctl gen secrets \
+    --from-controlplane-config talos/clusterconfig/kubernetes-<node>.yaml \
+    -o /tmp/talsecret.yaml --force
+  ```
+
+  This was how the bundle was recovered when the age key disappeared — regenerated configs were
+  verified byte-identical before the SOPS file was deleted.

--- a/docs/docs/operations/talos-upgrades.md
+++ b/docs/docs/operations/talos-upgrades.md
@@ -137,6 +137,40 @@ within a minor — v1.13.0 → v1.13.1 — don't need a talhelper update.)
 - Watch for a matching release at <https://github.com/budimanjojo/talhelper/releases>, then return
   to the normal `just talos gen-config` flow.
 
+### Image verification failures
+
+**Symptom:** an upgrade (or any image pull of a Sidero image) fails with:
+
+```text
+image verification failed: no valid signature found
+```
+
+Every node cosign-verifies `ghcr.io/siderolabs/*` and `factory.talos.dev/*` images at pull time —
+see [image verification](../architecture/image-verification.md) for the rules and identities.
+Upgrades pull the factory installer image through this check, so a verification failure blocks the
+upgrade before anything is written to disk.
+
+**Diagnosis order:**
+
+1. Verify the exact image manually and compare the signing identity against the rule:
+
+   ```bash
+   mise exec "aqua:sigstore/cosign@latest" -- cosign verify \
+     --certificate-oidc-issuer=https://accounts.google.com \
+     --certificate-identity=image-factory-signing@talos-production.iam.gserviceaccount.com \
+     "factory.talos.dev/installer-secureboot/<schematic>:<version>"
+   ```
+
+2. If cosign fails too, Sidero likely rotated its signing identity or changed signature format —
+   check recent `siderolabs/talos` and `siderolabs/image-factory` releases, update the identities
+   in `talos/patches/global/machine-image-verification.yaml`, regenerate and re-apply.
+3. If cosign succeeds but the node still rejects, suspect the Talos-side verifier (the
+   OCI-referrers format bug, siderolabs/talos#13639, is the known class of failure).
+
+**Emergency bypass:** drop the `machine-image-verification.yaml` line from the `patches` list in
+`talos/talconfig.yaml`, run `just talos gen-config`, apply to the affected node (no reboot), and
+restore it after the upgrade.
+
 ## Monitoring Upgrade Progress
 
 ```bash

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -33,6 +33,7 @@ nav = [
     { "Storage" = "architecture/storage.md" },
     { "Scaling" = "architecture/scaling.md" },
     { "Secrets" = "architecture/secrets.md" },
+    { "Image verification" = "architecture/image-verification.md" },
     { "AI / LLM stack" = "architecture/ai-llm-stack.md" },
   ] },
   { "Operations" = [


### PR DESCRIPTION
Documents this week's two Talos-side changes in the KB site:

- **New page: Architecture → Image verification** — the #3462 `ImageVerificationConfig` rollout: rules and signing identities, design decisions (Sidero-only scope, legacy-email `subjectRegex` fallback, why third-party registries are excluded per talos#13639), the on-node pull-test matrix (including the `installer:v1.0.0` pre-signing negative test), operational notes and emergency bypass.
- **secrets.md** — new "Talos machine secrets (talsecret)" section covering #3463: the bundle now lives as the `talsecret` document in the Talos 1Password vault, the op-backed `gen-config`/`gen-secret` flow, and the no-1Password recovery path (`talosctl gen secrets --from-controlplane-config` against the gitignored `clusterconfig/`).
- **talos-upgrades.md** — troubleshooting entry for `image verification failed` during upgrades: diagnosis order (manual cosign verify → upstream identity rotation → Talos-side verifier bug) and the bypass.
- Nav entry added in `zensical.toml`.

Validation: markdownlint-cli2 clean against the canonical `.markdownlint.yml`; `zensical build` succeeds; the cross-page anchor resolves in the built site.
