### PR TITLE
feat(plex): tail server log to stdout via busybox sidecar

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -86,6 +86,27 @@ spec:
               limits:
                 nvidia.com/gpu: 1
                 memory: 16Gi
+          # Plex only logs to files, never stdout — tail the main log so the
+          # VictoriaLogs collector ships it like every other app. The Logs dir is
+          # an emptyDir (config-logs) already globalMounted into all containers.
+          logs:
+            image:
+              repository: mirror.gcr.io/library/busybox
+              tag: "1.38"
+            command:
+              - /bin/sh
+              - -c
+              - tail -n0 -F "/config/Library/Application Support/Plex Media Server/Logs/Plex Media Server.log"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 10Mi
+              limits:
+                memory: 64Mi
     defaultPodOptions:
       labels:
         gpu-workload: "true"


### PR DESCRIPTION
From the Plex config audit (pattern from dapperdivers/dapper-cluster): Plex only logs to files under `Logs/` (an emptyDir that dies with the pod) and writes nothing useful to stdout — during the KB-026 investigation `kubectl logs` was useless and every log search needed `kubectl exec` into the pod.

Adds a 10m-CPU busybox sidecar that `tail -n0 -F`s `Plex Media Server.log` to stdout, so the VictoriaLogs collector ships it like every other app and the log survives pod restarts in the log store.

- No extra mounts needed: the `config-logs` emptyDir is already `globalMounts` into all containers.
- `tail -F` follows through Plex's log rotation.
- Renovate will digest-pin the busybox tag on its next run.

**Verification plan (post-merge):** `kubectl logs deploy/plex -c logs` shows live Plex Media Server.log lines; entries appear in VictoriaLogs.