### PR TITLE
fix(renovate): don't pin digests on ImageVerificationConfig glob patterns

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -436,6 +436,16 @@
       pinDigests: false,
     },
     {
+      // ImageVerificationConfig `image:` fields are GLOB PATTERNS matched by
+      // Talos against the registry+repository portion of a pulled ref (never
+      // the tag or digest). Appending `@sha256:...` produces a pattern no
+      // image context can ever match, silently disabling cosign verification
+      // for factory installer images (see PR #3465).
+      description: "Don't pin digests on ImageVerificationConfig glob patterns",
+      matchFileNames: ["talos/patches/global/machine-image-verification.yaml"],
+      pinDigests: false,
+    },
+    {
       // pulsarr upstream (github.com/jamcalli/Pulsarr) is still on 0.15.x.
       // Stray 1.x tags appeared on Docker Hub (1.1.5, 1.1.6) and were pulled.
       // Block the whole 1.x major until upstream legitimately ships a 1.0 release.


### PR DESCRIPTION
## What

Scoped `pinDigests: false` rule for `talos/patches/global/machine-image-verification.yaml`, same shape as the existing Flux OCIRepository exception.

## Why

Renovate's `docker:pinDigests` rewrote the `factory.talos.dev/*` glob into `factory.talos.dev@sha256:.../*` in #3465. Talos matches ImageVerificationConfig patterns against the **registry+repository portion of a pulled ref only** (never tag/digest), so the digested pattern can never match — merging #3465 would have silently disabled cosign verification for all factory installer images (live on all control-plane nodes since #3462). Talos's own validation warns on exactly this: *"imagePattern contains '@' but matching only applies to the image registry and repository"*.

After this merges, #3465 rebases to an empty diff and Renovate autocloses it.

Credit: caught by the AI reviewer on #3465.