### PR TITLE
refactor: finish internal-domain retirement + fail-closed DNS reclaim tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ CLAUDE.md
 
 # kubectl cache (kubeconfig lives in-repo, so kubectl drops its cache here)
 .kube/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,11 @@ Inside `app/`:
   Kustomization).
 - **Routing** is usually an inline `route:` in HR values on the `envoy-internal` / `envoy-external`
   listeners (namespace `network`); a standalone `httproute.yaml` is the rarer case. Hosts are
-  `${APP}.${SECRET_DOMAIN}` (and `${SECRET_INTERNAL_DOMAIN}` for internal).
+  `${APP}.${SECRET_DOMAIN}` — one hostname per route, whichever gateway it attaches to. Do not add a
+  `${SECRET_INTERNAL_DOMAIN}` alias: it resolves to the same gateway as the primary domain, so it
+  buys no extra restriction, and each alias costs an OPNsense host-override record. The record count
+  has a hard ceiling (~421) above which external-dns silently stops publishing anything cluster-wide
+  (see `docs/docs/architecture/split-dns.md`).
 - **App names avoid hyphens so the host stays clean.** The route host follows
   `{{ .Release.Name }}.${SECRET_DOMAIN}`, so a hyphen in the app name leaks into the URL. Name new
   apps hyphen-free end-to-end (directory, `ks.yaml` `&app`, HelmRelease, controller, PVC) — e.g.

--- a/docs/docs/architecture/split-dns.md
+++ b/docs/docs/architecture/split-dns.md
@@ -454,6 +454,49 @@ If you recreate the Cloudflare Tunnel:
 
 3. Wait 1-2 minutes for DNS propagation.
 
