### PR TITLE
ci(github-action): bump drift check to the self-pinning workflow

### DIFF
--- a/.github/workflows/docs-standard-check.yml
+++ b/.github/workflows/docs-standard-check.yml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   drift:
-    uses: LukeEvansTech/shared-workflows/.github/workflows/zensical-drift-check.yml@3771e1f9da1b3f6132eec9d63aacc0acb74660bc # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/zensical-drift-check.yml@ceee688a491289ee740499ed6d2aec30cbef84ea # v1


### PR DESCRIPTION
Bumps to the shared-workflows commit from [#26](https://github.com/LukeEvansTech/shared-workflows/pull/26), which replaces `ref: main` with `ref: ${{ job.workflow_sha }}`.

This is the **first** pin at a SHA carrying that change, so this PR's `drift` run is the first to actually exercise the self-pinned checkout. Until now `job.workflow_sha` was only validated against GitHub's documentation and actionlint — a green run here is the runtime proof.

All 16 consumers were bumped to a json5-capable script *before* #26 merged, so no repository regressed.