### PR TITLE
fix(volsync): bump 2Gi mover caches to 8Gi (pre-empt miroir ceiling)

### DIFF
--- a/kubernetes/apps/default/apprise/ks.yaml
+++ b/kubernetes/apps/default/apprise/ks.yaml
@@ -25,7 +25,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/contracthound/ks.yaml
+++ b/kubernetes/apps/default/contracthound/ks.yaml
@@ -22,7 +22,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/subspy/ks.yaml
+++ b/kubernetes/apps/default/subspy/ks.yaml
@@ -22,7 +22,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 1Gi
-      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/warracker/ks.yaml
+++ b/kubernetes/apps/default/warracker/ks.yaml
@@ -22,7 +22,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/downloads/stacks/ks.yaml
+++ b/kubernetes/apps/downloads/stacks/ks.yaml
@@ -17,7 +17,7 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
       VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Stacks
       HOMEPAGE_GROUP: Downloads

--- a/kubernetes/apps/observability/scrutiny/ks.yaml
+++ b/kubernetes/apps/observability/scrutiny/ks.yaml
@@ -21,7 +21,7 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_CACHE_CAPACITY: 2Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
       HOMEPAGE_GROUP: Tools
       HOMEPAGE_ICON: scrutiny.svg
       HOMEPAGE_DESCRIPTION: Disk S.M.A.R.T. health


### PR DESCRIPTION
## Why

Follow-up to #3587. That PR fixed the five `1Gi` VolSync caches that broke when
the `miroir` CSI migration (#3581/#3583) started **enforcing** the requested PVC
size — something `openebs-hostpath` never did. Any cache pinned below its real
Kopia footprint hits ENOSPC and crash-loops the mover.

The six apps still on `VOLSYNC_CACHE_CAPACITY: 2Gi` are the next-most-at-risk as
their caches grow under the long retention policy (hourly 168 / daily 90 / …).
This raises them to `8Gi` (the dominant tier) to pre-empt a repeat.

Loopfiles are thin-provisioned — nominal size costs nothing until used — and the
miroir pool has ~1.4 TiB free per node, so the headroom is effectively free.

Affected: `apprise`, `contracthound`, `subspy`, `warracker`, `stacks`, `scrutiny`.

## Validation

- `flate build-ks` renders clean; `cacheCapacity: 8Gi` propagates to all rendered
  ReplicationSource/Destination specs
- super-linter (`slim-v8`, scoped to changed files): all green
