### PR TITLE
feat(scrypted): deploy Scrypted as the Ring → HomeKit camera bridge

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -69,6 +69,7 @@ ALLOWLIST: dict[str, str] = {
     "kubernetes/apps/home/homeassistant/app/helmrelease.yaml": "trusted-proxy IP + multus MAC",
     "kubernetes/apps/home/matter-server/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/mosquitto/app/helmrelease.yaml": "multus static IP + MAC",
+    "kubernetes/apps/home/scrypted/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/kube-system/cilium/app/networks.yaml": "LB IP pool / API host",
     "kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml": "etcd-defrag node targets",

--- a/docs/docs/apps/scrypted.md
+++ b/docs/docs/apps/scrypted.md
@@ -1,0 +1,120 @@
+# Scrypted
+
+Camera and doorbell bridge in the `home` namespace. Brings Ring devices into
+Apple Home with HomeKit Secure Video (HKSV), and is the intended home for the
+Reolink cameras in a later phase.
+
+## Purpose
+
+- Node/TypeScript camera hub (`ghcr.io/koush/scrypted`) chosen over Frigate or a
+  Home Assistant–only setup because it ships first-party **Ring** *and*
+  **Reolink** plugins plus the strongest HKSV pipeline.
+- **Phase 0 (current):** the official Ring plugin bridges the existing Ring
+  fleet (2× Doorbell Pro 2, Doorbell 2nd Gen, Stick Up Cam Battery, Floodlight
+  Cam Wired Plus, Spotlight Cam Plus Battery, Indoor Cam) into HomeKit. Traffic
+  is cloud-relayed through the Ring account — expected at this stage.
+- **Phase 1+:** Reolink cameras (Doorbell PoE/WiFi, Duo/Elite Floodlight, Argus
+  4 Pro, E1 Pro) via `@scrypted/reolink`. Nothing here blocks local RTSP/ONVIF.
+- Internal-only: `scrypted.${SECRET_DOMAIN}` and
+  `scrypted.${SECRET_INTERNAL_DOMAIN}` on `envoy-internal`.
+
+## Division of labour with Homebridge
+
+Scrypted is **additive** — Homebridge stays.
+
+- **Scrypted** — cameras and doorbells only (HKSV, low-latency streams).
+- **Homebridge** — everything else, and optionally Ring Alarm/sensors/modes via
+  `homebridge-ring`. That plugin has no HKSV by design, so cameras must never
+  live there. If `homebridge-ring` is ever enabled, disable its camera support
+  to avoid duplicate accessories in Apple Home.
+
+!!! warning "Homebridge is currently an empty, unpaired bridge"
+    At the time Scrypted was added, Homebridge had `pairedClients: {}` (never
+    paired to HomeKit), an empty `cachedAccessories`, only the `homebridge-dummy`
+    plugin, and a crash-looping Avahi (`Failed to create runtime directory
+    /run/avahi-daemon/`). It is therefore **not** a working reference for
+    HomeKit networking — see the Avahi fix tracked separately. Scrypted does not
+    depend on it.
+
+## Design decisions
+
+- **Networking — Multus macvlan on the untagged legacy LAN (`iot-legacy` NAD).**
+  HomeKit pairing (HAP) needs L2 adjacency with the HomeKit hubs, or an mDNS
+  reflector. An mDNS probe run on both segments settled it empirically: both
+  Apple TVs answered `_airplay._tcp` / `_companion-link._tcp` / `_sleep-proxy._udp`
+  on the **untagged legacy LAN**, while **VLAN 68 returned zero services** — so
+  no reflection exists into the IoT VLAN. Scrypted therefore attaches to
+  `iot-legacy` (like `matter-server`), *not* the `iot` NAD used by Home
+  Assistant, zigbee2mqtt and mosquitto. Upstream's own compose uses
+  `network_mode: host` for exactly this reason; macvlan is the cluster's
+  equivalent of real LAN presence.
+- **Static IP + MAC.** The NAD uses static IPAM, so the pod carries a fixed
+  address and a MAC continuing the `02:00:00:00:00:0X` series used by the other
+  Multus workloads. The chosen address was verified unused before assignment —
+  two neighbouring candidates answered ping. It must sit outside the OPNsense
+  DHCP pool.
+- **`strategy: Recreate`.** The pod owns a fixed L2 address and a ReadWriteOnce
+  PVC; a RollingUpdate would briefly run two pods sharing one MAC/IP and
+  deadlock on the volume.
+- **UI routed over plain HTTP (`11080`), not HTTPS (`10443`).** Scrypted serves
+  the *same* application on both ports (`SCRYPTED_INSECURE_PORT` /
+  `SCRYPTED_SECURE_PORT`). Routing the gateway at `11080` avoids introducing a
+  `BackendTLSPolicy` + skip-verify for Scrypted's self-signed cert — the
+  repository has no such pattern anywhere today. The HTTPS port stays available on the pod
+  for direct access. TLS to the browser is still terminated by the gateway.
+- **Avahi deliberately left off.** `SCRYPTED_DOCKER_AVAHI` is not set: with a
+  real LAN interface, Scrypted's built-in mDNS advertiser reaches the hubs
+  directly, and enabling the bundled Avahi would reproduce Homebridge's
+  crash-loop.
+- **Runs as root.** The official image's entrypoint manages the plugin runtime
+  and npm-installs into `/server/volume`. Same documented exception as
+  Homebridge; most apps here run as UID 1000.
+- **Image variant `-noble-full`.** This is the variant upstream publishes as
+  `:latest` (identical digest). Renovate's docker versioning keeps updates
+  within the same suffix family. The `-noble-nvidia` variant is the drop-in
+  swap if GPU transcoding is ever wanted — the cluster's NVIDIA L4s and the
+  `runtimeClassName: nvidia` pattern are available, but Phase 0 needs no GPU.
+
+## Storage
+
+- `/server/volume` → a 10Gi `ceph-block` PVC with the standard volsync
+  treatment. This holds plugin installs, the device database and **the HomeKit
+  pairing keys** — losing it unpairs every accessory in Apple Home.
+- **No NVR volume.** HKSV clips live in iCloud, so Phase 0 provisions no bulk
+  storage. A commented TrueNAS NFS mount and the `SCRYPTED_NVR_VOLUME=/nvr`
+  variable are left in the HelmRelease for when the Reolink NVR plugin is
+  adopted.
+
+## Secrets
+
+**Nothing secret belongs in Git — this repository is public.** Scrypted has no
+`ExternalSecret`. Ring account credentials and the 2FA code are entered
+**interactively in the Scrypted UI** on first configuration, and Scrypted stores
+the resulting refresh token inside `/server/volume` (which is why that PVC is
+backed up rather than reproducible from Git).
+
+The admin account for the management UI is likewise created on first launch.
+
+## First-run checklist
+
+1. Reach the UI at `scrypted.${SECRET_INTERNAL_DOMAIN}` and create the admin
+   account.
+2. Install the **Ring** plugin; sign in with the Ring account and complete 2FA.
+   Confirm all devices appear under Devices.
+3. Install the **HomeKit** plugin and pair from the Home app.
+4. Pair the **doorbells as standalone accessories** rather than bridged —
+   per Scrypted's docs this is markedly more reliable for doorbell press
+   notifications. Cameras can stay bridged.
+5. Enable **HKSV recording** on at least one camera and verify clips play back
+   in the Home app.
+6. Check no duplicate camera accessories appeared in Apple Home.
+
+## Gotchas
+
+- **HAP port clash.** Scrypted's HomeKit plugin uses its own configurable port,
+  independent of Homebridge's. The two advertise as separate bridges and are on
+  different IPs, so co-scheduling on one node is fine.
+- **Pairing state is precious.** Restoring the PVC from a volsync snapshot
+  restores pairing; deleting it silently forces a re-pair of everything.
+- **The IoT VLAN is not an option for HomeKit** until an mDNS reflector exists
+  between VLAN 68 and the LAN the Apple TVs sit on.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -61,6 +61,7 @@ nav = [
     { "Reclaimerr" = "apps/reclaimerr.md" },
     { "iSponsorBlockTV" = "apps/isponsorblocktv.md" },
     { "changedetection.io" = "apps/changedetection.md" },
+    { "Scrypted" = "apps/scrypted.md" },
   ] },
   { "Troubleshooting" = [
     { "Symptom ladder" = "troubleshooting/index.md" },

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ./matter-server/ks.yaml
   - ./mosquitto/ks.yaml
   - ./node-red/ks.yaml
+  - ./scrypted/ks.yaml
   - ./shelly-fleet/ks.yaml
   - ./shelly-operator/ks.yaml
   - ./shelly-prometheus-exporter/ks.yaml

--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: scrypted
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: scrypted
+  values:
+    controllers:
+      scrypted:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # Recreate, not RollingUpdate: the pod owns a fixed macvlan IP/MAC
+        # (see defaultPodOptions) and a ReadWriteOnce PVC. Two pods alive at
+        # once would duplicate the L2 address and deadlock on the volume.
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/koush/scrypted
+              # `-noble-full` is the variant upstream ships as :latest (identical
+              # digest). Renovate's docker versioning pins updates to the same
+              # suffix family, so this tracks v0.144.x-noble-full only.
+              tag: v0.144.1-noble-full@sha256:25440767192b0d4a0709f50388d14cdf365ba6bff59d04e40a41ca2b7b9a6b70
+            env:
+              TZ: ${TIMEZONE}
+              # Scrypted serves the SAME app over HTTPS (10443, self-signed) and
+              # plain HTTP (11080). We route the gateway at 11080 so no
+              # BackendTLSPolicy is needed — the repo has no such pattern today.
+              SCRYPTED_INSECURE_PORT: &port 11080
+              SCRYPTED_SECURE_PORT: 10443
+              # Deliberately NOT setting SCRYPTED_DOCKER_AVAHI. The pod has a
+              # real LAN presence via macvlan, so Scrypted's built-in mDNS
+              # advertiser reaches the HomeKit hubs directly. Homebridge's
+              # bundled Avahi crash-loops in this cluster ("Failed to create
+              # runtime directory /run/avahi-daemon/") — don't repeat it.
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              # Scrypted installs plugins via npm into /server/volume at runtime
+              # and unpacks helpers to the image filesystem.
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                # Generous headroom: HKSV transcoding spikes hard when several
+                # cameras record at once.
+                memory: 4Gi
+
+    # KEY CONFIGURATION: Multus network attachment.
+    #
+    # HomeKit pairing (HAP) needs L2 adjacency with the HomeKit hubs, which an
+    # mDNS probe placed on the untagged legacy LAN — both Apple TVs answered
+    # there, and VLAN 68 returned zero services (no reflector). So Scrypted
+    # attaches to `iot-legacy`, matching matter-server, NOT the `iot` NAD that
+    # Home Assistant / zigbee2mqtt / mosquitto use.
+    #
+    # 10.32.8.106 was verified unused before assignment (.104 and .105 both
+    # answered ping). Confirm it sits outside the OPNsense DHCP pool.
+    # MAC continues the 02:00:00:00:00:0X series (:01 HA, :02 z2m, :03
+    # mosquitto, :04 matter-server).
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot-legacy",
+            "namespace": "kube-system",
+            "ips": ["10.32.8.106/24"],
+            "mac": "02:00:00:00:00:05"
+          }]
+      # Scrypted's official image runs as root: its entrypoint manages the
+      # plugin runtime and npm-installs into /server/volume. Same documented
+      # exception as homebridge; most apps here run as UID 1000.
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+
+    service:
+      app:
+        controller: scrypted
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+
+    # HKSV clips go to iCloud, so no local NVR volume is provisioned for Phase 0.
+    # When the Reolink NVR plugin lands, add a TrueNAS NFS volume alongside
+    # `config` below and set SCRYPTED_NVR_VOLUME=/nvr on the container:
+    #
+    #   nvr:
+    #     type: nfs
+    #     server: "${NAS_ADDR}"
+    #     path: /mnt/pool/scrypted
+    #     globalMounts:
+    #       - path: /nvr
+    persistence:
+      # Scrypted state: plugin installs, device DB, HomeKit pairing keys.
+      # Losing this unpairs every accessory, so it is volsync-backed.
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /server/volume

