### PR TITLE
feat(flux): verify home-operations chart signatures with cosign

### DIFF
--- a/kubernetes/apps/default/chaski/app/ocirepository.yaml
+++ b/kubernetes/apps/default/chaski/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.2.5
   url: oci://ghcr.io/home-operations/charts/chaski
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/chaski/\.github/workflows/release\.yaml@refs/tags/.+$

--- a/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.2.27
   url: oci://ghcr.io/home-operations/charts/konflate
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/konflate/\.github/workflows/release\.yaml@refs/tags/.+$

--- a/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
+++ b/kubernetes/apps/kopiur-system/kopiur/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.7.0
   url: oci://ghcr.io/home-operations/charts/kopiur
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/kopiur/\.github/workflows/release\.yaml@refs/tags/.+$

--- a/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.11.1
   url: oci://ghcr.io/home-operations/charts/miroir
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/miroir/\.github/workflows/release\.yaml@refs/tags/.+$

--- a/kubernetes/apps/observability/gatus/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/gatus/app/ocirepository.yaml
@@ -11,3 +11,8 @@ spec:
   ref:
     tag: 0.3.6
   url: oci://ghcr.io/home-operations/charts/gatus-sidecar
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/gatus\-sidecar/\.github/workflows/release\.yaml@refs/tags/.+$

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -12,3 +12,8 @@ spec:
   ref:
     tag: 0.2.7
   url: oci://ghcr.io/home-operations/charts/tuppr
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/tuppr/\.github/workflows/release\.yaml@refs/tags/.+$


### PR DESCRIPTION
Applies the chart-layer cosign pattern from the kromgo canary (#3606) across the remaining `home-operations` org charts.

> [!IMPORTANT]
> **Merge #3606 first and confirm its OCIRepository reconciles.** If Flux's verifier can't parse the bundle format, this PR fails six sources at once — including `tuppr` (Talos upgrades), `miroir` (CSI) and `konflate` (PR renders).

## Registry audit

I checked all 16 `ghcr.io/home-operations` sources directly against the registry:

| Group | Signed | Notes |
|---|---|---|
| `charts/*` | **8 / 8** | Sigstore bundle, GitHub Actions OIDC |
| `charts-mirror/*` | **1 / 8** | only `headlamp` |

Every org chart is signed by **its own repository's** `release.yaml`, tagged at the exact version:

```
https://github.com/home-operations/<chart>/.github/workflows/release.yaml@refs/tags/<version>
```

There is no shared `charts/*` identity, so this is six near-identical blocks rather than one patch on the root Kustomization. A shared regex would have to be loose enough (`home-operations/.*`) to let any org repo sign any chart, which defeats the point.

## Included

`chaski` · `gatus-sidecar` · `konflate` · `kopiur` · `miroir` · `tuppr`

## Excluded, deliberately

- **`echo`** — has an uncommitted local chart bump (`0.1.2 → 0.2.1`) in the working tree. Editing it here would force a manual conflict against unstaged work. The block is identical in shape; add it alongside that bump.
- **7 unsigned `charts-mirror/*`** — `ceph-csi-drivers`, `descheduler`, `external-dns`, `metrics-server`, `nvidia-gpu-operator`, `tailscale-operator`, `volsync-perfectra1n`. No signature artifact exists for any of them.
- **`headlamp`** — the one signed mirror chart, but its identity pins `refs/heads/main` rather than a tag, so the regex breaks if the workflow or branch is renamed. Held back as a judgement call, not a technical blocker.

## Caveat on the audit method

`cosign verify` hangs in my environment (times out fetching the Sigstore TUF root). The audit instead read the registry directly — confirming a Sigstore bundle exists for each pinned digest, then decoding the embedded X.509 to read its SAN and issuer.

That proves **a signature with the claimed identity is attached**. It does **not** prove the signature validates against the chart digest, nor check Rekor inclusion. Flux does both at pull time — which is the actual test, and the reason for canarying.

## Prior art

Verification was removed from this repository three times (051f6d9f9, 41bcb39a0, 78433df28), every time because the chart of the day was unsigned — never as a policy call. That constraint no longer holds for these eight.

Worth noting: neither `onedr0p/home-ops` nor `joryirving/home-ops` verifies today. onedr0p *did*, with `matchOIDCIdentity` across 24 files (2025-03-25), and it eroded as apps migrated to official upstream charts whose identities no longer matched his `charts-mirror` pin. Abandonment through refactoring, not rejection.

## Validation

- `kustomize build` — OK on all 6 app directories
- `yamlfmt` then `prettier` — clean
- Signature + identity confirmed per chart against ghcr.io