### PR TITLE
feat(paperless-gpt): update to v0.26.1, exec binary directly

### DIFF
--- a/kubernetes/apps/default/paperless/gpt/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/gpt/helmrelease.yaml
@@ -26,7 +26,15 @@ spec:
           app:
             image:
               repository: docker.io/icereed/paperless-gpt
-              tag: v0.25.1@sha256:c0ce6186028911101a2cfe68353f14a9dbb2653596f3f1cff94de4b6db3114ff
+              tag: v0.26.1@sha256:6b9024d1adebfcd6bd7ec5e9da2ca17f9879b1fb5ce749d72905bbb121091ef8
+            # v0.26.0 introduced a rootless entrypoint.sh (addgroup/chown/su-exec
+            # for PUID/PGID support) that cannot run under this pod's hardened
+            # context (runAsUser 1000, readOnlyRootFilesystem, all caps dropped).
+            # The securityContext already provides everything the entrypoint
+            # would set up, so exec the binary directly — same runtime shape as
+            # v0.25.1. If a future bump moves the binary, startup fails loudly.
+            command:
+              - "/app/paperless-gpt"
             env:
               TZ: ${TIMEZONE}
               PAPERLESS_BASE_URL: "http://paperless.default.svc.cluster.local:8000"


### PR DESCRIPTION
## What

- `docker.io/icereed/paperless-gpt` v0.25.1 → v0.26.1 (digest-pinned)
- `command: ["/app/paperless-gpt"]` override, bypassing the new rootless `entrypoint.sh`

## Why

v0.26.0 introduced an entrypoint (addgroup/adduser, `chown -R /app`, `su-exec`) for docker-compose PUID/PGID support. Under this pod's hardened context — `runAsUser: 1000`, `runAsNonRoot`, `readOnlyRootFilesystem`, all capabilities dropped — it dies at `mkdir /home/paperless-gpt`, `chown`, and `su-exec`, crashlooping before the app starts (flagged by the AI review on #3487). v0.26.1 fixes upstream regression icereed/paperless-gpt#995 but not the incompatibility with a non-root pod context.

Rather than weakening the security context (root start + CHOWN/SETUID/SETGID caps + writable rootfs), exec the binary directly: the securityContext already provides everything the entrypoint sets up, and all writable paths (`/app/db`, `/app/prompts`, `/app/config`, `/tmp`) are mounted volumes. v0.25.1 was `CMD ["/app/paperless-gpt"]` with no entrypoint, so this is an exact reproduction of the current runtime shape with the new binary.

Verified: `flate build hr` renders `command` + new tag correctly.

Supersedes Renovate #3487 (autocloses once main is on ≥ v0.26.1).