### PR TITLE
feat(llmkube): bump chart 0.8.18 → 0.9.3 (PR G prerequisite)

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/llmkube/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.8.18
+    tag: 0.9.3
   url: oci://ghcr.io/defilantech/charts/llmkube


### PR DESCRIPTION
Stage 1 of PR G from the [adoption roadmap](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md#pr-g--model-storage-de-workaround-requires-pr-d): operator/chart bump only, models stay on their pvc:// sources. See commit body for the 0.9.0 breaking-change assessment. Watch item: the 0.9.0 IPv6 bind change may alter generated pod templates and roll the inference pods once — litellm's cloud fallback covers the gap.