### PR TITLE
feat(mosquitto): migrate home broker storage to miroir-local (#3595)

### DIFF
--- a/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
+++ b/kubernetes/apps/home/mosquitto/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
         statefulset:
           volumeClaimTemplates:
             - name: data
-              storageClass: openebs-hostpath
+              storageClass: miroir-local
               accessMode: ReadWriteOnce
               size: 1Gi
               globalMounts:


### PR DESCRIPTION
Part of #3595 (OpenEBS → miroir, phase 2). First stateful volume migrated.

## Change
`home/mosquitto` StatefulSet `data` volumeClaimTemplate: `openebs-hostpath` → `miroir-local` (size 1Gi unchanged).

## Cutover (manual, out of band — volumeClaimTemplates are immutable)
1. Back up `/mosquitto/data/mosquitto.db` (293KB retained messages) — **done** before merge.
2. Merge + reconcile.
3. Delete the StatefulSet + old PVC so it recreates on `miroir-local`.
4. Restore `mosquitto.db`, restart the pod.
5. Verify broker reachable + data intact.

Brief MQTT downtime during the cutover (Shellys/HA/zigbee2mqtt reconnect automatically).

## Validation
- flate renders `storageClassName: miroir-local`
- super-linter (slim-v8, scoped): green
