### PR TITLE
fix(tuppr): raise memory limit 512Mi→768Mi for apiserver-reconnect headroom

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -15,8 +15,11 @@ spec:
       requests:
         cpu: 10m
         memory: 256Mi
+      # 768Mi (not 512Mi): steady state is ~320Mi, but on an apiserver
+      # reconnect all informers re-LIST at once (Secrets/Pods/Nodes) and the
+      # resync spike OOMKilled the follower at 512Mi. This headroom absorbs it.
       limits:
-        memory: 512Mi
+        memory: 768Mi
     monitoring:
       serviceMonitor:
         enabled: true


### PR DESCRIPTION
## What

Raises the tuppr `manager` container memory **limit** `512Mi → 768Mi` (requests unchanged at 256Mi).

## Why

The follower replica was **OOMKilled** (exit 137) during a ~40-second apiserver connectivity blip on 2026-07-21 (`12:50:35–12:51:17Z`). Both replicas lost their watch streams simultaneously (`http2: client connection lost` on every informer). On reconnect, client-go re-**LIST**s all watched types at once — `Secret` ×2, `Pod`, `Node`, `TalosUpgrade`, `KubernetesUpgrade`, webhook config — and that full-resync spike pushed the follower past `512Mi`.

Steady-state usage is only **~320Mi** (≈64% of the old limit), leaving too little headroom to absorb a reconnect burst. `768Mi` gives ~2.3× steady-state headroom.

Notes on the incident (why this is the right, and only, fix):
- The **leader** replica exited at the same moment with `leader election lost` (exit 1) — that's controller-runtime behaving **by design** on a lost lease, not a memory problem. Unchanged here.
- The trigger was an **external** transient apiserver-reachability blip (kube-system `reflector` + `netbox` readiness probes failed in the same window; no other pods restarted), not a tuppr fault.
- **No leak**: `restartCount` was 1, memory tracks steady with the blip rather than climbing. This is purely defensive headroom.

## Validation

- `yamlfmt -lint` — clean
- `yamllint -c .github/linters/.yaml-lint.yml` — clean (only pre-existing `line-length` warnings on the schema/prometheusrule comments)
- `just kube flate-build-hr system-upgrade tuppr` — renders; confirmed `memory: 768Mi` in output
- lefthook pre-commit — all hooks green