### PR TITLE
fix(network-ups-tools): isolate NUT drivers per-container to survive outage flaps

### DIFF
--- a/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
@@ -15,23 +15,88 @@ spec:
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"
+        # One container per NUT process instead of the image entrypoint's
+        # all-or-nothing `upsdrvctl start`. Every process runs foregrounded
+        # (-F) so no PID files exist — the post-outage "Duplicate driver
+        # instance detected" startup race cannot happen — and a driver that
+        # loses its UPS management card only crashloops its own container;
+        # upsd and the other driver keep serving. Drivers publish their unix
+        # sockets to upsd via the shared /var/run/nut emptyDir (the image's
+        # compiled-in STATEPATH). Shell vars are deliberately written
+        # unbraced ($VAR, not braced) so Flux postBuild doesn't substitute
+        # them.
         containers:
-          app:
-            image:
+          driver-comms:
+            image: &image
               repository: instantlinux/nut-upsd
               tag: 2.8.3-r3@sha256:edadf0d18b7e240fba0e4073dfcc13f19f93839de0656f4b39752c0cad880cd5
-            # upsdrvctl aborts with "Duplicate driver instance detected (PID file exists)"
-            # when a prior container left stale driver PID files in /run/nut (the image
-            # entrypoint runs `upsdrvctl start` once and never cleans them). Wipe stale
-            # PIDs before starting, then exec the image entrypoint unchanged.
             command:
               - /bin/sh
