### PR TITLE
ci: guard against internal-domain hostnames with no primary sibling

### DIFF
--- a/.github/scripts/check_route_hostname_pairs.py
+++ b/.github/scripts/check_route_hostname_pairs.py
@@ -41,13 +41,13 @@ HOSTNAME_RE = re.compile(r'^\s*-\s*"?([^"]*)\$\{SECRET_INTERNAL_DOMAIN\}"?\s*$')
 
 
 def sibling_re(prefix: str) -> re.Pattern:
+    """Return a regex pattern matching a SECRET_DOMAIN hostname with the given prefix."""
     return re.compile(r'^\s*-\s*"?' + re.escape(prefix) + r'\$\{SECRET_DOMAIN\}"?\s*$')
 
 
 def main() -> int:
-    files = subprocess.check_output(
-        ["grep", "-rl", "SECRET_INTERNAL_DOMAIN", "kubernetes/"], text=True
-    ).split()
+    """Check that all internal-domain hostnames have a primary-domain sibling; exit 0 if OK, 1 if orphans found."""
+    files = subprocess.check_output(["grep", "-rl", "SECRET_INTERNAL_DOMAIN", "kubernetes/"], text=True).split()
     orphans: list[str] = []
     for path in files:
         if path in ALLOWLIST:

--- a/.github/scripts/check_route_hostname_pairs.py
+++ b/.github/scripts/check_route_hostname_pairs.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Fail if a ${SECRET_INTERNAL_DOMAIN} hostname has no ${SECRET_DOMAIN} sibling.
+
+Deleting an internal-domain hostname is only safe when the same route also
+publishes the primary domain. This guard makes that property checkable, so the
+bulk removal cannot silently take an app offline (as it nearly did for memini).
+
+Non-route uses of the variable are expected and allowlisted: device IPMI probe
+targets, the NAS S3 endpoint, the external-dns domain filter, the wildcard cert
+SAN, and the variable's own definition.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+ALLOWLIST = {
+    "kubernetes/components/global-vars/cluster-secrets.yaml": "defines the variable",
+    "kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml": "device IPMI probe targets",
+    "kubernetes/apps/storage/garage/app/sync-cronjob.yaml": "NAS S3 endpoint, not a cluster route",
+    "kubernetes/apps/network/opnsense-dns/app/helmrelease.yaml": "external-dns domainFilters",
+    "kubernetes/apps/cert-manager/cert-manager/tls/certificate.yaml": "wildcard cert SAN",
+}
+
+# Anchored to a real YAML list item (`<indent>- "value"` or `<indent>- value`),
+# not just any hyphen in the line -- an unanchored `-` also matches inside
+# literal text like "prowler-api", which corrupts the captured hostname prefix
+# and produces a false-positive orphan (see kubernetes/apps/security/prowler/
+# app/helmrelease-api.yaml's comma-joined DJANGO_ALLOWED_HOSTS env value).
+#
+# The prefix capture excludes only the closing quote, not whitespace: most
+# routes use the `{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}` Helm template
+# idiom, which contains spaces inside the quotes. Excluding `\s` too (as a
+# naive first cut would) makes the regex blind to that idiom -- the majority
+# of hostnames in this repo -- while still passing on unrelated files, which
+# defeats the guard silently instead of loudly.
+HOSTNAME_RE = re.compile(r'^\s*-\s*"?([^"]*)\$\{SECRET_INTERNAL_DOMAIN\}"?\s*$')
+
+
+def sibling_re(prefix: str) -> re.Pattern:
+    return re.compile(r'^\s*-\s*"?' + re.escape(prefix) + r'\$\{SECRET_DOMAIN\}"?\s*$')
+
+
+def main() -> int:
+    files = subprocess.check_output(
+        ["grep", "-rl", "SECRET_INTERNAL_DOMAIN", "kubernetes/"], text=True
+    ).split()
+    orphans: list[str] = []
+    for path in files:
+        if path in ALLOWLIST:
+            continue
+        lines = pathlib.Path(path).read_text(encoding="utf-8").split("\n")
+        for i, line in enumerate(lines):
+            m = HOSTNAME_RE.search(line)
+            if not m:
+                continue
+            pat = sibling_re(m.group(1))
+            lo, hi = max(0, i - 4), min(len(lines), i + 5)
+            if not any(pat.search(lines[j]) for j in range(lo, hi) if j != i):
+                orphans.append(f"{path}:{i + 1}: {line.strip()}")
+
+    if orphans:
+        print("Internal-domain hostnames with no ${SECRET_DOMAIN} sibling:\n")
+        for o in orphans:
+            print(f"  {o}")
+        print(
+            "\nRemoving these would take the app offline. Switch them to "
+            "${SECRET_DOMAIN} instead, or allowlist them in this script if they "
+            "are not app routes."
+        )
+        return 1
+
+    print("OK -- every internal-domain hostname has a primary-domain sibling.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -39,3 +39,8 @@ jobs:
       # accepted-functional allowlist. See the script for the allowlist + rationale.
       - name: Scan tracked files for internal infrastructure identifiers
         run: python3 .github/scripts/check_internal_identifiers.py
+      # Deleting a ${SECRET_INTERNAL_DOMAIN} route hostname is only safe when the
+      # same route also publishes ${SECRET_DOMAIN} -- catches an app going fully
+      # offline before it merges. See the script for the allowlist + rationale.
+      - name: Route hostname pair check
+        run: python3 .github/scripts/check_route_hostname_pairs.py

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -80,7 +80,7 @@ spec:
     route:
       app:
         hostnames:
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
## Summary
- `fix(litellm): move route to the primary domain` -- litellm was a second app (after memini) whose `envoy-internal` route only published `${SECRET_INTERNAL_DOMAIN}`, with no `${SECRET_DOMAIN}` sibling. Since `envoy-internal` publishes DNS records for both domains identically and both resolve only via the internal resolver, the internal-only hostname gave litellm no extra access restriction. `parentRefs` is untouched -- the route stays internal-access-only.
- `ci: guard against internal-domain hostnames with no primary sibling` -- adds `.github/scripts/check_route_hostname_pairs.py` and wires it into the `Internal Identifier Scan` job in `security-scans.yaml`. Fails CI if a `${SECRET_INTERNAL_DOMAIN}` route hostname has no `${SECRET_DOMAIN}` sibling, so a later bulk removal of ~109 redundant internal-domain hostnames can't silently take an app offline.
- The guard's regex had two bugs relative to its original draft, both fixed here: an unanchored `-` matched hyphens inside literal text (false orphan on `prowler-api`), and a whitespace-excluding capture group was blind to the `{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}` idiom used by 92 of 123 internal-domain lines in this repo -- i.e. the original draft would have silently checked almost nothing. That blind spot is how litellm's issue went unnoticed until this guard actually scanned it.

## Test plan
- [x] `python3 .github/scripts/check_route_hostname_pairs.py` reports `OK -- every internal-domain hostname has a primary-domain sibling.` (exit 0) on this branch
- [x] Deliberately broke a `{{ .Release.Name }}.${SECRET_DOMAIN}` line (scrypted) -- guard reported it and exited 1; restored with `git checkout`, guard back to exit 0
- [x] `actionlint .github/workflows/security-scans.yaml` passes
- [x] `yamlfmt` + `prettier` produce no further diff on changed YAML