--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -78,10 +78,10 @@ spec:
     # attaches to `iot-legacy`, matching matter-server, NOT the `iot` NAD that
     # Home Assistant / zigbee2mqtt / mosquitto use.
     #
-    # 10.32.8.106 was verified unused before assignment (.104 and .105 both
-    # answered ping). Confirm it sits outside the OPNsense DHCP pool.
-    # MAC continues the 02:00:00:00:00:0X series (:01 HA, :02 z2m, :03
-    # mosquitto, :04 matter-server).
+    # The address below was verified unused before assignment (the two preceding
+    # candidates both answered ping). Confirm it sits outside the OPNsense DHCP
+    # pool. MAC continues the 02:00:00:00:00:0X series (:01 HA, :02 z2m,
+    # :03 mosquitto, :04 matter-server).
     defaultPodOptions:
       annotations:
         k8s.v1.cni.cncf.io/networks: |-

--- a/kubernetes/apps/home/scrypted/app/kustomization.yaml
+++ b/kubernetes/apps/home/scrypted/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/scrypted/app/ocirepository.yaml
+++ b/kubernetes/apps/home/scrypted/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: scrypted
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/scrypted/ks.yaml
+++ b/kubernetes/apps/home/scrypted/ks.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app scrypted
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: multus-networks
+      namespace: kube-system
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/home/scrypted/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_CACHE_CAPACITY: 8Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Phase 0 of the Ring → Reolink camera migration. Scrypted bridges the existing Ring fleet into Apple Home with HKSV. Additive to Homebridge: **Scrypted owns cameras/doorbells, Homebridge keeps everything else.**

