### PR TITLE
feat(talos): add LUKS2 slot-1 fallback key to STATE and EPHEMERAL

### DIFF
--- a/talos/mod.just
+++ b/talos/mod.just
@@ -12,6 +12,13 @@ gen-config:
     TALSECRET=$(mktemp)
     trap 'rm -f "${TALSECRET}"' EXIT
     op document get talsecret --vault Talos > "${TALSECRET}"
+    # LUKS2 slot-1 fallback passphrase, substituted into talconfig.yaml as ${TALOS_LUKS_FALLBACK}.
+    # Never committed: this repo is public and the rendered configs are gitignored.
+    export TALOS_LUKS_FALLBACK=$(op read "op://Talos/talos-luks-fallback/password")
+    if [[ -z "${TALOS_LUKS_FALLBACK}" ]]; then
+        just log error "TALOS_LUKS_FALLBACK is empty — refusing to generate config without the LUKS fallback key" "stage" "{{ recipe_name() }}"
+        exit 1
+    fi
     talhelper genconfig --config-file "{{ source_directory() }}/talconfig.yaml" --secret-file "${TALSECRET}" --out-dir "{{ source_directory() }}/clusterconfig"
 
 [doc('Generate secret if missing (stored as the talsecret document in 1Password)')]
@@ -29,12 +36,14 @@ gen-secret:
 [doc('Apply Talos config to a specific node')]
 apply-node node *args:
     just log info "Applying Talos config to node..." "stage" "{{ recipe_name() }}" "node" "{{ node }}"
+    export TALOS_LUKS_FALLBACK=$(op read "op://Talos/talos-luks-fallback/password")
     talhelper gencommand apply --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --node {{ node }} --extra-flags "{{ args }}" | bash
 
 [confirm('Upgrade Talos on node? [y|N]')]
 [doc('Upgrade Talos on a specific node')]
 upgrade-node node:
     just log info "Upgrading Talos on node..." "stage" "{{ recipe_name() }}" "node" "{{ node }}"
+    export TALOS_LUKS_FALLBACK=$(op read "op://Talos/talos-luks-fallback/password")
     TALOS_IMAGE=$(yq -r -e '.nodes[] | select(.ipAddress == "{{ node }}") | .talosImageURL' "{{ source_directory() }}/talconfig.yaml")
     TALOS_VERSION=$(yq -r -e '.talosVersion' "{{ source_directory() }}/talenv.yaml")
     talhelper gencommand upgrade --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --node {{ node }} --extra-flags "--image=${TALOS_IMAGE}:${TALOS_VERSION} --timeout=10m" | bash
@@ -43,6 +52,7 @@ upgrade-node node:
 [doc('Upgrade Kubernetes version')]
 upgrade-k8s:
     just log info "Upgrading Kubernetes..." "stage" "{{ recipe_name() }}"
+    export TALOS_LUKS_FALLBACK=$(op read "op://Talos/talos-luks-fallback/password")
     K8S_VERSION=$(yq -r -e '.kubernetesVersion' "{{ source_directory() }}/talenv.yaml")
     talhelper gencommand upgrade-k8s --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --extra-flags "--to ${K8S_VERSION}" | bash
 
@@ -50,4 +60,5 @@ upgrade-k8s:
 reset:
     gum confirm "This will destroy your cluster and reset the nodes back to maintenance mode. Continue?" --default=false || exit 0
     just log warn "Resetting cluster..." "stage" "{{ recipe_name() }}"
+    export TALOS_LUKS_FALLBACK=$(op read "op://Talos/talos-luks-fallback/password")
     talhelper gencommand reset --config-file "{{ source_directory() }}/talconfig.yaml" --out-dir "{{ source_directory() }}/clusterconfig" --extra-flags "--reboot --system-labels-to-wipe STATE --system-labels-to-wipe EPHEMERAL --graceful=false --wait=false" | bash

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -34,7 +34,36 @@ nodes:
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
     patches:
