### PR TITLE
fix(ai): mcp-searxng bind address + arr telemetry opt-in

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/arr-mcp/mcpserver.yaml
@@ -37,5 +37,7 @@ spec:
       memory: 128Mi
     limits:
       memory: 256Mi
+  telemetryConfigRef:
+    name: prometheus
   groupRef:
     name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/mcp-servers/searxng/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/searxng/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
             env:
               SEARXNG_URL: http://searxng.default.svc.cluster.local:8080
               MCP_HTTP_PORT: &port 3000
+              # Upstream flipped the default bind to 127.0.0.1 (localhost-only)
+              # after v1.2.1, which silently broke every in-cluster consumer —
+              # the ClusterIP Service needs the pod to listen on all interfaces.
+              MCP_HTTP_HOST: 0.0.0.0
               TZ: ${TIMEZONE}
             resources:
               requests:


### PR DESCRIPTION
Two follow-ups from post-merge verification of #3480/#3482 — see commit body. mcp-searxng has been unreachable in-cluster since the upstream bind default flipped to localhost; hermes' first-boot connection warnings surfaced it.