### PR TITLE
fix(renovate): repair minecraft datasource, unpark cilium/coredns pins, group toolhive

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -35,10 +35,13 @@
   // --- Custom datasources (from .renovate/customManagers.json5) ---
   customDatasources: {
     "minecraft-release": {
-      defaultRegistryUrlTemplate: "https://api.papermc.io/v2/projects/paper",
+      // Fill v3 API (api.papermc.io/v2 was sunset 2026-07-01, returns HTTP 410).
+      // v3 nests versions in per-minor-version arrays; `versions.*` flattens them
+      // back to the flat list the v2 endpoint used to return.
+      defaultRegistryUrlTemplate: "https://fill.papermc.io/v3/projects/paper",
       format: "json",
       transformTemplates: [
-        '{"releases": $map($filter(versions, function($v) { $not($contains($v, "-pre")) and $not($contains($v, "-rc")) }), function($v) { {"version": $v} }), "sourceUrl": "https://papermc.io", "homepage": "https://papermc.io"}',
+        '{"releases": $map($filter(versions.*, function($v) { $not($contains($v, "-pre")) and $not($contains($v, "-rc")) }), function($v) { {"version": $v} }), "sourceUrl": "https://papermc.io", "homepage": "https://papermc.io"}',
       ],
     },
   },
@@ -242,7 +245,10 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
+      // 1, not 2: a solo pinDigest event can never reach 2 members and parks
+      // forever under "Group Size Not Met" (protected-infra keeps merges manual
+      // regardless; 2+ simultaneous updates still group).
+      minimumGroupSize: 1,
     },
     {
       description: "CoreDNS Group",
@@ -252,7 +258,8 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
+      // 1, not 2: same solo-pinDigest parking issue as the Cilium group above.
+      minimumGroupSize: 1,
     },
     {
       description: "Flux Group",
@@ -359,6 +366,20 @@
         commitMessageTopic: "{{{groupName}}} group",
       },
       minimumGroupSize: 2,
+    },
+    {
+      // Operator and CRDs release together but aren't protected infra, so
+      // ungrouped they can auto-merge days apart; the operator running against
+      // stale CRDs is the failure mode (Flux dependsOn checks readiness, not
+      // version parity). Both OCI chart names contain "toolhive-operator".
+      description: "ToolHive Group (operator + crds move in lockstep)",
+      groupName: "ToolHive",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/toolhive-operator/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 1,
     },
 
     // === Labels (from labels.json5) ===


### PR DESCRIPTION
Three fixes from the 2026-07-13 Dependency Dashboard triage (4× Sonnet research → Opus synthesis → Opus adversarial review → Fable finalization):

## 1. `custom.minecraft-release` datasource → PaperMC Fill v3

PaperMC sunset `api.papermc.io/v2` on 2026-07-01 (returns **HTTP 410** with a sunset body) — the sole cause of the dashboard's "Package lookup failures" repository problem. Repointed at `https://fill.papermc.io/v3/projects/paper` and changed `versions` → `versions.*` in the JSONata transform (v3 nests versions in per-minor-version arrays; `.*` flattens them back to the v2 shape).

Validated against the live v3 response with the real `jsonata` library **and** re-verified locally: 66 versions flatten → 54 after the `-pre`/`-rc` filter, currently-pinned `1.21.11` present, zero prerelease leaks. Note: newest Paper releases are calendar-versioned (`26.2`), so with `versioning: loose` Renovate will offer `1.21.11 → 26.2` as a manual PR (custom datasource isn't covered by the docker/helm automerge rule).

## 2. Cilium/CoreDNS groups `minimumGroupSize: 2 → 1`

The two "Group Size Not Met" branches (coredns/cilium chart digest pins) park because the solo `pinDigest` event from `docker:pinDigests` gets swept into a group that can never reach 2 members — and it re-parks on every future digest churn, so the dashboard checkbox only clears it once. Mirrors the existing Busybox/Prowler `minimumGroupSize: 1` pattern. No automerge impact: both packages remain in the protected-infra guard (manual merge), and 2+ simultaneous updates still group.

## 3. New ToolHive group (operator + crds lockstep)

`toolhive-operator` and `toolhive-operator-crds` release together (currently both 0.30.0→0.34.0 pending) but are ungrouped and **not** protected, so they can auto-merge days apart. v0.33 adds CRD fields the operator expects, and Flux `dependsOn` only checks readiness, not version parity — operator-before-CRDs runs against a stale schema. `matchDatasources: ["docker"]` because these are Flux OCIRepository charts (same as every other OCI-chart group rule in this file).

## Validation

- `renovate-config-validator` (official, via npx): config validated successfully
- `just lint` (super-linter mirror): `RENOVATE`, `JSON`, `YAML`, prettier all pass on the changed file; remaining failures are pre-existing (`plex.json` formatting, docs-tree MD007 — CI excludes `docs/` and lints changed files only)
- Live Fill v3 API probe reproduced the expected transform output