### PR TITLE
feat(llmkube): shared CephFS model cache + convert abliterated model (PR G stage 2)

### DIFF
--- a/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/llmkube/app/helmrelease.yaml
@@ -17,11 +17,19 @@ spec:
     remediation:
       retries: 3
   values:
-    # Model weights now come from per-model RWO ceph-block PVCs (pvc:// sources),
-    # staged by one-off hf-download Jobs. Talos has no ceph kernel module and
-    # cannot mount CephFS, so the shared modelCache is disabled.
+    # Shared RWX model cache on CephFS: the operator provisions one
+    # llmkube-model-cache PVC and stages remote model sources into it itself,
+    # so any node can serve any model without re-staging. The old per-model RWO
+    # ceph-block PVCs + curl staging Jobs existed only because of the "Talos has
+    # no ceph kernel module" misdiagnosis (KB-025) — CephFS mounts natively.
+    # 100Gi: ~35Gi of GGUFs today + headroom; weights are re-downloadable, so
+    # the cache carries no VolSync.
     modelCache:
-      enabled: false
+      enabled: true
+      mode: shared
+      accessMode: ReadWriteMany
+      storageClass: ceph-filesystem
+      size: 100Gi
     prometheus:
       inferencePodMonitor:
         # Deliberately off: the hand-rolled llmkube-models ServiceMonitor (with

--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -1,4 +1,7 @@
 ---
+# ROLLBACK ONLY: kept until the shared-cache cutover is proven; revert the Model
+# source to pvc://llama-uncensored-models/… to serve from this again. Remove
+# once the cache-served pod has been healthy for a while.
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -11,75 +14,17 @@ spec:
     requests:
       storage: 30Gi # ~17Gi GGUF + headroom
 ---
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: stage-qwen3-30b-abliterated
-  annotations:
-    # One-shot staging Job (downloads the GGUF to the RWO PVC once). Flux must not
-    # re-apply it: a Job's spec.template is immutable, so Renovate bumping the curl
-    # image would fail the Kustomization. Created once, then left alone.
-    kustomize.toolkit.fluxcd.io/reconcile: disabled
-    # CKV_K8S_21: namespace is applied by the Flux Kustomization targetNamespace,
-    # not the raw manifest. CKV_K8S_40: UID 1000 is the cluster convention and a
-    # host-UID collision is not a concern on single-tenant Talos nodes.
-    checkov.io/skip1: CKV_K8S_21=Namespace injected by Flux targetNamespace
-    checkov.io/skip2: CKV_K8S_40=UID 1000 is the cluster convention on single-tenant Talos
-spec:
-  backoffLimit: 6
-  template:
-    spec:
-      restartPolicy: OnFailure
-      automountServiceAccountToken: false
-      # Non-root, drop-ALL, read-only rootfs (cluster security defaults).
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
-        seccompProfile:
-          type: RuntimeDefault
-      containers:
-        - name: fetch
-          image: docker.io/curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - "ALL"
-          command:
-            - /bin/sh
-            - -ec
-          args:
-            - |
-              cd /models
-              f=Qwen3-30B-A3B-abliterated.i1-Q4_K_S.gguf
-              base=https://huggingface.co/mradermacher/Qwen3-30B-A3B-abliterated-i1-GGUF/resolve/main
-              [ -s "$f" ] || curl -fSL --retry 5 --retry-delay 10 -o "$f" "$base/$f"
-          resources:
-            requests:
-              cpu: "500m"
-              memory: 256Mi
-            limits:
-              cpu: "1"
-              memory: 512Mi
-          volumeMounts:
-            - name: models
-              mountPath: /models
-      volumes:
-        - name: models
-          persistentVolumeClaim:
-            claimName: llama-uncensored-models
----
-# Model: pvc:// source (no download by the operator; staged by the Job above).
+# Model: operator-managed HF repo source. The operator stages the GGUF into the
+# shared llmkube-model-cache PVC (CephFS RWX) itself — the curl staging Job this
+# file used to carry is gone with it.
 apiVersion: inference.llmkube.dev/v1alpha1
 kind: Model
 metadata:
   name: qwen3-30b-a3b-abliterated
 spec:
-  source: pvc://llama-uncensored-models/Qwen3-30B-A3B-abliterated.i1-Q4_K_S.gguf
+  source: hf://mradermacher/Qwen3-30B-A3B-abliterated-i1-GGUF
+  files:
+    - Qwen3-30B-A3B-abliterated.i1-Q4_K_S.gguf
   format: gguf
   quantization: i1-Q4_K_S
   hardware:


### PR DESCRIPTION
Stage 2 of [PR G](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md#pr-g--model-storage-de-workaround-requires-pr-d): enable the shared RWX model cache (ceph-filesystem, 100Gi) and convert **one model** — qwen3-30b-abliterated — from pvc://+staging-Job to an operator-managed `hf://` repo source. Its staging Job (and the reconcile-disabled/Checkov-skip annotations that existed only for Job immutability) is deleted; the RWO PVC stays as the documented rollback target until the cache-served pod proves out. The vision model (llama-nvidia, mmproj) converts in stage 3.

Cutover expectation on merge: operator provisions `llmkube-model-cache` (CephFS RWX), stages the ~17Gi GGUF from HF into it, then rolls llama-uncensored. litellm's cloud fallback covers the gap. Rollback: revert the Model source to `pvc://llama-uncensored-models/…`.