+## OPNsense Host-Override Record Ceiling
+
+`opnsense-dns` reads and writes every record through OPNsense's `searchHostOverride`
+API endpoint, which has an operational ceiling this cluster has already hit once.
+
+!!! warning "Symptom: new apps get no DNS record, existing apps are unaffected"
+    Once the ceiling trips, `opnsense-dns` fails **every** reconcile with `failed
+    to get records with code 500`, so **no new record can be published anywhere in
+    the cluster** — but records already written to Unbound keep resolving
+    normally. The failure therefore presents narrowly, as "only new apps are
+    broken," rather than as an outage.
+
+- **It is a row-count threshold, not a byte limit.** OPNsense chunks its API
+  response and truncates once the payload exceeds 65,528 bytes. Verified
+  experimentally against a live host-override table: `rowCount=420` returns
+  113,794 bytes cleanly; `rowCount=425` truncates. The trip point sits at roughly
+  421-424 rows — it drifts slightly because row size varies with hostname length,
+  not because there is a fixed byte budget per record.
+- **`opnsense-dns` never deletes records.** It runs `--policy=upsert-only
+  --registry=noop`, so removing a hostname from Git stops new records from being
+  created but never reclaims the old one. Reclaiming a stale record is a manual
+  OPNsense operation (Services → Unbound DNS → Overrides → Host Overrides), not
+  something a Git revert alone fixes.
+- **`upsert-only`/`noop` is a deliberate choice, not a misconfiguration to "fix."**
+  A TXT registry adds roughly one bookkeeping row per managed record
+  (external-dns v0.21.0), which would push this domain filter to roughly 433 rows
+  — back over the ~421 ceiling that already tripped once. `policy: sync` with
+  `registry: noop` is worse: without ownership tracking, a sync policy would
+  delete every hand-made OPNsense host override outside external-dns's view,
+  including device records and unrelated third-party domains hosted on the same
+  OPNsense instance.
+- **`${SECRET_INTERNAL_DOMAIN}` still exists and is still needed.** It was never
+  only an app-hostname alias — it still carries device records that have no
+  `${SECRET_DOMAIN}` equivalent: IPMI probe targets, core switches, the
+  Kubernetes API endpoint, VM management interfaces, the NAS S3 endpoint, and a
+  handful of media-service aliases. Retiring the redundant *app* hostname aliases
+  removed roughly half the record set without touching any of those.
+- **Keep host-override rows well under ~420.** Each app now costs one record
+  instead of two (see "Routing" in `AGENTS.md`), which is most of the headroom
+  this migration bought back. Watch for the `failed to get records with code 500`
+  signature in `opnsense-dns` logs as the early warning before the ceiling trips
+  again.
+
 ## References
 
 - [External DNS Documentation](https://kubernetes-sigs.github.io/external-dns/)

--- a/docs/docs/troubleshooting/kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md
+++ b/docs/docs/troubleshooting/kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md
@@ -1,0 +1,110 @@
+# 027: A DNS cleanup scaled every NFS-backed app to zero
+
+## Symptom
+
+A dozen Gatus endpoints go red at once, within about sixty seconds of each other.
+Affected apps span the `media` and `downloads` namespaces — Plex, Jellyfin, Sonarr,
+Radarr, Bazarr, Pinchflat, SABnzbd, qBittorrent — plus their `-gluetun` sidecar
+routes.
+
+Every one returns **HTTP 503** on its normal hostname:
+
+```text
+[STATUS] (503) == 200   →   false
+```
+
+The hostname resolves correctly, so this does not look like a DNS fault.
+
+## Why it is confusing
+
+Three signals point away from the real cause:
+
+1. **DNS resolves.** The Gatus check reaches something and gets a 503 back, so the
+    record clearly exists.
+2. **The gateway is healthy.** Other apps on the same listener are fine.
+3. **The pods are not unhealthy — they are absent.** `kubectl get pods` simply does
+    not list them, which reads like a scheduling problem rather than a DNS one.
+
+A 503 from Envoy means *no healthy upstream*. With the Deployment scaled to zero
+there is no upstream at all.
+
+## Cause
+
+The apps are governed by the `zeroscaler` component. Its HPA scales on an external
+metric:
+
+```yaml
+metrics:
+  - type: External
+    external:
+      metric:
+        name: probe_success
+        selector:
+          matchLabels:
+            job: nfs_probe
+      target:
+        type: Value
+        value: "1"
+```
+
+`nfs_probe` is a blackbox TCP probe against `${SECRET_STORAGE_SERVER}:2049`. When
+the NAS becomes unreachable the probe returns `0` and every NFS-backed app is
+deliberately scaled to zero, rather than left with hung mounts. That behaviour is
+working as designed — see [024](024-zeroscaler-nfs-hpa.md).
+
+The failure is that **`SECRET_STORAGE_SERVER` is a hostname on the internal domain,
+and its DNS record had been deleted** during a host-override cleanup.
+
+## The trap: hostnames hidden inside secrets
+
+The cleanup built its keep-list by grepping the repository for
+`${SECRET_INTERNAL_DOMAIN}`. That is structurally incapable of finding the NAS,
+because manifests never contain its hostname — they contain
+`${SECRET_STORAGE_SERVER}`, and the hostname lives only in the `cluster-secrets`
+Secret, sourced from 1Password.
+
+Every other check agreed with itself and was wrong in the same way: the dry run,
+the record-count assertion, and the sibling guard all reasoned about Git, so none
+could see the reference.
+
+A scan of `cluster-secrets` afterwards found **five** values carrying internal-domain
+FQDNs — the storage server, the vSphere endpoint, and three network devices. Four
+survived the cleanup only by luck: they had no primary-domain twin, so the
+"redundant alias" filter skipped them anyway.
+
+## Fix
+
+Restore the deleted record, then confirm the metric recovers before checking apps —
+the HPAs need a healthy probe before they will scale back up.
+
+```bash
+# 1. restore the record (uuid + values come from the cleanup's JSON backup)
+#    POST /api/unbound/settings/addHostOverride  then  POST /api/unbound/service/reconfigure
+
+# 2. the probe should return 1 within a minute
+probe_success{job="nfs_probe"}
+
+# 3. HPAs move from 0/1 REPLICAS 0 to 1/1 REPLICAS 1
+kubectl get hpa -n media
+```
+
+Recovery took roughly four minutes end to end: about one minute for the probe, then
+pods rescheduling.
+
+## Prevention
+
+Use `scripts/reclaim_stale_dns.py`. It derives its keep-list from **two** sources —
+Git manifests *and* the values inside `cluster-secrets` / `cluster-settings` — and
+refuses to delete anything appearing in either. It also prints a full JSON backup
+with UUIDs before acting; capture that output, because it is the only route back
+from a mistake.
+
+The general lesson: when validating that something is unreferenced, enumerate every
+place a reference can live. A value held in a Secret is invisible to `grep`, and a
+check that only consults the repository will confidently report a clean result.
+
+## Related
+
+- [024: zeroscaler NFS scale-to-zero via native HPA](024-zeroscaler-nfs-hpa.md) — why the apps scale to zero
+- [Split DNS architecture](../../architecture/split-dns.md) — the host-override ceiling and why
+  `upsert-only` means cleanups are manual

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -91,6 +91,7 @@ nav = [
       { "023: Node conntrack saturation (scanner)" = "troubleshooting/kb/023-node-conntrack-saturation-host-network-scanner.md" },
       { "024: zeroscaler NFS scale-to-zero via native HPA" = "troubleshooting/kb/024-zeroscaler-nfs-hpa.md" },
       { "025: CephFS modprobe built-in misdiagnosis" = "troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md" },
+      { "027: DNS cleanup scaled NFS apps to zero" = "troubleshooting/kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md" },
     ] },
   ] },
   { "FAQ" = "faq.md" },

