### PR TITLE
feat(ai): hermes agent (NousResearch hermes-agent) — gateway + dashboard baseline

### DIFF
--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/configmap.json
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-config
+  namespace: ai
+data:
+  # NOTE: `$${VAR}` is intentional. Flux postBuild collapses it to a literal
+  # `${VAR}`, which Hermes' own config loader (_expand_env_vars) then resolves
+  # against the pod environment (populated by envFrom the `hermes` Secret) at
+  # startup. A single `${VAR}` would be consumed — and blanked — by Flux first.
+  config.yaml: |-
+    model:
+      default: self-hosted
+      provider: litellm
+    providers:
+      # LiteLLM's OpenAI-compatible surface. `self-hosted` is the local
+      # llama.cpp model group; LiteLLM handles its own cloud fallback.
+      litellm:
+        base_url: http://litellm.ai.svc.cluster.local:4000/v1
+        api_key: $${LITELLM_MASTER_KEY}
+    terminal:
+      backend: local
+      cwd: /opt/data/workspace
+      timeout: 180
+      persistent_shell: true
+    memory:
+      provider: memini
+    approvals:
+      # manual: every flagged terminal command is queued for approval. Hermes
+      # has a terminal + cluster-adjacent MCP tools, so the Pod is the only
+      # trust boundary — no unattended actions.
+      mode: manual
+    security:
+      redact_secrets: true
+    privacy:
+      redact_pii: true
+    mcp_servers:
+      # Wired directly to each ToolHive MCP proxy Service (same namespace), not
+      # the LiteLLM /mcp aggregate. All read-only.
+      kubectl:
+        url: http://mcp-kubectl.ai.svc.cluster.local:8000/mcp
+      flux:
+        url: http://mcp-flux.ai.svc.cluster.local:8000/mcp
+      talos:
+        url: http://mcp-talos-mcp.ai.svc.cluster.local:8080/mcp
+      searxng:
+        url: http://mcp-searxng.ai.svc.cluster.local:3000/mcp
+      github:
+        url: http://mcp-github-proxy.ai.svc.cluster.local:8080/mcp
+      grafana:
+        url: http://mcp-grafana-proxy.ai.svc.cluster.local:8080/mcp

--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -1,5 +1,5 @@
 ---
-# yaml-language-server: $schema=https://json.schemastore.org/configmap.json
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/configmap.json
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes
+    template:
+      engineVersion: v2
+      data:
+        # Gateway → LiteLLM (reuses the shared master key, open-webui precedent).
+        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        # Gateway → memini memory backend (bearer token).
+        MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
+        # Dashboard basic-auth (bound on 0.0.0.0, so auth is enforced). The
+        # session secret must persist across restarts or every rollout logs
+        # users out.
+        HERMES_DASHBOARD_BASIC_AUTH_USERNAME: "{{ .username }}"
+        HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .password }}"
+        HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .session_secret }}"
+  dataFrom:
+    - extract:
+        key: litellm
+    - extract:
+        key: memini
+    - extract:
+        key: hermes-agent

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -16,7 +16,7 @@ spec:
         # must be group-writable by GID 10000 (not the usual 1000).
         fsGroup: 10000
         fsGroupChangePolicy: OnRootMismatch
-        seccompProfile: {type: RuntimeDefault}
+        seccompProfile: { type: RuntimeDefault }
     controllers:
       hermes:
         annotations:
@@ -99,8 +99,11 @@ spec:
               limits:
                 memory: 1Gi
             ports:
+              # Named `dashboard`, not `http`: container port names must be
+              # unique across every container in a pod, and the app container
+              # already claims `http`.
               - containerPort: &dashboard_port 9119
