### PR TITLE
chore(cnpg): drop residual MinIO naming and secret extract

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/README.md
+++ b/kubernetes/apps/database/cloudnative-pg/README.md
@@ -46,14 +46,14 @@ cloudnative-pg/
 
 We implemented a **dual backup approach** for redundancy:
 
-#### 1. Barman Cloud (S3/MinIO) - Primary
+#### 1. Barman Cloud (S3/Garage) - Primary
 
 - **Method**: Continuous WAL archiving via Barman Object Store
 - **Schedule**: Daily scheduled backups via `ScheduledBackup` CR
 - **Retention**: 30 days
 - **Compression**: bzip2 for both WAL and data
 - **Performance**: 8 parallel WAL transfers, 2 parallel data jobs
-- **Location**: `s3://cloudnative-pg/` at `https://${SECRET_STORAGE_SERVER}:9000`
+- **Location**: `s3://cnpg/` at `http://garage.storage.svc.cluster.local:3900` (in-cluster Garage)
 - **Use Case**: Point-in-time recovery (PITR), cluster bootstrap/migration
 
 #### 2. NFS Database Dumps - Secondary
@@ -149,10 +149,11 @@ POSTGRES_SUPER_USER: postgres
 POSTGRES_SUPER_PASS: <generate-strong-password>
 ```
 
-**Note**: MinIO credentials are pulled from the existing `minio` vault item:
+**Note**: S3 credentials are pulled from the existing `garage` vault item and mapped
+onto `AWS_*` keys by the ExternalSecret template:
 
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
+- `CNPG_ACCESS_KEY_ID` → `AWS_ACCESS_KEY_ID`
+- `CNPG_SECRET_ACCESS_KEY` → `AWS_SECRET_ACCESS_KEY`
 
 ### 2. NFS Backup Configuration
 
@@ -171,20 +172,17 @@ backups:
 - Export path must exist and be writable
 - Verify with: `showmount -e <nas-server>`
 
-### 3. MinIO S3 Bucket
+### 3. Garage S3 Bucket
 
-Create the S3 bucket in MinIO:
+Create the S3 bucket in the in-cluster Garage:
 
 ```bash
