### PR TITLE
chore: protect miroir in Renovate + retire remaining OpenEBS doc refs

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -135,6 +135,7 @@
         "/controlplaneio-fluxcd/", // flux-operator + flux-instance
         "/rook-ceph/",
         "/rook-ceph-cluster/",
+        "/miroir/", // node-local storage CSI (successor to OpenEBS)
         "/kube-apiserver/",
         "/kube-controller-manager/",
         "/kube-proxy/",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ talos/                     # Talos OS machine configs (talconfig.yaml + patches)
 | Ingress  | Envoy Gateway (Gateway API)  | L7 routing via `HTTPRoute` (not Ingress)    |
 | DNS      | external-dns + cloudflared   | Internal (OPNsense) + external (Cloudflare) |
 | Secrets  | external-secrets + 1Password | Secret management                           |
-| Storage  | Rook-Ceph + OpenEBS          | Block + node-local volumes                  |
+| Storage  | Rook-Ceph + miroir           | Block + node-local volumes                  |
 | Backups  | VolSync (Kopia) → NFS/remote | PVC snapshots and backups                   |
 | Charts   | bjw-s `app-template`         | The chart most apps use                     |
 
@@ -125,17 +125,17 @@ out-of-band prerequisites and the validation the skill cannot do.
   (`op item create --vault Talos --category "API Credential" --title <app> "FIELD[password]=…"`);
   the app's `externalsecret.yaml` then `extract`s it. Generate values with `openssl rand -hex 32` and
   never echo them.
-- **Each shared data service needs its own step:**
-  - **CNPG Postgres** — add a `ghcr.io/home-operations/postgres-init` initContainer (`envFrom` the
-    app secret, `INIT_POSTGRES_*`) to create the database and role; mirror `paperless`. Connect with
-    `sslmode=require`. Node / `pg` apps additionally need `NODE_TLS_REJECT_UNAUTHORIZED=0` — the
-    bundled driver verifies the cert-manager CA it cannot reach from the app namespace.
-  - **Dragonfly (Redis)** — authenticated; template
-    `redis://default:{{ .DRAGONFLY_PASSWORD }}@dragonfly.database.svc.cluster.local:6379` from the
-    `dragonfly` item. A client without the password fails silently at runtime.
-  - **Garage (S3)** — provision a bucket and access key with the `/garage` CLI inside `garage-0`
-    (`storage` namespace), store the key in the `garage` item, and point the app at
-    `http://garage.storage.svc.cluster.local:3900` (region `us-east-1`, path-style).
+- **Each shared data service needs its own step** — one top-level item per service:
+- **CNPG Postgres** — add a `ghcr.io/home-operations/postgres-init` initContainer (`envFrom` the
+  app secret, `INIT_POSTGRES_*`) to create the database and role; mirror `paperless`. Connect with
+  `sslmode=require`. Node / `pg` apps additionally need `NODE_TLS_REJECT_UNAUTHORIZED=0` — the
+  bundled driver verifies the cert-manager CA it cannot reach from the app namespace.
+- **Dragonfly (Redis)** — authenticated; template
+  `redis://default:{{ .DRAGONFLY_PASSWORD }}@dragonfly.database.svc.cluster.local:6379` from the
+  `dragonfly` item. A client without the password fails silently at runtime.
+- **Garage (S3)** — provision a bucket and access key with the `/garage` CLI inside `garage-0`
+  (`storage` namespace), store the key in the `garage` item, and point the app at
+  `http://garage.storage.svc.cluster.local:3900` (region `us-east-1`, path-style).
 - **Anchored ports are unquoted integers** (`PORT: &port 3000`). A quoted `"3000"` reused for a
   probe `httpGet.port` is rejected at apply time ("must contain at least one letter").
 - **Validate** with `kustomize build <appDir>` and flate, but note they check the HelmRelease and

