### PR TITLE
fix(scrypted): use exec probes — macvlan blackholes kubelet httpGet

### DIFF
--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -38,18 +38,32 @@ spec:
               # advertiser reaches the HomeKit hubs directly. Homebridge's
               # bundled Avahi crash-loops in this cluster ("Failed to create
               # runtime directory /run/avahi-daemon/") — don't repeat it.
+            # exec, NOT httpGet. The macvlan interface cannot reach its own
+            # parent host (verified: EHOSTUNREACH to the node's LAN address), and
+            # this NAD puts the pod on the same subnet as the nodes. A kubelet
+            # httpGet arrives via eth0 but the reply routes out net1 and is
+            # blackholed, so the probe always times out even though the app is
+            # healthy. An exec probe goes through containerd, not the network.
+            # (This is why the other Multus apps here define no probes at all.)
             probes:
               liveness: &probes
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /
-                    port: *port
-                  initialDelaySeconds: 30
+                  exec:
+                    command:
+                      - curl
+                      - --silent
+                      - --fail
+                      - --output
+                      - /dev/null
+                      - --max-time
+                      - "5"
+                      - http://127.0.0.1:11080/
+                  initialDelaySeconds: 60
                   periodSeconds: 30
-                  timeoutSeconds: 5
-                  failureThreshold: 5
+                  timeoutSeconds: 10
+                  failureThreshold: 6
               readiness: *probes
               startup:
                 enabled: false


### PR DESCRIPTION
Follow-up to #3603. Scrypted deployed and is **healthy**, but never went `Ready`.

## Symptom

Both probes time out:

```
Readiness probe failed: Get "http://10.42.0.167:11080/": context deadline exceeded
```

Yet the app answers instantly over the LAN:

```
$ curl -o /dev/null -w "%{http_code} %{time_total}s" http://<macvlan-ip>:11080/
302 0.013398s
```

## Cause — macvlan host isolation

The `iot-legacy` NAD puts the pod on the **same subnet as the nodes**, so a kubelet probe originates from the node's LAN address. The request arrives via `eth0`, but the reply matches the `net1` route — and **a macvlan interface cannot reach its own parent host**. Verified directly from the pod:

```
own-node:50000 → ERR EHOSTUNREACH
```

So the reply is blackholed and the probe always times out, regardless of app health. `httpGet` **and** `tcpSocket` are both unusable here for the same reason.

## Fix

`exec` probes — kubelet runs these through containerd, not the network. Confirmed `curl` is present in the image and returns 302 from loopback:

```
$ kubectl exec … -- curl -sf http://127.0.0.1:11080/   →  302
```

This is also why the other four Multus apps in this namespace (`homeassistant`, `mosquitto`, `zigbee2mqtt`, `matter-server`) define **no probes at all**. Using `exec` keeps genuine liveness/readiness rather than dropping health checking entirely — and the inline comment records the constraint so nobody reintroduces `httpGet`.

Also raises `initialDelaySeconds` to 60 and `failureThreshold` to 6 to tolerate first-boot plugin installation.

## Validation

- `kustomize build` ✅ · identifier scan ✅ · yamlfmt → prettier ✅
- `helm template` confirms both probes render as `exec` with the expected command