### PR TITLE
chore(renovate): shorten the release burn-in from 3 days to 48 hours

### DIFF
--- a/.github/workflows/renovate-dashboard-groomer.yaml
+++ b/.github/workflows/renovate-dashboard-groomer.yaml
@@ -1,12 +1,12 @@
 ---
 # Prevents the two Renovate backlog failure modes cleaned up on 2026-07-19:
 #
-# 1. Fast releasers reset the 3-day minimumReleaseAge clock indefinitely
+# 1. Fast releasers reset the minimumReleaseAge clock indefinitely
 #    (Renovate targets the newest release; near-daily publishers never have one
-#    older than 3 days), so updates park in the dashboard's "Pending Status
+#    older than the burn-in window), so updates park in the dashboard's "Pending Status
 #    Checks" section forever. Ticking a box force-creates the PR, which then
 #    goes through full CI + automerge gating as normal — so this turns the age
-#    gate into "3 days OR at most a week", never an unbounded wait.
+#    gate into "the burn-in window OR at most a week", never an unbounded wait.
 #
 # 2. A transient bad state on main used to fail the merge-ref Internal
 #    Identifier Scan on every open PR, and rebaseWhen:conflicted means no new

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -106,7 +106,7 @@
       automergeType: "pr",
       platformAutomerge: false,
       ignoreTests: false,
-      minimumReleaseAge: "3 days",
+      minimumReleaseAge: "2 days",
     },
     {
       // No minimumReleaseAge here: digest bumps track mutable tags that upstream
@@ -158,7 +158,7 @@
     {
       // Docs toolchain lives in docs/requirements.txt (zensical). Same CI-gated
       // pattern as the container/chart rule above: self-merge minor/patch/digest
-      // after the 3-day age gate, gating on CI (docs build + drift check).
+      // after the 2-day age gate, gating on CI (docs build + drift check).
       description: "Auto-merge Python deps — minor/patch/digest, CI-gated",
       matchDatasources: ["pypi"],
       matchUpdateTypes: ["minor", "patch", "digest"],
@@ -166,7 +166,7 @@
       automergeType: "pr",
       platformAutomerge: false,
       ignoreTests: false,
-      minimumReleaseAge: "3 days",
+      minimumReleaseAge: "2 days",
     },
     {
       description: "Auto-merge GitHub Actions",
@@ -174,7 +174,7 @@
       automerge: true,
       automergeType: "branch",
       matchUpdateTypes: ["minor", "patch", "digest"],
-      minimumReleaseAge: "3 days",
+      minimumReleaseAge: "2 days",
       ignoreTests: true,
     },
     {


### PR DESCRIPTION
Per operator decision after today's backlog post-mortem: 48h keeps a meaningful supply-chain burn-in window while roughly a third fewer updates park long enough to need the Sunday groomer sweep.

- `minimumReleaseAge: "3 days" → "2 days"` on the three aged rules (docker/helm minor+patch, pypi, github-actions)
- trusted GitHub Actions stay at 1 day; digest/pin stay ungated (#3608)
- groomer workflow comments de-hardcoded