### PR TITLE
feat(plex): strip Range on /library/streams, disable Envoy route timeouts

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -134,6 +134,38 @@ spec:
         parentRefs:
           - name: envoy-external
             namespace: network
+        rules:
+          # Strip Range on external-subtitle fetches — SRT subtitles break through a
+          # reverse proxy otherwise.
+          # Ref: https://forums.plex.tv/t/external-srt-subtitles-are-not-working-w-reverse-proxy/886540
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /library/streams
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove: ["Range"]
+            backendRefs:
+              - identifier: app
+                port: *port
+            timeouts:
+              request: 0s
+              backendRequest: 0s
+          # Plex needs long-lived connections beyond Envoy's default route timeout:
+          # transcode decisions can take >15s, streams run for hours, and
+          # /:/eventsource/notifications is an SSE stream held open all session —
+          # Envoy otherwise returns 504 "upstream request timeout". 0s disables it.
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: app
+                port: *port
+            timeouts:
+              request: 0s
+              backendRequest: 0s
     persistence:
       config:
         existingClaim: "{{ .Release.Name }}"


### PR DESCRIPTION
Route hardening from the Plex config audit — two fixes carried by multiple community home-ops repos that our route was missing:

- **`Range`-header strip on `/library/streams`** (onedr0p + joryirving, with the Plex forums ref): external SRT subtitles break when fetched through a reverse proxy with a Range header.
- **`timeouts: request/backendRequest: 0s` on both rules** (dapperdivers): transcode decisions can take >15s, video streams run for hours, and `/:/eventsource/notifications` is an SSE stream held open for the whole session — all of which blow through Envoy's default route timeout and surface as 504 "upstream request timeout" for remote/web clients on `plex.${SECRET_DOMAIN}`.

Route-only change — no pod restart. LAN clients (direct to the LB) are unaffected.

**Verification plan (post-merge):** rendered HTTPRoute shows both rules with timeouts; `curl -H 'Range: bytes=0-1' https://plex.<domain>/library/streams/...` still 200s; a web playback session through the gateway starts.