### PR TITLE
fix(llmkube): allow scoped-root cache-prep init on llama-uncensored

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -86,8 +86,12 @@ spec:
           labelSelector:
             matchLabels:
               llm-gpu-model: "true"
+  # No runAsNonRoot: the operator's model-cache-prep init container must run as
+  # scoped root (drop ALL, add CHOWN+FOWNER only, no privesc, ro rootfs) to
+  # chown the shared cache on fsGroupPolicy:None backends like CephFS — the
+  # upstream-supported compatibility path (docs/MODEL-CACHE.md). Runtime
+  # containers still run as 1000 via runAsUser below.
   podSecurityContext:
-    runAsNonRoot: true
     runAsUser: 1000
     runAsGroup: 1000
     fsGroup: 1000


### PR DESCRIPTION
Unblocks the #3490 cutover: llama-uncensored stuck Init:CreateContainerConfigError because our pod-level `runAsNonRoot: true` rejects the operator's root-scoped model-cache-prep init container — the upstream-documented requirement for fsGroupPolicy:None backends (CephFS). self-hosted-uncensored is on litellm cloud fallback until this merges. See commit body.