### PR TITLE
fix(smtp-relay): switch client cert to ZeroSSL — M365 won't match the LE cert

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
@@ -19,3 +19,31 @@ spec:
         selector:
           dnsZones:
             - "${SECRET_DOMAIN}"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/clusterissuer_v1.json
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: zerossl-production
+spec:
+  acme:
+    # ZeroSSL (Sectigo/USERTrust hierarchy). Added for certs that must be accepted by
+    # validators that choke on Let's Encrypt's 2026 Gen-Y roots / CN-less subjects —
+    # first user: the smtp-relay client cert matched by the M365 inbound connector.
+    server: "https://acme.zerossl.com/v2/DV90"
+    privateKeySecretRef:
+      name: zerossl-production
+    externalAccountBinding:
+      keyID: "${SECRET_ZEROSSL_EAB_KID}"
+      keySecretRef:
+        name: zerossl-eab
+        key: hmac
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              name: cert-manager-secret
+              key: api-token
+        selector:
+          dnsZones:
+            - "${SECRET_DOMAIN}"

--- a/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
@@ -16,3 +16,21 @@ spec:
   dataFrom:
     - extract:
         key: cloudflare
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zerossl-eab
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: zerossl-eab
+    template:
+      data:
+        hmac: "{{ .ZEROSSL_EAB_HMAC }}"
+  dataFrom:
+    - extract:
+        key: zerossl

--- a/kubernetes/apps/infrastructure/smtp-relay/app/certificate.yaml
+++ b/kubernetes/apps/infrastructure/smtp-relay/app/certificate.yaml
@@ -5,9 +5,12 @@ metadata:
   name: smtp-relay
 spec:
   secretName: tls.smtp-relay
-  duration: 160h
+  # No duration: ZeroSSL ignores requested lifetimes and issues fixed 90-day certs;
+  # cert-manager renews off the actual notAfter.
   issuerRef:
-    name: letsencrypt-production
+    # ZeroSSL (Sectigo hierarchy, CN-bearing): the M365 inbound connector failed to
+    # match the Let's Encrypt cert (CN-less subject / Gen-Y roots, 2026 changes).
+    name: zerossl-production
     kind: ClusterIssuer
   commonName: smtp.${SECRET_DOMAIN}
   dnsNames:

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -18,6 +18,7 @@ stringData:
   ENVOY_EXTERNAL_IP: "10.0.0.2"
   GH_LAN_CIDR: "10.0.1.0/24"
   SECRET_ACME_EMAIL: "fake@example.com"
+  SECRET_ZEROSSL_EAB_KID: "placeholder-eab-kid"
   SECRET_DOMAIN: "example.com"
   SECRET_INTERNAL_DOMAIN: "internal.example.com"
   SECRET_STORAGE_SERVER: "storage.example.com"


### PR DESCRIPTION
Exchange Online never attributed the relay's TLS session to the
inbound connector despite a provably correct client-cert handshake
(verified with a direct SMTP session presenting the same cert: full
cross-signed chain, compatible sig algs; exact and wildcard
TlsSenderCertificateName both unmatched over 90+ min). The remaining
variables are Let's Encrypt's 2026 changes: CN-less subjects and the
Gen-Y root hierarchy (ISRG Root YE) absent from major trust stores.

Add a parallel zerossl-production ClusterIssuer (Sectigo/USERTrust
hierarchy, CSR CN honoured; EAB via 1Password->external-secrets,
same Cloudflare DNS-01 solver) and move only the smtp-relay
Certificate to it. Everything else stays on Let's Encrypt.
