### PR TITLE
fix(renovate): exempt digest updates from the 3-day age gate

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -99,14 +99,30 @@
     // platformAutomerge:false => Renovate self-gates on CI (flate, security-scans)
     // rather than GitHub-native auto-merge, so no branch-protection ruleset is needed.
     {
-      description: "Auto-merge apps — minor/patch/digest + pins (denylist model; protected guard below)",
+      description: "Auto-merge apps — minor/patch (denylist model; protected guard below)",
       matchDatasources: ["docker", "helm"],
-      matchUpdateTypes: ["minor", "patch", "digest", "pin", "pinDigest"],
+      matchUpdateTypes: ["minor", "patch"],
       automerge: true,
       automergeType: "pr",
       platformAutomerge: false,
       ignoreTests: false,
       minimumReleaseAge: "3 days",
+    },
+    {
+      // No minimumReleaseAge here: digest bumps track mutable tags that upstream
+      // rebuilds every few days (nginx:1.31-alpine, llama.cpp server-cuda …), so
+      // a 3-day age gate perpetually resets and renovate/stability-days never
+      // clears — 11 digest PRs sat pending up to 19 days. GHCR also often has no
+      // retrievable per-digest timestamp at all, which pends forever too. Digest
+      // bumps of an already-trusted tag stay CI-gated (ignoreTests: false) like
+      // everything else, and the protected-infra guard below still applies.
+      description: "Auto-merge apps — digest + pins, no age gate (denylist model; protected guard below)",
+      matchDatasources: ["docker", "helm"],
+      matchUpdateTypes: ["digest", "pin", "pinDigest"],
+      automerge: true,
+      automergeType: "pr",
+      platformAutomerge: false,
+      ignoreTests: false,
     },
     {
       description: "Protected infra — never auto-merge, manual review only",

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
     name: kromgo
   values:
     config:
-      prometheus: http://prometheus-operated.observability.svc.cluster.local:9090
+      prometheus: http://prometheus-operated.{{ .Release.Namespace }}.svc.cluster.local:9090
       badges:
         - title: Talos
           id: talos_version
@@ -76,6 +76,29 @@ spec:
           id: cluster_alert_count
           query: alertmanager_alerts{state="active"} - 1 # Ignore Watchdog
           colorExpr: 'colorScale(result, [1.0], ["green", "red"])'
+
+        # Gatus-backed service checks. min()/max() collapse the per-replica
+        # series so these keep working if gatus scales beyond one replica.
+        - title: Internet
+          id: gatus_connectivity
+          query: min(gatus_results_endpoint_success{group="connectivity"}) # Cloudflare + Google + Quad9
+          valueExpr: 'result == 1.0 ? "up" : "down"'
+          colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+          icon: si:cloudflare
+
+        - title: Alertmanager
+          id: gatus_alertmanager
+          query: max(gatus_results_endpoint_success{key="internal_kube-prometheus-stack-alertmanager"})
+          valueExpr: 'result == 1.0 ? "up" : "down"'
+          colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+          icon: si:prometheus
+
+        - title: Grafana
+          id: gatus_grafana
+          query: max(gatus_results_endpoint_success{key="internal_grafana"})
+          valueExpr: 'result == 1.0 ? "up" : "down"'
+          colorExpr: 'result == 1.0 ? "brightgreen" : "red"'
+          icon: si:grafana
     httpRoute:
       enabled: true
       annotations:

--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -5,10 +5,10 @@ kind: OCIRepository
 metadata:
   name: kromgo
 spec:
-  interval: 1h
+  interval: 15m
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.14.9
+    tag: 0.15.1
   url: oci://ghcr.io/home-operations/charts/kromgo


### PR DESCRIPTION
## Problem

`minimumReleaseAge: "3 days"` on digest/pin/pinDigest updates can structurally never clear:

- **Mutable tags are rebuilt upstream every 1–3 days** (`nginx:1.31-alpine`, llama.cpp `server-cuda`, …), so the target digest is always younger than 3 days — the `renovate/stability-days` clock resets on every rebuild.
- **GHCR often exposes no retrievable per-digest timestamp**, which pends forever too (reactive-resume digest untouched since Jul 4, still pending).

Result: 11 digest PRs stuck with `renovate/stability-days` pending for up to 19 days (#3351, #3353, #3355, #3356, #3359, #3371, #3373, #3531, #3553, #3561, #3586).

## Fix

Split the automerge enabler rule:
- **minor/patch** keep the 3-day supply-chain burn-in window
- **digest/pin/pinDigest** drop it — a digest bump of an already-trusted tag stays CI-gated (`ignoreTests: false`, Konflate, security scans, claude/renovate-review)

The protected-infra guard still matches after both rules (last-match-wins), so nothing protected gains automerge.