### PR TITLE
refactor(routes): drop internal-domain alias cluster-wide

### DIFF
--- a/kubernetes/apps/custom/loupe/app/helmrelease.yaml
+++ b/kubernetes/apps/custom/loupe/app/helmrelease.yaml
@@ -76,7 +76,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: database
   annotations:
     io.cilium/lb-ipam-ips: ${SVC_POSTGRES_ADDR}
-    external-dns.alpha.kubernetes.io/hostname: postgres18.${SECRET_INTERNAL_DOMAIN}
+    external-dns.alpha.kubernetes.io/hostname: postgres18.${SECRET_DOMAIN}
 spec:
   type: LoadBalancer
   ports:

--- a/kubernetes/apps/database/metabase/app/helmrelease.yaml
+++ b/kubernetes/apps/database/metabase/app/helmrelease.yaml
@@ -115,7 +115,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/database/pgadmin/app/helmrelease.yaml
+++ b/kubernetes/apps/database/pgadmin/app/helmrelease.yaml
@@ -58,7 +58,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/database/whodb/app/helmrelease.yaml
+++ b/kubernetes/apps/database/whodb/app/helmrelease.yaml
@@ -38,7 +38,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/default/invio/app/helmrelease.yaml
+++ b/kubernetes/apps/default/invio/app/helmrelease.yaml
@@ -42,11 +42,11 @@ spec:
             env:
               TZ: ${TIMEZONE}
               DATABASE_PATH: /app/data/invio.db
-              # SvelteKit CSRF: canonical origin for the app. Internal hostname
-              # is the primary access path; the SECRET_DOMAIN alias on the same
-              # internal listener will CSRF-reject if used for state-changing
-              # requests — switch to it here if that becomes the preferred URL.
-              ORIGIN: https://invio.${SECRET_INTERNAL_DOMAIN}
+              # SvelteKit CSRF: must match the route's hostname exactly, or
+              # state-changing requests get CSRF-rejected. The route only
+              # serves ${SECRET_DOMAIN} (the internal-domain alias was
+              # dropped), so ORIGIN follows it.
+              ORIGIN: https://invio.${SECRET_DOMAIN}
               # Envoy terminates TLS upstream; backend pod sees HTTP. Without
               # this, SvelteKit refuses to set login cookies.
               COOKIE_SECURE: "false"

--- a/kubernetes/apps/default/keeper/app/helmrelease.yaml
+++ b/kubernetes/apps/default/keeper/app/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
             env:
               TZ: ${TIMEZONE}
               BETTER_AUTH_URL: "https://keeper.${SECRET_DOMAIN}"
-              TRUSTED_ORIGINS: "https://keeper.${SECRET_DOMAIN},https://keeper.${SECRET_INTERNAL_DOMAIN}"
+              TRUSTED_ORIGINS: "https://keeper.${SECRET_DOMAIN}"
               WORKER_JOB_QUEUE_ENABLED: "true"
               BLOCK_PRIVATE_RESOLUTION: "false"
             envFrom:

--- a/kubernetes/apps/default/netbox/app/helmrelease.yaml
+++ b/kubernetes/apps/default/netbox/app/helmrelease.yaml
@@ -29,12 +29,10 @@ spec:
     existingSecret: netbox-secret
     allowedHosts:
       - "netbox.${SECRET_DOMAIN}"
-      - "netbox.${SECRET_INTERNAL_DOMAIN}"
     allowedHostsIncludesPodIP: true
     csrf:
       trustedOrigins:
         - "https://netbox.${SECRET_DOMAIN}"
-        - "https://netbox.${SECRET_INTERNAL_DOMAIN}"
     plugins: []
     persistence:
       enabled: true

--- a/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helm/values.yaml
@@ -18,7 +18,6 @@ web:
     enabled: true
     hostnames:
       - flux.${SECRET_DOMAIN}
-      - flux.${SECRET_INTERNAL_DOMAIN}
     parentRefs:
       - name: envoy-internal
         namespace: network

--- a/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/konflate/app/helmrelease.yaml
@@ -37,7 +37,6 @@ spec:
           namespace: network
       hostnames:
         - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
     persistence:
       # Ephemeral cache on the node filesystem (chart default). Konflate's
       # source/render/stage caches are millions of tiny files (~1.3M inodes

