### PR TITLE
feat(kromgo): verify the chart signature with cosign

### DIFF
--- a/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kromgo/app/ocirepository.yaml
@@ -12,3 +12,11 @@ spec:
   ref:
     tag: 0.15.1
   url: oci://ghcr.io/home-operations/charts/kromgo
+  # Canary for chart-layer cosign verification. Each home-operations chart is
+  # signed by its OWN repository's release workflow, so the subject is
+  # per-chart, not a shared charts/* identity.
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token\.actions\.githubusercontent\.com$
+        subject: ^https://github\.com/home-operations/kromgo/\.github/workflows/release\.yaml@refs/tags/.+$


### PR DESCRIPTION
Canary for chart-layer cosign verification. **This was meant to ride along with #3606 but missed the squash** — that PR was merged 12 minutes before this commit was pushed, so `main` currently pulls the kromgo chart unverified.

## The change

```yaml
  verify:
    provider: cosign
    matchOIDCIdentity:
      - issuer: ^https://token\.actions\.githubusercontent\.com$
        subject: ^https://github\.com/home-operations/kromgo/\.github/workflows/release\.yaml@refs/tags/.+$
```

## Why the subject is per-chart

A registry audit of all 16 `ghcr.io/home-operations` sources found every one of the 8 `charts/*` signed, each by **its own repository's** release workflow:

```
https://github.com/home-operations/<chart>/.github/workflows/release.yaml@refs/tags/<version>
```

There's no shared `charts/*` identity. A regex loose enough to cover them all (`home-operations/.*`) would let any org repo sign any chart, which defeats the purpose.

## What to watch after merge

`Ready=True` alone is **not** a pass — an unverified pull also reports Ready. The signal is the `SourceVerified` condition appearing on the OCIRepository:

```bash
kubectl -n observability get ocirepository kromgo \
  -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
```

If Flux can't parse the signature, expect `Ready=False` with a verification error, and kromgo pinned to its last-known-good artifact.

## Why this is worth canarying

These are OCI-referrers/bundle signatures, not legacy `.sig` tags — GHCR doesn't implement the referrers API, so they're reachable only via the `sha256-<digest>` tag fallback. `docs/docs/architecture/image-verification.md` records Talos's verifier as unable to parse this exact format. Flux uses a different implementation and is reported working, but that report is one person's, and #3631 applies the same pattern to six more sources including `tuppr`, `miroir` and `konflate`.

Blocks #3631.