--- a/docs/docs/operations/renovate-automerge.md
+++ b/docs/docs/operations/renovate-automerge.md
@@ -49,7 +49,7 @@ The protected-infra guard keeps these on manual review for all update types (inc
 | OS / kubelet | `siderolabs/` (Talos), `kubelet` |
 | Control plane | `kube-apiserver`, `kube-controller-manager`, `kube-proxy`, `kube-scheduler` |
 | CNI | `cilium` |
-| Storage | `rook-ceph`, `rook-ceph-cluster` |
+| Storage | `rook-ceph`, `rook-ceph-cluster`, `miroir` |
 | GitOps | `fluxcd/` (controllers), `controlplaneio-fluxcd` (operator + instance) |
 | Certs / DNS / secrets | `cert-manager`, `coredns`, `external-secrets`, `1password` (onepassword-connect) |
 | Image mirror | `spegel` |

--- a/kubernetes/apps/database/cloudnative-pg/README.md
+++ b/kubernetes/apps/database/cloudnative-pg/README.md
@@ -38,15 +38,9 @@ cloudnative-pg/
 
 - **Version**: PostgreSQL 18.0 (latest stable)
 - **Instances**: 3 for high availability with automatic failover
-- **Storage**: 20Gi using `openebs-hostpath`
-- **Resources**:
-  - Requests: 500m CPU, 2Gi memory
-  - Limits: 4Gi memory
-- **Tuning**: Optimized for mixed workloads
-  - `max_connections: 300`
-  - `shared_buffers: 512MB`
-  - `effective_cache_size: 1536MB`
-  - Transaction-level checkpoint completion
+- **Storage**: 200Gi using `miroir-local`
+- **Resources**: 500m CPU / 2Gi memory requests, 4Gi memory limit
+- **Tuning**: mixed-workload tuning — `max_connections: 300`, `shared_buffers: 512MB`, `effective_cache_size: 1536MB`, transaction-level checkpoint completion
 
 ### Backup Strategy
 
@@ -129,7 +123,7 @@ Flux will deploy components in this order (via `dependsOn`):
 1. external-secrets-onepassword (pre-existing)
    ↓
 2. cloudnative-pg (operator)
-   ↓ (also depends on openebs)
+   ↓ (also depends on miroir)
 3. cloudnative-pg-cluster (PostgreSQL 18)
    ↓
 4. cloudnative-pg-backup (NFS cronjob)
@@ -456,7 +450,7 @@ This implementation is based on:
 
 ## Notes
 
-- **Storage Class**: Using `openebs-hostpath` - data is local to nodes
+- **Storage Class**: Using `miroir-local` - data is local to nodes (loopfile-backed, size-enforced)
 - **Network Policy**: Not implemented - assume cluster network isolation
 - **TLS**: Not configured - rely on cluster network security (consider adding for production)
 - **Resource Limits**: Conservative - adjust based on workload monitoring


### PR DESCRIPTION
Follow-up to the OpenEBS decommission (#3736) — the two loose ends flagged there.

## 1. Protect miroir in Renovate

Added `/miroir/` to the `.renovaterc.json5` protected-infra guard. OpenEBS was protected; its successor `miroir` (node-local storage CSI underpinning Postgres, Garage, Mosquitto, and every VolSync cache) wasn't, so its chart bumps were auto-merging. Now they get manual review like the rest of cluster-critical infra. The renovate-review blast list (derived from this rule, #3563) picks it up automatically. `renovate-automerge.md` storage row updated to match.

## 2. Retire the last stale OpenEBS references

`AGENTS.md` (key-tech table) and the CNPG `README.md` (storage class, `dependsOn`, resources) still described OpenEBS as live. Updated to miroir.

**Why the lists got flattened:** both files carried pre-existing `MD007` violations, and CI runs markdownlint (indent-4) **and** prettier (2-space) on non-docs markdown with `soft-launch: false`. Those rules conflict on nested-list indentation — there is no indent both accept — so the fix is a flat single-level list (nothing for MD007 to check; prettier-canonical). Verified locally: markdownlint clean, prettier clean, and super-linter MARKDOWN / MARKDOWN_PRETTIER / NATURAL_LANGUAGE / RENOVATE all green.

## Intentionally kept

Comparative/historical OpenEBS mentions that explain the migration are **not** touched: the `fsGroup`-rationale comments in the runner helmreleases ("the openebs-hostpath directory it replaced… was already writable, so nothing needed fsGroup before"), `miroirnodegroup.yaml`, and `storage.md`'s "retired OpenEBS" note. These are accurate design-rationale, not stale claims.