-      # Encrypt system disk with TPM
+      # Encrypt system disk with TPM.
+      #
+      # slot 1 is a NON-NEGOTIABLE fallback. Talos seals slot 0 to PCR 7, which measures
+      # UEFI Secure Boot state + the PK/KEK/db/dbx certificates. A Supermicro H13SRD-F BIOS
+      # update from the 1.x "buggy line" WIPES those keys (proven on cr-node-02, 2026-07-15 —
+      # PreserveSECBOOTKEY is honoured only by an already-fixed OUTGOING BIOS). PCR 7 then
+      # changes, slot 0 cannot unseal, and with a single slot the node does not boot at all.
+      # All three nodes are control-plane, so a fleet-wide flash would take out etcd quorum.
+      #
+      # Talos does NOT self-heal a failed TPM slot (a PCR mismatch is not ErrTokenInvalid, so
+      # it never re-seals). Upstream declined to add recovery keys (siderolabs/talos#7868), so
+      # we provide our own.
+      #
+      # The passphrase is injected at `talhelper genconfig` time from 1Password
+      # (op://Talos/talos-luks-fallback/password). NEVER commit it — this repo is public.
+      # The rendered configs land in talos/clusterconfig/, which is gitignored.
+      #
+      # CAUTION: syncKeys() REMOVES slots absent from config. Always keep one working key.
+      # See: Scratch/homelab/biosfirmware/runlog/2026-07-15-VERDICT-buggy-line-wipes.md
+      #
+      # NOTE: slot 0 stays bound to PCR 7 — deliberately, after a failed attempt to drop it.
+      # `pcrs: []` on a VolumeConfig document does NOT survive talhelper: the empty list is
+      # dropped during serialisation, rendering as `options: {}`, which Talos then treats as
+      # unset and defaults straight back to PCR 7. Verified live on cr-talos-03 (2026-07-15):
+      # `talosctl get volumestatus STATE` still reported `tpmEncryptionOptions.pcrs: [7]`.
+      # It is a silent no-op, so the migration was reverted rather than left as dead config.
+      #
+      # Consequence, accepted: the BIOS flash wipes the Secure Boot keys -> PCR 7 changes ->
+      # slot 0 breaks. slot 1 keeps the node bootable; the TPM slot is then rotated by hand
+      # (remove tpm key -> apply+reboot -> re-add -> apply+reboot). Talos does not self-heal.
       - |-
         machine:
           systemDiskEncryption:
@@ -43,11 +72,17 @@ nodes:
               keys:
                 - slot: 0
                   tpm: {}
+                - slot: 1
+                  static:
+                    passphrase: ${TALOS_LUKS_FALLBACK}
             ephemeral:
               provider: luks2
               keys:
                 - slot: 0
                   tpm: {}
+                - slot: 1
+                  static:
+                    passphrase: ${TALOS_LUKS_FALLBACK}
       # Watchdog timer configuration
       - |-
         apiVersion: v1alpha1
@@ -80,7 +115,36 @@ nodes:
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
     patches:
-      # Encrypt system disk with TPM
+      # Encrypt system disk with TPM.
+      #
+      # slot 1 is a NON-NEGOTIABLE fallback. Talos seals slot 0 to PCR 7, which measures
+      # UEFI Secure Boot state + the PK/KEK/db/dbx certificates. A Supermicro H13SRD-F BIOS
+      # update from the 1.x "buggy line" WIPES those keys (proven on cr-node-02, 2026-07-15 —
+      # PreserveSECBOOTKEY is honoured only by an already-fixed OUTGOING BIOS). PCR 7 then
+      # changes, slot 0 cannot unseal, and with a single slot the node does not boot at all.
+      # All three nodes are control-plane, so a fleet-wide flash would take out etcd quorum.
+      #
+      # Talos does NOT self-heal a failed TPM slot (a PCR mismatch is not ErrTokenInvalid, so
+      # it never re-seals). Upstream declined to add recovery keys (siderolabs/talos#7868), so
+      # we provide our own.
+      #
+      # The passphrase is injected at `talhelper genconfig` time from 1Password
+      # (op://Talos/talos-luks-fallback/password). NEVER commit it — this repo is public.
+      # The rendered configs land in talos/clusterconfig/, which is gitignored.
+      #
+      # CAUTION: syncKeys() REMOVES slots absent from config. Always keep one working key.
+      # See: Scratch/homelab/biosfirmware/runlog/2026-07-15-VERDICT-buggy-line-wipes.md
+      #
+      # NOTE: slot 0 stays bound to PCR 7 — deliberately, after a failed attempt to drop it.
+      # `pcrs: []` on a VolumeConfig document does NOT survive talhelper: the empty list is
+      # dropped during serialisation, rendering as `options: {}`, which Talos then treats as
+      # unset and defaults straight back to PCR 7. Verified live on cr-talos-03 (2026-07-15):
+      # `talosctl get volumestatus STATE` still reported `tpmEncryptionOptions.pcrs: [7]`.
+      # It is a silent no-op, so the migration was reverted rather than left as dead config.
+      #
+      # Consequence, accepted: the BIOS flash wipes the Secure Boot keys -> PCR 7 changes ->
+      # slot 0 breaks. slot 1 keeps the node bootable; the TPM slot is then rotated by hand
+      # (remove tpm key -> apply+reboot -> re-add -> apply+reboot). Talos does not self-heal.
       - |-
         machine:
           systemDiskEncryption:
