### PR TITLE
feat(snmp-exporter): restart on config change via Reloader

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -65,3 +65,20 @@ spec:
         memory: 64Mi
       limits:
         memory: 128Mi
+  # snmp_exporter only reads its --config.file set at startup, so changes to the
+  # auth Secret / entity-sensor ConfigMap otherwise need a manual rollout restart.
+  # Chart 9.14.1 has no Deployment-level annotations value; patch the annotation
+  # in (same pattern as headlamp).
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: snmp-exporter
+            patch: |-
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: snmp-exporter
+                annotations:
+                  reloader.stakater.com/auto: "true"


### PR DESCRIPTION
snmp_exporter reads its `--config.file` set only at startup, so changes to the external-secrets-rendered auth Secret or the entity-sensor ConfigMap silently did nothing until a manual `kubectl rollout restart`. This adds `reloader.stakater.com/auto: "true"` to the Deployment so the in-cluster Reloader restarts it whenever a mounted ConfigMap/Secret changes.

Chart 9.14.1 exposes no Deployment-level annotations value (`podAnnotations` is the wrong object), so the annotation goes in via a `postRenderers` kustomize patch — same pattern as headlamp.

Verified: `kustomize build` renders the annotation onto the Deployment; scoped super-linter v8.6.0 green locally.
