### PR TITLE
feat(ai): hermeswebui chat frontend + enable hermes gateway API server

### DIFF
--- a/docs/docs/operations/jory-homeops-adoption.md
+++ b/docs/docs/operations/jory-homeops-adoption.md
@@ -1,9 +1,9 @@
 # joryirving/home-ops Adoption Roadmap
 
-**Status:** Largely SHIPPED 2026-07-10. PRs A–E landed as #3480–#3484 (+ follow-up fixes
-#3488 mcp-searxng bind / arr telemetry, #3492 cache-prep securityContext), seerr MCP as #3491,
-and PR G as the staged #3489 (operator 0.9.3) → #3490 (shared cache + abliterated model) →
-#3493 (vision model, first-class mmproj) with both models verified serving from the shared
+**Status:** Largely SHIPPED 2026-07-10. PRs A–E landed as #3480–#3484 (+ follow-up
+fixes #3488 mcp-searxng bind / arr telemetry, #3492 cache-prep securityContext), seerr
+MCP as #3491, and PR G as the staged #3489 (operator 0.9.3) → #3490 (shared cache +
+abliterated model) → #3493 (vision, first-class mmproj) with both models verified on the shared
 CephFS cache (text + vision end-to-end). The CephFS RWX smoke test passed on 2026-07-10.
 Still open: **ha MCP** (awaiting a user-created read-only Home Assistant token in 1Password),
 **PR F** (optional CPU auxiliary model), and **foreman** (parked — re-evaluate now CephFS is

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -17,6 +17,10 @@ spec:
         LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
         # Gateway → memini memory backend (bearer token).
         MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
+        # Bearer token for the gateway's OpenAI-compatible API server (enabled via
+        # API_SERVER_ENABLED/API_SERVER_HOST on the app container). Shared with
+        # hermeswebui's HERMES_WEBUI_GATEWAY_API_KEY — same 1Password field.
+        API_SERVER_KEY: "{{ .api_server_key }}"
         # Dashboard basic-auth (bound on 0.0.0.0, so auth is enforced). The
         # session secret must persist across restarts or every rollout logs
         # users out.

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -69,6 +69,20 @@ spec:
               HERMES_HOME: /opt/data
               HOME: /opt/data
               TZ: ${TIMEZONE}
+              # --- OpenAI-compatible API server (consumed by hermeswebui) ---
+              # Off by default upstream; turn it on so `gateway run` serves /v1/*
+              # and /health on :8642 (the containerPort + hermes-app Service below
+              # already exist; the dashboard's GATEWAY_HEALTH_URL probe also starts
+              # succeeding once this is live).
+              API_SERVER_ENABLED: "true"
+              # Bind 0.0.0.0, not the 127.0.0.1 default — the hermes-app ClusterIP
+              # Service cannot reach a loopback-only bind (same trap that bit
+              # mcp-searxng). Auth is still enforced by API_SERVER_KEY.
+              API_SERVER_HOST: 0.0.0.0
+              # Third API_SERVER_* var — the bearer token API_SERVER_KEY (upstream:
+              # required for every deployment) — is injected from the `hermes`
+              # Secret via the envFrom below; the ExternalSecret now maps it from
+              # the hermes-agent item's api_server_key field.
             envFrom:
               - secretRef:
                   name: hermes

--- a/kubernetes/apps/ai/hermeswebui/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermeswebui/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermeswebui
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermeswebui
+    template:
+      engineVersion: v2
+      data:
+        # Same 1Password field the hermes gateway maps to API_SERVER_KEY, so the
+        # UI authenticates to hermes-app's API server (upstream requires the two
+        # to match).
+        HERMES_WEBUI_GATEWAY_API_KEY: "{{ .api_server_key }}"
+        # Web login password. Upstream auth is off by default; setting this turns
+        # it on, which is required once the UI is bound beyond loopback (we route
+        # it on envoy-internal).
+        HERMES_WEBUI_PASSWORD: "{{ .webui_password }}"
+  dataFrom:
+    - extract:
+        key: hermes-agent

--- a/kubernetes/apps/ai/hermeswebui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermeswebui/app/helmrelease.yaml
@@ -1,0 +1,132 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermeswebui
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: hermeswebui
+  values:
+    controllers:
+      hermeswebui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # RWO state PVC: avoid a multi-attach deadlock on rollout.
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/nesquena/hermes-webui
+              tag: 0.52.0@sha256:39be03fb8981084bbbe089fb3764ea11ee84239a1f34e85636757095048d8385
+            env:
+              TZ: ${TIMEZONE}
+              # Image already bakes 0.0.0.0:8787; kept explicit for clarity.
+              HERMES_WEBUI_HOST: 0.0.0.0
+              HERMES_WEBUI_PORT: &port 8787
+              # Sessions, settings, the auth signing key, and attachments live
+              # here. It is the ONLY stateful path — persisted on the volsync PVC
+              # (mounted at /data below); losing it logs every user out.
+              HERMES_WEBUI_STATE_DIR: /data
+              # Chat through hermes-app's OpenAI-compatible gateway API server
+              # rather than the WebUI's own legacy backend.
+              HERMES_WEBUI_CHAT_BACKEND: gateway
+              # Base URL only — the WebUI appends /v1/* and /api/* itself, so no
+              # /v1 suffix here (matches upstream's default of http://127.0.0.1:8642).
+              HERMES_WEBUI_GATEWAY_BASE_URL: http://hermes-app.ai.svc.cluster.local:8642
+              # REQUIRED: the gateway runs approvals.mode: manual, and without the
+              # runs API the approval cards never surface — tool calls would hang
+              # invisibly. Truthy value opts into the runs-API approval path.
+              HERMES_WEBUI_GATEWAY_USE_RUNS_API: "true"
+            envFrom:
+              # HERMES_WEBUI_GATEWAY_API_KEY + HERMES_WEBUI_PASSWORD.
+              - secretRef:
+                  name: hermeswebui
+            probes:
+              # The WebUI serves an unauthenticated GET /health on :8787.
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probe
+              # First boot (and every pod start — the venv lives on the ephemeral
+              # image layer, not the PVC) builds a Python venv via `uv pip install`
+              # before /health answers, so gate liveness/readiness on a generous
+              # startup probe (~5 min) instead of a long initialDelaySeconds.
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              # The entrypoint seeds /app and builds the venv on the writable
+              # image layer, so the root FS cannot be read-only.
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            ports:
+              - containerPort: *port
+                name: http
+                protocol: TCP
+    defaultPodOptions:
+      securityContext:
+        # The image bakes `groupadd -g 1024 / useradd -u 1024 hermeswebui`. Its
+        # /hermeswebui_init.bash entrypoint normally starts as root only to align
+        # the runtime UID/GID with mounted volumes, then execs the server as 1024.
+        # Started directly as 1024 it detects the non-root start, skips that root
+        # branch, seeds /app + builds the venv as 1024, and asserts UID/GID == 1024
+        # — so we bypass the root init entirely (no self-chown needed). fsGroup
+        # 1024 makes the /data PVC group-writable so HERMES_WEBUI_STATE_DIR persists.
+        runAsNonRoot: true
+        runAsUser: 1024
+        runAsGroup: 1024
+        fsGroup: 1024
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: hermeswebui
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          # Probe /health, not /: once HERMES_WEBUI_PASSWORD is set the app root
+          # redirects to the login page, which a bare uptime check would read as
+          # down. /health is unauthenticated and always 200.
+          gatus.home-operations.com/endpoint: |-
+            url: https://{{ .Release.Name }}.${SECRET_DOMAIN}/health
+            conditions: ["[STATUS] == 200"]
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data

--- a/kubernetes/apps/ai/hermeswebui/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermeswebui/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/hermeswebui/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermeswebui/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermeswebui
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermeswebui/ks.yaml
+++ b/kubernetes/apps/ai/hermeswebui/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermeswebui
+  namespace: &namespace ai
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    # hermes serves the OpenAI-compatible gateway API server this UI chats through.
+    - name: hermes
+      namespace: *namespace
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/ai/hermeswebui/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./netpol.yaml
   - ./hermes/ks.yaml
+  - ./hermeswebui/ks.yaml
   - ./litellm/ks.yaml
   - ./llmkube/ks.yaml
   - ./memini/ks.yaml


### PR DESCRIPTION
Deploys [nesquena/hermes-webui](https://github.com/nesquena/hermes-webui) (the most popular hermes-agent web UI — 15.8k★, MIT, v0.52.0 digest-pinned multi-arch) as `hermeswebui`, chatting through our existing hermes gateway. Two-sided change:

**Gateway side (hermes app):** the OpenAI-compatible API server is off by default and binds 127.0.0.1 — verified live that nothing listens on :8642 today. Enabled with `API_SERVER_ENABLED` + `API_SERVER_HOST: 0.0.0.0` (the mcp-searxng loopback trap, dodged proactively) + bearer `API_SERVER_KEY` from the `hermes-agent` 1Password item (new `api_server_key` field, created out-of-band). Side benefit: the dashboard's `GATEWAY_HEALTH_URL` probe starts succeeding.

**UI side:** explicit gateway mode (`HERMES_WEBUI_CHAT_BACKEND=gateway`) with **`HERMES_WEBUI_GATEWAY_USE_RUNS_API=true`** — load-bearing: our gateway runs `approvals.mode: manual`, and without the runs API approval cards never surface (tool calls would hang invisibly). Web login via `HERMES_WEBUI_PASSWORD` (required once bound beyond loopback; routed on envoy-internal). Stateful `HERMES_WEBUI_STATE_DIR` on a 5Gi VolSync PVC (sessions + auth signing key + attachments). Runs rootless as the image's UID 1024 (its init script explicitly supports non-root start, verified from source — no self-chown needed). gatus probes the unauthenticated `/health`.

Env names verified against upstream source (`gateway/config.py`, `api/gateway_chat.py`, `api/auth.py`), not docs alone. Every secret key chain proven in the rendered manifests. Rider commit: reflow the roadmap status paragraph so PR refs don't start lines (MD018).

Post-merge: hermes pod rolls (reloader) to bring up the API server; first webui boot builds its venv (~5 min startup probe headroom); expect `https://hermeswebui.${SECRET_DOMAIN}` behind its password.