@@ -89,11 +153,17 @@ nodes:
               keys:
                 - slot: 0
                   tpm: {}
+                - slot: 1
+                  static:
+                    passphrase: ${TALOS_LUKS_FALLBACK}
             ephemeral:
               provider: luks2
               keys:
                 - slot: 0
                   tpm: {}
+                - slot: 1
+                  static:
+                    passphrase: ${TALOS_LUKS_FALLBACK}
       # Watchdog timer configuration
       - |-
         apiVersion: v1alpha1
@@ -126,7 +196,36 @@ nodes:
     talosImageURL: factory.talos.dev/installer-secureboot/44186a005dfca322f81df634a457384455475fbfa518777f3ee58d35f173d73b
     controlPlane: true
     patches:
-      # Encrypt system disk with TPM
+      # Encrypt system disk with TPM.
+      #
+      # slot 1 is a NON-NEGOTIABLE fallback. Talos seals slot 0 to PCR 7, which measures
+      # UEFI Secure Boot state + the PK/KEK/db/dbx certificates. A Supermicro H13SRD-F BIOS
+      # update from the 1.x "buggy line" WIPES those keys (proven on cr-node-02, 2026-07-15 —
+      # PreserveSECBOOTKEY is honoured only by an already-fixed OUTGOING BIOS). PCR 7 then
+      # changes, slot 0 cannot unseal, and with a single slot the node does not boot at all.
+      # All three nodes are control-plane, so a fleet-wide flash would take out etcd quorum.
+      #
+      # Talos does NOT self-heal a failed TPM slot (a PCR mismatch is not ErrTokenInvalid, so
+      # it never re-seals). Upstream declined to add recovery keys (siderolabs/talos#7868), so
+      # we provide our own.
+      #
+      # The passphrase is injected at `talhelper genconfig` time from 1Password
+      # (op://Talos/talos-luks-fallback/password). NEVER commit it — this repo is public.
+      # The rendered configs land in talos/clusterconfig/, which is gitignored.
+      #
+      # CAUTION: syncKeys() REMOVES slots absent from config. Always keep one working key.
+      # See: Scratch/homelab/biosfirmware/runlog/2026-07-15-VERDICT-buggy-line-wipes.md
+      #
+      # NOTE: slot 0 stays bound to PCR 7 — deliberately, after a failed attempt to drop it.
+      # `pcrs: []` on a VolumeConfig document does NOT survive talhelper: the empty list is
+      # dropped during serialisation, rendering as `options: {}`, which Talos then treats as
+      # unset and defaults straight back to PCR 7. Verified live on cr-talos-03 (2026-07-15):
+      # `talosctl get volumestatus STATE` still reported `tpmEncryptionOptions.pcrs: [7]`.
+      # It is a silent no-op, so the migration was reverted rather than left as dead config.
+      #
+      # Consequence, accepted: the BIOS flash wipes the Secure Boot keys -> PCR 7 changes ->
+      # slot 0 breaks. slot 1 keeps the node bootable; the TPM slot is then rotated by hand
+      # (remove tpm key -> apply+reboot -> re-add -> apply+reboot). Talos does not self-heal.
       - |-
         machine:
           systemDiskEncryption:
