### PR TITLE
fix(renovate): Flux group minimumGroupSize 2 → 1 (solo pinDigest parks forever)

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -298,7 +298,11 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
-      minimumGroupSize: 2,
+      // 1, not 2: same solo-pinDigest parking issue as the Cilium/CoreDNS
+      // groups above — a lone flux-operator-manifests digest pin sat under
+      // "Group Size Not Met" forever (protected-infra keeps merges manual
+      // regardless; 2+ simultaneous updates still group).
+      minimumGroupSize: 1,
     },
     {
       description: "Profilarr Group (app + parser move in lockstep)",


### PR DESCRIPTION
Third instance of the known solo-pinDigest parking trap — the config comment on the Cilium/CoreDNS groups predicted exactly this: a solo `pinDigest` event (here `flux-operator-manifests → 4325d96`) can never satisfy `minimumGroupSize: 2` and parks under **Group Size Not Met** forever.

Same fix as Cilium (#history) and CoreDNS: `minimumGroupSize: 1`. The protected-infra guard keeps every Flux merge manual regardless, and simultaneous multi-member updates still group.