### PR TITLE
fix(ci): allowlist nut-exporter prometheusrule for internal-identifier scan

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -78,6 +78,7 @@ ALLOWLIST: dict[str, str] = {
     "kubernetes/apps/observability/mktxp/app/externalsecret.yaml": "mktxp.conf instance labels",
     "kubernetes/apps/observability/network-ups-tools/app/configmap.yaml": "NUT UPS device names",
     "kubernetes/apps/observability/network-ups-tools/app/helmrelease.yaml": "NUT UPS device + address",
+    "kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml": "NUT UPS alert selectors",
     "kubernetes/apps/observability/nut-exporter/app/servicemonitor.yaml": "NUT scrape targets",
     "kubernetes/apps/observability/snmp-exporter/app/configmap-entity-sensor.yaml": "SNMP sensor module",
     "kubernetes/apps/observability/snmp-exporter/app/configmap.yaml": "SNMP module config",


### PR DESCRIPTION
The `UPSMetricsMissing` expression added in #3542 selects on the NUT UPS names (`ups="cr-ups-..."`), which the internal-identifier scan flags as `cr-*` device hostnames — and since the scan checks the whole tree, **every push and PR since that merge has failed the Internal Identifier Scan**, including unrelated Renovate PRs.

These names are already documented accepted functional config in three sibling files (`network-ups-tools` configmap + helmrelease, `nut-exporter` servicemonitor); the PrometheusRule is a fourth use of the same values, so this follows the script's own remediation guidance (add path + reason to ALLOWLIST).

Verified locally: `python3 .github/scripts/check_internal_identifiers.py` → OK.

After merge I'll re-run the failed scans on open Renovate PRs so they can auto-merge again.