### PR TITLE
fix(gitops): correct/escape postBuild vars for strict kustomize-controller v1.9.3

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: database
   annotations:
     io.cilium/lb-ipam-ips: ${SVC_POSTGRES_ADDR}
-    external-dns.alpha.kubernetes.io/hostname: postgres18.${SECRET_DOMAIN_INT}
+    external-dns.alpha.kubernetes.io/hostname: postgres18.${SECRET_INTERNAL_DOMAIN}
 spec:
   type: LoadBalancer
   ports:

--- a/kubernetes/apps/default/searxng/app/resources/settings.yml
+++ b/kubernetes/apps/default/searxng/app/resources/settings.yml
@@ -17,7 +17,7 @@ search:
   favicon_resolver: ""
   default_lang: "en"
 server:
-  secret_key: "${SEARXNG_SECRET_KEY}"
+  secret_key: "$${SEARXNG_SECRET_KEY}"
   limiter: false
   image_proxy: true
   method: "GET"

--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -192,8 +192,8 @@ spec:
                 # dcr_stream_name). No managed_identity/client_app_* option — with none set, the
                 # plugin uses Azure DefaultAzureCredential, which auto-detects the federated
                 # workload identity from the AZURE_* env + projected token (no secret).
-                # $$ escapes Flux postBuild substitution so these reach Logstash as ${DCE_URI} /
-                # ${DCR_IMMUTABLE_ID}, which Logstash resolves from the container env (cluster-secrets).
+                # $$ escapes Flux postBuild substitution so these reach Logstash as $${DCE_URI} /
+                # $${DCR_IMMUTABLE_ID}, which Logstash resolves from the container env (cluster-secrets).
                 data_collection_endpoint => "$${DCE_URI}"
                 dcr_id                   => "$${DCR_IMMUTABLE_ID}"
                 stream_name              => "Custom-SyslogStream"


### PR DESCRIPTION
## Summary

Renovate PR #3653 upgraded Flux's `kustomize-controller` to v1.9.3, which makes `postBuild` variable substitution **strict**: an undefined `${VAR}` now hard-fails the Kustomization build instead of silently becoming an empty string. Three latent bugs became blocking failures today, one of which cascades `database/cloudnative-pg-cluster` -> `ai/litellm` -> `ai/hermes` -> `ai/hermeswebui` -> `ai/memini`. The Postgres data plane itself is healthy (3/3) - this is reconciliation-only.

- **`kubernetes/apps/database/cloudnative-pg/cluster/service.yaml`**: `SECRET_DOMAIN_INT` was never defined anywhere; the real `cluster-secrets` key is `SECRET_INTERNAL_DOMAIN`. **Behaviour change**: previously this substituted to empty, producing the malformed hostname `postgres18.` (no DNS record was ever published — `dig postgres18.<domain>` returns nothing today). After this fix, a new `postgres18.${SECRET_INTERNAL_DOMAIN}` DNS record will appear via opnsense-dns. This is the evidently-intended behaviour, called out explicitly per the ask.
- **`kubernetes/apps/default/searxng/app/resources/settings.yml`**: `secret_key` is a *runtime* env var consumed by SearXNG itself (`SEARXNG_SECRET_KEY`, injected from the app's ExternalSecret), not a Flux postBuild variable. Escaped to `$${SEARXNG_SECRET_KEY}` so Flux leaves it intact for the container to resolve.
- **`kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml`**: a YAML *comment* referenced `${DCE_URI}` / `${DCR_IMMUTABLE_ID}` unescaped. Strict envsubst processes raw text and doesn't skip comments. Escaped to `$${DCE_URI}` / `$${DCR_IMMUTABLE_ID}` to match the already-correctly-escaped `data_collection_endpoint` / `dcr_id` lines directly below it. Lines 197-198 (the actual plugin config) were untouched — already correct.

No other changes.

## Test plan

- [x] `yamlfmt` then `prettier --write` on all three changed files (both reported "unchanged" - already compliant)
- [x] `python3 .github/scripts/check_internal_identifiers.py` -> OK
- [x] `python3 .github/scripts/check_route_hostname_pairs.py` -> OK
- [x] `kustomize build kubernetes/apps/database/cloudnative-pg/cluster` -> OK
- [x] `kustomize build kubernetes/apps/default/searxng/app` -> OK
- [x] `kustomize build kubernetes/apps/security/sentinel-syslog/app` -> OK
- [x] Rendered output manually inspected to confirm `${SECRET_INTERNAL_DOMAIN}`, `$${SEARXNG_SECRET_KEY}`, and `$${DCE_URI}`/`$${DCR_IMMUTABLE_ID}` (comment) appear exactly as intended, unmangled by kustomize
- [ ] Not merging - controller gates it per the request (Konflate render/diff will confirm in-cluster)