### PR TITLE
feat(miroir): deploy miroir CSI (phase 1 of OpenEBS retirement)

### DIFF
--- a/kubernetes/apps/miroir-system/kustomization.yaml
+++ b/kubernetes/apps/miroir-system/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: miroir-system
+components:
+  - ../../components/global-vars
+  - ../../components/alerts
+resources:
+  - ./namespace.yaml
+  - ./miroir/ks.yaml

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: miroir
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: miroir
+  values:
+    # Warm-standby controller; leader election auto-enables above 1 replica.
+    replicaCount: 2
+    agent:
+      # Must list every loopfile.baseDir used by MiroirNode specs — the chart
+      # cannot read the topology CRs at render time.
+      loopfileBaseDirs:
+        - /var/mnt/extra/miroir
+    monitoring:
+      podMonitor:
+        enabled: true
+      prometheusRule:
+        enabled: true
+      dashboards:
+        enabled: true
+        grafanaOperator:
+          enabled: true
+          matchLabels:
+            grafana.internal/instance: grafana

--- a/kubernetes/apps/miroir-system/miroir/app/kustomization.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: miroir
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.11.1
+  url: oci://ghcr.io/home-operations/charts/miroir

--- a/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./miroirnodegroup.yaml
+  - ./storageclass.yaml
+  - ./volumesnapshotclass.yaml

--- a/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/miroirnodegroup.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/miroir.home-operations.com/miroirnodegroup_v1alpha1.json
+apiVersion: miroir.home-operations.com/v1alpha1
+kind: MiroirNodeGroup
+metadata:
+  name: default
+spec:
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/control-plane: ""
+  template:
+    pools:
+      # Loopfile pool on the system disk's EPHEMERAL filesystem — same disk
+      # OpenEBS hostpath used, so identical capacity and failure domain. The
+      # name leaves room for a future Optane-backed pool.
+      - name: system
+        loopfile:
+          baseDir: /var/mnt/extra/miroir

--- a/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/storageclass.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/storage.k8s.io/storageclass_v1.json
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: miroir-local
+provisioner: miroir.home-operations.com
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  miroir.home-operations.com/pool: system
+  miroir.home-operations.com/replicas: "1"
+  csi.storage.k8s.io/fstype: ext4

--- a/kubernetes/apps/miroir-system/miroir/config/volumesnapshotclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/volumesnapshotclass.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/snapshot.storage.k8s.io/volumesnapshotclass_v1.json
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: miroir
+driver: miroir.home-operations.com
+deletionPolicy: Delete

--- a/kubernetes/apps/miroir-system/miroir/ks.yaml
+++ b/kubernetes/apps/miroir-system/miroir/ks.yaml
@@ -1,0 +1,58 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app miroir
+  namespace: &namespace miroir-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: miroir
+      namespace: miroir-system
+  interval: 1h
+  path: ./kubernetes/apps/miroir-system/miroir/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app miroir-config
+  namespace: &namespace miroir-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: miroir
+      namespace: miroir-system
+  interval: 1h
+  path: ./kubernetes/apps/miroir-system/miroir/config
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/miroir-system/namespace.yaml
+++ b/kubernetes/apps/miroir-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
Deploys miroir 0.11.1 side-by-side with OpenEBS: loopfile pool `system` on the EPHEMERAL filesystem, `miroir-local` (replicas:1) StorageClass. No consumers flipped yet. Spec: local docs/superpowers/specs/2026-07-17-openebs-to-miroir-migration-design.md (gitignored).