### PR TITLE
fix(volsync): bump 1Gi mover caches to 8Gi (miroir enforces the size)

### DIFF
--- a/kubernetes/apps/default/domainpulse/ks.yaml
+++ b/kubernetes/apps/default/domainpulse/ks.yaml
@@ -20,7 +20,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 1Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/invoiceshelf/ks.yaml
+++ b/kubernetes/apps/default/invoiceshelf/ks.yaml
@@ -20,7 +20,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 1Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/isponsorblocktv/ks.yaml
+++ b/kubernetes/apps/media/isponsorblocktv/ks.yaml
@@ -20,7 +20,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 1Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/metube/ks.yaml
+++ b/kubernetes/apps/media/metube/ks.yaml
@@ -20,7 +20,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 1Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/reclaimerr/ks.yaml
+++ b/kubernetes/apps/media/reclaimerr/ks.yaml
@@ -21,7 +21,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 2Gi
-      VOLSYNC_CACHE_CAPACITY: 1Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
       HOMEPAGE_NAME: Reclaimerr
       HOMEPAGE_GROUP: Media
       HOMEPAGE_ICON: mdi-broom


### PR DESCRIPTION
## Problem

The `miroir` CSI migration (#3581 / #3583) moved Kopia mover caches from
`openebs-hostpath` onto loopfile-backed ext4 volumes. `openebs-hostpath` is
just a node directory and **never enforced** the requested PVC size; miroir
loopfiles are real filesystems with a **hard ceiling**. The five apps pinned
to `VOLSYNC_CACHE_CAPACITY: 1Gi` had been silently overflowing 1Gi on
hostpath, so under miroir they immediately fill and Kopia fails to write even
`CACHEDIR.TAG` (`no space left on device`) on a fresh volume, crash-looping
the movers.

Symptoms observed:
- `KubePersistentVolumeFillingUp` — `volsync-src-invoiceshelf-nfs-cache` at ~100%
- 7× `VolSyncVolumeOutOfSync`; movers stuck `Init` / crash-looping (`Error`)
- Four 1Gi caches pegged at an identical 98.36% used; every 2Gi+ cache healthy

Not a Ceph or disk-space issue: the miroir pool is ~1.75 TiB/node at 10–19%
allocated (0 failed disks, 0 split-brain).

## Fix

Raise `VOLSYNC_CACHE_CAPACITY` from `1Gi` → `8Gi` (the dominant tier, 21 apps)
for the five affected apps. Loopfiles are thin-provisioned, so the nominal
size costs nothing until used, and there is ~1.4 TiB free per node.

Affected: `domainpulse`, `invoiceshelf`, `isponsorblocktv`, `metube`, `reclaimerr`.

## Validation

- `flate build-ks` renders clean; `cacheCapacity: 8Gi` propagates to all four
  rendered ReplicationSource/Destination specs
- super-linter (`slim-v8`, scoped to changed files): YAML / prettier /
  editorconfig / codespell all green
