### PR TITLE
feat(rook-ceph): enable CephFS (csi driver + filesystem + RWX StorageClass)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -104,17 +104,69 @@ spec:
       name: csi-ceph-blockpool
       isDefault: false
       deletionPolicy: Delete
-    # NOTE: After disabling the filesystem, the filesystem can be removed with the following commands:
+    # CephFS provides the cluster's RWX StorageClass (ceph-filesystem). The kernel
+    # CephFS client is built into the Talos v1.13.5+ kernel (CONFIG_CEPH_FS=y);
+    # the earlier "Talos ships no `ceph` kernel module" claim was a modprobe-vs-
+    # builtin misdiagnosis — see KB-025
+    # (docs/docs/troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md).
+    # The cephfs CSI driver must also be enabled in the ceph-csi-drivers
+    # HelmRelease (msgr2 kernel mount options live there).
+    # To tear the filesystem back down:
     # ceph fs fail ceph-filesystem && ceph fs rm ceph-filesystem --yes-i-really-mean-it
-    # CephFS is unused on this cluster: Talos ships no `ceph` kernel module, so
-    # CephFS can't be kernel-mounted (the llmkube model cache uses RWO ceph-block
-    # instead). Kept empty/disabled. To re-enable you also need the cephfs CSI
-    # driver (csi-drivers helmrelease) + a FUSE mounter or a ceph-module image.
-    cephFileSystems: []
-    # cephFileSystemVolumeSnapshotClass:
-    #   enabled: true
-    #   name: csi-ceph-filesystem
-    #   isDefault: false
-    #   deletionPolicy: Delete
+    cephFileSystems:
+      - name: &cephFilesystemName ceph-filesystem
+        spec:
+          # Distinct metadata + data0 pools, both replicated x3 across hosts.
+          metadataPool:
+            failureDomain: host
+            replicated:
+              size: 3
+          dataPools:
+            - name: data0
+              failureDomain: host
+              replicated:
+                size: 3
+          metadataServer:
+            activeCount: 1
+            activeStandby: true
+            priorityClassName: system-cluster-critical
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+            # Keep the active + standby MDS on separate nodes so a single node
+            # loss can't take out both.
+            placement:
+              topologySpreadConstraints:
+                - maxSkew: 1
+                  topologyKey: kubernetes.io/hostname
+                  whenUnsatisfiable: DoNotSchedule
+                  labelSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: ceph-mds
+                      app.kubernetes.io/part-of: *cephFilesystemName
+        storageClass:
+          enabled: true
+          name: ceph-filesystem
+          isDefault: false
+          pool: data0
+          reclaimPolicy: Delete
+          allowVolumeExpansion: true
+          volumeBindingMode: Immediate
+          parameters:
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+            csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/fstype: ext4
+    cephFileSystemVolumeSnapshotClass:
+      enabled: true
+      name: csi-ceph-filesystem
+      isDefault: false
+      deletionPolicy: Delete
     # Object storage (RGW) removed — migrated to Garage (storage/garage).
     cephObjectStores: []

--- a/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml
@@ -11,9 +11,15 @@ spec:
     name: ceph-csi-drivers
   values:
     # Rook v1.20 split CSI driver deployment out of the operator chart into the
-    # ceph-csi-operator-managed ceph-csi-drivers chart. RBD (ceph-block) only;
-    # CephFS/NFS/NVMeoF disabled (Talos has no `ceph` kernel module, so CephFS
-    # can't be kernel-mounted — llmkube uses RWO ceph-block instead).
+    # ceph-csi-operator-managed ceph-csi-drivers chart. RBD (ceph-block) and
+    # CephFS (ceph-filesystem, the cluster's RWX StorageClass) are enabled;
+    # NFS/NVMeoF disabled.
+    # The earlier "Talos has no `ceph` kernel module, so CephFS can't be
+    # kernel-mounted" note was a misdiagnosis — see KB-025
+    # (docs/docs/troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md):
+    # CONFIG_CEPH_FS=y is built into the Talos v1.13.5+ kernel, so `modprobe ceph`
+    # reports "module not found" even though the in-kernel CephFS client is
+    # present. It mounts natively — no FUSE mounter or ceph-module image needed.
     drivers:
       rbd:
         enabled: true
@@ -30,7 +36,25 @@ spec:
         # it for every *-nfs/-r2 ReplicationSource.
         snapshotPolicy: volumeSnapshot
       cephfs:
-        enabled: false
+        enabled: true
+        # Same operator-namespace prefix requirement as RBD above: the chart
+        # defaults the CephFS driver to the unprefixed "cephfs.csi.ceph.com",
+        # but the rook-ceph-cluster chart names the ceph-filesystem SC
+        # provisioner {operatorNamespace}.cephfs.csi.ceph.com, so PVCs only bind
+        # if the Driver name matches.
+        name: rook-ceph.cephfs.csi.ceph.com
+        # Mirror the RBD snapshotter: deploy the csi-snapshotter sidecar so the
+        # csi-ceph-filesystem VolumeSnapshotClass and VolSync copyMethod:
+        # Snapshot movers have a working CreateSnapshot path.
+        snapshotPolicy: volumeSnapshot
+        # msgr2-only cluster (cephClusterSpec.network.connections.requireMsgr2:
+        # true). The in-kernel CephFS client must negotiate msgr2 or it falls
+        # back to the v1 wire protocol the mons no longer accept and the mount
+        # hangs. prefer-crc = msgr2 with CRC32c integrity (not full encryption).
+        # NB: kernelMountOptions is a map (csi.ceph.io/v1 Driver spec), not the
+        # "key=value" string the legacy rook operator config used.
+        kernelMountOptions:
+          ms_mode: prefer-crc
       nfs:
         enabled: false
       nvmeof:


### PR DESCRIPTION
PR D of the [jory/home-ops adoption roadmap](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md) — values-only CephFS enablement; the in-use `ceph-blockpool`/`ceph-block` StorageClass is untouched.

## What

- **csi-drivers HR**: `drivers.cephfs.enabled: true`, driver named `rook-ceph.cephfs.csi.ceph.com` (must match the SC provisioner), snapshotter mirrored from RBD (`snapshotPolicy: volumeSnapshot`), and `kernelMountOptions: {ms_mode: prefer-crc}` — this cluster is msgr2-only (`requireMsgr2: true`), and the in-kernel client needs `ms_mode` to negotiate it.
- **cluster HR**: `ceph-filesystem` CephFilesystem (distinct metadata + `data0` pools, replicated ×3, `failureDomain: host`), MDS `activeCount: 1` + `activeStandby: true` with a topology spread keeping active+standby on separate nodes, resources 100m/1Gi req + 4Gi limit, the `ceph-filesystem` StorageClass, and the `csi-ceph-filesystem` VolumeSnapshotClass.
- Stale "Talos ships no ceph kernel module" comments rewritten per [KB-025](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md) — `CONFIG_CEPH_FS=y` is built into the Talos kernel; the June 2026 diagnosis was a modprobe-vs-builtin trap.

## Render-verified (helm template with these exact values)

- Driver CR carries `cephFsClientType: kernel` + `kernelMountOptions: {ms_mode: prefer-crc}` (not silently pruned).
- StorageClass provisioner `rook-ceph.cephfs.csi.ceph.com` == Driver name; pool `ceph-filesystem-data0`; secrets templated into `rook-ceph`.

## Post-merge gate (blocks PR G)

MDS pods Ready → `ceph -s` HEALTH_OK → throwaway RWX PVC mounted read-write by two pods on different nodes. The June attempt failed at a layer never pinned down; this smoke test is the insurance before the llmkube model cache moves onto CephFS.
