### PR TITLE
ci: prevent the Renovate backlog failure modes from recurring

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -44,24 +44,16 @@ SELF_PATH = ".github/scripts/check_internal_identifiers.py"
 # what it is meant to keep out of git). It catches the structural naming scheme
 # (site-prefixed `cr-*` / `sw-*` hostnames, private IPs, MACs, internal TLDs).
 PATTERNS: dict[str, re.Pattern] = {
-    "LAN IP": re.compile(
-        r"(?<![\d.])(?:10\.32|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d+\.\d+(?![\d.])"
-    ),
+    "LAN IP": re.compile(r"(?<![\d.])(?:10\.32|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d+\.\d+(?![\d.])"),
     # Tailscale hands out addresses from the CGNAT range 100.64.0.0/10
     # (100.64.x.x-100.127.x.x); a literal one maps a tailnet node.
-    "tailnet IP (CGNAT)": re.compile(
-        r"(?<![\d.])100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+(?![\d.])"
-    ),
+    "tailnet IP (CGNAT)": re.compile(r"(?<![\d.])100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+(?![\d.])"),
     "node name": re.compile(r"cr-talos-\d+"),
     # site-prefixed device hostnames, kept as two single-line patterns so black and
     # ruff agree; both exclude cr-talos-* and "ghcr-auth"-style substrings.
-    "device hostname (cr)": re.compile(
-        r"(?<![a-z0-9])cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)+"
-    ),
+    "device hostname (cr)": re.compile(r"(?<![a-z0-9])cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)+"),
     "device hostname (sw)": re.compile(r"(?<![a-z0-9])sw-(?:main|comms)-[a-z0-9]+"),
-    "MAC address": re.compile(
-        r"(?<![0-9a-fA-F:])(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}(?![0-9a-fA-F:])"
-    ),
+    "MAC address": re.compile(r"(?<![0-9a-fA-F:])(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}(?![0-9a-fA-F:])"),
     "internal hostname": re.compile(r"\b[a-z0-9_-]+\.(?:lan|internal)\b"),
 }
 
