### PR TITLE
fix(renovate): require dashboard approval for minecraft-release updates

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -475,5 +475,19 @@
       matchPackageNames: ["docker.io/lakker/pulsarr"],
       allowedVersions: "<1.0.0",
     },
+    {
+      // Paper lists new Minecraft versions before any STABLE build exists
+      // (e.g. 26.2 shipped ALPHA/BETA only — PR #3533); the itzg image
+      // defaults PAPER_CHANNEL to stable-only, so merging early crash-loops
+      // the server with "No build found for version X with channel 'default'".
+      // The Fill v3 version list carries no per-version channel data (builds
+      // channels are a per-version endpoint; GraphQL is POST-only), so gate PR
+      // creation on a human check instead. Before ticking the dashboard box,
+      // confirm STABLE builds exist:
+      //   curl -s https://fill.papermc.io/v3/projects/paper/versions/<ver>/builds | jq '[.[].channel] | unique'
+      description: "Minecraft (Paper) — dashboard approval; wait for a STABLE Paper build",
+      matchDatasources: ["custom.minecraft-release"],
+      dependencyDashboardApproval: true,
+    },
   ],
 }


### PR DESCRIPTION
Follow-up to the #3533 AI review (Paper 26.2 has ALPHA/BETA builds only; the itzg image's default stable-only `PAPER_CHANNEL` would crash-loop the server with `No build found for version 26.2 with channel 'default'`).

A fully automatic stable-only datasource isn't achievable: the Fill v3 version list (`/v3/projects/paper/versions`) exposes build **numbers** but no channels (verified live — `support.status` is `SUPPORTED` for 26.2 despite zero stable builds), channels only exist on the per-version builds endpoint (N+1, not expressible in a Renovate custom datasource), and the channel-filterable GraphQL API rejects GET (405), which is all `customDatasources` can issue.

So gate on `dependencyDashboardApproval` instead: minecraft-release updates sit in the Dependency Dashboard until a human ticks the box, and the config comment documents the one-liner to check for STABLE builds first:

```bash
curl -s https://fill.papermc.io/v3/projects/paper/versions/<ver>/builds | jq '[.[].channel] | unique'
```

PR #3533 (1.21.11 → 26.2) will be closed as premature; when Paper ships a STABLE build for a 26.x version, the update reappears in the dashboard for approval. Current latest stable is 26.1.2 if moving to the calendar scheme sooner is preferred.

Validation: `renovate-config-validator` passes; scoped super-linter (`RENOVATE`, `JSONC`, `JSONC_PRETTIER`, `EDITORCONFIG`) passes on the changed file.