### PR TITLE
chore(llmkube): remove rollback PVCs; mark adoption roadmap shipped

### DIFF
--- a/docs/docs/operations/jory-homeops-adoption.md
+++ b/docs/docs/operations/jory-homeops-adoption.md
@@ -1,7 +1,13 @@
 # joryirving/home-ops Adoption Roadmap
 
-**Status:** Planned 2026-07-09 (multi-agent gap analysis + adversarial review, verified against
-the live cluster). Nothing below is implemented yet — this page is the pick-up point.
+**Status:** Largely SHIPPED 2026-07-10. PRs A–E landed as #3480–#3484 (+ follow-up fixes
+#3488 mcp-searxng bind / arr telemetry, #3492 cache-prep securityContext), seerr MCP as #3491,
+and PR G as the staged #3489 (operator 0.9.3) → #3490 (shared cache + abliterated model) →
+#3493 (vision model, first-class mmproj) with both models verified serving from the shared
+CephFS cache (text + vision end-to-end). The CephFS RWX smoke test passed on 2026-07-10.
+Still open: **ha MCP** (awaiting a user-created read-only Home Assistant token in 1Password),
+**PR F** (optional CPU auxiliary model), and **foreman** (parked — re-evaluate now CephFS is
+proven). Planned 2026-07-09 via multi-agent gap analysis + adversarial review.
 
 A survey of [joryirving/home-ops](https://github.com/joryirving/home-ops) (`kubernetes/apps/base/llm`
 and `.agents`) against this cluster. Most of his stack was already ported (open-webui, litellm,
@@ -35,13 +41,13 @@ except where noted.
 
 | PR  | Contents                                                                | Blockers / prerequisites                        |
 | --- | ----------------------------------------------------------------------- | ----------------------------------------------- |
-| A   | LLM observability: litellm PrometheusRule, ToolHive telemetry, llama.cpp serving dashboard | none                         |
-| B   | Config cherry-picks: SearXNG hardening, litellm `context_window_fallbacks`, add-app SKILL.md wording | none               |
-| C   | MCP servers over existing apps: arr + ha (+ optional seerr), with netpol rules | HA token in 1Password; pinnable images   |
-| D   | CephFS enablement + comment corrections + RWX smoke test                 | none                                            |
-| E   | hermes                                                                   | `hermes-agent` 1Password item; decisions below  |
+| A   | ✅ #3480 — LLM observability: litellm PrometheusRule, ToolHive telemetry, llama.cpp serving dashboard | none              |
+| B   | ✅ #3481 — Config cherry-picks: SearXNG hardening, litellm `context_window_fallbacks`, add-app SKILL.md wording | none    |
+| C   | ✅ #3482 arr (+ seerr #3491) — MCP servers over existing apps, with netpol rules; **ha still open** | HA token in 1Password |
+| D   | ✅ #3483 — CephFS enablement + comment corrections; RWX smoke test PASSED 2026-07-10 | none                              |
+| E   | ✅ #3484 — hermes (gateway + dashboard baseline, no chat platforms)      | none — item created, defaults applied           |
 | F   | (optional) CPU-served ~4B auxiliary model                                | none                                            |
-| G   | Model-storage de-workaround (shared CephFS model cache)                  | PR D merged + smoke test green                  |
+| G   | ✅ #3489/#3490/#3493 — model-storage de-workaround (shared CephFS cache); both models cache-served, vision verified | none |
 
 ### PR A — LLM observability
 

--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -1,19 +1,4 @@
 ---
-# ROLLBACK ONLY: kept until the shared-cache cutover is proven; revert the Model
-# source to pvc://llama-uncensored-models/… to serve from this again. Remove
-# once the cache-served pod has been healthy for a while.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: llama-uncensored-models
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-block
-  resources:
-    requests:
-      storage: 30Gi # ~17Gi GGUF + headroom
----
 # Model: operator-managed HF repo source. The operator stages the GGUF into the
 # shared llmkube-model-cache PVC (CephFS RWX) itself — the curl staging Job this
 # file used to carry is gone with it.

--- a/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
@@ -1,19 +1,4 @@
 ---
-# ROLLBACK ONLY: kept until the shared-cache cutover is proven for this model;
-# revert the Model source to pvc://llama-nvidia-models/… (and restore the
-# --mmproj /model-source/mmproj-F16.gguf extraArg) to serve from this again.
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: llama-nvidia-models
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: ceph-block
-  resources:
-    requests:
-      storage: 40Gi # ~18Gi GGUF + ~1.4Gi mmproj + headroom
----
 # Model: operator-managed HF repo source. The operator stages the GGUF and the
 # mmproj projector into the shared llmkube-model-cache PVC (CephFS RWX) and
 # passes the projector to the runtime itself — no staging Job, no hand-rolled


### PR DESCRIPTION
Closes out [PR G](https://github.com/LukeEvansTech/talos-cluster/blob/main/docs/docs/operations/jory-homeops-adoption.md): both models verified serving from the shared CephFS cache (abliterated answered a text prompt, qwen3.6 answered a vision prompt with the operator-staged mmproj), so the rollback PVCs (30Gi + 40Gi ceph-block) go away via Flux prune. Roadmap doc status updated to reflect what shipped today (#3480–#3484, #3488–#3493) and what remains (ha MCP awaiting your token, PR F optional, foreman parked).