### PR TITLE
fix(apps): collapse split tag/digest image pins to the combined form

### DIFF
--- a/kubernetes/apps/default/subspy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/subspy/app/helmrelease.yaml
@@ -18,8 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/subspy
-              tag: 1.6.3
-              digest: sha256:d39aa1b6b72962eb3c1293400e4d9303bfc06e6fbbf7583a45f6894c1f57e792
+              tag: 1.6.3@sha256:d39aa1b6b72962eb3c1293400e4d9303bfc06e6fbbf7583a45f6894c1f57e792
             env:
               TZ: ${TIMEZONE}
               DATABASE_URL: sqlite:///./data/subspy.db

--- a/kubernetes/apps/observability/acinfinity-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/acinfinity-exporter/app/helmrelease.yaml
@@ -18,8 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/lukeevanstech/acinfinity-exporter
-              tag: 1.0.0
-              digest: sha256:cd83f82a9a3347c6838e381c3797754b775569c3923a5461376c5170d9d72229
+              tag: 1.0.0@sha256:cd83f82a9a3347c6838e381c3797754b775569c3923a5461376c5170d9d72229
             env:
               TZ: ${TIMEZONE:=UTC}
               METRICS_PORT: "8000"

--- a/kubernetes/apps/observability/opnsense-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/helmrelease.yaml
@@ -18,8 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/athennamind/opnsense-exporter
-              tag: "0.0.16"
-              digest: sha256:64469206eb955b6c87ec2737cd4884b0bec01b518408cf1ac6d5c153f6c0cf1f
+              tag: 0.0.16@sha256:64469206eb955b6c87ec2737cd4884b0bec01b518408cf1ac6d5c153f6c0cf1f
             env:
               # OPS_API / OPS_API_KEY / OPS_API_SECRET come from the secret (envFrom).
               OPNSENSE_EXPORTER_OPS_PROTOCOL: https

--- a/kubernetes/apps/observability/plex-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plex-exporter/app/helmrelease.yaml
@@ -18,8 +18,7 @@ spec:
           app:
             image:
               repository: ghcr.io/timothystewart6/prometheus-plex-exporter
-              tag: 3e7a4da
-              digest: sha256:90dc0799601c334f2945a3d5b4b552a06352b208a8ce88a428cf90d6c9aa51cd
+              tag: 3e7a4da@sha256:90dc0799601c334f2945a3d5b4b552a06352b208a8ce88a428cf90d6c9aa51cd
             env:
               # In-cluster Plex service (media namespace). If Plex "Secure
               # connections" is set to Required, switch to the LB IP

--- a/kubernetes/apps/observability/vmware-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/vmware-exporter/app/helmrelease.yaml
@@ -18,8 +18,7 @@ spec:
           app:
             image:
               repository: docker.io/pryorda/vmware_exporter
-              tag: v0.18.4
-              digest: sha256:79925e63e59ffe962762697da3c9f14bc1c132e0b0ca873f75d0e2cadaff361e
+              tag: v0.18.4@sha256:79925e63e59ffe962762697da3c9f14bc1c132e0b0ca873f75d0e2cadaff361e
             env:
               # The target vCenter is supplied per-scrape via the ServiceMonitor
               # `?vsphere_host=` param (see servicemonitor.yaml); creds come from


### PR DESCRIPTION
Fleet-wide fix for the latent Renovate trap that stalled `mktxp` (companion PR #3707).

## The trap

A standalone `digest:` field next to `tag:` is not a style choice — it is a time bomb.

`docker:pinDigests` is inherited from the shared house preset (`github>LukeEvansTech/renovate-config`). On bump, Renovate’s **helm-values** manager rewrites `tag: X` → `tag: X@sha256:NEW`, but that manager has no concept of a sibling `digest:` key, so the old digest survives. app-template concatenates both:

```
repo:X@sha256:new@sha256:old
```

kubelet rejects it (`InspectFailed`), pods never start, and the HelmRelease stalls into rollback.

## This is not hypothetical

`mktxp`’s pre-bump state in #3612 was:

```yaml
tag: v1.2.17
digest: sha256:bd6f22…
```

— the exact layout these five apps carry today. Each was one image bump away from an identical stall.

| App | Was | Now |
|---|---|---|
| `subspy` | `1.6.3` + digest | `1.6.3@sha256:d39aa1b…` |
| `plex-exporter` | `3e7a4da` + digest | `3e7a4da@sha256:90dc079…` |
| `vmware-exporter` | `v0.18.4` + digest | `v0.18.4@sha256:79925e6…` |
| `opnsense-exporter` | `"0.0.16"` + digest | `0.0.16@sha256:6446920…` |
| `acinfinity-exporter` | `1.0.0` + digest | `1.0.0@sha256:cd83f82…` |

Collapsed all five to the combined `tag: X@sha256:Y` form used by ~157 other apps — the shape Renovate actually round-trips. Removing the standalone `digest:` loses nothing, since Renovate never managed it.

The repo already disables `pinDigests` in three places for this same appended-`@sha256` class of bug (flux/OCIRepository, ImageVerificationConfig, helmfile). The helm-values variant had not been spotted. OCIRepository keeps its split `tag:`/`digest:` — helm rejects `@sha256` on a chart ref, so that exemption is correct and untouched.

## Verification — this is a no-op

- **Each app’s rendered image is byte-identical to the image currently running in-cluster**, so reconcile causes **zero pod restarts**. All five were `Ready=True` before and stay pinned to the same digest.
- `kustomize build` passes for all five; yamlfmt + prettier clean.
- Repo-wide sweep: zero remaining split `tag`/`digest` pairs outside OCIRepository, and zero double-digest refs.

No functional change — purely removes the trap.