### PR TITLE
feat(ai): arr MCP server (sonarr/radarr/prowlarr) + consumer netpols

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -114,8 +114,8 @@ data:
       drop_params: true
       num_retries: 2
       request_timeout: 600
-      # Surfaces only the top-k relevant MCP tools per request (6 servers, ~110
-      # tools) using the all-minilm embedding model above.
+      # Surfaces only the top-k relevant MCP tools per request (7 servers) using
+      # the all-minilm embedding model above.
       mcp_semantic_tool_filter:
         enabled: true
         embedding_model: all-minilm
@@ -123,8 +123,8 @@ data:
         similarity_threshold: 0.3
 
     # MCP tools proxied to any LiteLLM client (ToolHive-managed endpoints, ai ns).
-    # ~110 tools across 6 servers — the semantic filter above trims each request
-    # to the top-k relevant tools.
+    # 7 servers — the semantic filter above trims each request to the top-k
+    # relevant tools.
     mcp_servers:
       kubectl:
         url: http://mcp-kubectl.ai.svc.cluster.local:8000/mcp
@@ -138,6 +138,10 @@ data:
         url: http://mcp-github-proxy.ai.svc.cluster.local:8080/mcp
       grafana:
         url: http://mcp-grafana-proxy.ai.svc.cluster.local:8080/mcp
+      # Sonarr/Radarr/Prowlarr tools (mcp-arr). stdio server behind ToolHive's
+      # streamable-http proxy, same as github/grafana above.
+      arr:
+        url: http://mcp-arr-proxy.ai.svc.cluster.local:8080/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/externalsecret.yaml
@@ -1,0 +1,57 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Reuses the EXISTING 1Password items the media/downloads *arr apps already read
+# (sonarr / radarr / prowlarr), extracting only each item's API-key property into
+# a dedicated ai-namespace Secret. No new 1Password items are created.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-sonarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      data:
+        SONARR_API_KEY: "{{ .SONARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: sonarr
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-radarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      data:
+        RADARR_API_KEY: "{{ .RADARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: radarr
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-prowlarr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      data:
+        PROWLARR_API_KEY: "{{ .PROWLARR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: prowlarr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/kustomization.yaml
@@ -3,10 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kubectl
-  - ./flux
-  - ./talos
-  - ./searxng
-  - ./github
-  - ./grafana
-  - ./arr-mcp
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: arr
+spec:
+  # Official multi-arch GHCR image for mcp-arr-server (github.com/aplaceforallmystuff/mcp-arr),
+  # digest-pinned. Runs `node dist/index.js` directly as non-root, so unlike the upstream npx
+  # recipe it needs no writable /tmp, HOME, or NPM_CONFIG_CACHE. Defaults to stdio transport.
+  image: ghcr.io/aplaceforallmystuff/mcp-arr:1.7.2@sha256:46f2356c2161a8561b6f5680429594cf34aaad0712d1a030f8d662b99556c415
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    # The server auto-detects which *arr services are configured and only exposes their tools.
+    - name: SONARR_URL
+      value: http://sonarr.media.svc.cluster.local
+    - name: RADARR_URL
+      value: http://radarr.media.svc.cluster.local
+    # Prowlarr's API Service is `prowlarr-app` (it runs behind a gluetun sidecar).
+    - name: PROWLARR_URL
+      value: http://prowlarr-app.downloads.svc.cluster.local
+  secrets:
+    - name: toolhive-sonarr
+      key: SONARR_API_KEY
+      targetEnvName: SONARR_API_KEY
+    - name: toolhive-radarr
+      key: RADARR_API_KEY
+      targetEnvName: RADARR_API_KEY
+    - name: toolhive-prowlarr
+      key: PROWLARR_API_KEY
+      targetEnvName: PROWLARR_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/downloads/netpol.yaml
+++ b/kubernetes/apps/downloads/netpol.yaml
@@ -15,3 +15,23 @@ spec:
             io.kubernetes.pod.namespace: media
     - fromEntities:
         - world
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-arr-mcp-from-ai
+spec:
+  # The `arr` ToolHive MCP server (ai namespace) queries Prowlarr over its API.
+  # Additive to the namespace-wide policy above (Cilium unions allows), scoped to
+  # the prowlarr endpoint and to the arr MCP pod as the source. Prowlarr runs
+  # behind a gluetun sidecar whose firewall already admits cluster ingress on :80.
+  description: "Allow the arr MCP server (ai) to reach prowlarr"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prowlarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            toolhive-name: arr

--- a/kubernetes/apps/media/netpol.yaml
+++ b/kubernetes/apps/media/netpol.yaml
@@ -15,3 +15,26 @@ spec:
             io.kubernetes.pod.namespace: downloads
     - fromEntities:
         - world
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-arr-mcp-from-ai
+spec:
+  # The `arr` ToolHive MCP server (ai namespace) queries Sonarr and Radarr over
+  # their APIs. Additive to the namespace-wide policy above (Cilium unions
+  # allows), scoped to the two arr endpoints and to the arr MCP pod as the source.
+  description: "Allow the arr MCP server (ai) to reach sonarr/radarr"
+  endpointSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - sonarr
+          - radarr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            toolhive-name: arr


### PR DESCRIPTION
PR C of the [jory/home-ops adoption roadmap](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md) — arr only (ha needs a user-created Home Assistant token; seerr is a possible follow-on).

## What

- **`arr` ToolHive MCPServer** wired to sonarr/radarr (media) and prowlarr (downloads). Image is `ghcr.io/aplaceforallmystuff/mcp-arr:1.7.2` **digest-pinned** (jory runs it via `npx` at runtime, which violates this repo's pinning convention — the containerised build of the same project was verified multi-arch via the registry API). stdio transport behind ToolHive's streamable-http proxy on :8080, same shape as github/grafana.
- **Secrets** — a new ai-namespace ExternalSecret per app extracting the API-key property from the *existing* 1Password items (`sonarr`/`radarr`/`prowlarr`); property names verified against the apps' own ExternalSecrets. No new 1Password items.
- **CiliumNetworkPolicies** on `media` and `downloads` (the hidden prerequisite from the roadmap's finding 2): ingress scoped to endpoint `app.kubernetes.io/name in (sonarr,radarr)` / `prowlarr`, from source `{io.kubernetes.pod.namespace: ai, toolhive-name: arr}` — labels verified against live ToolHive proxy pods. Additive to the existing namespace policies (Cilium unions allows).
- **litellm registration** — `arr` added to `mcp_servers` (`http://mcp-arr-proxy.ai.svc.cluster.local:8080/mcp`).

## Watch item

litellm's `mcp_semantic_tool_filter` (top_k 8, similarity_threshold 0.3) now ranks a 7th server's tools; if arr tools crowd out or get crowded out, retune top_k/threshold.

Service targets verified live: `sonarr.media`/`radarr.media`/`prowlarr-app.downloads` all on :80 (prowlarr's API service is `prowlarr-app` behind the gluetun sidecar).
