### PR TITLE
fix(network-ups-tools): add FOWNER cap so /var/run/nut perms setup survives restarts

### DIFF
--- a/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
               - |
                 cp /etc/nut/local/ups.conf /etc/nut/ups.conf
                 chgrp nut /etc/nut/ups.conf && chmod 640 /etc/nut/ups.conf
-                chown nut:nut /var/run/nut && chmod 2750 /var/run/nut
+                chmod 2750 /var/run/nut && chown nut:nut /var/run/nut
                 exec /usr/lib/nut/snmp-ups -a cr-ups-comms -F -u root
             env: &env
               TZ: ${TIMEZONE:=UTC}
@@ -55,6 +55,10 @@ spec:
                 add:
                   - CHOWN
                   - DAC_OVERRIDE
+                  # FOWNER: chmod on /var/run/nut once it is owned by nut
+                  # (the emptyDir keeps nut ownership across container
+                  # restarts, so the perms commands must stay idempotent)
+                  - FOWNER
                   - SETGID
                   - SETUID
           driver-main:
@@ -65,7 +69,7 @@ spec:
               - |
                 cp /etc/nut/local/ups.conf /etc/nut/ups.conf
                 chgrp nut /etc/nut/ups.conf && chmod 640 /etc/nut/ups.conf
-                chown nut:nut /var/run/nut && chmod 2750 /var/run/nut
+                chmod 2750 /var/run/nut && chown nut:nut /var/run/nut
                 exec /usr/lib/nut/snmp-ups -a cr-ups-main -F -u root
             env: *env
             resources: *driver-resources
@@ -93,7 +97,7 @@ spec:
                 } > /etc/nut/upsd.users
                 chgrp nut /etc/nut/ups.conf /etc/nut/upsd.conf /etc/nut/upsd.users
                 chmod 640 /etc/nut/ups.conf /etc/nut/upsd.conf /etc/nut/upsd.users
-                chown nut:nut /var/run/nut && chmod 2750 /var/run/nut
+                chmod 2750 /var/run/nut && chown nut:nut /var/run/nut
                 exec /usr/sbin/upsd -F -u nut
             env:
               TZ: ${TIMEZONE:=UTC}


### PR DESCRIPTION
Follow-up to #3542, which crashlooped all three containers on rollout: the command ran `chown nut:nut` before `chmod`, and once the dir is nut-owned, root cannot chmod without CAP_FOWNER (dropped with ALL — the original image dodged this via `mkdir -m` ordering on a fresh tmpfs).

- Flip to `chmod 2750 && chown nut:nut` (works on first start while the emptyDir is still root-owned)
- Add `FOWNER` to the shared securityContext so the same line stays idempotent on container restarts (the emptyDir persists with nut ownership within the pod)

Verified via `flate build hr`: FOWNER renders in all three containers, command order flipped.