### PR TITLE
fix(netdata): size k8sState memory to real usage to stop OOMKill loop

### DIFF
--- a/kubernetes/apps/observability/netdata/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/netdata/app/helmrelease.yaml
@@ -53,9 +53,9 @@ spec:
       resources:
         requests:
           cpu: 10m
-          memory: 256Mi
-        limits:
           memory: 1Gi
+        limits:
+          memory: 4Gi
       persistence:
         enabled: true
         storageclass: ceph-block


### PR DESCRIPTION
## Problem

`netdata-k8s-state` OOMKilled **3 times in ~2 hours** after the recent Talos host work (`OomKilled` fired in Alertmanager in the last 24h).

## Root cause

Its resources were mis-sized for this cluster:

| | request | limit | real usage |
|---|---|---|---|
| k8sState (before) | 256Mi | 1Gi | **585Mi steady, ~990Mi burst** |

- Steady-state working set is **~585Mi — 2.3x the 256Mi request**.
- It bursts to **~990Mi** while replicating history to the parent (logs show 19,274 replication requests). The netdata **parent restarted** during the host work, forcing children to re-replicate.
- ~990Mi burst against a 1Gi (1024Mi) limit leaves ~34Mi headroom → OOMKill → restart → re-replicate → OOMKill.

**This is not a leak.** The previous pod held flat at 576→587Mi over 22h. The limit was simply too tight for the cluster's object count plus replication burst.

## Fix

Sized to the same 1:4 request:limit pattern its siblings already use:

| | request | limit |
|---|---|---|
| parent | 4Gi | 16Gi |
| child | 2Gi | 8Gi |
| k8sState (after) | **1Gi** | **4Gi** |

Nodes are at 24% / 24% / 8% memory, so the larger request costs nothing.

## Verification

- `kustomize build kubernetes/apps/observability/netdata/app` renders clean.
- Post-merge: confirm `restartCount` stops climbing and working set settles ~585Mi.