### PR TITLE
docs: 1Password vault seedbox -> Seedbox in mirror comment

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/seedbox/app/externalsecret.yaml
@@ -12,7 +12,7 @@ spec:
     name: seedbox-qbittorrent-exporter-secret
     template:
       data:
-        # seedbox-monitoring MANUALLY mirrors op://seedbox/qbittorrent (Connect
+        # seedbox-monitoring MANUALLY mirrors op://Seedbox/qbittorrent (Connect
         # serves only Talos) — update BOTH on password rotation.
         QBITTORRENT_USERNAME: "{{ .username }}"
         QBITTORRENT_PASSWORD: "{{ .password }}"


### PR DESCRIPTION
The `seedbox` 1Password vault was renamed `Seedbox` on 2026-07-11 (estate naming consistency; UUID unchanged). This updates the one comment referencing it. Comment-only change — the ExternalSecret reads the `Talos` vault via Connect and is unaffected.