## ⚠️ The brief's core assumption was wrong

The task brief said *"Homebridge already pairs from this cluster, so mDNS is a solved problem here — reuse whatever it does."* It isn't, and it doesn't:

| Check | Finding |
|---|---|
| `pairedClients` | `{}` — **never paired to HomeKit** |
| `cachedAccessories` / `accessories` | `[]` / `[]` — zero accessories |
| Plugins | only `homebridge-dummy` |
| Avahi | crash-looping: `Failed to create runtime directory /run/avahi-daemon/` |
| Advertiser in config | `bonjour-hap` — Avahi isn't even the advertiser |
| Networking | plain Cilium pod net `10.42.0.33/32`, no Multus |

Copying Homebridge's networking would have reproduced a non-working setup. `homebridge-ring` is not installed either, so "disable its cameras" and "existing accessories unaffected" are moot.

## Which segment? Determined empirically, not assumed

I ran a short-lived mDNS probe pod on **both** segments (python-zeroconf, `_hap`/`_airplay`/`_raop`/`_companion-link`/`_sleep-proxy`), then deleted them:

- **Untagged legacy LAN** — both Apple TVs answered (`AppleTV11,1`, Living Room + Main Bedroom), incl. `_sleep-proxy` (i.e. acting as HomeKit hubs). 8 services.
- **VLAN 68 (IoT-Trusted)** — **0 services.** No mDNS reflection into the IoT VLAN.

