### PR TITLE
fix(hermes): swap litellm master key for a scoped virtual key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/superpowers/
 .DS_Store
 Thumbs.db
 CLAUDE.md
+
+# kubectl cache (kubeconfig lives in-repo, so kubectl drops its cache here)
+.kube/

--- a/kubernetes/apps/ai/hermes/app/configmap.yaml
+++ b/kubernetes/apps/ai/hermes/app/configmap.yaml
@@ -16,10 +16,11 @@ data:
       provider: litellm
     providers:
       # LiteLLM's OpenAI-compatible surface. `self-hosted` is the local
-      # llama.cpp model group; LiteLLM handles its own cloud fallback.
+      # llama.cpp model group; LiteLLM handles its own cloud fallback. The key
+      # is a scoped virtual key (see externalsecret.yaml) — NOT the master key.
       litellm:
         base_url: http://litellm.ai.svc.cluster.local:4000/v1
-        api_key: $${LITELLM_MASTER_KEY}
+        api_key: $${HERMES_LITELLM_API_KEY}
     terminal:
       backend: local
       cwd: /opt/data/workspace

--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -13,8 +13,12 @@ spec:
     template:
       engineVersion: v2
       data:
-        # Gateway → LiteLLM (reuses the shared master key, open-webui precedent).
-        LITELLM_MASTER_KEY: "{{ .LITELLM_MASTER_KEY }}"
+        # Gateway → LiteLLM: a SCOPED virtual key (models self-hosted,
+        # self-hosted-uncensored, openrouter/auto; alias hermes-agent), not the
+        # master key — the dashboard's /api/config returns the resolved provider
+        # api_key in plaintext to any logged-in session, so what it can expose
+        # must be a revocable, least-privilege key.
+        HERMES_LITELLM_API_KEY: "{{ .litellm_virtual_key }}"
         # Gateway → memini memory backend (bearer token).
         MEMINI_API_KEY: "{{ .MEMINI_API_KEY }}"
         # Bearer token for the gateway's OpenAI-compatible API server (enabled via
@@ -28,8 +32,6 @@ spec:
         HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: "{{ .password }}"
         HERMES_DASHBOARD_BASIC_AUTH_SECRET: "{{ .session_secret }}"
   dataFrom:
-    - extract:
-        key: litellm
     - extract:
         key: memini
     - extract:


### PR DESCRIPTION
Hardening from today's /api/config finding: the hermes dashboard returns the resolved litellm `api_key` in plaintext to any logged-in session, and until now that was the **master key**. hermes now uses a dedicated virtual key (alias `hermes-agent`, scoped to `self-hosted`/`self-hosted-uncensored`/`openrouter/auto` so litellm-side health + context-window fallbacks keep working), minted out-of-band into the `hermes-agent` 1Password item. The `litellm` item extract is removed — the master key no longer enters the hermes pod at all. Worst case on a dashboard-session compromise drops from litellm admin to revocable inference on three models. open-webui's master-key use is unchanged (separate app, pre-existing precedent). Rider: gitignore kubectl's `.kube/` cache dir.