### PR TITLE
fix(mktxp): repair malformed image ref and close alert blind spot

### DIFF
--- a/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/mktxp/app/helmrelease.yaml
@@ -22,7 +22,6 @@ spec:
             image:
               repository: ghcr.io/akpw/mktxp
               tag: 1.2.19@sha256:2c594a5f8b52dcc7e5a8b28042c91ff4d020cd375be93129571ba50e36725a30
-              digest: sha256:bd6f22f7db0a79557c4af8a73aa22517f4c32d54fafa19fb0de29e7332440613
             command:
               - "sh"
               - "-c"
@@ -47,7 +46,6 @@ spec:
             image:
               repository: ghcr.io/akpw/mktxp
               tag: 1.2.19@sha256:2c594a5f8b52dcc7e5a8b28042c91ff4d020cd375be93129571ba50e36725a30
-              digest: sha256:bd6f22f7db0a79557c4af8a73aa22517f4c32d54fafa19fb0de29e7332440613
             command:
               - "mktxp"
               - "--cfg-dir"

--- a/kubernetes/apps/observability/mktxp/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/mktxp/app/prometheusrule.yaml
@@ -16,16 +16,28 @@ spec:
           for: 5m
           labels:
             severity: critical
-        # mktxp drops a router's series when it can't reach it. Confirm the exact
-        # uptime metric/label against live /metrics before relying on this.
-        # mktxp drops a router's series when it can't reach it. Both
-        # switches should report mktxp_system_uptime; fewer than 2 means one is
-        # unreachable. (Adjust the threshold if the switch count changes.)
+        # When mktxp cannot reach ANY router the scrape still returns HTTP 200
+        # with an empty body, so up==1 and count(mktxp_system_uptime) yields an
+        # empty vector — a `< N` comparison can never fire. absent() is the only
+        # expression that catches total blindness (verified: both switches were
+        # unreachable 8 days with zero alerts). mktxp_system_uptime is confirmed
+        # against historical data as the per-router presence series.
+        - alert: MktxpNoRouterData
+          annotations:
+            summary: "mktxp is up but collecting from zero RouterOS devices — every switch is unreachable."
+          expr: |-
+            absent(mktxp_system_uptime)
+          for: 10m
+          labels:
+            severity: critical
+        # Partial loss: at least one router reports but not all. count()<2 only
+        # fires when count==1 (never when 0 — see absent() alert above). 15m
+        # tolerates a flapping switch dropping its series briefly between scrapes.
         - alert: MktxpRouterUnreachable
           annotations:
             summary: "mktxp is collecting from fewer than 2 RouterOS devices — a switch is unreachable."
           expr: |-
             count(mktxp_system_uptime) < 2
-          for: 10m
+          for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
Two independent faults on `mktxp`, one of which was hiding the other.

## 1. Malformed image ref — HelmRelease stalled

Renovate #3612 (1.2.17 ➔ 1.2.19) wrote the new digest into `tag:` but left the stale 1.2.17 `digest:` field, so app-template rendered:

```
ghcr.io/akpw/mktxp:1.2.19@sha256:2c594a…@sha256:bd6f22…
```

kubelet rejected the double digest (`InspectFailed: Failed to apply default image tag`), the Deployment never went Ready, helm timed out, and the HR rolled back to v7 with `Stalled/RetriesExceeded`. The cluster is still running the old 1.2.17 image.

Collapsed to the combined `tag: 1.2.19@sha256:2c594a…` form (used by ~157 other apps) and dropped the stray `digest:` in both the init and app containers. Confirmed against ghcr that upstream tags are unprefixed and `1.2.19` → `sha256:2c594a5f…`; the old `v1.2.17` tag no longer resolves at all.

> The same latent pattern on five other apps is fixed separately in the companion PR.

## 2. Alerts could not fire — 8 days of silent blindness

Both CRS354 switches have been unreachable since **2026-07-11** and neither alert fired. `/metrics` currently returns **zero** `mktxp_` series.

When mktxp cannot reach *any* router it still returns HTTP 200 with an empty body, so:

- `MktxpExporterDown` → `up{job="mktxp"} == 0` — the scrape **succeeds**, `up == 1`. Silent.
- `MktxpRouterUnreachable` → `count(mktxp_system_uptime) < 2` — with zero series `count()` returns an **empty vector**, so the comparison yields nothing. Silent.

Total blindness was precisely the case neither rule could catch. Added `MktxpNoRouterData` (critical) on `absent(mktxp_system_uptime)`, and widened the partial-loss warning to `for: 15m` to tolerate a flapping switch.

## Verification

- `kustomize build` OK (6 resources); yamlfmt + prettier clean.
- All three alert expressions parse against live Prometheus.
- **`absent(mktxp_system_uptime)` returns `1` right now** — the new critical alert would fire for the current outage. The other two correctly stay silent.
- `mktxp_system_uptime` confirmed as the per-router presence series from historical data (148 points, 07-05 → 07-11), resolving the stale “confirm the exact metric before relying on this” comment.

## Not addressed here

The switches themselves are device-side and need out-of-band access: PoE (`sw-comms-access`) is up but `api-ssl` is not listening (8728/8729 refused, 22/443 open) — needs `/ip service enable api-ssl`; NonPoE (`sw-main-mgmt`) is currently flapping. mktxp will keep exporting zero series until both are reachable — this PR just means you will now be told about it.