### PR TITLE
feat(config): searxng hardening, litellm context-window fallbacks, add-app wording

### DIFF
--- a/.agents/skills/add-app/SKILL.md
+++ b/.agents/skills/add-app/SKILL.md
@@ -28,7 +28,7 @@ Scaffold a new application for this repository's **single-cluster** Flux layout.
 
 ### Step 1: Collect application details
 
-Use the **AskUserQuestion** tool to gather:
+Ask the user for the following (in Claude Code, use the **AskUserQuestion** tool):
 
 1. App name
 2. Namespace (existing dir under `kubernetes/apps/`, e.g. `default`, `media`, `downloads`, `observability`)

--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -2,9 +2,11 @@
 # NotIn — Kubernetes label-selector operator literal (cilium-policies/*)
 # adn   — part of adn.20765.psicdn.net (EdgeCast CDN host in smokeping Targets)
 # flate  — home-operations/flate, our flux-local replacement (CI workflows)
+# informations — "Self Informations", SearXNG's exact plugin display name (searxng
+#                enabled_plugins list); upstream's spelling, must stay verbatim
 # intoto — SLSA in-toto provenance paths in mise.lock (provenance.intoto.jsonl)
 # showin — Grafana annotation schema key `showIn` (vendored dashboard JSON)
-ignore-words-list = NotIn,adn,flate,intoto,showin
+ignore-words-list = NotIn,adn,flate,informations,intoto,showin
 # mise.lock is a generated lockfile (checksums/URLs); not prose. NB: super-linter
 # passes files explicitly with its own --skip, so the config `skip` below is
 # ignored in CI — `intoto` above is the load-bearing fix. Kept for local runs.

--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -99,6 +99,11 @@ data:
       # If the local model is cooling-down / unhealthy, spill to cloud.
       fallbacks:
         - self-hosted: ["openrouter/auto"]
+      # Prompts that overflow the 32k self-hosted context spill to the larger
+      # 64k self-hosted-uncensored model (YaRN-extended) instead of erroring.
+      # ContextWindowExceededError only — orthogonal to the health fallback above.
+      context_window_fallbacks:
+        - self-hosted: ["self-hosted-uncensored"]
 
     litellm_settings:
       success_callback: ["prometheus"]

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -74,6 +74,9 @@ spec:
           - path: /etc/searxng/settings.yml
             subPath: settings.yml
             readOnly: true
+          - path: /etc/searxng/limiter.toml
+            subPath: limiter.toml
+            readOnly: true
       tmp:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/default/searxng/app/kustomization.yaml
+++ b/kubernetes/apps/default/searxng/app/kustomization.yaml
@@ -10,5 +10,6 @@ configMapGenerator:
   - name: searxng-config
     files:
       - ./resources/settings.yml
+      - ./resources/limiter.toml
 generatorOptions:
   disableNameSuffixHash: true

--- a/kubernetes/apps/default/searxng/app/resources/limiter.toml
+++ b/kubernetes/apps/default/searxng/app/resources/limiter.toml
@@ -1,0 +1,31 @@
+# SearXNG bot-detection / limiter configuration.
+#
+# The limiter middleware itself stays off (server.limiter: false) because it
+# needs a Valkey/Redis backend this instance deliberately does not run. This
+# file ships the intended policy so the limiter is one flag away: pass_ip lets
+# our in-cluster automation callers (mcp-searxng, open-webui RAG) and LAN
+# clients through unthrottled if it is ever enabled.
+
+[real_ip]
+# Number of values to trust from X-Forwarded-For (one hop: Envoy Gateway).
+x_for = 1
+ipv4_prefix = 32
+ipv6_prefix = 48
+
+[botdetection.ip_limit]
+# Link-local networks are never rate-limited.
+filter_link_local = true
+# link_token needs the Valkey backend, so keep it off here.
+link_token = false
+
+[botdetection.ip_lists]
+block_ip = []
+
+# RFC1918 pass list. This cluster's pods, services, and LAN all live inside
+# 10.0.0.0/8, so that single block covers every internal caller. The 172.16/12
+# and 192.168/16 RFC1918 blocks are unused here and are intentionally omitted.
+pass_ip = [
+  '10.0.0.0/8', # RFC1918 private range in use by this cluster
+]
+
+pass_searxng_org = false

--- a/kubernetes/apps/default/searxng/app/resources/settings.yml
+++ b/kubernetes/apps/default/searxng/app/resources/settings.yml
@@ -1,3 +1,4 @@
+---
 use_default_settings: true
 general:
   instance_name: "SearXNG"
@@ -8,7 +9,12 @@ general:
   enable_metrics: false
 search:
   safe_search: 0
-  autocomplete: "google"
+  # autocomplete + favicon_resolver each fire one upstream request per keystroke
+  # and per result row. This instance is automation-driven (mcp-searxng,
+  # open-webui RAG), so those calls add no value and drive upstream captcha /
+  # rate-limits. Empty string disables both.
+  autocomplete: ""
+  favicon_resolver: ""
   default_lang: "en"
 server:
   secret_key: "${SEARXNG_SECRET_KEY}"
@@ -20,6 +26,25 @@ ui:
   default_theme: simple
   theme_args:
     simple_style: dark
+enabled_plugins:
+  - Basic Calculator
+  - Hash plugin
+  - Open Access DOI rewrite
+  - Self Informations
+  - Tracker URL remover
+  - Unit converter plugin
+hostnames:
+  # Boost canonical docs / reference sources so they outrank SEO spam.
+  high_priority:
+    - (.*)\/blog\/(.*)
+    - (.*\.)?wikipedia.org$
+    - (.*\.)?github.com$
+    - (.*\.)?reddit.com$
+    - (.*\.)?docker.com$
+    - (.*\.)?archlinux.org$
+    - (.*\.)?stackoverflow.com$
+    - (.*\.)?askubuntu.com$
+    - (.*\.)?superuser.com$
 engines:
   - name: bing
     disabled: true


### PR DESCRIPTION
PR B of the [jory/home-ops adoption roadmap](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md).

## What

- **SearXNG hardening** — `autocomplete`/`favicon_resolver` disabled (this instance is automation-driven via mcp-searxng + open-webui RAG; per-keystroke upstream calls only trip captchas/rate limits), jory's `enabled_plugins` set, hostname priority boosting for canonical docs sources, and a `limiter.toml` with an RFC1918 `pass_ip`. The limiter file is deliberately inert (`server.limiter: false` — no Valkey backend); it ships the policy so the limiter is one flag away. Skipped per the roadmap: Redis-backed limiter, `replicas: 2`, Brave engine.
- **litellm `context_window_fallbacks`** — prompts overflowing the 32k `self-hosted` context spill to the 64k YaRN-extended `self-hosted-uncensored` instead of erroring. Note the content implication: overflow prompts get answered by the abliterated model. `ContextWindowExceededError` only; orthogonal to the existing health fallback to `openrouter/auto`.
- **add-app SKILL.md** — `AskUserQuestion` reference reworded host-neutrally (named as the Claude Code example).
- `.codespellrc`: `informations` ignored — "Self Informations" is SearXNG's exact plugin name and must stay verbatim.

## Caveat

`hostnames.high_priority` may require SearXNG's Hostnames plugin to be active to take effect — carried verbatim from jory's known config; if inert it's harmless ranking sugar (cheap follow-up if we care).