-              - -c
-              - rm -f /run/nut/*.pid /var/run/nut/*.pid 2>/dev/null; exec /usr/local/bin/entrypoint.sh
+              - -ec
+              - |
+                cp /etc/nut/local/ups.conf /etc/nut/ups.conf
+                chgrp nut /etc/nut/ups.conf && chmod 640 /etc/nut/ups.conf
+                chown nut:nut /var/run/nut && chmod 2750 /var/run/nut
+                exec /usr/lib/nut/snmp-ups -a cr-ups-comms -F -u root
+            env: &env
+              TZ: ${TIMEZONE:=UTC}
+            resources: &driver-resources
+              requests:
+                cpu: 5m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
+            securityContext: &security-context
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+                add:
+                  - CHOWN
+                  - DAC_OVERRIDE
+                  - SETGID
+                  - SETUID
+          driver-main:
+            image: *image
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                cp /etc/nut/local/ups.conf /etc/nut/ups.conf
+                chgrp nut /etc/nut/ups.conf && chmod 640 /etc/nut/ups.conf
+                chown nut:nut /var/run/nut && chmod 2750 /var/run/nut
+                exec /usr/lib/nut/snmp-ups -a cr-ups-main -F -u root
+            env: *env
+            resources: *driver-resources
+            securityContext: *security-context
+          upsd:
+            image: *image
+            # upsd.users keeps the upsmon entry for external NUT clients that
+            # log in via the LoadBalancer IP. The image's in-pod upsmon is
+            # dropped: inside a container its SHUTDOWNCMD can't shut anything
+            # down, so it was a no-op. MAXAGE 25 marks a UPS stale after 25s
+            # (ups.conf pollfreq is 15).
+            command:
+              - /bin/sh
+              - -ec
+              - |
+                cp /etc/nut/local/ups.conf /etc/nut/ups.conf
+                {
+                  echo 'LISTEN 0.0.0.0'
+                  echo 'MAXAGE 25'
+                } > /etc/nut/upsd.conf
+                {
+                  echo "[$API_USER]"
+                  echo "  password = $API_PASSWORD"
+                  echo '  upsmon primary'
+                } > /etc/nut/upsd.users
+                chgrp nut /etc/nut/ups.conf /etc/nut/upsd.conf /etc/nut/upsd.users
+                chmod 640 /etc/nut/ups.conf /etc/nut/upsd.conf /etc/nut/upsd.users
+                chown nut:nut /var/run/nut && chmod 2750 /var/run/nut
+                exec /usr/sbin/upsd -F -u nut
             env:
               TZ: ${TIMEZONE:=UTC}
-              NAME: cr-ups-main
-              MAXAGE: "25"
               API_USER: ${NUT_API_USER}
               API_PASSWORD: ${NUT_API_PASSWORD}
             probes:
@@ -54,21 +119,13 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
+                memory: 32Mi
               limits:
-                memory: 128Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                drop:
-                  - ALL
-                add:
-                  - CHOWN
-                  - DAC_OVERRIDE
-                  - SETGID
-                  - SETUID
+                memory: 64Mi
+            securityContext: *security-context
     defaultPodOptions:
+      annotations:
+        kubectl.kubernetes.io/default-container: upsd
       securityContext:
         runAsNonRoot: false
         runAsUser: 0
@@ -81,10 +138,19 @@ spec:
           - path: /etc/nut/local/ups.conf
             subPath: ups.conf
             readOnly: true
+      nut-run:
+        type: emptyDir
+        medium: Memory
+        globalMounts:
+          - path: /var/run/nut
     service:
       app:
         controller: *app
         type: LoadBalancer
+        # A crashlooping driver container makes the pod NotReady; without this
+        # the Service would drop its endpoints and take a healthy upsd (and
+        # all monitoring) down with it.
+        publishNotReadyAddresses: true
         annotations:
           lbipam.cilium.io/ips: ${SVC_NUT_ADDR:=10.32.8.89}
         ports:

--- a/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
@@ -51,6 +51,35 @@ spec:
           labels:
             severity: critical
             pushover_priority: emergency
+        # Since the network-ups-tools driver-isolation change, one snmp-ups
+        # driver can fail independently of upsd: that UPS's metrics vanish
+        # while the other keeps reporting. absent() carries the ups label
+        # from its matcher, so this stays per-UPS.
+        - alert: UPSMetricsMissing
+          annotations:
+            description: >-
+              No nut_ups_status metrics for UPS {{ $labels.ups }} for over 5 minutes.
+              Its snmp-ups driver container is likely crashlooping or the UPS
+              management card is unreachable, so this UPS is unmonitored.
+            summary: UPS {{ $labels.ups }} is not reporting metrics.
+          expr: absent(nut_ups_status{ups="cr-ups-main"}) or absent(nut_ups_status{ups="cr-ups-comms"})
+          for: 5m
+          labels:
+            severity: critical
+        # A UPS can shut its output down during an outage and never restart it
+        # (seen 2026-07-14: mains restored, battery 100%, output 0V, downstream
+        # devices dark) — no other rule covers status OFF.
+        - alert: UPSOutputOff
+          annotations:
+            description: >-
+              UPS {{ $labels.ups }} reports status OFF — its output is switched off
+              and everything downstream is unpowered. It will not restart output by
+              itself; power it back on at the front panel.
+            summary: UPS {{ $labels.ups }} output is OFF — downstream load is dark.
+          expr: max by (ups) (nut_ups_status{status="OFF"}) == 1
+          for: 2m
+          labels:
+            severity: critical
         - alert: UpsLowBattery
           annotations:
             description: UPS {{ $labels.ups }} battery charge is {{ $value | humanizePercentage }} which is below 50%.


### PR DESCRIPTION
## Problem

Three manual pod-deletes were needed on 2026-07-14 alone: every power flap that makes a UPS management card briefly unreachable crashloops the whole `network-ups-tools` pod, taking **all** UPS monitoring down during the exact window it matters.

Root cause: the image entrypoint runs `upsdrvctl start` (both drivers, all-or-nothing) under `sh -e`. When the comms NMC is flaky, the comms driver's first start attempt writes its PID file and hangs; upsdrvctl's retry then dies on `Duplicate driver instance detected (PID file exists)`, the script exits, and the pod crashloops until someone deletes it. The existing `rm -f *.pid` pre-entrypoint wipe can't help — the race is within a single startup, not stale files across restarts.

## Fix

One container per NUT process, each foregrounded with `-F` so **no PID files exist at all** (race structurally impossible):

- `driver-main` / `driver-comms` — `snmp-ups -a <ups> -F`, publishing sockets to upsd via a memory-backed emptyDir at `/var/run/nut` (the image's compiled-in STATEPATH). A driver losing its NMC now only crashloops its own container and self-heals via normal backoff; the other driver and upsd keep serving.
- `upsd` — generates `upsd.conf`/`upsd.users` exactly as the entrypoint did (upsmon entry kept for external NUT clients on the LB IP), runs `upsd -F -u nut`. The in-pod `upsmon` is dropped: inside a container its SHUTDOWNCMD can't shut anything down — it was a no-op.
- Service gains `publishNotReadyAddresses: true` — a crashlooping driver container makes the pod NotReady, which would otherwise unpublish a perfectly healthy upsd.

## Alert coverage for the new failure mode

Driver isolation converts "loud pod crash" into "quiet per-UPS staleness", so:

- **UPSMetricsMissing** — `absent(nut_ups_status{ups=...})` per UPS, 5m — fires when one driver is down/its NMC unreachable. (Verified live against Prometheus; both exprs parse and return per-UPS labels.)
- **UPSOutputOff** — `status="OFF"` — covers the gap found today where the comms UPS sat with output off (mains present, battery 100%, downstream dark) and nothing fired. **This will fire immediately on merge** — the comms UPS is genuinely OFF right now and needs its front-panel power-on.

## Validation

- `flate build hr` render inspected: 3 containers, shared Memory emptyDir, probes on upsd only, publishNotReadyAddresses set
- `flate test all --namespace observability` — 72 passed
- Both new alert exprs executed against live Prometheus via promtool
- `just lint` — YAML linters pass (remaining failures are pre-existing docs-tree markdown findings that CI excludes)