### PR TITLE
fix(miroir): repoint storage dependsOn edges and pin loopfile baseDir

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -31,8 +31,8 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: actions-runner-controller
-    - name: openebs
-      namespace: openebs-system
+    - name: miroir
+      namespace: miroir-system
   interval: 1h
   path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/runners
   prune: true

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -7,8 +7,8 @@ metadata:
   namespace: volsync-system
 spec:
   dependsOn:
-    - name: openebs
-      namespace: openebs-system
+    - name: miroir
+      namespace: miroir-system
     - name: snapshot-controller
       namespace: kube-system
   interval: 1h

--- a/talos/patches/global/machine-files.yaml
+++ b/talos/patches/global/machine-files.yaml
@@ -1,3 +1,4 @@
+---
 machine:
   files:
     - op: create
@@ -6,3 +7,9 @@ machine:
       content: |-
         [plugins."io.containerd.cri.v1.images"]
           discard_unpacked_layers = false
+    - op: create
+      path: /var/mnt/extra/miroir/.keep
+      permissions: 0o644
+      content: |-
+        # Guarantees the miroir loopfile pool baseDir exists on first boot —
+        # the miroir agent does not create it (crash-loops on a missing dir).


### PR DESCRIPTION
volsync and the runner scale sets now provision on miroir-local, so
their Kustomization dependsOn edges move openebs→miroir (stale edges
would hard-wedge both with "dependency not found" once openebs-system
is archived). The Talos machine-files patch creates the loopfile
baseDir at first boot — the miroir agent does not create it and
crash-loops without it (bit us on deploy; a reimage would regress it).
