### PR TITLE
fix(snapshot-controller): keep CRDs on Helm release deletion

### DIFF
--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -14,3 +14,16 @@ spec:
       replicaCount: 2
       serviceMonitor:
         create: true
+  # The chart templates its CRDs (templates/crds.yaml) rather than shipping them
+  # in crds/, so they are inside the Helm release's delete scope — dropping this
+  # HelmRelease would cascade-delete every VolumeSnapshot in the cluster. The
+  # chart exposes no annotation knob, so stamp the keep policy post-render.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: CustomResourceDefinition
+            patch: |-
+              - op: add
+                path: /metadata/annotations/helm.sh~1resource-policy
+                value: keep


### PR DESCRIPTION
## Problem

The piraeus chart renders its CRDs from `templates/crds.yaml` behind `installCRDs`,
rather than shipping them untemplated in `crds/`. That puts all six snapshot CRDs
inside the Helm release's delete scope:

```
volumesnapshots / volumesnapshotcontents / volumesnapshotclasses      (snapshot.storage.k8s.io)
volumegroupsnapshots / …contents / …classes                     (groupsnapshot.storage.k8s.io)
```

They currently carry `helm.sh/resource-policy: NONE`. Dropping or pruning this
HelmRelease — an errant edit to `kubernetes/apps/kube-system/kustomization.yaml`
is enough — cascade-deletes **every VolumeSnapshot in the cluster** (286 at time
of writing) and every VolSync restore point with them.

## Fix

The chart exposes no annotation knob, so the `keep` policy is stamped onto the
rendered CRDs with a `postRenderers` kustomize patch — the same mechanism already
used by `headlamp` and `snmp-exporter`. Applied post-render, it is reasserted on
every reconcile rather than existing as untracked cluster drift.

## Verification

Chart pulled and rendered with this HelmRelease's exact values, then the patch
applied through kustomize:

- **6 of 35** rendered objects carry `helm.sh/resource-policy: keep`
- all six are `CustomResourceDefinition`; the kind-only selector catches nothing else
- all six already have an `annotations` map, so `op: add` cannot fail on a missing path
- `kustomize build kubernetes/apps/kube-system/snapshot-controller/app` passes

## Related

Also the documented prerequisite for #3607 (migrating to the home-operations
`snapshot-controller` chart). onedr0p migrated his own cluster without this
annotation and lost the CRDs — this lands the protection well ahead of any
such move.