### PR TITLE
fix(memini): move route to the primary domain

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -86,7 +86,7 @@ spec:
       internal:
         enabled: true
         hostnames:
-          - "memini.${SECRET_INTERNAL_DOMAIN}"
+          - "memini.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
memini was the only app published solely on ${SECRET_INTERNAL_DOMAIN}, with no
${SECRET_DOMAIN} twin. Switch it rather than delete it, so the internal-domain
alias removal that follows can treat every remaining occurrence as redundant.
