### PR TITLE
feat(volsync): move mover caches and runner scratch to miroir-local

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
       kubernetesModeWorkVolumeClaim:
         accessModes:
           - "ReadWriteOnce"
-        storageClassName: openebs-hostpath
+        storageClassName: miroir-local
         resources:
           requests:
             storage: 40Gi

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
@@ -47,7 +47,7 @@ spec:
                 spec:
                   accessModes:
                     - "ReadWriteOnce"
-                  storageClassName: openebs-hostpath
+                  storageClassName: miroir-local
                   resources:
                     requests:
                       storage: 25Gi

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
       kubernetesModeWorkVolumeClaim:
         accessModes:
           - "ReadWriteOnce"
-        storageClassName: openebs-hostpath
+        storageClassName: miroir-local
         resources:
           requests:
             # Remote state + small providers — terraform needs little scratch.

--- a/kubernetes/components/volsync/nfs/replicationdestination.yaml
+++ b/kubernetes/components/volsync/nfs/replicationdestination.yaml
@@ -15,7 +15,7 @@ spec:
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
     cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=10Gi}
-    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=miroir-local}
     capacity: ${VOLSYNC_CAPACITY:=5Gi}
     cleanupCachePVC: true
     cleanupTempPVC: true

--- a/kubernetes/components/volsync/nfs/replicationsource.yaml
+++ b/kubernetes/components/volsync/nfs/replicationsource.yaml
@@ -14,7 +14,7 @@ spec:
     cacheAccessModes:
       - ${VOLSYNC_CACHE_ACCESSMODES:=ReadWriteOnce}
     cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=10Gi}
-    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=openebs-hostpath}
+    cacheStorageClassName: ${VOLSYNC_CACHE_STORAGECLASS:=miroir-local}
     compression: zstd-fastest
     copyMethod: ${VOLSYNC_COPYMETHOD:=Snapshot}
     moverSecurityContext:

--- a/kubernetes/components/volsync/remote/replicationdestination.yaml
+++ b/kubernetes/components/volsync/remote/replicationdestination.yaml
@@ -15,7 +15,7 @@ spec:
     cacheAccessModes:
       - ReadWriteOnce
     cacheCapacity: ${VOLSYNC_CACHE_CAPACITY:=10Gi}
-    cacheStorageClassName: openebs-hostpath
+    cacheStorageClassName: miroir-local
     capacity: ${VOLSYNC_CAPACITY:=5Gi}
     cleanupCachePVC: true
     cleanupTempPVC: true

--- a/kubernetes/components/volsync/remote/replicationsource.yaml
+++ b/kubernetes/components/volsync/remote/replicationsource.yaml
@@ -17,7 +17,7 @@ spec:
     cacheAccessModes:
       - ReadWriteOnce
     cacheCapacity: "${VOLSYNC_CACHE_CAPACITY:=10Gi}"
-    cacheStorageClassName: openebs-hostpath
+    cacheStorageClassName: miroir-local
     accessModes:
       - "${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}"
     moverSecurityContext:


### PR DESCRIPTION
Flips the VolSync cache default (`VOLSYNC_CACHE_STORAGECLASS`), the two hardcoded remote-component cache classes, and the three runner work-volume classes to `miroir-local`. Existing cache PVCs get deleted post-merge so movers recreate them on miroir.