### PR TITLE
fix(miroir): raise agent memory limit to 512Mi (stop OOMKill crashloop)

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
         - /var/mnt/extra/miroir
       # The busiest node (most loopfiles) bursts past the chart's 128Mi default
       # during the initial agent-volume reconcile sweep — steady state is ~27Mi,
-      # but the sweep OOMKills the agent into CrashLoopBackOff. Raise the ceiling
+      # but the sweep OOMKills it into CrashLoopBackOff, so raise the ceiling
       # (deep-merged over the chart's requests: cpu 10m / memory 32Mi).
       resources:
         limits:

--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -17,6 +17,13 @@ spec:
       # cannot read the topology CRs at render time.
       loopfileBaseDirs:
         - /var/mnt/extra/miroir
+      # The busiest node (most loopfiles) bursts past the chart's 128Mi default
+      # during the initial agent-volume reconcile sweep — steady state is ~27Mi,
+      # but the sweep OOMKills the agent into CrashLoopBackOff. Raise the ceiling
+      # (deep-merged over the chart's requests: cpu 10m / memory 32Mi).
+      resources:
+        limits:
+          memory: 512Mi
     monitoring:
       podMonitor:
         enabled: true


### PR DESCRIPTION
## Problem

The `miroir-agent` DaemonSet uses the chart-default **128Mi** memory limit. On the
busiest storage node (the one with the most loopfiles), the initial `agent-volume`
reconcile sweep bursts past 128Mi and the container is **OOMKilled** (exit 137),
dropping that node's agent into `CrashLoopBackOff` (52 restarts over 12h). While it's
down, CSI mount/resize on that node stalls.

Steady-state usage is only ~27Mi and the other two nodes' agents are healthy, so this
is a transient reconcile spike proportional to volume count — not a leak.

## Fix

Override `agent.resources.limits.memory` → `512Mi` in the HelmRelease values. Helm
deep-merges, so the chart's requests (`cpu 10m` / `memory 32Mi`) are preserved.

## Validation

- `flate build-hr` renders clean; agent container shows `limits.memory: 512Mi` with
  requests intact
- super-linter (`slim-v8`, scoped): all green
