### PR TITLE
fix(renovate): exempt flux-operator-manifests from digest pinning

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -538,6 +538,21 @@
       pinDigests: false,
     },
     {
+      // The preset's `oci` custom manager (managers/oci.json5) matches inline
+      // `oci://repo:tag` strings — here the FluxInstance distribution.artifact —
+      // with `(?<currentValue>\S+)` and NO currentDigest group: a first-time
+      // digest pin can't be appended (renovate#24942 crash, same as the
+      // annotated installer/kubelet case), and seeding a digest by hand would
+      // make \S+ swallow `tag@sha256:...` into currentValue and break version
+      // updates entirely. Version bumps keep flowing through the Flux group.
+      description: "Don't pin digests on flux-operator-manifests (inline oci:// manager has no digest support)",
+      matchDatasources: ["docker"],
+      matchPackageNames: [
+        "ghcr.io/controlplaneio-fluxcd/flux-operator-manifests",
+      ],
+      pinDigests: false,
+    },
+    {
       // The home-operations preset forces regex versioning
       // (^server-<variant>-b<build>$) on every llama.cpp reference repo-wide,
       // but memini's model init containers use the bare legacy `server` tag,


### PR DESCRIPTION
Instance #7 of the first-time-digest-pin crash, exposed minutes after #3718 let the solo flux-operator-manifests pin branch be attempted (it went straight to **Errored**).

- Manager: preset `managers/oci.json5` — `oci://(?<depName>[^:]+):(?<currentValue>\S+)`, **no digest group**.
- Reference: `kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml:15` (FluxInstance `distribution.artifact`).
- Why not seed a digest like cnpg (#3716): `\S+` would capture `v0.55.0@sha256:…` as the whole currentValue → docker versioning can't parse it → version updates break. `pinDigests: false` is the only safe option (same precedent as annotated installer/kubelet + talos-mcp).

Version bumps of the artifact keep flowing through the Flux group (protected-infra, manual merge) exactly as today.