### PR TITLE
fix(cnpg): seed the postgres image digest so Renovate can maintain it

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -6,7 +6,12 @@ metadata:
   name: postgres18
 spec:
   instances: 3
-  imageName: ghcr.io/cloudnative-pg/postgresql:18.4
+  # Digest seeded by hand once (2026-07-19): the preset's CNPG imageName custom
+  # manager can SUBSTITUTE an existing digest but has no autoReplaceStringTemplate
+  # to APPEND a first one — a first-time pinDigest throws update-failure and
+  # aborts Renovate's whole combined pin branch (renovate#24942; confirmed via
+  # local dry-run). With the digest present, Renovate maintains it normally.
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.4@sha256:dabf20b4a1d0d2d26ad3f39b25dc57a270ffdaf0ca7105a6c897dc9f17c0ac83
 
   primaryUpdateStrategy: unsupervised
 


### PR DESCRIPTION
Round 3 (and per the local dry-run repro, the last identified) unblock for `renovate/pin-dependencies`.

**Definitive evidence** (local `renovate --dry-run=full` with debug logging): exactly one `Error updating branch: update failure` in the run — thrown while processing `ghcr.io/cloudnative-pg/postgresql` in this file. gluetun-webui and litellm updated fine right before it; everything after it was never reached.

**Mechanism:** the home-operations CNPG `imageName` custom manager has an optional `currentDigest` capture but **no `autoReplaceStringTemplate`** — verified in Renovate's source that without one, `doAutoReplace` can only substitute an existing digest, never append a first one → no-op write → `confirmIfDepUpdated` fails → `WORKER_FILE_UPDATE_FAILED` aborts the entire combined branch. (`autoReplaceStringTemplate` is schema-restricted to customManagers, so a packageRule can't inject it.)

**Why seed instead of `pinDigests: false`:** the repo convention is digest-pinned images, and with a digest present the manager's *substitute* path works — Renovate maintains it from here on.

⚠️ Merge effect: upstream rebuilt `18.4` since the cluster pulled it, so CNPG will roll the instances onto the fresher build (graceful, same as any digest bump; the cluster rolled cleanly for the 1.30.0 operator upgrade earlier today). I'll watch it.