### PR TITLE
chore: retire flux-local remnants from tooling, comments, and docs

### DIFF
--- a/.github/workflows/docs-standard-check.yml
+++ b/.github/workflows/docs-standard-check.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/**"
-      - "renovate.json"
+      - ".renovaterc.json5"
       - ".markdownlint.yml"
 
 permissions:

--- a/docs/docs/apps/netbox.md
+++ b/docs/docs/apps/netbox.md
@@ -41,10 +41,11 @@ and its `existingSecret` contract are already modelled by the upstream chart.
   - `password` and `api_token` (superuser).
   - `db_password` (the value of `externalDatabase.existingSecretKey`).
   - `tasks_password` and `cache_password` (the Dragonfly tasks/caching DB keys).
-- These mismatches do **not** show up in `flate`/`flux-local` render or CI — the manifest is
-    valid. They only fail at runtime as pod `FailedMount` (`references non-existent secret key`) or
-    `CreateContainerConfigError` (`couldn't find key …`). Before wiring the ExternalSecret, render
-    the chart and grep the output for every `secretKeyRef` `key:` and projected-volume `items[].key`:
+- These mismatches do **not** show up in a `flate` (local) or Konflate (in-cluster PR render) —
+    the manifest is valid. They only fail at runtime as pod `FailedMount` (`references
+    non-existent secret key`) or `CreateContainerConfigError` (`couldn't find key …`). Before
+    wiring the ExternalSecret, render the chart and grep the output for every `secretKeyRef`
+    `key:` and projected-volume `items[].key`:
 
     ```bash
     flate build hr netbox -n default --path kubernetes/flux/cluster

--- a/docs/docs/troubleshooting/kb/020-httproute-drifts-to-placeholder-hostnames.md
+++ b/docs/docs/troubleshooting/kb/020-httproute-drifts-to-placeholder-hostnames.md
@@ -21,8 +21,9 @@ Where the placeholder comes from — the **first-render substitution race**:
 
 - `kubernetes/components/global-vars/` is a Component included by every namespace. It ships
   **both** a placeholder `cluster-secrets` Secret (fake `SECRET_DOMAIN: "example.com"`, fake
-  CIDRs/paths — needed so flux-local CI can render) **and** the real `cluster-secrets`
-  ExternalSecret (`creationPolicy: Owner`, 1Password).
+  CIDRs/paths — needed for offline rendering, both `flate` locally and Konflate's in-cluster PR
+  renders) **and** the real `cluster-secrets` ExternalSecret (`creationPolicy: Owner`,
+  1Password).
 - The placeholder applies **instantly**; ESO overwrites it seconds later. Any app whose
   Kustomization runs PostBuild substitution **in that window** bakes the *placeholder* value of
   `${SECRET_DOMAIN}` (or any `${VAR}`) into its helm-rendered objects.

--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -33,7 +33,7 @@ spec:
               MEMINI_EMBED_DIMS: "384"
               MEMINI_RERANK: http://llama-rerank.ai.svc.cluster.local:8080/v1
               MEMINI_RERANK_MODEL: qwen3-reranker
-              # Consolidation LLM via LiteLLM's self-hosted group (-> Ollama).
+              # Consolidation LLM via LiteLLM's self-hosted group (-> llmkube/llama.cpp).
               MEMINI_LLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000
               MEMINI_LLM_MODEL: self-hosted
               MEMINI_LLM_API_KEY:

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/pushsecret_v1alpha1.json
-# Fake cluster-secrets for flux-local CI builds
+# Placeholder cluster-secrets so CI (flate) can render ${VAR} substitutions
 # These values are placeholders - real values come from ExternalSecret in production
 apiVersion: v1
 kind: Secret

--- a/kubernetes/mod.just
+++ b/kubernetes/mod.just
@@ -95,4 +95,4 @@ view-secret namespace secret:
 
 [private]
 render-local-ks ns ks:
-    flux-local build ks --namespace "{{ ns }}" --path "{{ source_directory() }}/flux/cluster" "{{ ks }}"
+    flate build ks "{{ ks }}" --namespace "{{ ns }}" --path "{{ source_directory() }}/flux/cluster" --allow-missing-secrets


### PR DESCRIPTION
Part of the architecture-review working set (candidate 4, dead-code slice).

The repo migrated CI rendering from flux-local to flate (#2798) and PR renders moved in-cluster to Konflate (#3375), but flux-local-era artifacts survived:

- **`kubernetes/mod.just`** — `render-local-ks` (backing `apply-ks`/`delete-ks`) still shelled out to `flux-local build ks`, which is no longer in the mise toolchain, so the recipe was hard-broken. Rewritten to `flate build ks` mirroring the existing `flate-build-ks` flags. Smoke-tested: `just kube render-local-ks default bentopdf` renders valid manifests.
- **`.github/workflows/docs-standard-check.yml`** — PR trigger listed `renovate.json`, which doesn't exist. The shared drift-check genuinely validates the renovate config, so the intent was real; fixed to `.renovaterc.json5`.
- **`kubernetes/components/global-vars/cluster-secrets.yaml`** — stale "flux-local CI builds" comment updated to flate wording (matches the sibling kustomization.yaml).
- **`docs/docs/apps/netbox.md`, `docs/docs/troubleshooting/kb/020-*.md`** — updated flux-local CI-render references to reality (flate locally, Konflate in-cluster).
- **`kubernetes/apps/ai/memini/app/helmrelease.yaml`** — stale "→ Ollama" comment; the self-hosted group resolves to llmkube/llama.cpp since #3320.

Validation: scoped super-linter (slim-v8, same flags as `just lint`) clean; yamllint/actionlint/markdownlint/`just --list` clean; render smoke test above.

Touches a CI workflow trigger — holding merge for explicit OK.