-                name: http
+                name: dashboard
                 protocol: TCP
     service:
       app:

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: hermes
+  values:
+    defaultPodOptions:
+      securityContext:
+        # Image bakes `useradd -u 10000 hermes` with HOME=/opt/data, so the PVC
+        # must be group-writable by GID 10000 (not the usual 1000).
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+    controllers:
+      hermes:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init:
+            image:
+              repository: docker.io/library/alpine
+              tag: 3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+            command:
+              - sh
+              - -c
+              - |
+                set -euo pipefail
+                cp /tmp/config.yaml /opt/data/config.yaml
+                chown 10000:10000 /opt/data/config.yaml
+                # Install the memini memory-provider plugin from the upstream
+                # standalone mirror eleboucher/memini-hermes (a release-synced
+                # copy of integrations/hermes/plugin/memini). Pinned to a
+                # commit, guarded by a .ref marker so normal restarts stay
+                # offline and it only refetches when the pin changes. The mirror
+                # is untagged, so bump this SHA by hand (verify the new commit
+                # and diff the two files before bumping).
+                MEMINI_PLUGIN_REF=c36842f6e2fa4a5e89f689d78d6d2daa2bf73219
+                PLUGIN_DIR=/opt/data/plugins/memini
+                if [ "$(cat "$PLUGIN_DIR/.ref" 2>/dev/null)" != "$MEMINI_PLUGIN_REF" ]; then
+                  BASE="https://raw.githubusercontent.com/eleboucher/memini-hermes/$MEMINI_PLUGIN_REF"
+                  if wget -qO /tmp/memini-init.py "$BASE/__init__.py" && wget -qO /tmp/memini-plugin.yaml "$BASE/plugin.yaml"; then
+                    rm -rf "$PLUGIN_DIR"
+                    mkdir -p "$PLUGIN_DIR"
+                    mv /tmp/memini-init.py "$PLUGIN_DIR/__init__.py"
+                    mv /tmp/memini-plugin.yaml "$PLUGIN_DIR/plugin.yaml"
+                    printf '%s' "$MEMINI_PLUGIN_REF" > "$PLUGIN_DIR/.ref"
+                    chown -R 10000:10000 "$PLUGIN_DIR"
+                  else
+                    echo "WARN: memini plugin fetch failed; starting with whatever is present"
+                  fi
+                fi
+        containers:
+          app:
+            image: &image
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.7.7.2@sha256:9c841866021c54c4596849f6135717e8a4d52ba510b7f52c50aef1de1a283973
+            args:
+              - "gateway"
+              - "run"
+            env:
+              MEMINI_URL: http://memini.ai.svc.cluster.local:8080
+              MEMINI_NAMESPACE: hermes
+              HERMES_HOME: /opt/data
+              HOME: /opt/data
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: hermes
+            resources:
+              requests:
+                cpu: 500m
+              limits:
+                memory: 2Gi
+            ports:
+              - containerPort: &port 8642
+                name: http
+                protocol: TCP
+          dashboard:
+            image: *image
+            args:
+              - dashboard
+              - --host
+              - "0.0.0.0"
+            env:
+              GATEWAY_HEALTH_URL: http://localhost:8642
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: hermes
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 1Gi
+            ports:
+              - containerPort: &dashboard_port 9119
+                name: http
+                protocol: TCP
+    service:
+      app:
+        controller: hermes
+        ports:
+          http:
+            port: *port
+      dashboard:
+        controller: hermes
+        ports:
+          http:
+            port: *dashboard_port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: dashboard
+                port: http
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /opt/data
+      configmap:
+        type: configMap
+        name: "{{ .Release.Name }}-config"
+        defaultMode: 0755
+        globalMounts:
+          - path: /tmp/config.yaml
+            subPath: config.yaml

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./configmap.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/hermes/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: litellm
+      namespace: *namespace
+    - name: memini
+      namespace: *namespace
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermes/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 resources:
   - ./namespace.yaml
   - ./netpol.yaml
+  - ./hermes/ks.yaml
   - ./litellm/ks.yaml
   - ./llmkube/ks.yaml
   - ./memini/ks.yaml


### PR DESCRIPTION
PR E of the [jory/home-ops adoption roadmap](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md) — [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) as a standard app-template app, gateway + dashboard baseline (no chat platforms; it idles fine with zero).

## What

- **Image** `docker.io/nousresearch/hermes-agent:v2026.7.7.2` digest-pinned (newest stable; the only delta over jory's v2026.7.7 is a WhatsApp dependency fix). Gateway port **8642** and dashboard port **9119** were verified from upstream *source* (`api_server.py DEFAULT_PORT`, `dashboard.py --port default`), not guessed.
- **Config** via ConfigMap → copied into `/opt/data/config.yaml` by the init container. `$${VAR}` double-escaping is load-bearing: Flux collapses it to literal `${VAR}`, which hermes' own `_expand_env_vars` resolves from the pod env at startup. LiteLLM provider (`self-hosted` default, master-key reuse per open-webui precedent), memini memory provider (`MEMINI_NAMESPACE: hermes`), local terminal backend, `approvals.mode: manual` (hermes gets a terminal + cluster-adjacent MCP tools — the Pod is the only trust boundary), secret/PII redaction on, MCP wired directly to the six ToolHive proxy Services.
- **memini plugin** installed by the init container from the release-synced mirror, **pinned to a commit SHA** with a `.ref` marker (normal restarts stay offline; refetch only on pin bump). Flat `/opt/data/plugins/memini/` layout confirmed from the plugin loader source.
- **Runtime**: `fsGroup: 10000` (image bakes `useradd -u 10000`), reloader annotation so config changes actually roll the pod, VolSync 10Gi on `/opt/data`, route on `envoy-internal` → dashboard (basic-auth from the `hermes-agent` 1Password item, created out-of-band).

## First-boot expectations

Dashboard at `hermes.${SECRET_DOMAIN}` behind basic-auth; gateway reachable in-cluster only. Chat platforms, scoped LiteLLM virtual key, and `approvals.mode: smart` are deliberate later steps.
