### PR TITLE
fix(subspy): bump to 1.6.3 — global Apprise setting now actually delivers

### DIFF
--- a/kubernetes/apps/default/subspy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/subspy/app/helmrelease.yaml
@@ -18,8 +18,8 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/subspy
-              tag: 1.6.2
-              digest: sha256:f320a2318544fc29db7481d59e45497a714eeb577c61ec6104092e1c77b36033
+              tag: 1.6.3
+              digest: sha256:d39aa1b6b72962eb3c1293400e4d9303bfc06e6fbbf7583a45f6894c1f57e792
             env:
               TZ: ${TIMEZONE}
               DATABASE_URL: sqlite:///./data/subspy.db


### PR DESCRIPTION
## What

subspy `1.6.2` → `1.6.3`. Fixes dead notification config discovered while checking why the "Send Test" button did nothing.

## The finding

subspy's settings page advertises **"Configure global notification channels (Apprise URLs)"**, writes `apprise_urls` to its database, and exports it into backups/Git config — but **nothing ever read it back**. Delivery only consulted `search.notification_channels` or the `APPRISE_URLS` env var.

On **this cluster**:

| where | value | actually used? |
|---|---|---|
| settings page → DB `apprise_urls` | the Pushover URL | **no — inert** |
| `search 1 (Mechmarket).notification_channels` | the same URL, byte-identical | **yes — this is what fires your alerts** |
| `APPRISE_URLS` env | unset | no |

So alerts work only because the URL is duplicated onto the search. **Clearing it there would have silently stopped every alert** while the settings page still displayed a URL — with no error, because a match with no channels is logged `skipped`, not failed.

## Fixed upstream in LukeEvansTech/subspy#41 (v1.6.3)

Resolution is now, most specific first:

```
search.notification_channels  ->  apprise_urls setting  ->  APPRISE_URLS env
```

Per-search still wins, so **delivery on this cluster is unchanged** — this is a latent-bug fix, not a behaviour change.

Also in 1.6.3:

- **Parser trap**: the textarea says *"One URL per line"* but the parser split on **commas only** — a second URL entered as instructed would have collapsed into one malformed entry. Now splits on both.
- **Send Test button** actually sends and reports the truth (channel count on success, reason on failure) instead of unconditionally claiming success.

## Verification

- Upstream tests 68 → 90. `send_match_notification` — the live alerting path — had **no coverage at all**; it's now pinned, including a test reproducing this cluster's exact shape (URL on the search, global unset).
- Real super-linter v8: exit 0. All CI green on subspy#41.
- `flate build hr default subspy` renders `ghcr.io/lukeevanstech/subspy:1.6.3@sha256:d39aa1b6...`; digest resolved from GHCR.

## Follow-up

The duplicate URL on the Mechmarket search is now redundant — the global setting alone would deliver. Worth clearing for a single source of truth, but that's a live-data change and not part of this PR.