### PR TITLE
feat(certwarden): pin IPMI ExternalSecret key sets with explicit templates

### DIFF
--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/externalsecret.yaml
@@ -11,6 +11,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-storage-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-storage-ipmi
@@ -27,6 +34,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-01-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-01-ipmi
@@ -43,6 +57,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-02-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-02-ipmi
@@ -59,6 +80,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-03-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-03-ipmi
@@ -75,6 +103,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-04-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-04-ipmi
@@ -91,6 +126,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-05-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-05-ipmi
@@ -107,6 +149,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-06-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-06-ipmi
@@ -123,6 +172,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-07-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-07-ipmi
@@ -139,6 +195,13 @@ spec:
     name: onepassword-connect
   target:
     name: supermicro-cr-node-08-ipmi
+    template:
+      data:
+        IPMI_URL: "{{ .IPMI_URL }}"
+        IPMI_MODEL: "{{ .IPMI_MODEL }}"
+        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
+        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
+        IPMI_IP: "{{ .IPMI_IP }}"
   dataFrom:
     - extract:
         key: cr-node-08-ipmi


### PR DESCRIPTION
## Why

The nine Supermicro IPMI ExternalSecrets were bare `dataFrom: extract`, so each target Secret mirrored the whole 1Password item verbatim. Verified against the live cluster, every one carries **seven** keys, not the five anyone would expect:

```
IPMI_IP  IPMI_MODEL  IPMI_PASSWORD  IPMI_URL  IPMI_USERNAME  notesPlain  password
```

`notesPlain` and the built-in `password` are both zero-length on all nine, and nothing reads them.

That implicit contract is about to become a real problem. The Talos 1Password items are being converted from `PASSWORD` to `LOGIN` category so 1Password can autofill the BMC web UIs (consolidating seven duplicate Personal logins into the single ES-referenced item). Making them Logins populates the built-in username/password — which under bare `dataFrom: extract` would land in all nine Secrets as a **live second copy of the IPMI credential under a different key**.

This PR declares the contract explicitly so that can't happen.

## What

Adds a `target.template.data` stanza to all nine, matching the pattern the arr stack already uses (`kubernetes/apps/media/sonarr/app/externalsecret.yaml`):

```yaml
  target:
    name: supermicro-cr-node-02-ipmi
    template:
      data:
        IPMI_URL: "{{ .IPMI_URL }}"
        IPMI_MODEL: "{{ .IPMI_MODEL }}"
        IPMI_USERNAME: "{{ .IPMI_USERNAME }}"
        IPMI_PASSWORD: "{{ .IPMI_PASSWORD }}"
        IPMI_IP: "{{ .IPMI_IP }}"
  dataFrom:
    - extract:
        key: cr-node-02-ipmi
```

All five real keys keep their exact current values. Only the two empty keys are dropped.

`IPMI_IP` is **deliberately retained** even though nothing reads it today — the certwarden deploy script consumes only `IPMI_URL`/`IPMI_MODEL`/`IPMI_USERNAME`/`IPMI_PASSWORD` (`scripts-configmap.yaml`). Dropping a populated field as a side effect of an unrelated autofill cleanup isn't a call this PR should make silently.

## Verification

- Live Secret key sets and per-key byte lengths read from the cluster for all nine before the change; `notesPlain`/`password` confirmed zero-length.
- All nine docs parse; asserted each `template.data` key set is exactly the five `IPMI_*` keys and each `target.name` matches `supermicro-<extract key>`.
- super-linter v8.6.0 (the SHA pinned via shared-workflows) run locally, YAML scope: exit 0. The nine `line-length` warnings are pre-existing `$schema` comment lines.

## Expected effect on reconcile

Each Secret loses two empty keys and keeps five unchanged values. No consumer reads the dropped keys, so no restart or cert-deployment behaviour change is expected.

**Merge and confirm reconcile before the 1Password category change lands** — that ordering is the entire point.