### PR TITLE
refactor(routes): drop internal-domain alias in media, downloads, home

### DIFF
--- a/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/autobrr/app/helmrelease.yaml
@@ -84,7 +84,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -227,7 +227,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -238,7 +237,6 @@ spec:
       gluetun-webui:
         hostnames:
           - "{{ .Release.Name }}-gluetun.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}-gluetun.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -279,7 +279,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -290,7 +289,6 @@ spec:
       gluetun-webui:
         hostnames:
           - "{{ .Release.Name }}-gluetun.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}-gluetun.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/downloads/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qui/app/helmrelease.yaml
@@ -67,7 +67,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -237,7 +237,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -248,7 +247,6 @@ spec:
       gluetun-webui:
         hostnames:
           - "{{ .Release.Name }}-gluetun.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}-gluetun.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/downloads/seasonpackerr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/seasonpackerr/app/helmrelease.yaml
@@ -82,7 +82,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/downloads/stacks/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/stacks/app/helmrelease.yaml
@@ -80,7 +80,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/esphome/app/helmrelease.yaml
+++ b/kubernetes/apps/home/esphome/app/helmrelease.yaml
@@ -53,7 +53,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/go2rtc/app/helmrelease.yaml
+++ b/kubernetes/apps/home/go2rtc/app/helmrelease.yaml
@@ -66,7 +66,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
@@ -72,7 +72,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/homeassistanttimemachine/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistanttimemachine/app/helmrelease.yaml
@@ -85,7 +85,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/homebridge/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homebridge/app/helmrelease.yaml
@@ -109,7 +109,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/node-red/app/helmrelease.yaml
+++ b/kubernetes/apps/home/node-red/app/helmrelease.yaml
@@ -53,7 +53,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -128,7 +128,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/shelly-operator/app/httproute.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/httproute.yaml
@@ -10,7 +10,6 @@ spec:
       namespace: network
   hostnames:
     - "shelly.${SECRET_DOMAIN}"
-    - "shelly.${SECRET_INTERNAL_DOMAIN}"
   rules:
     - matches:
         - path:

--- a/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml
@@ -77,7 +77,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/home/zwave/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zwave/app/helmrelease.yaml
@@ -71,7 +71,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/agregarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/agregarr/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
+++ b/kubernetes/apps/media/audiobookshelf/app/helmrelease.yaml
@@ -69,7 +69,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/autopulse/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autopulse/app/helmrelease.yaml
@@ -19,7 +19,8 @@ spec:
             image:
               repository: ghcr.io/dan-online/autopulse
               tag: v2.0.0@sha256:a9b37936c849b34d3473caf7d83aeddc2c39ec066e18a14a0f4164846d1e4718
-            command: ["/bin/autopulse"]
+            command:
+              - "/bin/autopulse"
             env:
               TZ: ${TIMEZONE}
             securityContext:
@@ -53,7 +54,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -119,7 +119,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -79,7 +79,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -91,7 +91,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/maintainerr/app/helmrelease.yaml
@@ -59,7 +59,6 @@ spec:
             conditions: ["[STATUS] == 404"]
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/metube/app/helmrelease.yaml
+++ b/kubernetes/apps/media/metube/app/helmrelease.yaml
@@ -65,7 +65,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pinchflat/app/helmrelease.yaml
@@ -85,7 +85,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/profilarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/profilarr/app/helmrelease.yaml
@@ -109,7 +109,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/pulsarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/pulsarr/app/helmrelease.yaml
@@ -65,7 +65,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -98,7 +98,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
@@ -77,7 +77,6 @@ spec:
             conditions: ["[STATUS] == 200"]
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/recommendarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recommendarr/app/helmrelease.yaml
@@ -72,7 +72,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/sortarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sortarr/app/helmrelease.yaml
@@ -70,7 +70,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/suggestarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/suggestarr/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -64,7 +64,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/tdarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tdarr/app/helmrelease.yaml
@@ -108,7 +108,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/tracearr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tracearr/app/helmrelease.yaml
@@ -103,7 +103,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/watchstate/app/helmrelease.yaml
+++ b/kubernetes/apps/media/watchstate/app/helmrelease.yaml
@@ -61,7 +61,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/media/yourspotify/app/helmrelease.yaml
+++ b/kubernetes/apps/media/yourspotify/app/helmrelease.yaml
@@ -143,7 +143,6 @@ spec:
       api:
         hostnames:
           - "{{ .Release.Name }}-api.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}-api.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -154,7 +153,6 @@ spec:
       web:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
## Summary
- Bulk-deletion batch B (Task 4): removes redundant `${SECRET_INTERNAL_DOMAIN}` HTTPRoute hostname entries under `kubernetes/apps/media/`, `kubernetes/apps/downloads/`, `kubernetes/apps/home/`.
- Every removed hostname has a `${SECRET_DOMAIN}` sibling on the same route, both bound to the `envoy-internal` gateway, so this is a pure alias removal — no route loses reachability.
- Includes the `*-gluetun` routes (prowlarr, qbittorrent, sabnzbd) and `yourspotify-api`, previously verified to have primary-domain twins.
- `media/reclaimerr`'s `CORS_ORIGINS` line (which also mentions `${SECRET_INTERNAL_DOMAIN}`) was intentionally left untouched — that's a config string, not a route hostname, and is in scope for a later task.

## Test plan
- [x] `git diff` purity check: only `SECRET_INTERNAL_DOMAIN` hostname lines added/removed (one incidental yamlfmt reflow of a pre-existing flow-style `command:` array in `media/autopulse`, unrelated to this change)
- [x] Empty-`hostnames:` check: none
- [x] `kustomize build` on every touched app directory: all succeed
- [x] `python3 .github/scripts/check_internal_identifiers.py`: OK
- [x] `python3 .github/scripts/check_route_hostname_pairs.py`: OK