### PR TITLE
refactor(routes): drop internal-domain alias in default and ai

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -51,7 +51,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/actual/app/helmrelease.yaml
+++ b/kubernetes/apps/default/actual/app/helmrelease.yaml
@@ -45,7 +45,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/apprise/app/helmrelease.yaml
+++ b/kubernetes/apps/default/apprise/app/helmrelease.yaml
@@ -69,7 +69,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/atuin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/atuin/app/helmrelease.yaml
@@ -67,7 +67,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/bentopdf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/bentopdf/app/helmrelease.yaml
@@ -52,7 +52,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/changedetection/app/helmrelease.yaml
+++ b/kubernetes/apps/default/changedetection/app/helmrelease.yaml
@@ -65,7 +65,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/coder/app/httproute.yaml
+++ b/kubernetes/apps/default/coder/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   hostnames:
     - coder.${SECRET_DOMAIN}
-    - coder.${SECRET_INTERNAL_DOMAIN}
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/default/convertx/app/helmrelease.yaml
+++ b/kubernetes/apps/default/convertx/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/cyberchef/app/helmrelease.yaml
+++ b/kubernetes/apps/default/cyberchef/app/helmrelease.yaml
@@ -49,7 +49,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/domainlocker/app/helmrelease.yaml
+++ b/kubernetes/apps/default/domainlocker/app/helmrelease.yaml
@@ -79,7 +79,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/domainpulse/app/helmrelease.yaml
+++ b/kubernetes/apps/default/domainpulse/app/helmrelease.yaml
@@ -92,7 +92,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/filebrowser/app/helmrelease.yaml
+++ b/kubernetes/apps/default/filebrowser/app/helmrelease.yaml
@@ -72,7 +72,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/fusion/app/helmrelease.yaml
+++ b/kubernetes/apps/default/fusion/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/giteamirror/app/helmrelease.yaml
+++ b/kubernetes/apps/default/giteamirror/app/helmrelease.yaml
@@ -96,7 +96,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/gitsave/app/helmrelease.yaml
+++ b/kubernetes/apps/default/gitsave/app/helmrelease.yaml
@@ -52,7 +52,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/gotify/app/helmrelease.yaml
+++ b/kubernetes/apps/default/gotify/app/helmrelease.yaml
@@ -55,7 +55,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/guacamole/app/helmrelease.yaml
+++ b/kubernetes/apps/default/guacamole/app/helmrelease.yaml
@@ -96,7 +96,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/homebox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homebox/app/helmrelease.yaml
@@ -51,7 +51,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -117,7 +117,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/invoiceshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invoiceshelf/app/helmrelease.yaml
@@ -94,7 +94,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/it-tools/app/helmrelease.yaml
+++ b/kubernetes/apps/default/it-tools/app/helmrelease.yaml
@@ -41,7 +41,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/default/karakeep/app/helmrelease.yaml
@@ -119,7 +119,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/keeper/app/helmrelease.yaml
+++ b/kubernetes/apps/default/keeper/app/helmrelease.yaml
@@ -87,7 +87,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/mail-archiver/app/helmrelease.yaml
+++ b/kubernetes/apps/default/mail-archiver/app/helmrelease.yaml
@@ -80,7 +80,6 @@ spec:
       app:
         hostnames:
           - "mailarchiver.${SECRET_DOMAIN}"
-          - "mailarchiver.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/manyfold/app/helmrelease.yaml
+++ b/kubernetes/apps/default/manyfold/app/helmrelease.yaml
@@ -102,7 +102,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/miniflux/app/helmrelease.yaml
+++ b/kubernetes/apps/default/miniflux/app/helmrelease.yaml
@@ -85,7 +85,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/netbox/app/httproute.yaml
+++ b/kubernetes/apps/default/netbox/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   hostnames:
     - "netbox.${SECRET_DOMAIN}"
-    - "netbox.${SECRET_INTERNAL_DOMAIN}"
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/default/netronome/app/helmrelease.yaml
+++ b/kubernetes/apps/default/netronome/app/helmrelease.yaml
@@ -53,7 +53,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/pairdrop/app/helmrelease.yaml
+++ b/kubernetes/apps/default/pairdrop/app/helmrelease.yaml
@@ -61,7 +61,6 @@ spec:
       app:
         hostnames:
           - "drop.${SECRET_DOMAIN}"
-          - "drop.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/paperless/ai/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/ai/helmrelease.yaml
@@ -87,7 +87,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -103,7 +103,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/paperless/gpt/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/gpt/helmrelease.yaml
@@ -83,7 +83,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/privatebin/app/helmrelease.yaml
+++ b/kubernetes/apps/default/privatebin/app/helmrelease.yaml
@@ -72,7 +72,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/rackula/app/helmrelease.yaml
+++ b/kubernetes/apps/default/rackula/app/helmrelease.yaml
@@ -50,7 +50,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/reconcilable/app/helmrelease.yaml
+++ b/kubernetes/apps/default/reconcilable/app/helmrelease.yaml
@@ -68,7 +68,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/redditvault/app/helmrelease.yaml
+++ b/kubernetes/apps/default/redditvault/app/helmrelease.yaml
@@ -58,7 +58,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/searxng/app/helmrelease.yaml
+++ b/kubernetes/apps/default/searxng/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         hostnames:
           - "search.${SECRET_DOMAIN}"
-          - "search.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/shlink/app/helmrelease.yaml
+++ b/kubernetes/apps/default/shlink/app/helmrelease.yaml
@@ -85,7 +85,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "s.${SECRET_DOMAIN}"
-          - "s.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/smokeping/app/helmrelease.yaml
+++ b/kubernetes/apps/default/smokeping/app/helmrelease.yaml
@@ -58,7 +58,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/tandoor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tandoor/app/helmrelease.yaml
@@ -118,7 +118,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/termix/app/helmrelease.yaml
+++ b/kubernetes/apps/default/termix/app/helmrelease.yaml
@@ -42,7 +42,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/universal/app/helmrelease.yaml
+++ b/kubernetes/apps/default/universal/app/helmrelease.yaml
@@ -52,7 +52,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/uptimekuma/app/helmrelease.yaml
+++ b/kubernetes/apps/default/uptimekuma/app/helmrelease.yaml
@@ -45,7 +45,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/wallos/app/helmrelease.yaml
+++ b/kubernetes/apps/default/wallos/app/helmrelease.yaml
@@ -46,7 +46,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/wapy/app/helmrelease.yaml
+++ b/kubernetes/apps/default/wapy/app/helmrelease.yaml
@@ -103,7 +103,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/warracker/app/helmrelease.yaml
+++ b/kubernetes/apps/default/warracker/app/helmrelease.yaml
@@ -100,7 +100,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
Each of these routes also publishes ${SECRET_DOMAIN} at the same gateway IP, so
the second hostname is a pure alias costing one OPNsense host-override record
each. Removing them keeps the record count clear of the ~421 ceiling that halts
all external-dns publishing.
