### PR TITLE
fix(cilium): drop socketLB.hostNamespaceOnly to unbreak DSR hairpinning

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -55,7 +55,6 @@ loadBalancer:
 localRedirectPolicy: true
 socketLB:
   enabled: true
-  hostNamespaceOnly: true
 operator:
   dashboards:
     enabled: true


### PR DESCRIPTION
Adopts [onedr0p/cluster-template#2258](https://github.com/onedr0p/cluster-template/pull/2258).

## Why

`socketLB.hostNamespaceOnly` was a workaround for connections breaking on coredns pod restart. Cilium has covered that since **v1.17.0** via `socketLB.terminatePodConnections` (defaults true) — we run **1.19.6**, so it is obsolete.

It is also actively harmful here. Per the upstream author:

> Having `hostNamespaceOnly` enabled together with DSR breaks hairpinning (eg an envoy SecurityPolicy pointing at another route in the same gateway).

We run exactly that combination — `loadBalancer.mode: dsr` + Envoy Gateway + Cilium 1.19.6.

**This is latent, not live.** There are currently no `SecurityPolicy` resources in the cluster (`kubectl get securitypolicies -A` → none), so nothing is broken today. It would surface the first time extAuth/OIDC is placed in front of an app.

## Safety

Removing the flag widens socket LB from host-namespace-only to host **and** pod namespaces. Host-namespace behaviour is unchanged, so Talos `forwardKubeDNSToHost` — which depends on host socket LB — is unaffected. Upstream ships `forwardKubeDNSToHost` and bare `socketLB.enabled: true` together, confirmed against the current template.

## Validation

- `flate test all --namespace kube-system` — 38 passed
- rendered output confirmed: `socketLB: {enabled: true}`, `mode: dsr` intact, zero `hostNamespaceOnly` occurrences
- local super-linter (CI image): YAML + YAML_PRETTIER pass, no findings in the changed file

## Rollout note

This rolls the Cilium agent DaemonSet. Merging deliberately so the reconcile can be watched; node-by-node agent restart may cause brief per-node dataplane blips.