@@ -107,9 +99,7 @@ ALLOWLIST: dict[str, str] = {
 
 def allowlisted(path: str) -> bool:
     """Return True if the path matches an accepted-functional-config glob."""
-    return any(
-        fnmatch(path, glob) or path.startswith(glob.rstrip("*")) for glob in ALLOWLIST
-    )
+    return any(fnmatch(path, glob) or path.startswith(glob.rstrip("*")) for glob in ALLOWLIST)
 
 
 def tracked_files() -> list[str]:
@@ -120,9 +110,7 @@ def tracked_files() -> list[str]:
 
 def changed_files(base: str) -> list[str]:
     """List tracked files changed between *base* and HEAD (deletions excluded)."""
-    out = subprocess.check_output(
-        ["git", "diff", "--name-only", "--diff-filter=d", base, "HEAD"], text=True
-    )
+    out = subprocess.check_output(["git", "diff", "--name-only", "--diff-filter=d", base, "HEAD"], text=True)
     tracked = set(tracked_files())
     return [f for f in out.splitlines() if f in tracked]
 

--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -44,16 +44,24 @@ SELF_PATH = ".github/scripts/check_internal_identifiers.py"
 # what it is meant to keep out of git). It catches the structural naming scheme
 # (site-prefixed `cr-*` / `sw-*` hostnames, private IPs, MACs, internal TLDs).
 PATTERNS: dict[str, re.Pattern] = {
-    "LAN IP": re.compile(r"(?<![\d.])(?:10\.32|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d+\.\d+(?![\d.])"),
+    "LAN IP": re.compile(
+        r"(?<![\d.])(?:10\.32|192\.168|172\.(?:1[6-9]|2\d|3[01]))\.\d+\.\d+(?![\d.])"
+    ),
     # Tailscale hands out addresses from the CGNAT range 100.64.0.0/10
     # (100.64.x.x-100.127.x.x); a literal one maps a tailnet node.
-    "tailnet IP (CGNAT)": re.compile(r"(?<![\d.])100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+(?![\d.])"),
+    "tailnet IP (CGNAT)": re.compile(
+        r"(?<![\d.])100\.(?:6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+(?![\d.])"
+    ),
     "node name": re.compile(r"cr-talos-\d+"),
     # site-prefixed device hostnames, kept as two single-line patterns so black and
     # ruff agree; both exclude cr-talos-* and "ghcr-auth"-style substrings.
-    "device hostname (cr)": re.compile(r"(?<![a-z0-9])cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)+"),
+    "device hostname (cr)": re.compile(
+        r"(?<![a-z0-9])cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)+"
+    ),
     "device hostname (sw)": re.compile(r"(?<![a-z0-9])sw-(?:main|comms)-[a-z0-9]+"),
-    "MAC address": re.compile(r"(?<![0-9a-fA-F:])(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}(?![0-9a-fA-F:])"),
+    "MAC address": re.compile(
+        r"(?<![0-9a-fA-F:])(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}(?![0-9a-fA-F:])"
+    ),
     "internal hostname": re.compile(r"\b[a-z0-9_-]+\.(?:lan|internal)\b"),
 }
 
@@ -99,7 +107,9 @@ ALLOWLIST: dict[str, str] = {
 
 def allowlisted(path: str) -> bool:
     """Return True if the path matches an accepted-functional-config glob."""
-    return any(fnmatch(path, glob) or path.startswith(glob.rstrip("*")) for glob in ALLOWLIST)
+    return any(
+        fnmatch(path, glob) or path.startswith(glob.rstrip("*")) for glob in ALLOWLIST
+    )
 
 
 def tracked_files() -> list[str]:

--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -5,11 +5,20 @@ This repository is PUBLIC. The house rule (see CLAUDE.md / AGENTS.md) is: never
 commit LAN IPs, node names, internal hostnames, MAC addresses, or vendor device
 models that map the home network. This guard enforces that on every PR.
 
-It scans all *tracked* files (so gitignored paths like docs/superpowers/ are never
+It scans *tracked* files (so gitignored paths like docs/superpowers/ are never
 seen) for the patterns below, skipping a small ALLOWLIST of files where a value is
 an unavoidable, accepted functional config (Talos machine config, device cert
 deployment, monitoring scrape targets, etc.). Anything matching OUTSIDE the
 allowlist fails the build.
+
+By default every tracked file is scanned (push-to-main + nightly runs). With
+--diff-base REV, only files changed between REV and HEAD are scanned: PR runs
+pass --diff-base HEAD^1 so a PR is judged ONLY on the files it touches. (PR
+events run on the merge ref; a full scan there re-scans all of main, so a
+transient bad state on main used to fail every open PR, and with
+rebaseWhen:conflicted the stale FAILURE check-run then blocked Renovate's
+self-merge forever. Main's own state stays covered by the push and schedule
+runs.)
 
 The allowlist is the authoritative list of "accepted functional configs" -- each
 entry says why the identifier has to live there. To template one out of git later,
@@ -21,6 +30,7 @@ Run locally:  python3 .github/scripts/check_internal_identifiers.py
 
 from __future__ import annotations
 
+import argparse
 import re
 import subprocess
 import sys
@@ -98,10 +108,28 @@ def tracked_files() -> list[str]:
     return [f for f in out.splitlines() if not f.startswith(".private/")]
 
 
+def changed_files(base: str) -> list[str]:
+    """List tracked files changed between *base* and HEAD (deletions excluded)."""
+    out = subprocess.check_output(
+        ["git", "diff", "--name-only", "--diff-filter=d", base, "HEAD"], text=True
+    )
+    tracked = set(tracked_files())
+    return [f for f in out.splitlines() if f in tracked]
+
+
 def main() -> int:
     """Scan tracked files and fail (exit 1) on any non-allowlisted identifier."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--diff-base",
+        metavar="REV",
+        help="scan only files changed between REV and HEAD (PR scope)",
+    )
+    args = parser.parse_args()
+
+    paths = changed_files(args.diff_base) if args.diff_base else tracked_files()
     violations: list[str] = []
-    for path in tracked_files():
+    for path in paths:
         if allowlisted(path) or path == SELF_PATH:
             continue
         try:
@@ -130,7 +158,8 @@ def main() -> int:
         )
         return 1
 
-    print("OK -- no new internal infrastructure identifiers in tracked files.")
+    scope = f"{len(paths)} changed" if args.diff_base else f"all {len(paths)} tracked"
+    print(f"OK -- no new internal infrastructure identifiers ({scope} files).")
     return 0
 
 

--- a/.github/workflows/renovate-dashboard-groomer.yaml
+++ b/.github/workflows/renovate-dashboard-groomer.yaml
@@ -79,11 +79,9 @@ jobs:
           with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
               f.write(body)
               path = f.name
-          subprocess.run(
-              ["gh", "api", "-X", "PATCH", f"repos/{repo}/issues/1",
-               "-F", f"body=@{path}", "-q", ".updated_at"],
-              check=True,
-          )
+          cmd = ["gh", "api", "-X", "PATCH", f"repos/{repo}/issues/1"]
+          cmd += ["-F", f"body=@{path}", "-q", ".updated_at"]
+          subprocess.run(cmd, check=True)
           print(f"ticked {ticked[1]} parked update(s)")
           PYEOF
 

--- a/.github/workflows/renovate-dashboard-groomer.yaml
+++ b/.github/workflows/renovate-dashboard-groomer.yaml
@@ -1,0 +1,105 @@
+---
+# Prevents the two Renovate backlog failure modes cleaned up on 2026-07-19:
+#
+# 1. Fast releasers reset the 3-day minimumReleaseAge clock indefinitely
+#    (Renovate targets the newest release; near-daily publishers never have one
+#    older than 3 days), so updates park in the dashboard's "Pending Status
+#    Checks" section forever. Ticking a box force-creates the PR, which then
+#    goes through full CI + automerge gating as normal — so this turns the age
+#    gate into "3 days OR at most a week", never an unbounded wait.
+#
+# 2. A transient bad state on main used to fail the merge-ref Internal
+#    Identifier Scan on every open PR, and rebaseWhen:conflicted means no new
+#    SHA ever replaces the stale FAILURE — Renovate then refuses to self-merge
+#    a PR that is green everywhere else. Re-running the failed run heals it
+#    (the scan is PR-scoped since the same change that added this workflow, so
+#    re-runs judge only the PR's own files and are deterministic).
+name: renovate-dashboard-groomer
+
+on:
+  schedule:
+    - cron: "0 6 * * 0" # Sundays 06:00 UTC
+  workflow_dispatch:
+
+# Top-level: read-only. The job widens only what it needs.
+permissions:
+  contents: read
+
+jobs:
+  groom:
+    name: Groom dashboard + heal stale checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # tick dashboard checkboxes (issue body edit)
+      actions: write # re-run failed workflow runs
+    steps:
+      - name: Tick parked Pending Status Checks boxes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import os
+          import re
+          import subprocess
+          import tempfile
+
+          repo = os.environ["REPO"]
+          issue = subprocess.run(
+              ["gh", "api", f"repos/{repo}/issues/1"],
+              check=True, capture_output=True, text=True,
+          )
+          data = json.loads(issue.stdout)
+          if "Renovate Dashboard" not in data["title"]:
+              raise SystemExit(f"issue #1 is not the dashboard: {data['title']!r}")
+          body = data["body"]
+
+          # Only the "Pending Status Checks" section, only approvePr boxes.
+          # Other sections (Errored retries, Pending Approval, rebase-all) stay
+          # human-driven on purpose.
+          section = re.search(
+              r"## Pending Status Checks\n.*?(?=\n## |\Z)", body, re.DOTALL
+          )
+          if not section:
+              print("no Pending Status Checks section - nothing to do")
+              raise SystemExit(0)
+
+          ticked = re.subn(
+              r"- \[ \] (<!-- approvePr-branch=)",
+              r"- [x] \1",
+              section.group(0),
+          )
+          if ticked[1] == 0:
+              print("no unticked boxes - nothing to do")
+              raise SystemExit(0)
+
+          body = body[: section.start()] + ticked[0] + body[section.end():]
+          with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+              f.write(body)
+              path = f.name
+          subprocess.run(
+              ["gh", "api", "-X", "PATCH", f"repos/{repo}/issues/1",
+               "-F", f"body=@{path}", "-q", ".updated_at"],
+              check=True,
+          )
+          print(f"ticked {ticked[1]} parked update(s)")
+          PYEOF
+
+      - name: Re-run failed security-scans on open Renovate PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |-
+          gh pr list --repo "$REPO" --limit 100 --json headRefName,author \
+            --jq '.[] | select(.author.login | test("renovate")) | .headRefName' |
+            while read -r branch; do
+              gh run list --repo "$REPO" --branch "$branch" \
+                --workflow security-scans.yaml --status failure --limit 3 \
+                --json databaseId --jq '.[].databaseId' |
+                while read -r run_id; do
+                  echo "re-running failed run ${run_id} on ${branch}"
+                  gh run rerun "$run_id" --failed --repo "$REPO" || true
+                done
+            done

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -34,11 +34,22 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          # PR runs diff against the merge ref's first parent (main at merge
+          # time), so both parents of the merge commit must be present.
+          fetch-depth: 2
       # This repo is PUBLIC. Fail the build if a tracked file introduces a LAN IP,
       # node/device hostname, MAC, internal hostname, or device model outside the
       # accepted-functional allowlist. See the script for the allowlist + rationale.
+      #
+      # PR runs scan ONLY the files the PR changes (--diff-base HEAD^1): the
+      # merge ref includes all of main, and a full scan there let a transient
+      # bad state on main fail every open PR — the stale FAILURE check-run then
+      # blocked Renovate self-merge forever (rebaseWhen:conflicted never makes
+      # a new SHA). Push-to-main + nightly runs still scan everything.
       - name: Scan tracked files for internal infrastructure identifiers
-        run: python3 .github/scripts/check_internal_identifiers.py
+        env:
+          DIFF_BASE: ${{ github.event_name == 'pull_request' && 'HEAD^1' || '' }}
+        run: python3 .github/scripts/check_internal_identifiers.py ${DIFF_BASE:+--diff-base "$DIFF_BASE"}
       # Deleting a ${SECRET_INTERNAL_DOMAIN} route hostname is only safe when the
       # same route also publishes ${SECRET_DOMAIN} -- catches an app going fully
       # offline before it merges. See the script for the allowlist + rationale.

--- a/.mise.toml
+++ b/.mise.toml
@@ -50,8 +50,13 @@ run = "uv pip install -r requirements.txt"
 "github:home-operations/yayamlls" = "latest"
 python = "3.14.6"
 uv = "0.11.29"
-node = "24"
+# Exact pins (not ranges): an in-range update is LOCKFILE-ONLY for Renovate,
+# and that artifact path fails on Mend hosted — the node/prettier
+# "-lockfile" branches errored on every dashboard tick while ordinary
+# bump-toml+lock updates (e.g. just 1.57.0, #3601) work fine. Every other
+# tool here is exact-pinned already; keep it that way.
+node = "24.14.0"
 "npm:markdownlint-cli" = "0.49.1"
-"npm:prettier" = "3"
+"npm:prettier" = "3.8.1"
 "pipx:codespell" = "2.4.3"
 "pipx:yamllint" = "1.38.0"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -501,7 +501,7 @@
       // check → WORKER_FILE_UPDATE_FAILED aborts the ENTIRE combined
       // renovate/pin-dependencies branch ("Error updating branch: update
       // failure"; renovatebot/renovate#24942). The same charts' runtime twins
-      // in kubernetes/**/ocirepository.yaml are already exempt via the flux
+      // in the per-app kubernetes ocirepository.yaml files are already exempt via the flux
       // rule above — bootstrap/helmfile.d/ is only the cold-start path.
       description: "Don't pin digests on Helmfile OCI chart releases (no digest field; crashes the pin branch)",
       matchManagers: ["helmfile"],


### PR DESCRIPTION
Systemic prevention for the two remaining backlog causes from today's cleanup (causes 1+2 were fixed in #3608/#3652/#3705):

## 1. Weekly dashboard groomer (new workflow)
- Sundays 06:00 UTC + manual dispatch.
- Ticks every `approvePr-branch` box in **Pending Status Checks** only — Errored retries and Pending Approval (e.g. Minecraft's deliberate human gate) stay manual.
- Forced PRs still pass through Konflate, security scans, claude review, and the protected-infra automerge guard, so this only bounds the wait: **3-day age gate OR at most a week**.
- Second step re-runs failed `security-scans` runs on open Renovate branches — heals stale-red PRs like #3543/#3696.

## 2. PR-scope the Internal Identifier Scan
The 'flaky' scan wasn't flaky: `pull_request` runs execute on the **merge ref**, so a transient identifier leak on main failed **every open PR**, and `rebaseWhen: conflicted` means the stale FAILURE check-run is never replaced. Verified on #3543: the 10:10 failure was `nut-exporter/prometheusrule.yaml` — a file the PR never touched, later allowlisted on main.

- PR runs: `--diff-base HEAD^1` → judged only on the PR's changed files (`fetch-depth: 2` for the merge parents).
- Push-to-main + nightly schedule: unchanged full scan.
- Tested locally: full scan (1669 files) ✅, diff scope (21 files over 10 commits) ✅, empty diff ✅, actionlint ✅.