### PR TITLE
fix(arc): chown runner work volumes via fsGroup for miroir-local

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/packer/helmrelease.yaml
@@ -28,6 +28,16 @@ spec:
             storage: 40Gi
     template:
       spec:
+        # miroir-local provisions a real ext4 block device, whose root directory
+        # comes up root:root 0755. The openebs-hostpath directory it replaced
+        # (#3583) was already writable, so nothing here needed fsGroup before.
+        # This image runs as uid/gid 1001, so without the chown below the runner
+        # cannot create _work/_tool and every job dies in ~2s with
+        # UnauthorizedAccessException before a single step executes.
+        # miroir's CSIDriver is fsGroupPolicy: ReadWriteOnceWithFSType and this
+        # claim is RWO + ext4, so kubelet honours fsGroup and chowns the volume.
+        securityContext:
+          fsGroup: 1001
         serviceAccountName: packer-runner
         containers:
           - name: runner

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
@@ -19,6 +19,20 @@ spec:
       type: dind
     template:
       spec:
+        # miroir-local provisions a real ext4 block device, whose root directory
+        # comes up root:root 0755. The openebs-hostpath directory it replaced
+        # (#3583) was already writable, so nothing here needed fsGroup before.
+        # This image runs as uid/gid 1001, so without the chown below the runner
+        # cannot create _work/_tool and every job dies in ~2s with
+        # UnauthorizedAccessException before a single step executes.
+        # miroir's CSIDriver is fsGroupPolicy: ReadWriteOnceWithFSType and this
+        # claim is RWO + ext4, so kubelet honours fsGroup and chowns the volume.
+        # This dind runner is affected too — its live _work is root:root 0755 —
+        # it just fails silently: the kubernetes-mode runners failed visibly
+        # because jobs ran, while this one's only consumer (image-pull) has kept
+        # skipping, so no job has exercised _work/_tool since the flip.
+        securityContext:
+          fsGroup: 1001
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.335.1@sha256:0c6f38e8194f6c3714aa86c6dc8a72574484818ed625dd66074920b25c118508

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/terraform-vsphere/helmrelease.yaml
@@ -29,6 +29,16 @@ spec:
             storage: 5Gi
     template:
       spec:
+        # miroir-local provisions a real ext4 block device, whose root directory
+        # comes up root:root 0755. The openebs-hostpath directory it replaced
+        # (#3583) was already writable, so nothing here needed fsGroup before.
+        # This image runs as uid/gid 1001, so without the chown below the runner
+        # cannot create _work/_tool and every job dies in ~2s with
+        # UnauthorizedAccessException before a single step executes.
+        # miroir's CSIDriver is fsGroupPolicy: ReadWriteOnceWithFSType and this
+        # claim is RWO + ext4, so kubelet honours fsGroup and chowns the volume.
+        securityContext:
+          fsGroup: 1001
         serviceAccountName: terraform-vsphere-runner
         containers:
           - name: runner


### PR DESCRIPTION
## Root cause

All three ARC runner work volumes were flipped from `openebs-hostpath` to `miroir-local` in #3583. `openebs-hostpath` handed out an already-writable host directory; `miroir-local` provisions a real **ext4 block device whose root directory comes up `root:root 0755`**. The runner images run as **uid/gid 1001**, so they can no longer create `_work/_tool` — every job dies in ~2 s with `System.UnauthorizedAccessException` before a single step executes.

### Verified, not assumed

| Check | Result |
| --- | --- |
| Runner image UID (`home-operations` **and** `packer-runner`) | `uid=1001(runner) gid=1001(runner)` |
| `miroir-local` provisioner | CSI block, `csi.storage.k8s.io/fstype: ext4` |
| CSIDriver `fsGroupPolicy` | `ReadWriteOnceWithFSType` (RWO + ext4 ⇒ kubelet honours `fsGroup`) |
| Live dind runner `_work` ownership | `drwxr-xr-x root root` — uid 1001 write **FAILED** |
| Timeline | last green tf-vsphere CI `07-17 19:04`; #3583 merged `07-18 00:30`; first failures `07-18` |

All three runners are affected — not just the two the issue flagged:

- **terraform-vsphere** (k8s mode) — failed visibly ([run 29744541728](https://github.com/codelooks-com/terraform-vsphere/actions/runs/29744541728)).
- **packer** (k8s mode) — the weekly `build-templates` died with the **identical** error ([run 29631154546](https://github.com/codelooks-com/packer-vsphere/actions/runs/29631154546)), every matrix leg 2–3 s. The green packer runs the linked issue read as "works" are all `runs-on: ubuntu-latest` — they never touched the ARC runner.
- **talos-cluster** (dind) — equally broken; its live `_work` is `root:root 0755`. It has stayed *silent* only because its one consumer (`image-pull` → "Pull Images") has skipped every run since the flip, so no job has exercised `_work/_tool`.

## Fix

Add `securityContext.fsGroup: 1001` to all three runner pod specs. Because the CSIDriver is `ReadWriteOnceWithFSType` and the claims are RWO + ext4, kubelet chowns the volume to GID 1001 on mount. Verified by rendering the chart (`helm template`, chart `0.14.2`): `fsGroup` lands at pod level over the `_work` volume.

Rollback to `openebs-hostpath` is **not** an option — it was decommissioned in #3736.

Each pod spec carries an inline comment explaining the root cause, matching the house style of the surrounding runner definitions.

## Corrects codelooks-com/terraform-vsphere#54

That issue's analysis mis-identified the trigger as an image × `containerMode` interaction ("only the kubernetes-mode + home-operations combo breaks"). That was a coincidence: the real common factor is the **miroir work volume shared by all three runners**. The proposed `fsGroup` fix (its candidate #1) is correct — but for the verified reason above, and it must be applied to the dind runner too.

## Verification

- [x] `helm template` shows `fsGroup: 1001` at pod level over the `_work` volume (all three).
- [x] Real super-linter (`v8.6.0`, repo config) — `yamllint` + `prettier` clean on the three changed files; lefthook pre-commit green.
- [ ] After Flux reconciles: trigger a real `terraform-vsphere` CI run and confirm `Validate & Plan` executes steps and posts a plan (tracked on codelooks-com/terraform-vsphere#54 / #53).
