### PR TITLE
fix(plex): tvOS client-profile override — transcode EAC3 audio (KB-026)

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -209,6 +209,15 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /config/Library/Application Support/Plex Media Server/Logs
+      # Custom client-profile overrides (KB-026: tvOS EAC3 direct-play freeze).
+      # Remove this mount to restore stock client profiles.
+      profiles:
+        type: configMap
+        name: plex-client-profiles
+        advancedMounts:
+          plex:
+            app:
+              - path: /config/Library/Application Support/Plex Media Server/Profiles
       tmp:
         type: emptyDir
       transcode:

--- a/kubernetes/apps/media/plex/app/kustomization.yaml
+++ b/kubernetes/apps/media/plex/app/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
   - ./ocirepository.yaml
   - ./pvc.yaml
   - ./helmrelease.yaml
+configMapGenerator:
+  - name: plex-client-profiles
+    files:
+      - tvOS.xml=./resources/tvOS.xml
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/media/plex/app/resources/tvOS.xml
+++ b/kubernetes/apps/media/plex/app/resources/tvOS.xml
@@ -2,24 +2,24 @@
 <Client name="tvOS">
   <!-- Custom server-side override for the Plex tvOS app (see KB-026).
 
-       tvOS 26.5 + Plex for Apple TV breaks EAC3 direct play: the player stalls on
-       the first frame and wedges the app (community reports match; Infuse plays the
-       same files fine). This profile mirrors the Apple TV 4K's real capabilities but
-       removes eac3 from every audioCodec list, so EAC3 titles direct-stream with an
-       ac3 5.1 audio transcode (Atmos metadata lost on this client only) while video
-       is still copied, never transcoded (hevc is in the HLS transcode target).
+        tvOS 26.5 + Plex for Apple TV breaks EAC3 direct play: the player stalls on
+        the first frame and wedges the app (community reports match; Infuse plays the
+        same files fine). This profile mirrors the Apple TV 4K's real capabilities but
+        removes eac3 from every audioCodec list, so EAC3 titles direct-stream with an
+        ac3 5.1 audio transcode (Atmos metadata lost on this client only) while video
+        is still copied, never transcoded (hevc is in the HLS transcode target).
 
-       Delete this file (and its ConfigMap mount) to restore stock behaviour once
-       Plex ships a fixed tvOS app. -->
+        Delete this file (and its ConfigMap mount) to restore stock behaviour once
+        Plex ships a fixed tvOS app. -->
   <Settings>
     <Setting name="DirectPlayStreamSelection" value="true" />
     <Setting name="StreamUnselectedIncompatibleAudioStreams" value="true" />
   </Settings>
   <TranscodeTargets>
     <!-- hevc listed so 4K HEVC video direct-streams (copy) instead of transcoding;
-         ac3 first so surround EAC3 falls back to AC3 5.1 rather than stereo aac.
-         eac3 deliberately absent: listing it would let audio "copy" straight back
-         into the broken client path. -->
+          ac3 first so surround EAC3 falls back to AC3 5.1 rather than stereo aac.
+          eac3 deliberately absent: listing it would let audio "copy" straight back
+          into the broken client path. -->
     <VideoProfile protocol="hls" container="mpegts" codec="h264,hevc" audioCodec="ac3,aac" subtitleCodec="eia_608_embedded" context="streaming" />
     <MusicProfile container="mp3" codec="mp3" />
     <PhotoProfile container="jpeg" />

--- a/kubernetes/apps/media/plex/app/resources/tvOS.xml
+++ b/kubernetes/apps/media/plex/app/resources/tvOS.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Client name="tvOS">
+  <!-- Custom server-side override for the Plex tvOS app (see KB-026).
+
+       tvOS 26.5 + Plex for Apple TV breaks EAC3 direct play: the player stalls on
+       the first frame and wedges the app (community reports match; Infuse plays the
+       same files fine). This profile mirrors the Apple TV 4K's real capabilities but
+       removes eac3 from every audioCodec list, so EAC3 titles direct-stream with an
+       ac3 5.1 audio transcode (Atmos metadata lost on this client only) while video
+       is still copied, never transcoded (hevc is in the HLS transcode target).
+
+       Delete this file (and its ConfigMap mount) to restore stock behaviour once
+       Plex ships a fixed tvOS app. -->
+  <Settings>
+    <Setting name="DirectPlayStreamSelection" value="true" />
+    <Setting name="StreamUnselectedIncompatibleAudioStreams" value="true" />
+  </Settings>
+  <TranscodeTargets>
+    <!-- hevc listed so 4K HEVC video direct-streams (copy) instead of transcoding;
+         ac3 first so surround EAC3 falls back to AC3 5.1 rather than stereo aac.
+         eac3 deliberately absent: listing it would let audio "copy" straight back
+         into the broken client path. -->
+    <VideoProfile protocol="hls" container="mpegts" codec="h264,hevc" audioCodec="ac3,aac" subtitleCodec="eia_608_embedded" context="streaming" />
+    <MusicProfile container="mp3" codec="mp3" />
+    <PhotoProfile container="jpeg" />
+  </TranscodeTargets>
+  <DirectPlayProfiles>
+    <!-- Apple TV 4K reality (mkv + hevc + surround), minus eac3 -->
+    <VideoProfile container="mkv,mp4,mov,mpegts" codec="h264,hevc,mpeg4,mpeg2video" audioCodec="aac,ac3,alac,flac,dca,truehd,opus,mp2,mp3,pcm" subtitleCodec="srt,ass,ssa,mov_text,tx3g,ttxt,text,pgs,vobsub,eia_608" />
+    <VideoProfile protocol="hls" container="mpegts" codec="h264" audioCodec="aac,ac3" />
+    <MusicProfile container="mp3" codec="mp3" />
+    <MusicProfile container="mp4,m4a" codec="aac,alac" />
+    <MusicProfile container="flac" codec="flac" />
+    <PhotoProfile container="jpeg,png,gif" />
+  </DirectPlayProfiles>
+</Client>


### PR DESCRIPTION
Server-side workaround for the KB-026 Apple TV freeze, now root-caused to **EAC3 direct play on tvOS 26.5** (all failing titles were EAC3; the Opus-audio control played fine; Infuse — own decoder — plays the same files fine; community reports the identical symptom on tvOS 26.5 with 26.4 unaffected: https://forums.plex.tv/t/938778).

Ships a custom `Profiles/tvOS.xml` (ConfigMap → mounted over the config dir's `Profiles/`) that mirrors the Apple TV 4K's real capabilities **minus `eac3`** in every audioCodec list:

- EAC3 titles now **direct-stream with an ac3 5.1 audio transcode** — surround preserved, only Atmos metadata lost, and only for the Plex tvOS app.
- Video is **copied, never transcoded** (`hevc` is in the HLS transcode target), so no GPU/quality cost for 4K.
- `eac3` deliberately absent from the transcode target too — listing it would let audio "copy" straight back into the broken client path.
- Infuse and all other clients are untouched (profile applies to `profile=tvOS` clients only).

**Reversible:** delete `resources/tvOS.xml` + the `profiles` mount when Plex ships a fixed tvOS app.

**Verification plan (post-merge):** profile file present in pod; play an EAC3 title on the Apple TV Plex app and confirm `/status/sessions` shows `videoDecision=copy` + `audioDecision=transcode` (and that playback no longer freezes). Known risk: the app's client-profile-extra may re-add eac3 client-side — if the decision doesn't change, this reverts.