### PR TITLE
fix(memini): point route at the new ui service port

### DIFF
--- a/kubernetes/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/memini/app/helmrelease.yaml
@@ -90,6 +90,18 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        # Chart v0.7.5 split the web UI onto its own `ui` service port (8081);
+        # `http` (8080) is now API-only and 404s on `/`. This is a custom route
+        # key, so it inherits neither of the chart's `main`/`ui` route defaults
+        # and would otherwise fall back to the primary `http` port.
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            backendRefs:
+              - identifier: main
+                port: ui
     serviceMonitor:
       main:
         enabled: true


### PR DESCRIPTION
Chart v0.7.5 split the web UI onto its own `ui` service port (8081). `http` (8080) is now API-only and 404s on `/`, so the UI is unreachable through the route.

This route uses a custom route key, so it inherits neither of the chart's `main`/`ui` route defaults and silently falls back to the primary `http` port. Adding an explicit rule pins the backend to `port: ui`.

**Change:** one file — adds an explicit `rules` block with `backendRefs: [{identifier: main, port: ui}]`.

**Verification:** chart render — confirmed the rendered HTTPRoute backend now resolves to the `ui` port (8081) rather than `http` (8080).