### PR TITLE
fix(plex): 15m helm timeout — 300s grace exceeds default 5m during Recreate

### DIFF
--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -6,6 +6,11 @@ metadata:
   name: plex
 spec:
   interval: 1h
+  # Recreate strategy + terminationGracePeriodSeconds=300 means a rollout can
+  # legitimately spend ~5min waiting for the old pod to exit; Helm's default 5m
+  # timeout then fails the upgrade and Flux rolls back mid-rollout. Same failure
+  # mode and fix as dapperdivers/dapper-cluster.
+  timeout: 15m
   chartRef:
     kind: OCIRepository
     name: plex


### PR DESCRIPTION
Follow-up to #3523: with the Recreate strategy, the old pod can ride the full 300s terminationGracePeriod before the new one starts, blowing through Helm's default 5m timeout — the upgrade fails and Flux rolls back mid-rollout (observed live deploying #3526: `timeout waiting for: [Deployment/media/plex status: 'InProgress']` → rollback). Same failure mode and fix as dapperdivers/dapper-cluster: `spec.timeout: 15m`.