### PR TITLE
feat(ci): add talos/siderolabs to renovate-review blast regex

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -77,9 +77,10 @@ jobs:
           LABELS: ${{ steps.gate.outputs.labels }}
         run: |
           # High-blast-radius components for this cluster: networking, storage,
-          # secrets/certs, and the GitOps engine itself. Anything matching these
-          # always gets the deeper Opus "full" review regardless of bump size.
-          blast='cilium|rook|ceph|envoy|cert-manager|external-secrets|volsync|flux|cloudnative-pg|spegel'
+          # secrets/certs, the GitOps engine, and the node OS itself. Anything
+          # matching these always gets the deeper Opus "full" review regardless
+          # of bump size.
+          blast='cilium|rook|ceph|envoy|cert-manager|external-secrets|volsync|flux|cloudnative-pg|spegel|talos|siderolabs'
 
           # Sonnet for routine patch container bumps (the light tier decides for
           # itself whether to escalate to full depth, so it needs real judgment);


### PR DESCRIPTION
## What

Adds `talos|siderolabs` to the high-blast-radius regex in the renovate-review model-tier step.

## Why

Talos is protected-infra for auto-merge, but wasn't in the review workflow's blast list — a Talos **patch** container bump labelled `type/patch` + `renovate/container` would have been routed to the light (Sonnet) tier. Node-OS bumps now always get the full Opus review, matching the treatment of cilium/rook/flux/etc.

Follow-up to #3500.