### PR TITLE
fix(home): matter-server sysctl init container must be privileged

### DIFF
--- a/kubernetes/apps/home/matter-server/app/helmrelease.yaml
+++ b/kubernetes/apps/home/matter-server/app/helmrelease.yaml
@@ -32,11 +32,10 @@ spec:
               runAsNonRoot: false
               runAsUser: 0
               runAsGroup: 0
-              capabilities:
-                add:
-                  - NET_ADMIN
-                drop:
-                  - ALL
+              # /proc/sys is mounted read-only for non-privileged containers;
+              # NET_ADMIN alone cannot write sysctls. Privileged here is scoped
+              # to this pod's own netns (the sysctls touch only net1).
+              privileged: true
         containers:
           app:
             image:


### PR DESCRIPTION
Follow-up to #3505 — the sysctl init container crashloops because /proc/sys is read-only for non-privileged containers (NET_ADMIN is not sufficient). Switch the init container to privileged (scoped to the pod's own netns; it only writes accept_ra/accept_ra_rt_info_max_plen on net1). Observed: Init:CrashLoopBackOff x44, 'cannot create /proc/sys/net/ipv6/conf/net1/accept_ra: Read-only file system'.