### PR TITLE
feat(cnpg): migrate postgres18 storage to miroir-local (#3595)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -17,7 +17,7 @@ spec:
 
   storage:
     size: 200Gi
-    storageClass: openebs-hostpath
+    storageClass: miroir-local
 
   superuserSecret:
     name: cloudnative-pg-secret


### PR DESCRIPTION
Part of #3595 (OpenEBS → miroir, phase 2c — the final stateful volume). Retires OpenEBS.

## Change
CNPG `postgres18` cluster `storage.storageClass`: `openebs-hostpath` → `miroir-local` (size 200Gi unchanged).

## Cutover (manual, out of band — CNPG applies storageClass only to new PVCs)
Per the [CNPG storage-class-migration procedure](https://github.com/cloudnative-pg/cloudnative-pg/issues/8605), after merge:
1. Delete each **replica** PVC+pod one at a time → operator re-clones onto miroir, waits for streaming.
2. Switchover to a migrated standby, then delete the old **primary** so it re-clones onto miroir.

Safe: 588MB DB, both replicas streaming in-sync, fresh base backup taken pre-migration, WAL archiving current (backups in the Garage `cnpg` bucket + NAS mirror). DB stays online throughout (always a primary + ≥1 replica).

Also fixes the primary's stale **20Gi** PVC (openebs silently ignored the 200Gi resize; new instances provision at 200Gi).

## Validation
- `kubectl kustomize` renders `storageClass: miroir-local`
- super-linter (slim-v8, scoped): green
