### PR TITLE
fix(homebridge): set ENABLE_AVAHI=0 explicitly — image bakes in =1

### DIFF
--- a/kubernetes/apps/home/homebridge/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homebridge/app/helmrelease.yaml
@@ -21,12 +21,16 @@ spec:
               tag: "2026-07-15@sha256:8dc6094334437b1adb03f376d87d4c8d26847315c307af99020cf4d08359dac4"
             env:
               TZ: ${TIMEZONE}
-              # ENABLE_AVAHI intentionally NOT set. It started an Avahi daemon
-              # that crash-looped forever on "Failed to create runtime directory
-              # /run/avahi-daemon/" — Avahi chowns that dir to the avahi user and
-              # then verifies ownership, but CAP_CHOWN is dropped below, so the
-              # chown returns EPERM and the check fails. Granting CHOWN clears
-              # that error but only exposes the next one: dbus cannot bind
+              # Must be explicitly "0" — the image bakes in ENV ENABLE_AVAHI=1,
+              # so merely omitting this falls back to the image default and the
+              # daemon still starts. /etc/s6-overlay/s6-rc.d/avahi/run gates on
+              # `[ "$ENABLE_AVAHI" = "1" ]`.
+              #
+              # Avahi crash-looped forever on "Failed to create runtime directory
+              # /run/avahi-daemon/": it chowns that dir to the avahi user then
+              # verifies ownership, but CAP_CHOWN is dropped below, so the chown
+              # returns EPERM and the check fails. Granting CHOWN clears that but
+              # only exposes the next wall: dbus cannot bind
               # /run/dbus/system_bus_socket as root (an unprivileged user can,
               # which points at SELinux rather than capabilities).
               #
@@ -34,6 +38,7 @@ spec:
               # so Avahi was never used for HomeKit advertisement anyway. Note
               # that HAP still cannot work over Cilium pod networking — pairing
               # needs LAN presence (see the Multus attachment used by scrypted).
+              ENABLE_AVAHI: "0"
             probes:
               liveness:
                 enabled: true


### PR DESCRIPTION
Follow-up to #3604, **which did not work**. I verified after it merged and the crash-loop was still running — so this corrects it.

## Why #3604 was ineffective

Removing the variable wasn't enough: the `homebridge/homebridge` image sets **`ENV ENABLE_AVAHI=1` in its own Dockerfile**, so dropping it from the HelmRelease just falls back to the image default.

Verified on the running pod after #3604 merged:

```
# k8s-level env — clean
$ kubectl get pod … -o jsonpath='{.spec.containers[0].env[*]}'
TZ=Europe/London

# but PID 1's actual environment still has it
$ kubectl exec … -- tr '\0' '\n' < /proc/1/environ | grep -i avahi
ENABLE_AVAHI=1

# and the loop continues, live
count in last 60s: 60
```

`kubectl get pod -o jsonpath='…env'` only shows k8s-level env, never image `ENV` — which is what hid this.

## The fix

`/etc/s6-overlay/s6-rc.d/avahi/run` gates on:

```sh
if [ "$ENABLE_AVAHI" = "1" ]; then
  … exec avahi-daemon …
else
  echo "Avahi disabled, not starting avahi-daemon"
  exec sleep infinity
fi
```

So an explicit `"0"` is what actually stops it. The comment now leads with *why* it must be explicit, so nobody "tidies up" the seemingly redundant variable and silently reintroduces the loop.

Underlying cause is unchanged and still documented inline: Avahi chowns `/run/avahi-daemon` to the `avahi` user then verifies ownership, but `CAP_CHOWN` is dropped → EPERM → misleading "Failed to create runtime directory". Granting `CHOWN` only exposes a dbus/SELinux socket-bind wall, and `config.json` uses `advertiser: bonjour-hap` so Avahi was never used for HomeKit anyway.

## Validation

- `kustomize build` ✅ · identifier scan ✅ · yamlfmt → prettier ✅
- Will confirm the loop is actually gone on the live pod after merge — that verification gap is what let #3604 through.