### PR TITLE
fix(homebridge): drop ENABLE_AVAHI to stop the Avahi crash-loop

### DIFF
--- a/kubernetes/apps/home/homebridge/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homebridge/app/helmrelease.yaml
@@ -21,7 +21,19 @@ spec:
               tag: "2026-07-12@sha256:d26cf915f2e0a9aa6e8323116db87f55a74e3b488dbc5b782f7b878b12eade5a"
             env:
               TZ: ${TIMEZONE}
-              ENABLE_AVAHI: "1"
+              # ENABLE_AVAHI intentionally NOT set. It started an Avahi daemon
+              # that crash-looped forever on "Failed to create runtime directory
+              # /run/avahi-daemon/" — Avahi chowns that dir to the avahi user and
+              # then verifies ownership, but CAP_CHOWN is dropped below, so the
+              # chown returns EPERM and the check fails. Granting CHOWN clears
+              # that error but only exposes the next one: dbus cannot bind
+              # /run/dbus/system_bus_socket as root (an unprivileged user can,
+              # which points at SELinux rather than capabilities).
+              #
+              # Not worth chasing: config.json sets `advertiser: bonjour-hap`,
+              # so Avahi was never used for HomeKit advertisement anyway. Note
+              # that HAP still cannot work over Cilium pod networking — pairing
+              # needs LAN presence (see the Multus attachment used by scrypted).
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Homebridge has been logging this on an endless loop:

```
Starting Avahi daemon
Failed to create runtime directory /run/avahi-daemon/.
```

## The message is misleading

`/run` is writable and `/run/avahi-daemon` **already exists**. The real chain:

1. Avahi's `init_runtime_dir()` chowns that directory to the `avahi` user, then verifies ownership.
2. **`CAP_CHOWN` is dropped** (effective caps are `0xc0` = `cap_setgid,cap_setuid` only), so the chown returns EPERM — confirmed directly: `chown avahi:avahi /run/avahi-daemon` → `Operation not permitted`.
3. The ownership check then fails and reports the misleading "Failed to create runtime directory".

## Why not just add CAP_CHOWN?

I tested it in an isolated pod with the same image and securityContext plus `CHOWN`. It **does** clear the error — `/run/avahi-daemon` comes up correctly as `avahi:avahi` — but only exposes the next blocker:

```
dbus-daemon: Failed to start message bus: Failed to bind socket "/run/dbus/system_bus_socket": Permission denied
```

`/run/dbus` is correctly owned `messagebus:messagebus`, and I verified that user **can** bind a socket there — while **root cannot**. Root being denied where an unprivileged user succeeds isn't DAC (root bypasses that), which points at SELinux, enforced on Talos. `avahi-daemon` still isn't running afterwards.

## Why it isn't worth chasing

`config.json` sets **`advertiser: bonjour-hap`** — so Avahi was never used for HomeKit advertisement in the first place. Fixing it end-to-end would deliver nothing.

Removing the variable stops an infinite restart loop and the log spam it generates. The reasoning is captured in an inline comment so nobody re-adds it.

## ⚠️ Separately worth knowing

This bridge **cannot serve HomeKit as deployed**, independent of Avahi:

| Check | Finding |
|---|---|
| `pairedClients` | `{}` — never paired |
| `cachedAccessories` / `accessories` | `[]` / `[]` |
| Plugins | only `homebridge-dummy` |
| Networking | Cilium pod net `10.42.0.33/32` — unreachable by HomeKit hubs |

An mDNS probe on the LAN found **no `_hap._tcp` service anywhere**, independently confirming it isn't advertising.

If a working Homebridge is wanted, the fix is real LAN presence — the `iot-legacy` Multus attachment that #3603 uses for Scrypted. Deliberately not bundled here.

## Validation

- `kustomize build` ✅ · yamlfmt → prettier ✅
- Behaviour verified empirically in an isolated pod (since deleted); no live resources were mutated.