### PR TITLE
fix(shelly-operator): update to 0.3.3 (registry policy labels)

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.3.2@sha256:4f51a71fb21548b6b8031422af994d9185ac247acdfa93211ea9d3676f5d0e21
+      tag: 0.3.3@sha256:31b1ec219fe012f3dde9ec822b10611a27ccb8de18f7481026da1e4f1cc87256
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.3.2
+    tag: 0.3.3
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator


### PR DESCRIPTION
Prerequisite for the power-policy profile split discussed today.

## What 0.3.3 adds

LukeEvansTech/shelly-operator#44 — the device registry can stamp free-form labels under `registry.shelly.thirdimpact.io/`, so a `ShellyProfile` can select on a **policy** axis independent of `room`/`appliance`.

## Why it's needed

Right now power-on behaviour is decided by **hardware type, not intent**:

| | behaviour |
|---|---|
| 9 relays (PDU-01…04, CR-SW-CORE, …) | FORCED ON + 30s `autoOn` watchdog |
| 5 rack plugs (Main Rack, Rack PDU, Comms Rack Mains/UPS, Test Bench) | `restore_last` — stays off if it was off |

Everything above is `appliance=rack`, but they land in different profiles. So a PDU or the core switch that happened to be off when power died would **stay off** after an outage.

`room`/`type` can't express the fix: a dishwasher is both *"kitchen"* and *"must power back on after an outage"*, and a device gets exactly one `type`. Overloading it destroys the semantics; guessing with `type In [rack, kitchen]` drags in Test Bench and Water filter.

## Safety

**Inert on deploy** — no registry entry declares a `labels` map yet, so this is a no-op until the `shelly-fleet` side lands. Deliberately shipped separately so the operator upgrade and the behaviour change aren't entangled.

## Validation

- `flate` renders the new digest-pinned image
- super-linter (real slim-v8) clean; internal-identifier guard OK
- operator side: `make lint` 0 issues, full suite green, CI green on #44