### PR TITLE
feat(ai): seerr MCP server (native streamable-http) + media netpol

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -119,7 +119,7 @@ data:
       drop_params: true
       num_retries: 2
       request_timeout: 600
-      # Surfaces only the top-k relevant MCP tools per request (7 servers) using
+      # Surfaces only the top-k relevant MCP tools per request (8 servers) using
       # the all-minilm embedding model above.
       mcp_semantic_tool_filter:
         enabled: true
@@ -128,7 +128,7 @@ data:
         similarity_threshold: 0.3
 
     # MCP tools proxied to any LiteLLM client (ToolHive-managed endpoints, ai ns).
-    # 7 servers — the semantic filter above trims each request to the top-k
+    # 8 servers — the semantic filter above trims each request to the top-k
     # relevant tools.
     mcp_servers:
       kubectl:
@@ -147,6 +147,10 @@ data:
       # streamable-http proxy, same as github/grafana above.
       arr:
         url: http://mcp-arr-proxy.ai.svc.cluster.local:8080/mcp
+      # Seerr request/discovery tools (overseerr-mcp). Native streamable-http
+      # container (no proxy hop), so the Service is mcp-seerr:8085 directly.
+      seerr:
+        url: http://mcp-seerr.ai.svc.cluster.local:8085/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Reuses the EXISTING `seerr` 1Password item the media/seerr app already reads,
+# extracting only its SEERR_API_KEY property into a dedicated ai-namespace Secret.
+# No new 1Password items are created.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-seerr
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      data:
+        SEERR_API_KEY: "{{ .SEERR_API_KEY }}"
+  dataFrom:
+    - extract:
+        key: seerr

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/kustomization.yaml
@@ -3,11 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kubectl
-  - ./flux
-  - ./talos
-  - ./searxng
-  - ./github
-  - ./grafana
-  - ./arr-mcp
-  - ./seerr-mcp
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/seerr-mcp/mcpserver.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: seerr
+spec:
+  # Official multi-arch GHCR image for overseerr-mcp (github.com/jhomen368/overseerr-mcp),
+  # digest-pinned. The Dockerfile bakes HTTP_MODE=true PORT=8085, so the container runs
+  # native streamable-HTTP (MCP endpoint /mcp, health /health) — no stdio proxy hop. This
+  # is the same project jory runs via npx; our convention pins the container by digest.
+  image: ghcr.io/jhomen368/overseerr-mcp:2.2.0@sha256:71d7c3a008e78a881995855df575f69bf68fb89ac41459544f510fa00012acca
+  transport: streamable-http
+  mcpPort: 8085
+  env:
+    - name: SEERR_URL
+      value: http://seerr.media.svc.cluster.local
+  secrets:
+    - name: toolhive-seerr
+      key: SEERR_API_KEY
+      targetEnvName: SEERR_API_KEY
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  telemetryConfigRef:
+    name: prometheus
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/media/netpol.yaml
+++ b/kubernetes/apps/media/netpol.yaml
@@ -38,3 +38,22 @@ spec:
         - matchLabels:
             io.kubernetes.pod.namespace: ai
             toolhive-name: arr
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-seerr-mcp-from-ai
+spec:
+  # The `seerr` ToolHive MCP server (ai namespace) queries Seerr over its API.
+  # Additive to the namespace-wide policy above (Cilium unions allows), scoped to
+  # the seerr endpoint and to the seerr MCP pod as the source.
+  description: "Allow the seerr MCP server (ai) to reach seerr"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: seerr
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            toolhive-name: seerr


### PR DESCRIPTION
The roadmap's seerr follow-on, now nearly free after the arr netpol pattern (#3482). Same project jory runs via npx — but it publishes its own multi-arch GHCR image (`ghcr.io/jhomen368/overseerr-mcp:2.2.0`, digest-pinned, registry-API-verified), and the container speaks **native streamable-HTTP** (baked `HTTP_MODE=true PORT=8085`), so unlike arr there's no stdio proxy hop: `transport: streamable-http` + `mcpPort: 8085`, litellm pointed at the direct `mcp-seerr:8085/mcp` Service (kubectl/flux precedent). Reuses the existing `seerr` 1Password item's `SEERR_API_KEY` property; `telemetryConfigRef` included from day one (arr lesson, #3488). Our seerr is the unified Seerr successor, which this MCP server explicitly supports.

Post-merge: litellm needs its reloader-triggered roll for the ConfigMap change; semantic tool filter now ranks an 8th server (top_k 8 / threshold 0.3 — retune if crowding appears).