### PR TITLE
fix(shelly-operator): update to 0.3.2 (stop tripping firmware 2.0.0's nonce throttle)

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.3.1@sha256:8c0c019036f4f219345e85a865a0cbd883bc96e8d12b4c7332dc59119986ba63
+      tag: 0.3.2@sha256:4f51a71fb21548b6b8031422af994d9185ac247acdfa93211ea9d3676f5d0e21
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.3.1
+    tag: 0.3.2
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator


### PR DESCRIPTION
## Why

Three plugs — `Speaker left`, `Monitor right`, `Label Printer Small` — auto-updated to **Shelly firmware 2.0.0** at 00:01 on 14 Jul and have flapped `ShellyDeviceOutOfSync` ever since, claiming config drift that never happened:

```
status=Unknown  reason=ConfigFetchFailed  driftedSections=None
msg: fetching device config: shelly: Shelly.GetConfig <addr>: status 429 Too Many Requests
```

`driftedSections` is empty — **nothing drifted**. 2.0.0 added RFC 7616 nonce management with a **32-entry circular nonce buffer**; while it's exhausted the device opens a 2s throttle window and returns **429**. The operator's `Shelly.GetConfig` hit that, which became `InSync=Unknown`, and `inSyncValue()` maps `Unknown` to 0 exactly like a real drift — so the alert fired with a misleading message.

Exactly 3 devices were on 2.0.0; exactly 3 alerted. The other 45 are on 1.7.5, which has no nonce buffer — same polling load, no 429s.

## What 0.3.2 fixes

The operator was minting and discarding ~24–36 nonces per device per hour:

| Source | Before | After 0.3.2 |
|---|---|---|
| Reconcile — fresh client (and 401) every cycle | ~12–24/hr | **~1/hr** |
| Discovery sweep — credential-less `Sys.GetStatus`, could only 401 | 12/hr | **0/hr** |

- LukeEvansTech/shelly-operator#41 — cache the device RPC client so its digest nonce survives reconciles.
- LukeEvansTech/shelly-operator#43 — drop the sweeper's doomed `Sys.GetStatus`; read `availableFirmware` in the reconciler, which holds the password.

## Bonus: a dead alert comes back

#43 also revives `status.availableFirmware`, which was **empty on all 49 devices**. That pinned `shelly_device_update_available` at 0, so `ShellyDevicePendingFirmware` could never fire — which is exactly why 2.0.0 landed on three plugs with no warning. It should now warn before the rest of the fleet follows.

## Validation

- `flate build hr shelly-operator -n home` renders the new digest-pinned image
- super-linter (real `slim-v8` image, repo config) → all clean
- `check_internal_identifiers.py` → OK
- operator side: `make lint` 0 issues, full suite green, CI green on both PRs

Hand-bumped rather than waiting out Renovate's 3-day `minimumReleaseAge`, to stop the noise now and confirm the 429s actually clear. Renovate resumes managing the tag+digest afterwards.