Notably, no `_hap._tcp` was found anywhere — independently corroborating that Homebridge isn't advertising.

So Scrypted attaches to the **`iot-legacy`** NAD (like `matter-server`), **not** the `iot` NAD used by Home Assistant / zigbee2mqtt / mosquitto. Upstream's own compose uses `network_mode: host` for exactly this reason; macvlan is this cluster's equivalent of real LAN presence.

## Decisions worth reviewing

- **Static IP verified free before assignment** — the two neighbouring candidates both answered ping, so this would otherwise have been an IP conflict. **Please confirm the chosen address sits outside the OPNsense DHCP pool.** MAC continues the `02:00:00:00:00:0X` series.
- **`strategy: Recreate`** — fixed L2 address + RWO PVC must never overlap during rollout.
- **UI routed at plain HTTP `11080`, not HTTPS `10443`** — a deviation from the brief. Scrypted serves the *same* app on both ports (verified in `server-settings.ts`), so this avoids introducing a `BackendTLSPolicy` + skip-verify pattern that exists **nowhere** in this repository. Gateway still terminates TLS to the browser.
- **`SCRYPTED_DOCKER_AVAHI` deliberately unset** — real LAN presence makes it unnecessary, and enabling the bundled Avahi would reproduce Homebridge's crash-loop.
- **Image `v0.144.1-noble-full`** — the variant upstream publishes as `:latest` (identical digest); Renovate's docker versioning keeps updates within the same suffix family. `-noble-nvidia` is the drop-in swap if GPU transcoding is ever wanted.
- **Runs as root** — the official image npm-installs plugins into `/server/volume`. Same documented exception as Homebridge.

## Storage & secrets

- `/server/volume` → 10Gi volsync-backed `ceph-block` PVC. **This holds the HomeKit pairing keys** — losing it unpairs everything.
- No NVR volume (HKSV clips → iCloud). A commented TrueNAS NFS path + `SCRYPTED_NVR_VOLUME=/nvr` is left for the Reolink phase.
- **No ExternalSecret.** Ring credentials + 2FA are entered in the UI; nothing secret lands in Git.

## Validation

- `kustomize build` ✅
- `helm template` against app-template 5.0.1 ✅ — schema-validated; confirmed rendered `strategy: Recreate`, Multus annotation, digest-pinned image, env coerced to strings (`'11080'`), probe port, `/server/volume` mount, route → `envoy-internal` backend `11080`
- `markdownlint` ✅ · `zensical build --strict` ✅ · yamlfmt → prettier ✅
- `flate-build-hr` timed out pulling charts locally (known offline/slow-registry limitation) — leaving the render to in-cluster Konflate

## Follow-up (separate PR, as agreed)

Homebridge's Avahi runtime-directory crash-loop is fixed on its own branch — deliberately not bundled here.

## Post-merge, manual

Admin account, Ring plugin sign-in + 2FA, HomeKit pairing (**doorbells standalone, not bridged**), and HKSV enablement are all first-run UI steps — see the checklist in `docs/docs/apps/scrypted.md`.