### PR TITLE
fix(bazarr): raise app memory limit 2Gi->3Gi (subtitle-sync spike OOM)

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -47,7 +47,11 @@ spec:
               requests:
                 cpu: 500m
               limits:
-                memory: 2Gi
+                # Baseline sits flat at ~390Mi; a subtitle-sync spike on large
+                # 4K files occasionally blows past the limit and OOM-kills
+                # (~2x/30d, self-heals). 1Gi->2Gi (#3383) cut the rate but a
+                # big-enough spike still breached; 3Gi buys more headroom.
+                memory: 3Gi
           subcleaner:
             image:
               repository: registry.k8s.io/git-sync/git-sync


### PR DESCRIPTION
Baseline sits flat at ~390Mi, but an occasional subtitle-sync spike on
large 4K files breaches the limit and OOM-kills the app container
(~2x/30d, self-heals). The 1Gi->2Gi bump in #3383 lowered the rate but a
big-enough spike still breached 2Gi; 3Gi buys more headroom. Peak is
unbounded (killed at the limit) so this reduces rather than eliminates.
