### PR TITLE
fix(renovate): unblock the pin-dependencies branch, round 2

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -534,6 +534,24 @@
       pinDigests: false,
     },
     {
+      // The home-operations preset forces regex versioning
+      // (^server-<variant>-b<build>$) on every llama.cpp reference repo-wide,
+      // but memini's model init containers use the bare legacy `server` tag,
+      // which that scheme cannot parse — an unparseable currentValue under
+      // strict custom versioning wedges the combined pin-dependencies branch
+      // (same renovatebot/renovate#24942 failure family as PR #3652).
+      // Fall back to plain docker versioning for these two files so the tag
+      // is treated as an ordinary mutable tag and digest-pins normally.
+      description: "memini llama.cpp images use the bare 'server' tag — preset regex versioning can't parse it",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["ghcr.io/ggml-org/llama.cpp"],
+      matchFileNames: [
+        "kubernetes/apps/ai/memini/models/llama-embed.yaml",
+        "kubernetes/apps/ai/memini/models/llama-rerank.yaml",
+      ],
+      versioning: "docker",
+    },
+    {
       // pulsarr upstream (github.com/jamcalli/Pulsarr) is still on 0.15.x.
       // Stray 1.x tags appeared on Docker Hub (1.1.5, 1.1.6) and were pulled.
       // Block the whole 1.x major until upstream legitimately ships a 1.0 release.

--- a/kubernetes/apps/custom/todoist-sort/app/helmrelease.yaml
+++ b/kubernetes/apps/custom/todoist-sort/app/helmrelease.yaml
@@ -38,7 +38,12 @@ spec:
           failedJobsHistory: 1
         containers:
           app:
-            image: &image
+            # NOT anchored/aliased into plan-day: Renovate's helm-values
+            # extractor walks the resolved YAML, so an `image: *image` alias
+            # becomes a second identical dep whose digest-pin write corrupts
+            # the first (tag@sha256@sha256), crashing the whole combined
+            # renovate/pin-dependencies branch (renovate#24942 family).
+            image:
               repository: ghcr.io/lukeevanstech/todoist-sort
               tag: 0.2.3
             command:
@@ -79,7 +84,10 @@ spec:
           failedJobsHistory: 1
         containers:
           app:
-            image: *image
+            # Duplicated from sort-inbox on purpose — see the comment there.
+            image:
+              repository: ghcr.io/lukeevanstech/todoist-sort
+              tag: 0.2.3
             command:
               - "plan-day"
               - "--root"


### PR DESCRIPTION
Round 2 of the `renovate/pin-dependencies` unblock (round 1 = #3652, which cleared `renovate/talos` and shrank the errored branch 24 → 15 members).

Two more crash members root-caused:

1. **todoist-sort** — `image: &image` in `sort-inbox` aliased as `image: *image` in `plan-day`. Renovate's helm-values extractor walks the **resolved** YAML tree, so the alias registers a second identical dependency; the second first-time digest-pin write lands inside the already-pinned value (`0.2.3@sha256:…@sha256:…`), re-extraction can't confirm, and `doAutoReplace` throws `update-failure` — killing the whole combined branch (renovate#24942 family). Fix: un-share the anchor (rendered manifests are identical).
2. **llama.cpp in memini models** — the preset's repo-wide `server-<variant>-b<build>` regex versioning can't parse the bare `server` tag in `llama-embed.yaml`/`llama-rerank.yaml`. Fix: file-scoped fallback to `docker` versioning (the llmkube CRs keep the regex scheme; their pins already work, see #3355).

Remaining 13 members verified structurally sound — after this merges, a dashboard retry should finally produce the pin PR.