### PR TITLE
feat(home): add matter-server (matter.js) for Phase 2 Matter-over-Thread

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -67,6 +67,7 @@ ALLOWLIST: dict[str, str] = {
     ".github/workflows/image-pull.yaml": "talosctl --nodes in CI",
     "kubernetes/apps/default/shlink/app/helmrelease.yaml": "RFC1918 blocks (DISABLE_TRACKING_FROM)",
     "kubernetes/apps/home/homeassistant/app/helmrelease.yaml": "trusted-proxy IP + multus MAC",
+    "kubernetes/apps/home/matter-server/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/mosquitto/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/kube-system/cilium/app/networks.yaml": "LB IP pool / API host",

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./homeassistant/ks.yaml
   - ./homeassistanttimemachine/ks.yaml
   - ./homebridge/ks.yaml
+  - ./matter-server/ks.yaml
   - ./mosquitto/ks.yaml
   - ./node-red/ks.yaml
   - ./shelly-fleet/ks.yaml

--- a/kubernetes/apps/home/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/matter-server/app/helmrelease.yaml
@@ -1,0 +1,104 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: matter-server
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: matter-server
+  values:
+    controllers:
+      matter-server:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          # Thread devices are reached via IPv6 routes the OTBR advertises in
+          # RAs (Route Information Options) on the multus interface; the kernel
+          # ignores RIOs unless accept_ra_rt_info_max_plen > 0.
+          sysctl:
+            image:
+              repository: ghcr.io/matter-js/matterjs-server
+              tag: 1.2.2@sha256:9a51306da8fdc42283f5f497873cd2b2647ac3228342be745c676ffce627db80
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                echo 2 > /proc/sys/net/ipv6/conf/net1/accept_ra
+                echo 64 > /proc/sys/net/ipv6/conf/net1/accept_ra_rt_info_max_plen
+            securityContext:
+              runAsNonRoot: false
+              runAsUser: 0
+              runAsGroup: 0
+              capabilities:
+                add:
+                  - NET_ADMIN
+                drop:
+                  - ALL
+        containers:
+          app:
+            image:
+              # Open Home Foundation matter.js server — drop-in replacement for
+              # the archived python-matter-server (same ws API on :5580, same
+              # CLI flags), and what HA's Matter integration targets going
+              # forward.
+              repository: ghcr.io/matter-js/matterjs-server
+              tag: 1.2.2@sha256:9a51306da8fdc42283f5f497873cd2b2647ac3228342be745c676ffce627db80
+            args:
+              - --storage-path
+              - /data
+              - --primary-interface
+              - net1
+              - --log-level
+              - info
+            env:
+              TZ: ${TIMEZONE}
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      annotations:
+        # Temporary legacy flat-LAN attachment (L2 adjacency with the
+        # coordinator's on-device OTBR) — move to the `iot` NAD when the
+        # coordinator re-homes to VLAN 68.
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot-legacy",
+            "namespace": "kube-system",
+            "ips": ["10.32.8.103/24"],
+            "mac": "02:00:00:00:00:04"
+          }]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: matter-server
+        ports:
+          ws:
+            port: 5580
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home/matter-server/app/kustomization.yaml
+++ b/kubernetes/apps/home/matter-server/app/kustomization.yaml
@@ -3,5 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./iot.yaml
-  - ./iot-legacy.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/matter-server/app/ocirepository.yaml
+++ b/kubernetes/apps/home/matter-server/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: matter-server
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/matter-server/ks.yaml
+++ b/kubernetes/apps/home/matter-server/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app matter-server
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/home/matter-server/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/kube-system/multus/networks/iot-legacy.yaml
+++ b/kubernetes/apps/kube-system/multus/networks/iot-legacy.yaml
@@ -1,0 +1,27 @@
+---
+# TEMPORARY: untagged legacy flat-LAN attachment. matter-server needs L2
+# adjacency with the Zigbee/Thread coordinator's on-device OTBR (still on the
+# legacy LAN) to receive its IPv6 RAs and mDNS-proxied Thread services. Remove
+# once the coordinator re-homes to VLAN 68 (post network-ops Gate D) and
+# matter-server moves to the `iot` NAD.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: iot-legacy
+  namespace: kube-system
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "iot-legacy",
+      "plugins": [
+        {
+          "type": "macvlan",
+          "master": "enp1s0np0",
+          "mode": "bridge",
+          "ipam": {
+            "type": "static"
+          }
+        }
+      ]
+    }


### PR DESCRIPTION
## What

Adds **matterjs-server 1.2.2** (Open Home Foundation matter.js server) as a new `home`-namespace app — the Matter controller for Phase 2 (Lafaer LWR01 presence sensors, Matter-over-Thread), per the roadmap design spec §Phase 2.

**Why matter.js and not python-matter-server:** python-matter-server has been archived; matterjs-server is its drop-in successor (same ws API on `:5580/ws`, same CLI flags) and is what HA's Matter integration targets going forward.

## How

- **App**: app-template 5.0.1, digest-pinned image, volsync-backed 1Gi PVC at `/data`, ws service `:5580`, hardened pod context (image runs natively as UID 1000).
- **Temporary `iot-legacy` NAD** (untagged flat-LAN macvlan on `enp1s0np0`): matter-server needs L2 adjacency with the coordinator's on-device OTBR to receive its RA-advertised Thread routes and mDNS-proxied device services. The coordinator can't reach VLAN 68 wired until network-ops Gate D lands. **Remove when the coordinator re-homes to VLAN 68** and matter-server moves to the `iot` NAD.
- **sysctl init container** (root + NET_ADMIN, drops everything else): sets `accept_ra=2` + `accept_ra_rt_info_max_plen=64` on `net1` — the kernel ignores RA Route Information Options by default, which would silently black-hole all Thread traffic.
- **Identifier-scan allowlist**: one new entry for the helmrelease (multus static IP + MAC), mirroring the existing z2m/mosquitto entries.

## Verification

- Identifier scan: clean.
- super-linter v8.6.0 locally (CI-equivalent set; kubeconform disabled in CI per lint.yml): clean.
- lefthook pre-commit (yamllint / prettier / codespell / editorconfig): clean.
- Post-merge: pod up with `net1` on the flat LAN, RA route to the Thread OMR prefix present, HA Matter integration connects to `ws://matter-server.home.svc.cluster.local:5580/ws`.

## Follow-ups (not this PR)

- HA UI: Thread integration → OTBR REST (`:8080`), **regenerate the Thread dataset** (currently the OpenThread example/demo dataset — publicly-known network key), Matter integration → ws URL above.
- Commission first LWR01 via iPhone Companion app.