### PR TITLE
fix(hermes): accept the dashboard login redirect in the gatus check

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -118,6 +118,12 @@ spec:
             port: *dashboard_port
     route:
       app:
+        annotations:
+          # The dashboard 302-redirects to its login (basic-auth), so gatus'
+          # default 200 check marks it down. Anything below 400 = route,
+          # Service, and pod are alive.
+          gatus.home-operations.com/endpoint: |-
+            conditions: ["[STATUS] < 400"]
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:


### PR DESCRIPTION
Silences the one alert today's hermes deploy introduced: gatus auto-discovers the new HTTPRoute and its default 200 condition fails on the dashboard's 302 login redirect. Override via the established `gatus.home-operations.com/endpoint` annotation (flux-instance precedent) with `[STATUS] < 400`.