### PR TITLE
feat: port July upstream learnings from onedr0p/home-ops

### DIFF
--- a/kubernetes/apps/default/chaski/app/helmrelease.yaml
+++ b/kubernetes/apps/default/chaski/app/helmrelease.yaml
@@ -32,8 +32,8 @@ spec:
           title: "Movie {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
             <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
-            {{ .payload.movie.overview | ellipsis 300 }}
-            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
+            <small>{{ .payload.movie.overview | ellipsis 300 }}</small>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
             format: html
             priority: low
@@ -45,7 +45,7 @@ spec:
           title: Movie Requires Manual Interaction
           message: |-
             <b>{{ .payload.movie.title }} ({{ .payload.movie.year }})</b>
-            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
             format: html
             priority: high
@@ -57,8 +57,8 @@ spec:
           title: "Episode {{ if .payload.isUpgrade }}Upgraded{{ else }}Added{{ end }}"
           message: |-
             <b>{{ .payload.series.title }} ({{ printf "S%02dE%02d" (toInt (index .payload.episodes 0).seasonNumber) (toInt (index .payload.episodes 0).episodeNumber) }})</b>
-            {{ (index .payload.episodes 0).title }}
-            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
+            <small>{{ (index .payload.episodes 0).title }}</small>
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
             format: html
             priority: low
@@ -70,7 +70,7 @@ spec:
           title: Episode Requires Manual Interaction
           message: |-
             <b>{{ .payload.series.title }}</b>
-            <b>Client:</b> {{ .payload.downloadClient | default "unknown" }}
+            <small><b>Client:</b> {{ .payload.downloadClient | default "unknown" }}</small>
           params:
             format: html
             priority: high

--- a/kubernetes/apps/home/zwave/app/externalsecret.yaml
+++ b/kubernetes/apps/home/zwave/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zwave-secret
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: zwave-secret
+    template:
+      engineVersion: v2
+      data:
+        # Fixed session secret so browser logins survive pod restarts —
+        # zwave-js-ui otherwise generates a random one at every boot.
+        SESSION_SECRET: "{{ .SESSION_SECRET }}"
+  dataFrom:
+    - extract:
+        key: zwave

--- a/kubernetes/apps/home/zwave/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zwave/app/helmrelease.yaml
@@ -22,6 +22,9 @@ spec:
             env:
               TZ: ${TIMEZONE}
               PORT: &port 8091
+            envFrom:
+              - secretRef:
+                  name: zwave-secret
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/home/zwave/app/kustomization.yaml
+++ b/kubernetes/apps/home/zwave/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml

--- a/kubernetes/apps/home/zwave/ks.yaml
+++ b/kubernetes/apps/home/zwave/ks.yaml
@@ -11,6 +11,9 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/home/zwave/app
   postBuild:

--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -114,6 +114,12 @@ spec:
             port: 3900
           admin:
             port: 3903
+    # Garage serves Prometheus metrics on the admin API port; /metrics is
+    # unauthenticated because metrics_token is unset in garage.toml.
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: admin
     route:
       app:
         annotations:

--- a/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
+++ b/kubernetes/components/kopiur/backup/snapshotpolicy.yaml
@@ -10,6 +10,9 @@ metadata:
     # computation differ. No-op while identityDefaults stays unchanged.
     kopiur.home-operations.com/allow-identity-change: "true"
 spec:
+  # zstd trades a little mover CPU for materially smaller repository blobs.
+  compression:
+    compressor: zstd
   repository:
     kind: ClusterRepository
     name: nas
@@ -22,12 +25,8 @@ spec:
   copyMethod: Snapshot
   volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=csi-ceph-blockpool}
   retention:
+    keepLatest: 3
     keepDaily: 7
     keepWeekly: 4
-  verification:
-    quick:
-      schedule:
-        cron: H 3 * * *
-    deep:
-      schedule:
-        cron: H 5 1 * *
+    # No verification schedules: repository maintenance (ClusterRepository
+    # maintenance.enabled) already runs kopia's verify pass.


### PR DESCRIPTION
Ports the applicable non-Renovate July changes from onedr0p/home-ops:

- **zwave** ([58b07e6f](https://github.com/onedr0p/home-ops/commit/58b07e6f)): fixed `SESSION_SECRET` via ExternalSecret so UI logins survive pod restarts. 1Password `zwave` item created out-of-band.
- **garage** ([e876ecaf](https://github.com/onedr0p/home-ops/commit/e876ecaf), adapted): ServiceMonitor on the admin port — upstream scrapes a NAS garage via ScrapeConfig; ours is in-cluster so app-template's serviceMonitor does the job. `/metrics` is unauthenticated while `metrics_token` is unset.
- **chaski** ([1152f20b](https://github.com/onedr0p/home-ops/commit/1152f20b)): `<small>` wrapping for secondary Pushover lines.
- **kopiur** ([65a06336](https://github.com/onedr0p/home-ops/commit/65a06336) / [b7e1ae63](https://github.com/onedr0p/home-ops/commit/b7e1ae63) / [209a775f](https://github.com/onedr0p/home-ops/commit/209a775f)): zstd compression, `keepLatest: 3`, drop explicit verification schedules (maintenance already verifies). Trial stays paused; config is ready for resume.

Not ported: miroir migration (deferred), kopiur replica scaling (upstream reverted it), snapshot-controller x2 / rook-ceph HR timeout / justfile `default-list` (already present here), bazarr stays 1.5.6 (upstream reverted 1.6.0).