--- a/kubernetes/apps/games/epicgames/app/helmrelease.yaml
+++ b/kubernetes/apps/games/epicgames/app/helmrelease.yaml
@@ -66,7 +66,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/games/gameyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/games/gameyfin/app/helmrelease.yaml
@@ -62,7 +62,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/games/romm/app/helmrelease.yaml
+++ b/kubernetes/apps/games/romm/app/helmrelease.yaml
@@ -83,7 +83,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/infrastructure/certwarden/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/app/helmrelease.yaml
@@ -70,7 +70,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/infrastructure/cupdate/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/cupdate/app/helmrelease.yaml
@@ -97,7 +97,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/kube-system/cilium/app/httproute.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   hostnames:
     - hubble.${SECRET_DOMAIN}
-    - hubble.${SECRET_INTERNAL_DOMAIN}
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/reclaimerr/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
               API_HOST: 0.0.0.0
               API_PORT: &port 8000
               COOKIE_SECURE: "true"
-              CORS_ORIGINS: https://reclaimerr.${SECRET_DOMAIN},https://reclaimerr.${SECRET_INTERNAL_DOMAIN}
+              CORS_ORIGINS: https://reclaimerr.${SECRET_DOMAIN}
               LOG_LEVEL: INFO
             probes:
               liveness: &probes

--- a/kubernetes/apps/network/scanopy/app/helmrelease.yaml
+++ b/kubernetes/apps/network/scanopy/app/helmrelease.yaml
@@ -84,7 +84,6 @@ spec:
       app:
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/observability/headlamp/app/httproute.yaml
+++ b/kubernetes/apps/observability/headlamp/app/httproute.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   hostnames:
     - headlamp.${SECRET_DOMAIN}
-    - headlamp.${SECRET_INTERNAL_DOMAIN}
   parentRefs:
     - name: envoy-internal
       namespace: network

--- a/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/oxidized/app/helmrelease.yaml
@@ -167,7 +167,6 @@ spec:
       app:
         hostnames:
           - oxidized.${SECRET_DOMAIN}
-          - oxidized.${SECRET_INTERNAL_DOMAIN}
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/security/anubis/app/helmrelease.yaml
+++ b/kubernetes/apps/security/anubis/app/helmrelease.yaml
@@ -68,7 +68,6 @@ spec:
           gatus.home-operations.com/enabled: "false"
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-          - "{{ .Release.Name }}.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -113,7 +113,6 @@ spec:
       app:
         hostnames:
           - "id.${SECRET_DOMAIN}"
-          - "id.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
+++ b/kubernetes/apps/security/prowler/app/helmrelease-api.yaml
@@ -42,7 +42,7 @@ spec:
               DJANGO_SETTINGS_MODULE: config.django.production
               DJANGO_BIND_ADDRESS: 0.0.0.0
               DJANGO_PORT: "8080"
-              DJANGO_ALLOWED_HOSTS: "prowler-api,prowler.${SECRET_DOMAIN},prowler.${SECRET_INTERNAL_DOMAIN}"
+              DJANGO_ALLOWED_HOSTS: "prowler-api,prowler.${SECRET_DOMAIN}"
               DJANGO_LOGGING_FORMATTER: ndjson
               DJANGO_LOGGING_LEVEL: INFO
               DJANGO_MANAGE_DB_PARTITIONS: "True"

--- a/kubernetes/apps/security/prowler/app/httproute.yaml
+++ b/kubernetes/apps/security/prowler/app/httproute.yaml
@@ -10,7 +10,6 @@ spec:
       namespace: network
   hostnames:
     - "prowler.${SECRET_DOMAIN}"
-    - "prowler.${SECRET_INTERNAL_DOMAIN}"
   rules:
     # Prowler REST API — longest-prefix wins, so this beats `/` for /api/v1/*.
     - matches:

--- a/kubernetes/apps/storage/garage/app/configmap.yaml
+++ b/kubernetes/apps/storage/garage/app/configmap.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/v1/configmap.json
-# garage.toml (non-secret). Flux postBuild substitutes ${SECRET_INTERNAL_DOMAIN}.
+# garage.toml (non-secret). Flux postBuild substitutes ${SECRET_DOMAIN}.
 # rpc_secret / admin_token are NOT here — they are injected as env (GARAGE_RPC_SECRET,
 # GARAGE_ADMIN_TOKEN) from the garage-secret Secret, so no secrets live in this ConfigMap.
 apiVersion: v1