-# Using mc (MinIO Client)
-mc mb minio/cloudnative-pg
-
-# Or via MinIO UI
-# Navigate to https://${SECRET_STORAGE_SERVER}:9000
-# Create bucket: cloudnative-pg
+# From a garage pod (kubectl -n storage exec deploy/garage -- ...)
+garage bucket create cnpg
+garage bucket allow --read --write cnpg --key cnpg-key
 ```
 
-Verify credentials in the `minio` 1Password vault have access.
+Verify credentials in the `garage` 1Password item have access to the `cnpg` bucket.
 
 ## Post-Deployment Verification
 

--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -29,6 +29,4 @@ spec:
     - extract:
         key: cloudnative-pg
     - extract:
-        key: minio
-    - extract:
         key: garage

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -65,7 +65,7 @@ spec:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
-        barmanObjectName: postgres18-minio
+        barmanObjectName: postgres18-garage
         serverName: postgres18
 
   backup:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -3,7 +3,7 @@
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
-  name: postgres18-minio
+  name: postgres18-garage
 spec:
   # Retention policy
   retentionPolicy: 90d

--- a/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
@@ -36,25 +36,25 @@ spec:
                 - /bin/sh
                 - -c
                 - |
-                  export RCLONE_CONFIG_MINIO_ACCESS_KEY_ID=$(cat /secrets/AWS_ACCESS_KEY_ID)
-                  export RCLONE_CONFIG_MINIO_SECRET_ACCESS_KEY=$(cat /secrets/AWS_SECRET_ACCESS_KEY)
+                  export RCLONE_CONFIG_GARAGE_ACCESS_KEY_ID=$(cat /secrets/AWS_ACCESS_KEY_ID)
+                  export RCLONE_CONFIG_GARAGE_SECRET_ACCESS_KEY=$(cat /secrets/AWS_SECRET_ACCESS_KEY)
                   export RCLONE_CONFIG_CLOUDFLARE_ACCESS_KEY_ID=$(cat /secrets/R2_ACCESS_KEY_ID)
                   export RCLONE_CONFIG_CLOUDFLARE_SECRET_ACCESS_KEY=$(cat /secrets/R2_SECRET_ACCESS_KEY)
                   export RCLONE_CONFIG_CLOUDFLARE_ENDPOINT=$(cat /secrets/R2_ENDPOINT)
-                  exec rclone copy --verbose --stats-one-line --stats=5m --fast-list minio:cnpg/ cloudflare:cnpg/
+                  exec rclone copy --verbose --stats-one-line --stats=5m --fast-list garage:cnpg/ cloudflare:cnpg/
               env:
                 # Logging
                 - name: RCLONE_VERBOSE
                   value: "1"
 
                 # Garage (source) configuration
-                - name: RCLONE_CONFIG_MINIO_TYPE
+                - name: RCLONE_CONFIG_GARAGE_TYPE
                   value: s3
-                - name: RCLONE_CONFIG_MINIO_PROVIDER
+                - name: RCLONE_CONFIG_GARAGE_PROVIDER
                   value: Other
-                - name: RCLONE_CONFIG_MINIO_ENDPOINT
+                - name: RCLONE_CONFIG_GARAGE_ENDPOINT
                   value: http://garage.storage.svc.cluster.local:3900
-                - name: RCLONE_CONFIG_MINIO_ACL
+                - name: RCLONE_CONFIG_GARAGE_ACL
                   value: private
 
                 # Cloudflare R2 (destination) configuration

--- a/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
@@ -83,8 +83,8 @@ spec:
           for: 5m
           labels:
             severity: critical
-        # "exited|dead" scoped to the doco-cd-managed fleet so intentionally
-        # stopped containers (e.g. the decommissioned minio app) don't page.
+        # "exited|dead" scoped to the doco-cd-managed fleet so containers outside
+        # that fleet (or intentionally stopped) never page.
         - alert: TrueNASContainerDown
           annotations:
             summary: "TrueNAS container {{ $labels.name }} is not running (state: {{ $labels.status }})."

--- a/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
@@ -29,7 +29,7 @@ spec:
   # keyed by container ID and disappear once a container stops, so they can't).
   # metricRelabelings drop the ~25 noisy container_label_* values (compose/doco-cd
   # shas) but keep cd_doco_metadata_manager so "container down" scopes to the
-  # GitOps-managed fleet (auto-excludes the intentionally-stopped minio app).
+  # GitOps-managed fleet, so non-doco-cd containers never page.
   staticConfigs:
     - targets:
         - ${SECRET_STORAGE_SERVER}:9419


### PR DESCRIPTION
## What

Cleans up the last MinIO references left behind after the CNPG backup path moved to in-cluster Garage.

- `ObjectStore` `postgres18-minio` → `postgres18-garage` (+ matching `barmanObjectName` plugin parameter in `cluster.yaml`)
- rclone source remote `MINIO` → `GARAGE` in the R2 offsite cronjob
- drops the dead `minio` extract from the CNPG `ExternalSecret`
- README updated (MinIO → Garage, `mc` → `garage` CLI, credential mapping)
- drops two `truenas-exporter` comments referencing the decommissioned MinIO container, leaving the scoping rationale intact

## Why this is low risk

The data path had **already** migrated — only the naming lagged. Verified against the live cluster before making the change:

```
$ kubectl get objectstore postgres18-minio -n database \
    -o jsonpath='{.spec.configuration.destinationPath} -> {.spec.configuration.endpointURL}'
s3://cnpg/  ->  http://garage.storage.svc.cluster.local:3900
```

- `serverName` (`postgres18`) and `destinationPath` (`s3://cnpg/`) are unchanged — this renames a Kubernetes object, not a backup target, so history and PITR continuity are preserved.
- Credential resolution is unchanged: `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` were already templated from the `garage` item's `CNPG_*` fields, so the removed `minio` extract was dead weight.
- `cloudnative-pg-cluster` has `prune: true`, so Flux creates the renamed ObjectStore and prunes the old one in the same reconcile.

Cluster state at time of change: `Continuous archiving is working`, `Backup was successful` (2026-07-21).

## Validation

- `flate test all --namespace database` — 24 passed (sole warning is a pre-existing, unrelated `dragonfly-operator` values warning)
- local super-linter (`just lint`, the CI image) — no findings in any changed file; YAML and YAML_PRETTIER pass cleanly
- lefthook pre-commit — all hooks pass

> Note: the local full-codebase super-linter run surfaces 65 pre-existing textlint/prettier findings under `docs/**`. Those are excluded from CI via `filter-regex-exclude` and are untouched by this PR — flagging separately rather than folding them in here.

## Post-merge

Watch that `postgres18-garage` is created and `postgres18-minio` pruned, and that `ContinuousArchiving` stays `True` — a brief archive retry during the swap would be self-healing.
