### PR TITLE
feat(observability): litellm alerts, toolhive telemetry, llama.cpp dashboard

### DIFF
--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/ai/litellm/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/app/prometheusrule.yaml
@@ -67,8 +67,8 @@ spec:
     # `self-hosted`. `up` is the per-target scrape health already produced by the
     # llmkube-models ServiceMonitor (service label = the InferenceService's
     # Service name, e.g. llama-nvidia / llama-uncensored). max by (service)
-    # collapses the ServiceMonitor + operator PodMonitor targets so it only fires
-    # when every scrape of a backend is unreachable. A long `for:` absorbs pod
+    # collapses multiple scrape endpoints of a backend so it only fires when
+    # every scrape of that backend is unreachable. A long `for:` absorbs pod
     # restarts and cold GGUF loads (the startup probe allows a lengthy first
     # load); a fully-scaled-to-zero pod drops its endpoint and would go stale
     # rather than up==0, which is out of scope for this cheap check.

--- a/kubernetes/apps/ai/litellm/app/prometheusrule.yaml
+++ b/kubernetes/apps/ai/litellm/app/prometheusrule.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: litellm
+spec:
+  groups:
+    # LiteLLM router health, built on the litellm_deployment_* counters the
+    # existing ServiceMonitor already scrapes at /metrics/. Thresholds are tuned
+    # down from a busier upstream for this single-replica, single-self-hosted-
+    # backend gateway: with one replica each increase() is the true event count
+    # (no cross-replica summing), so small counts are already meaningful.
+    #
+    # Note on absent(): the *_fallbacks_total series only materialise after the
+    # first fallback event (LiteLLM registers them lazily). increase()>N over an
+    # empty series simply yields nothing, so these alerts stay silent until a
+    # real fallback happens — no absent() liveness guard is added on them, since
+    # their absence is the healthy steady state, not a fault.
+    - name: litellm.rules
+      rules:
+        - alert: LiteLLMFallbackChainExhausted
+          expr: |-
+            sum by (requested_model, exception_status, exception_class) (
+              increase(litellm_deployment_failed_fallbacks_total[15m])
+            ) > 0
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.requested_model }} fallback chain exhausted — no working deployment
+              ({{ $labels.exception_status }} {{ $labels.exception_class }})
+          labels:
+            severity: critical
+        - alert: LiteLLMModelFailover
+          expr: |-
+            sum by (requested_model, fallback_model, exception_status, exception_class) (
+              increase(litellm_deployment_successful_fallbacks_total[10m])
+            ) > 2
+          for: 5m
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.requested_model }} failing over to {{ $labels.fallback_model }}
+              ({{ $labels.exception_status }} {{ $labels.exception_class }})
+          labels:
+            severity: warning
+        - alert: LiteLLMDeploymentOutage
+          expr: |-
+            max by (litellm_model_name) (litellm_deployment_state) >= 2
+          for: 10m
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.litellm_model_name }} out of rotation (deployment_state >= 2)
+          labels:
+            severity: warning
+        - alert: LiteLLMAuthOrQuotaFailures
+          expr: |-
+            sum by (litellm_model_name, exception_status) (
+              increase(litellm_deployment_failure_responses_total{exception_status=~"403|429"}[15m])
+            ) > 3
+          for: 5m
+          annotations:
+            summary: >-
+              LiteLLM {{ $labels.litellm_model_name }} returning {{ $labels.exception_status }}
+              (auth/quota — check the upstream key or plan cap)
+          labels:
+            severity: warning
+    # Direct backend-down signal for the llmkube InferenceServices that back
+    # `self-hosted`. `up` is the per-target scrape health already produced by the
+    # llmkube-models ServiceMonitor (service label = the InferenceService's
+    # Service name, e.g. llama-nvidia / llama-uncensored). max by (service)
+    # collapses the ServiceMonitor + operator PodMonitor targets so it only fires
+    # when every scrape of a backend is unreachable. A long `for:` absorbs pod
+    # restarts and cold GGUF loads (the startup probe allows a lengthy first
+    # load); a fully-scaled-to-zero pod drops its endpoint and would go stale
+    # rather than up==0, which is out of scope for this cheap check.
+    - name: llmkube.rules
+      rules:
+        - alert: InferenceServiceDown
+          expr: |-
+            max by (service) (up{service=~"llama-.+"}) == 0
+          for: 15m
+          annotations:
+            summary: >-
+              llmkube InferenceService {{ $labels.service }} is down — no llama.cpp scrape target
+              reachable (self-hosted routing degrades to the cloud fallback)
+          labels:
+            severity: critical

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -24,4 +24,8 @@ spec:
       enabled: false
     prometheus:
       inferencePodMonitor:
