### PR TITLE
feat(kromgo): align with onedr0p reference config and add gatus badges

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
     name: kromgo
   values:
     config:
-      prometheus: http://prometheus-operated.observability.svc.cluster.local:9090
+      prometheus: http://prometheus-operated.{{ .Release.Namespace }}.svc.cluster.local:9090
       badges:
         - title: Talos
           id: talos_version
@@ -76,6 +76,29 @@ spec:
           id: cluster_alert_count
           query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
           colorExpr: 'colorScale(result, [1.0], ["green", "red"])'
+
+        # Gatus-backed service checks. min()/max() collapse the per-replica
+        # series so these keep working if gatus scales beyond one replica.
+        - title: Internet
+          id: gatus_connectivity
+          query: min(gatus_results_endpoint_success{group="connectivity"}) # Cloudflare + Google + Quad9
+          valueExpr: 'result == 1.0 ? "up" : "down"'
+          colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+          icon: si:cloudflare
+
+        - title: Alertmanager
+          id: gatus_alertmanager
+          query: max(gatus_results_endpoint_success{key="internal_kube-prometheus-stack-alertmanager"})
+          valueExpr: 'result == 1.0 ? "up" : "down"'
+          colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+          icon: si:prometheus
+
+        - title: Grafana
+          id: gatus_grafana
+          query: max(gatus_results_endpoint_success{key="internal_grafana"})
+          valueExpr: 'result == 1.0 ? "up" : "down"'
+          colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+          icon: si:grafana
     httpRoute:
       enabled: true
       annotations:

--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -5,10 +5,10 @@ kind: OCIRepository
 metadata:
   name: kromgo
 spec:
-  interval: 1h
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.14.9
+    tag: 0.15.1
   url: oci://ghcr.io/home-operations/charts/kromgo


### PR DESCRIPTION
Aligns `observability/kromgo` with [onedr0p/home-ops](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/o11y/kromgo), plus three gatus-backed badges.

## Changes

| | Before | After |
| --- | --- | --- |
| Chart tag | `0.14.9` | `0.15.1` |
| OCIRepository interval | `1h` | `15m` |
| Prometheus URL | hardcoded `observability` | `{{ .Release.Namespace }}` |
| Badges | 11 | 14 |

### Chart bump

`0.15.0` carried three breaking changes — `KROMGO_` env var prefix, health served on the main port, and removal of the legacy `/-/health` / `/-/ready` aliases. All are chart-internal; the chart ships lockstep with the app, so no values changes are needed. The gatus check on this route asserts `[STATUS] == 200` against the root, not `/-/health`, so the alias removal doesn't affect it either.

### New badges

Adapted from onedr0p's `buddy_*` badges to this cluster's real gatus endpoint keys:

- **Internet** — `min()` across the whole `connectivity` group (Cloudflare, Google, Quad9); reads up only when all three answer
- **Alertmanager** — `internal_kube-prometheus-stack-alertmanager`
- **Grafana** — `internal_grafana`

All three verified against live Prometheus before commit — each returns exactly one series with value `1`.

## Deliberate deviations from onedr0p

- **`min()`/`max()` wrappers.** His queries are bare. Gatus runs one replica here, so bare would work today; the aggregation is insurance against a future scale-up producing multiple series per key.
- **Node selectors left on `kubernetes_node!=""`.** He uses `pod!=""`. Which label is present depends on each cluster's node-exporter relabeling — the current selectors return data, so switching is risk with no upside.
- **`group: external` kept** on the gatus annotation. He has no group.
- **No cosign `verify:` block.** He doesn't use one anywhere in `home-ops`. Tracked separately — see below.

## Note: kromgo is on `envoy-external`

These badges are publicly readable. They expose only up/down for services already named in this public repository, consistent with the existing node/pod/CPU/alert badges.

## Follow-up (not in this PR)

`home-operations/charts/*` charts have been cosigned since ~2026-06-09. Cosign verification was removed from this repository historically (051f6d9f9, 41bcb39a0, 78433df28) purely because charts *were not signed* — not as a policy call. Worth revisiting across all 8 org charts; `charts-mirror/*` needs separate checking.

## Validation

- `kustomize build kubernetes/apps/observability/kromgo/app` — OK
- `yamlfmt` then `prettier` — clean
- Badge queries verified against live Prometheus