--- a/kubernetes/apps/cert-manager/cert-manager/tls/certificate.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/tls/certificate.yaml
@@ -18,6 +18,5 @@ spec:
   dnsNames:
     - "${SECRET_DOMAIN}"
     - "*.${SECRET_DOMAIN}"
-    - "*.${SECRET_INTERNAL_DOMAIN}"
   usages:
     - digital signature

--- a/scripts/reclaim_stale_dns.py
+++ b/scripts/reclaim_stale_dns.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Reclaim redundant internal-domain host overrides from OPNsense Unbound.
+
+WHY THIS EXISTS
+---------------
+`opnsense-dns` runs external-dns with `--policy=upsert-only --registry=noop`, so
+external-dns NEVER deletes a record. Removing a hostname from Git stops new
+records being created but never reclaims the old one. Reclaiming is therefore a
+manual operation -- this script.
+
+That matters because OPNsense's `searchHostOverride` endpoint truncates its
+chunked response once the row count reaches ~421-424, at which point the webhook
+gets malformed JSON and external-dns fails EVERY reconcile: no new DNS record can
+be published cluster-wide. See the KB entry on the host-override ceiling.
+
+THE TRAP THIS SCRIPT EXISTS TO AVOID
+------------------------------------
+An earlier ad-hoc version of this cleanup took the media stack offline. It built
+its keep-list by grepping Git for `${SECRET_INTERNAL_DOMAIN}`, which structurally
+cannot see an internal hostname stored as a *value* inside the `cluster-secrets`
+Secret -- the repository only ever contains the variable name. It deleted the NFS
+server's record (`SECRET_STORAGE_SERVER`), the NFS blackbox probe went red, and
+the zeroscaler HPAs scaled every NFS-backed app to zero replicas.
+
+So this script derives its keep-list from BOTH sources:
+  1. Git manifests that reference `${SECRET_INTERNAL_DOMAIN}` directly.
+  2. cluster-secrets / cluster-settings VALUES that contain an internal FQDN.
+
+A candidate is deleted only if it is redundant (the same hostname already exists
+on the primary domain) AND appears in neither source.
+
+USAGE
+-----
+Runs in-cluster so it can read the Secret and reach the firewall:
+
+    kubectl run reclaim-dns -n network --rm -i --restart=Never \\
+      --image=python:3.12-slim --overrides='<see the KB entry>' -- \\
+      python3 /scripts/reclaim_stale_dns.py
+
+Environment:
+  OPNSENSE_HOST / OPNSENSE_API_KEY / OPNSENSE_API_SECRET  (from opnsense-dns-secret)
+  INTERNAL_DOMAIN / PRIMARY_DOMAIN                        (bare domains, no leading dot)
+  KEEP_EXTRA      optional comma-separated extra hostnames to preserve
+  APPLY=yes       actually delete; anything else is a dry run
+
+It always prints a full JSON backup of every record (with UUIDs) before acting.
+Capture that output -- it is the only way to restore a mistake.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import re
+import ssl
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+
+HOST = os.environ["OPNSENSE_HOST"].rstrip("/")
+INTERNAL = os.environ.get("INTERNAL_DOMAIN", "")
+PRIMARY = os.environ.get("PRIMARY_DOMAIN", "")
+APPLY = os.environ.get("APPLY") == "yes"
+
+_auth = base64.b64encode(f"{os.environ['OPNSENSE_API_KEY']}:{os.environ['OPNSENSE_API_SECRET']}".encode()).decode()
+_ctx = ssl.create_default_context()
+_ctx.check_hostname = False
+_ctx.verify_mode = ssl.CERT_NONE
+
+
+class KeepListUnavailable(RuntimeError):
+    """A keep-list source could not be read.
+
+    This is fatal on purpose. If a source is unreachable the keep-list comes back
+    short, every still-referenced hostname looks like a redundant alias, and the
+    script would propose deleting exactly the records that must be preserved --
+    which is the outage this tool exists to prevent. Fail closed, never open.
+    """
+
+
+def call(method: str, path: str) -> dict:
+    """Call the OPNsense API. Content-Type is POST-only; a GET carrying it 400s."""
+    headers = {"Authorization": f"Basic {_auth}"}
+    data = None
+    if method == "POST":
+        headers["Content-Type"] = "application/json"
+        data = b"{}"
+    req = urllib.request.Request(f"{HOST}/api/unbound/{path}", method=method, data=data, headers=headers)
+    with urllib.request.urlopen(req, context=_ctx, timeout=90) as resp:
+        return json.loads(resp.read() or b"{}")
+
+
+def fetch_all() -> list[dict]:
+    """Page through every host override. Never request all rows -- that is what truncates."""
+    out: list[dict] = []
+    page = 1
+    while True:
+        query = urllib.parse.urlencode({"current": page, "rowCount": 200})
+        batch = call("GET", f"settings/searchHostOverride?{query}")
+        rows = batch.get("rows") or []
+        if not rows:
+            break
+        out.extend(rows)
+        if len(out) >= batch.get("total", 0):
+            break
+        page += 1
+    return out
+
+
+def hostnames_referenced_in_secrets() -> set[str]:
+    """Internal-domain hostnames stored as VALUES in cluster-secrets / cluster-settings.
+
+    This is the source the original cleanup missed. These never appear in Git --
+    manifests only ever contain the variable name (e.g. ${SECRET_STORAGE_SERVER}).
+    """
+    found: set[str] = set()
+    pattern = re.compile(rf"([a-z0-9][a-z0-9.-]*)\.{re.escape(INTERNAL)}\b")
+    for kind, name in (("secret", "cluster-secrets"), ("configmap", "cluster-settings")):
+        try:
+            raw = subprocess.check_output(
+                ["kubectl", "get", kind, name, "-n", "flux-system", "-o", "json"],
+                text=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            raise KeepListUnavailable(
+                f"could not read {kind}/{name} in namespace flux-system ({type(exc).__name__}). "
+                "Run where kubectl is available and authorised."
+            ) from exc
+        data = json.loads(raw).get("data", {}) or {}
+        for value in data.values():
+            text = str(value)
+            if kind == "secret":
+                try:
+                    text = base64.b64decode(value).decode()
+                except Exception:  # pylint: disable=broad-exception-caught  # non-utf8 values are not hostnames
+                    continue
+            found.update(m.group(1) for m in pattern.finditer(text))
+    return found
+
+
+def hostnames_referenced_in_git() -> set[str]:
+    """Internal-domain hostnames written literally into tracked manifests."""
+    try:
+        raw = subprocess.check_output(
+            ["git", "grep", "-hoE", r"[a-z0-9][a-z0-9.-]*\.\$\{SECRET_INTERNAL_DOMAIN\}", "--", "kubernetes/"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError as exc:
+        raise KeepListUnavailable("git is not available. Run from inside a checkout of this repository.") from exc
+    except subprocess.CalledProcessError as exc:
+        # git grep exits 1 when there are no matches, which is a legitimate empty result.
+        if exc.returncode != 1:
+            raise KeepListUnavailable(f"git grep failed (exit {exc.returncode}).") from exc
+        return set()
+    return {line.split(".${")[0] for line in raw.split() if line}
+
+
+def main() -> int:
+    """Classify every internal-domain record and delete only the provably redundant ones."""
+    if not INTERNAL or not PRIMARY:
+        print("ABORT: set INTERNAL_DOMAIN and PRIMARY_DOMAIN")
+        return 2
+
+    rows = fetch_all()
+    print(f"fetched {len(rows)} records")
+    print("BACKUP_JSON_START")
+    print(json.dumps(rows))
+    print("BACKUP_JSON_END")
+
+    try:
+        keep = hostnames_referenced_in_secrets() | hostnames_referenced_in_git()
+    except KeepListUnavailable as exc:
+        print(f"\nABORT: {exc}")
+        print("Refusing to continue with an incomplete keep-list -- that is how the NFS outage happened.")
+        return 2
+    keep |= {h.strip() for h in os.environ.get("KEEP_EXTRA", "").split(",") if h.strip()}
+    print(f"\nkeep-list ({len(keep)} hostnames still referenced): {sorted(keep)}")
+
+    primary_hosts = {r.get("hostname") for r in rows if r.get("domain") == PRIMARY}
+    internal = [r for r in rows if r.get("domain") == INTERNAL]
+
+    referenced = [r for r in internal if r.get("hostname") in keep]
+    internal_only = [r for r in internal if r.get("hostname") not in primary_hosts and r.get("hostname") not in keep]
+    targets = [r for r in internal if r.get("hostname") in primary_hosts and r.get("hostname") not in keep]
+
+    print(f"\n{INTERNAL} records : {len(internal)}")
+    print(f"  keep (referenced)  : {len(referenced)} -> {sorted(str(r.get('hostname') or '') for r in referenced)}")
+    print(
+        f"  keep (no twin)     : {len(internal_only)} -> {sorted(str(r.get('hostname') or '') for r in internal_only)}"
+    )
+    print(f"  DELETE (redundant) : {len(targets)} -> {sorted(str(r.get('hostname') or '') for r in targets)}")
+
+    expected = os.environ.get("EXPECTED")
+    if expected and len(targets) != int(expected):
+        print(f"\nABORT: EXPECTED={expected} but computed {len(targets)}")
+        return 1
+
+    if not APPLY:
+        print("\nDRY RUN -- set APPLY=yes to delete")
+        return 0
+
+    ok = fail = 0
+    for record in targets:
+        try:
+            result = call("POST", f"settings/delHostOverride/{record['uuid']}")
+            if result.get("result") in ("deleted", "ok"):
+                ok += 1
+            else:
+                fail += 1
+                print(f"  unexpected result for {record.get('hostname')}: {result}")
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # continue; partial success is recoverable
+            fail += 1
+            print(f"  FAILED {record.get('hostname')}: {exc}")
+
+    print(f"\ndeleted={ok} failed={fail}")
+    print("reconfigure:", call("POST", "service/reconfigure"))
+    print(f"records now: {len(fetch_all())}")
+    return 0 if fail == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Final task of the `${SECRET_INTERNAL_DOMAIN}` retirement (#3704, #3710, #3715, #3722, #3723), plus the tooling and KB entry from **an outage I caused during the manual record cleanup**.

## Commits

**1. `refactor(cert-manager)`** — drops the `*.${SECRET_INTERNAL_DOMAIN}` wildcard SAN (nothing serves TLS there any more), updates the `AGENTS.md` routing convention to one hostname per route, and adds a split-DNS section documenting the host-override ceiling.

**2. `feat(scripts)`** — the reclaim tool and KB 027.

## The outage this exists to prevent

The manual cleanup deleted 161 redundant `core.*` records. One of them was the NFS server. Its hostname lives in `SECRET_STORAGE_SERVER` **inside cluster-secrets**, so grepping the repository for `${SECRET_INTERNAL_DOMAIN}` could never find it — manifests only ever contain the variable name.

Cascade: record deleted → `probe_success{job="nfs_probe"}` = 0 → zeroscaler HPAs scaled every NFS-backed app to **0 replicas** → 12 Gatus endpoints returned **503**. It reads like a routing fault because DNS still resolves and the pods aren't unhealthy — they're absent.

Restored; recovery took ~4 minutes. Gatus is back to 1 down (`memini`, a pre-existing root-path 404 from Renovate #3700).

A follow-up scan found **five** cluster-secrets values carrying internal FQDNs. Four survived only by luck — they had no primary-domain twin, so the filter skipped them anyway.

## Why the tool is fail-closed

`scripts/reclaim_stale_dns.py` builds its keep-list from **both** Git manifests and cluster-secrets/settings values.

The first version *warned and continued* when a source was unreadable. An in-cluster dry run proved that was catastrophic: with no `kubectl` and no `git`, the keep-list came back empty and it proposed deleting the NFS record **and all eight IPMI probe targets** — the same outage again. It now raises `KeepListUnavailable` and aborts.

Verified both directions:

- **fails closed** — with `APPLY=yes` and no `kubectl`, exits 2 without deleting
- **protects correctly** — with both sources readable, the keep-list covers `cr-storage-data` (**secrets-only**), plus the IPMI targets and `s3-nas` (**Git-only**). The two sources are genuinely complementary; neither alone is sufficient.

## Validation

- black / ruff-format / pylint **10.00/10** at the repo's line-length 120
- `markdownlint` clean · `zensical build --strict` clean · both guard scripts clean
- terminology check (Git/repository) clean

## Note

KB `026-plex-apple-tv-app-receive-window-deadlock.md` exists as a file but is missing from the `zensical.toml` nav, so it isn't reachable on the docs site. I added only 027 rather than widen this PR's scope — flagging it as a separate fix.

## Post-merge

`flux reconcile ks cert-manager -n cert-manager`, then confirm the certificate reissues `READY=True` — removing a wildcard SAN triggers reissuance.