-        enabled: true
+        # Deliberately off: the hand-rolled llmkube-models ServiceMonitor (with
+        # targetLabels for per-backend dashboard filtering) is the single scrape
+        # path for the llama.cpp backends. Enabling this too would scrape every
+        # pod twice under a second job label and double llamacpp:* series.
+        enabled: false

--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -24,4 +24,4 @@ spec:
       enabled: false
     prometheus:
       inferencePodMonitor:
-        enabled: false
+        enabled: true

--- a/kubernetes/apps/ai/llmkube/models/grafanadashboard.yaml
+++ b/kubernetes/apps/ai/llmkube/models/grafanadashboard.yaml
@@ -1,0 +1,626 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: llama-server
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  # Ported from joryirving/home-ops llama-server.json. Every Grafana variable is
+  # escaped by doubling its leading `$` ($${datasource}, $$service, $$node,
+  # $$__range) so Flux postBuild passes the literal ${...}/$... through to Grafana
+  # instead of blanking it. Datasource variable resolves to the lowercase
+  # `prometheus` datasource (KB-021). The upstream "Prompt cache (from logs)"
+  # panels were dropped: they query a victoriametrics-logs-datasource that this
+  # cluster's Grafana does not have wired (only `prometheus`/`alertmanager`
+  # GrafanaDatasources exist).
+  json: |-
+    {
+      "id": null,
+      "panels": [
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+          "id": 1,
+          "panels": [],
+          "title": "Primary signals",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Highest observed prefill throughput in the current time window.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(max_over_time(llamacpp:prompt_tokens_seconds{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"}[1h]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Peak PP tok/s (1h)",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Current prefill speed, overlaid by service below.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+          "id": 3,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(max_over_time(llamacpp:prompt_tokens_seconds{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"}[$$__range]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "PP tok/s (peak)",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Current generation speed, overlaid by service below.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(max_over_time(llamacpp:predicted_tokens_seconds{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"}[$$__range]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "TG tok/s (peak)",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Highest observed generation throughput in the current time window.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(max_over_time(llamacpp:predicted_tokens_seconds{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"}[1h]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Peak TG tok/s (1h)",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Prefill speed overlaid for all selected services.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
+          "id": 6,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:prompt_tokens_total{service=~\"$$service\"}[5m]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "PP throughput by service (wall-clock avg)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Generation speed overlaid for all selected services.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
+          "id": 7,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:tokens_predicted_total{service=~\"$$service\"}[5m]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "TG throughput by service (wall-clock avg)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Active queue pressure. Processing is live work, deferred is backlog.",
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
+          "id": 8,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(llamacpp:requests_processing{service=~\"$$service\"})",
+              "legendFormat": "processing {{service}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(llamacpp:requests_deferred{service=~\"$$service\"})",
+              "legendFormat": "deferred {{service}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Inflight requests by service",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Used RAM overlaid with total RAM for the selected node, so the panel stays node-agnostic.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "showPoints": "never",
+                "spanNulls": false
+              },
+              "min": 0,
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {"id": "byRegexp", "options": "^used "},
+                "properties": [
+                  {"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}},
+                  {"id": "custom.lineWidth", "value": 3},
+                  {"id": "custom.fillOpacity", "value": 18},
+                  {"id": "custom.lineStyle", "value": {"fill": "solid"}}
+                ]
+              },
+              {
+                "matcher": {"id": "byRegexp", "options": "^total "},
+                "properties": [
+                  {"id": "color", "value": {"fixedColor": "gray", "mode": "fixed"}},
+                  {"id": "custom.lineWidth", "value": 2},
+                  {"id": "custom.fillOpacity", "value": 0},
+                  {"id": "custom.lineStyle", "value": {"dash": [10, 6], "fill": "dash"}}
+                ]
+              }
+            ]
+          },
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+          "id": 9,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "(node_memory_MemTotal_bytes{job=\"node-exporter\"} - node_memory_MemFree_bytes{job=\"node-exporter\"} - (node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"})) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "used {{nodename}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\"} * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "total {{nodename}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Host RAM used vs total (UMA)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Percent of real RAM in use on the selected node.",
+          "fieldConfig": {"defaults": {"unit": "percent"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 8, "x": 0, "y": 21},
+          "id": 10,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "100 * ((node_memory_MemTotal_bytes{job=\"node-exporter\"} - node_memory_MemFree_bytes{job=\"node-exporter\"} - (node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"})) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}) / clamp_min(((node_memory_MemTotal_bytes{job=\"node-exporter\"} - node_memory_MemFree_bytes{job=\"node-exporter\"} - (node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"})) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"} + (node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"}) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"} + node_memory_MemFree_bytes{job=\"node-exporter\"} * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}), 1)",
+              "legendFormat": "{{nodename}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Host RAM used %",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Cached, buffered, and reclaimable memory.",
+          "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 8, "x": 8, "y": 21},
+          "id": 11,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "(node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"}) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "{{nodename}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Host RAM cache/reclaimable",
+          "type": "stat"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Free RAM on the selected node.",
+          "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+          "gridPos": {"h": 4, "w": 8, "x": 16, "y": 21},
+          "id": 12,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "node_memory_MemFree_bytes{job=\"node-exporter\"} * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "{{nodename}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Host RAM free",
+          "type": "stat"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 25},
+          "id": 13,
+          "panels": [],
+          "title": "Secondary metrics",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Combined comparison view for prefill and generation speed.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 9, "w": 24, "x": 0, "y": 26},
+          "id": 14,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:prompt_tokens_total{service=~\"$$service\"}[5m]))",
+              "legendFormat": "PP {{service}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:tokens_predicted_total{service=~\"$$service\"}[5m]))",
+              "legendFormat": "TG {{service}}",
+              "refId": "B"
+            }
+          ],
+          "title": "PP vs TG throughput (wall-clock avg)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Latency view. Lower is better.",
+          "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 35},
+          "id": 15,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:prompt_seconds_total{service=~\"$$service\"}[5m])) / clamp_min(sum by (service)(rate(llamacpp:prompt_tokens_total{service=~\"$$service\"}[5m])), 0.001)",
+              "legendFormat": "PP {{service}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:tokens_predicted_seconds_total{service=~\"$$service\"}[5m])) / clamp_min(sum by (service)(rate(llamacpp:tokens_predicted_total{service=~\"$$service\"}[5m])), 0.001)",
+              "legendFormat": "TG {{service}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Prompt and generation seconds per token (5m)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Decoder loops per second and average busy slots per decode.",
+          "fieldConfig": {"defaults": {"unit": "none"}, "overrides": []},
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 35},
+          "id": 16,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "sum by (service)(rate(llamacpp:n_decode_total{service=~\"$$service\"}[5m]))",
+              "legendFormat": "decode/s {{service}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "avg by (service)(llamacpp:n_busy_slots_per_decode{service=~\"$$service\"})",
+              "legendFormat": "busy slots {{service}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Decode activity",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Stacked host memory view like Node Exporter: used + cache/reclaimable + free = total.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 85,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {"group": "A", "mode": "normal"}
+              },
+              "unit": "bytes"
+            },
+            "overrides": [
+              {
+                "matcher": {"id": "byRegexp", "options": "^used "},
+                "properties": [
+                  {"id": "color", "value": {"fixedColor": "green", "mode": "fixed"}},
+                  {"id": "custom.fillOpacity", "value": 85}
+                ]
+              },
+              {
+                "matcher": {"id": "byRegexp", "options": "^cache/reclaimable "},
+                "properties": [
+                  {"id": "color", "value": {"fixedColor": "yellow", "mode": "fixed"}},
+                  {"id": "custom.fillOpacity", "value": 75}
+                ]
+              },
+              {
+                "matcher": {"id": "byRegexp", "options": "^free "},
+                "properties": [
+                  {"id": "color", "value": {"fixedColor": "blue", "mode": "fixed"}},
+                  {"id": "custom.fillOpacity", "value": 65}
+                ]
+              }
+            ]
+          },
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 43},
+          "id": 17,
+          "options": {
+            "legend": {"displayMode": "table", "placement": "bottom", "showLegend": true},
+            "tooltip": {"mode": "multi", "sort": "desc"}
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "(node_memory_MemTotal_bytes{job=\"node-exporter\"} - node_memory_MemFree_bytes{job=\"node-exporter\"} - (node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"})) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "used {{nodename}}",
+              "refId": "A"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "(node_memory_Cached_bytes{job=\"node-exporter\"} + node_memory_Buffers_bytes{job=\"node-exporter\"} + node_memory_SReclaimable_bytes{job=\"node-exporter\"}) * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "cache/reclaimable {{nodename}}",
+              "refId": "B"
+            },
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "node_memory_MemFree_bytes{job=\"node-exporter\"} * on(instance) group_left(nodename) node_uname_info{job=\"node-exporter\", nodename=~\"$$node\"}",
+              "legendFormat": "free {{nodename}}",
+              "refId": "C"
+            }
+          ],
+          "title": "Host memory breakdown",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {"h": 1, "w": 24, "x": 0, "y": 51},
+          "id": 22,
+          "panels": [],
+          "title": "Model speed (per request) & context",
+          "type": "row"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Peak prefill speed (tok/s) per service over the selected window, from llama.cpp's per-request gauge — real model speed, not diluted by idle time.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 7, "w": 8, "x": 0, "y": 52},
+          "id": 23,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "showUnfilled": true
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(max_over_time(llamacpp:prompt_tokens_seconds{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"}[$$__range]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "PP speed by service (peak)",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Peak generation speed (tok/s) per service over the selected window — real model speed, not diluted by idle time.",
+          "fieldConfig": {"defaults": {"unit": "tok/s"}, "overrides": []},
+          "gridPos": {"h": 7, "w": 8, "x": 8, "y": 52},
+          "id": 24,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "showUnfilled": true
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(max_over_time(llamacpp:predicted_tokens_seconds{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"}[$$__range]))",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "TG speed by service (peak)",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+          "description": "Configured context window (n_tokens_max) per service. Note: a service that reports 0 has not advertised a max yet.",
+          "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+          "gridPos": {"h": 7, "w": 8, "x": 16, "y": 52},
+          "id": 25,
+          "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "showUnfilled": true
+          },
+          "targets": [
+            {
+              "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+              "expr": "max by (service)(llamacpp:n_tokens_max{service=~\"$$service\", service!~\"llama-embed|memini-embed|memini-rerank|memini-summary|toolhive-embed\"})",
+              "legendFormat": "{{service}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Context window by service",
+          "type": "bargauge"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 39,
+      "style": "dark",
+      "tags": ["llm", "llama.cpp", "pp", "tg"],
+      "templating": {
+        "list": [
+          {
+            "current": {"text": "prometheus", "value": "prometheus"},
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "datasource",
+            "query": "prometheus",
+            "type": "datasource"
+          },
+          {
+            "allValue": ".*",
+            "current": {"selected": true, "text": "All", "value": "$$__all"},
+            "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+            "definition": "label_values(llamacpp:prompt_tokens_total, service)",
+            "refresh": 1,
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "service",
+            "query": {
+              "query": "label_values(llamacpp:prompt_tokens_total, service)",
+              "refId": "StandardVariableQuery"
+            },
+            "sort": 1,
+            "type": "query"
+          },
+          {
+            "current": {},
+            "datasource": {"type": "prometheus", "uid": "$${datasource}"},
+            "definition": "label_values(node_uname_info{job=\"node-exporter\"}, nodename)",
+            "hide": 0,
+            "includeAll": false,
+            "multi": false,
+            "name": "node",
+            "query": {
+              "query": "label_values(node_uname_info{job=\"node-exporter\"}, nodename)",
+              "refId": "StandardVariableQuery"
+            },
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {"from": "now-1h", "to": "now"},
+      "title": "LLM / llama-server",
+      "uid": "llamserver",
+      "version": 12
+    }

--- a/kubernetes/apps/ai/llmkube/models/kustomization.yaml
+++ b/kubernetes/apps/ai/llmkube/models/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./grafanadashboard.yaml
   - ./priorityclass.yaml
   - ./servicemonitor.yaml
   - ./qwen3.6-35b-a3b.yaml

--- a/kubernetes/apps/ai/llmkube/models/servicemonitor.yaml
+++ b/kubernetes/apps/ai/llmkube/models/servicemonitor.yaml
@@ -12,6 +12,12 @@ spec:
   namespaceSelector:
     matchNames:
       - ai
+  # Copy the operator's per-InferenceService labels onto every series so the
+  # llama-server dashboard can filter per backend (app.kubernetes.io/instance is
+  # the InferenceService, e.g. llama-nvidia / llama-uncensored).
+  targetLabels:
+    - app.kubernetes.io/instance
+    - app.kubernetes.io/name
   endpoints:
     - port: http
       path: /metrics

--- a/kubernetes/apps/ai/toolhive/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/app/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./mcpgroup.yaml
+  - ./mcptelemetryconfig.yaml
+  - ./podmonitor.yaml

--- a/kubernetes/apps/ai/toolhive/app/mcptelemetryconfig.yaml
+++ b/kubernetes/apps/ai/toolhive/app/mcptelemetryconfig.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcptelemetryconfig_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPTelemetryConfig
+metadata:
+  name: prometheus
+spec:
+  prometheus:
+    enabled: true

--- a/kubernetes/apps/ai/toolhive/app/podmonitor.yaml
+++ b/kubernetes/apps/ai/toolhive/app/podmonitor.yaml
@@ -17,6 +17,10 @@ spec:
     matchNames:
       - ai
   podMetricsEndpoints:
-    - port: "8080"
+    # The ToolHive operator names the proxy container port `http` (not `8080`);
+    # prometheus-operator matches podMetricsEndpoints[].port by port NAME, so a
+    # numeric value here would resolve no target. /metrics is served on the same
+    # proxy port once telemetryConfigRef is set on each MCPServer.
+    - port: http
       path: /metrics
       interval: 15s

--- a/kubernetes/apps/ai/toolhive/app/podmonitor.yaml
+++ b/kubernetes/apps/ai/toolhive/app/podmonitor.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/podmonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: mcp-servers
+spec:
+  # Scrapes the ToolHive proxy pods (one Deployment per MCPServer: kubectl, flux,
+  # talos, github, grafana), which expose Prometheus metrics on the proxy port
+  # once the MCPTelemetryConfig above enables them. No `release:
+  # kube-prometheus-stack` label — this cluster's Prometheus selects monitors
+  # without it, so copying that selector would silently drop the target.
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mcpserver
+  namespaceSelector:
+    matchNames:
+      - ai
+  podMetricsEndpoints:
+    - port: "8080"
+      path: /metrics
+      interval: 15s

--- a/kubernetes/apps/ai/toolhive/mcp-servers/flux/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/flux/mcpserver.yaml
@@ -31,5 +31,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+  telemetryConfigRef:
+    name: prometheus
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/github/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/github/mcpserver.yaml
@@ -27,5 +27,7 @@ spec:
       memory: 128Mi
     limits:
       memory: 256Mi
+  telemetryConfigRef:
+    name: prometheus
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/grafana/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/grafana/mcpserver.yaml
@@ -30,5 +30,7 @@ spec:
       memory: 128Mi
     limits:
       memory: 256Mi
+  telemetryConfigRef:
+    name: prometheus
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/kubectl/mcpserver.yaml
@@ -34,5 +34,7 @@ spec:
               value: in-cluster
             - name: PYTHONUNBUFFERED
               value: "1"
+  telemetryConfigRef:
+    name: prometheus
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/talos/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/talos/mcpserver.yaml
@@ -8,6 +8,8 @@ spec:
   image: registry.erwanleboucher.dev/eleboucher/talos-mcp:0.0.2
   transport: streamable-http
   mcpPort: 8080
+  telemetryConfigRef:
+    name: prometheus
   groupRef:
     name: mcp-tools
   permissionProfile:


### PR DESCRIPTION
PR A of the [jory/home-ops adoption roadmap](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md).

## What

- **litellm PrometheusRule** — jory's four alerts (`LiteLLMFallbackChainExhausted` critical, `LiteLLMModelFailover`, `LiteLLMDeploymentOutage`, `LiteLLMAuthOrQuotaFailures`) ported onto the `litellm_deployment_*` series the existing ServiceMonitor already scrapes, thresholds tuned for a single replica. The lazily-registered `*_fallbacks_total` series are deliberately not `absent()`-guarded — their absence is the healthy state. Plus a direct `InferenceServiceDown` alert on `up{service=~"llama-.+"}` with a long `for:` to absorb cold GGUF loads.
- **ToolHive telemetry** — `MCPTelemetryConfig` (`prometheus.enabled: true`) + `telemetryConfigRef` opt-in on all five proxied MCPServers (the CR is inert without it — verified against the pinned toolhive-operator 0.30.0 CRDs), and a PodMonitor matching `app.kubernetes.io/name: mcpserver` on port name `http` (prometheus-operator matches by port *name*; the operator names the proxy port `http`).
- **llama.cpp serving dashboard** — jory's `llama-server.json` as a GrafanaDashboard (every Grafana var escaped `$${…}` so Flux substitution can't blank it; datasource template var defaults to lowercase `prometheus`, KB-021), plus `targetLabels` on the `llmkube-models` ServiceMonitor for per-backend filtering.

## Decisions

- `release: kube-prometheus-stack` selector labels dropped everywhere — this cluster's Prometheus selects monitors without them.
- llmkube's `prometheus.inferencePodMonitor` stays **off** (review finding): enabling it alongside the hand-rolled ServiceMonitor double-scrapes every backend pod under a second job label.

## Post-merge verification

- `promtool`-equivalent check: the `litellm` + `llmkube` rule groups appear in Prometheus (`/api/v1/rules`) — rules must be *loaded*, not just applied (KB lesson from the gatus alert).
- PodMonitor targets for the 5 MCP proxies appear once the operator rolls the proxies with telemetry args.
