### PR TITLE
feat(garage): migrate S3 node storage to miroir-local (#3595)

### DIFF
--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -73,13 +73,13 @@ spec:
         statefulset:
           volumeClaimTemplates:
             - name: meta
-              storageClass: openebs-hostpath
+              storageClass: miroir-local
               accessMode: ReadWriteOnce
               size: 5Gi
               globalMounts:
                 - path: /mnt/meta
             - name: data
-              storageClass: openebs-hostpath
+              storageClass: miroir-local
               accessMode: ReadWriteOnce
               size: 100Gi
               globalMounts:


### PR DESCRIPTION
Part of #3595 (OpenEBS → miroir, phase 2). Garage in-cluster S3 (RF=3, zone-redundant).

## Change
Garage StatefulSet `meta` (5Gi) + `data` (100Gi) volumeClaimTemplates: `openebs-hostpath` → `miroir-local`.

## Cutover (node-by-node, out of band)
volumeClaimTemplates are immutable, so after merge the StatefulSet is orphan-recreated to adopt the new template, then each node is migrated one at a time:
1. Wipe garage-N onto fresh miroir PVCs (RF=3 keeps 2/3 serving).
2. New node self-registers via `kubernetes_discovery`; `garage layout assign <new> --replace <old> -c 100G -z nodeN` + apply.
3. Wait for `garage stats -a` resync queue → 0 (~13GB re-replicates from peers).
4. Verify, then next node.

Safety: RF=3 + zone redundancy maximum (1 node down tolerated); `cnpg` bucket mirrored to NAS hourly.

## Validation
- flate renders both templates `storageClassName: miroir-local`
- super-linter (slim-v8, scoped): green