@@ -135,11 +234,17 @@ nodes:
               keys:
                 - slot: 0
                   tpm: {}
+                - slot: 1
+                  static:
+                    passphrase: ${TALOS_LUKS_FALLBACK}
             ephemeral:
               provider: luks2
               keys:
                 - slot: 0
                   tpm: {}
+                - slot: 1
+                  static:
+                    passphrase: ${TALOS_LUKS_FALLBACK}
       # Watchdog timer configuration
       - |-
         apiVersion: v1alpha1


### PR DESCRIPTION
## Why

Talos seals the LUKS2 key to **PCR 7**, which measures UEFI Secure Boot state and the PK/KEK/db/dbx certificates. A Supermicro H13SRD-F BIOS update from the "buggy line" (≤ 1.7) **wipes those keys** despite `PreserveSECBOOTKEY: true`.

Proven on hardware (cr-node-02, 2026-07-15):

| Flash | Outgoing BIOS | Secure Boot keys |
|---|---|---|
| 1.8 → 1.9 | fixed | preserved |
| 1.9 → 1.7 | fixed | preserved |
| **1.7 → 1.9** | **buggy** | **WIPED** |

**The preservation logic runs in the OUTGOING BIOS**, so flashing *to* a fixed version does not help — you must already *be* on one. All three Talos sleds are on **BIOS 1.4**, so each takes the wipe exactly once when we update them.

PCR 7 therefore changes, slot 0 cannot unseal, and **with a single key slot the node does not boot**. All three nodes are control-plane, so a fleet-wide flash would take out etcd quorum and force a restore from backup. Talos does not self-heal a failed TPM slot, and upstream declined to add recovery keys ([siderolabs/talos#7868](https://github.com/siderolabs/talos/issues/7868)) — so we provide our own.

## What

`slot 1` static-passphrase fallback on STATE and EPHEMERAL, for all three nodes.

- Passphrase from 1Password (`op://Talos/talos-luks-fallback/password`), injected at genconfig time as `${TALOS_LUKS_FALLBACK}`.
- This repo is **public**; `talconfig.yaml` carries only the placeholder and the rendered configs under `talos/clusterconfig/` are gitignored. Verified: not in git history, not in tracked files.
- `gen-config` hard-fails on an empty value rather than rendering an empty passphrase. The four other recipes that parse talconfig export the variable too.

## Verification

Applied one node at a time; etcd never dropped below 3 members. Verified via `talosctl get volumestatus` (**actual** state, not `volumeconfig`):

```
cr-talos-01  STATE: static tpm   EPHEMERAL: static tpm
cr-talos-02  STATE: static tpm   EPHEMERAL: static tpm
cr-talos-03  STATE: static tpm   EPHEMERAL: static tpm
```

Talos log confirms the keyslot reached LUKS, not just config:

```
INFO added encryption key {"volume": "EPHEMERAL", "slot": 1, "handler": "*keys.StaticKeyHandler"}
```

⚠️ **STATE needs TWO reboots.** It is opened early to read the config, so a keyslot addition only lands on the following boot. `volumeconfig` (desired state) reports slot 1 immediately and **will mislead** — two of three nodes initially had `STATE: tpm` only while claiming otherwise. Trust `volumestatus`.

## Not done: `pcrs: []`

Attempted and reverted — it is a **silent no-op**. `pcrs: []` does not survive talhelper: the empty list is dropped, rendering as `options: {}`, which Talos treats as unset and defaults back to PCR 7. Confirmed live (`tpmEncryptionOptions.pcrs: [7]` after the migration). Left on legacy `machine.systemDiskEncryption`, which is functionally identical here and proven on all three nodes, rather than keep dead config implying a protection we do not have.

Consequence, accepted: slot 0 breaks at the flash; slot 1 keeps the node bootable; the TPM slot is rotated by hand afterwards.

## Lint

super-linter v8.6.0 (matching the `shared-workflows` v8 pin), `VALIDATE_YAML=true` scoped to the changed files: **pass**. Repo lefthook pre-commit (yamllint, codespell, prettier, editorconfig): **pass**.

Full background: `~/Scratch/homelab/biosfirmware`.