@@ -9,7 +9,7 @@ metadata:
   name: garage-config
   namespace: storage
 data:
-  garage.toml: |
+  garage.toml: |-
     metadata_dir = "/mnt/meta"
     data_dir = "/mnt/data"
     db_engine = "lmdb"
@@ -27,11 +27,11 @@ data:
     [s3_api]
     s3_region = "us-east-1"
     api_bind_addr = "[::]:3900"
-    root_domain = ".s3.${SECRET_INTERNAL_DOMAIN}"
+    root_domain = ".s3.${SECRET_DOMAIN}"
 
     [s3_web]
     bind_addr = "[::]:3902"
-    root_domain = ".web.${SECRET_INTERNAL_DOMAIN}"
+    root_domain = ".web.${SECRET_DOMAIN}"
     index = "index.html"
 
     [admin]

--- a/kubernetes/apps/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/app/helmrelease.yaml
@@ -128,7 +128,6 @@ spec:
             conditions: ["[STATUS] == any(200, 403)"]
         hostnames:
           - "s3.${SECRET_DOMAIN}"
-          - "s3.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/storage/garage/webui/helmrelease.yaml
+++ b/kubernetes/apps/storage/garage/webui/helmrelease.yaml
@@ -40,7 +40,8 @@ spec:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
               capabilities:
-                drop: ["ALL"]
+                drop:
+                  - "ALL"
             probes:
               liveness:
                 enabled: true
@@ -85,7 +86,6 @@ spec:
       app:
         hostnames:
           - "garage.${SECRET_DOMAIN}"
-          - "garage.${SECRET_INTERNAL_DOMAIN}"
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
Final batch of the `${SECRET_INTERNAL_DOMAIN}` retirement (Tasks 1–4: #3704, #3710, #3715, #3722). Removes the last alias hostnames, trims the app-config strings that named them, and repoints Garage's S3 virtual-host domains.

## What remains afterwards (deliberately kept)

`core.codelooks.com` still exists — it just stops carrying app records. Exactly 5 non-route uses remain (12 occurrences):

| Use | Why kept |
|---|---|
| `cluster-secrets.yaml` | defines the variable |
| `blackbox-exporter/lan/probes.yaml` × 8 | **device** IPMI probe targets, not app routes |
| `garage/app/sync-cronjob.yaml` (`s3-nas.`) | the NAS endpoint, not a cluster route |
| `opnsense-dns` `domainFilters` | external-dns must still manage the device records |
| `cert-manager` wildcard SAN | Task 6 handles this once nothing serves TLS there |

## Notable changes

- **`pocket-id`** — only the redundant route alias removed. **`APP_URL` is untouched** and remains `https://id.${SECRET_DOMAIN}`, so the OIDC issuer and every callback URL are unaffected.
- **`garage`** — `[s3_api]` and `[s3_web]` `root_domain` repointed to `${SECRET_DOMAIN}`. Safe: every in-cluster S3 client connects via `garage.storage.svc.cluster.local:3900`, not vhost addressing.
- **Config trims** — `prowler` `DJANGO_ALLOWED_HOSTS`, `reclaimerr` `CORS_ORIGINS`, plus netbox/keeper/invio. No dangling commas or empty list elements.
- The insertions are yamlfmt normalising to the repo's block-array style (`drop: ["ALL"]`, `garage.toml: |`) plus the rewritten config strings.

## Recovery note

This commit was authored before a tooling crash killed its `git push`. The work survived as a local commit; the intermediate reports did not. **It was therefore re-verified from scratch** rather than trusted:

- both guard scripts pass (`check_internal_identifiers.py`, `check_route_hostname_pairs.py`)
- `yamlfmt` → `prettier` over every changed file produces a **zero diff**
- `kustomize build` passes on every touched app directory
- no route left with an empty `hostnames:` block
- `grep` confirms only the 5 allowlisted uses remain
- commit parent is exactly current `origin/main` (clean fast-forward, no rebase)

## Expected result

Host-override records drop to roughly 270–280, well clear of the ~421 ceiling where OPNsense truncates its response and external-dns stops publishing entirely (the incident fixed earlier today).