### PR TITLE
fix(smtp-relay): present client cert to M365 for TLS-based connector auth

### DIFF
--- a/kubernetes/apps/infrastructure/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/smtp-relay/app/helmrelease.yaml
@@ -77,6 +77,12 @@ spec:
                 targets tcp://{env:SMTP_RELAY_SERVER}:25
                 starttls yes
                 auth off
+                # Present client cert so the M365 inbound connector can match
+                # on the certificate subject name (IP-independent relay auth)
+                tls_client {
+                    cert /certs/tls.crt
+                    key /certs/tls.key
+                }
             }
     persistence:
       cache:
@@ -87,3 +93,9 @@ spec:
         globalMounts:
           - path: /data/maddy.conf
             subPath: maddy.conf
+      certs:
+        type: secret
+        name: tls.smtp-relay
+        globalMounts:
+          - path: /certs
+            readOnly: true


### PR DESCRIPTION
Estate outbound mail has been rejected by M365 since ~2026-07-16 (Spamhaus block on the dynamic home egress IP; the IP-based inbound connector is not matching). This mounts the existing cert-manager secret `tls.smtp-relay` into the maddy pods and presents it via a `tls_client` block on the outbound leg, so the M365 inbound connector can authenticate the relay by certificate subject name (`smtp.<domain>`) instead of source IP — permanently removing the dynamic-IP failure mode.

Notes:
- The cert is serverAuth-EKU-only: Let's Encrypt ended clientAuth-EKU issuance on 2026-07-08 (industry-wide CA/root-program change). Exchange Online connector matching does not require the clientAuth EKU.
- maddy 0.9.5 ignores `require_tls` (deprecated; no plaintext fallback exists with `starttls yes`), so it is deliberately omitted.
- `reloader.stakater.com/auto` already on the controller picks up the ~weekly cert-manager renewals of the mounted secret.
- M365 side (enabling the TLS-based inbound connector) is being done separately; the currently-enabled IP-based connector is unaffected by this change.
