### PR TITLE
chore(cilium): remove duplicate PDB block and fix policyEnforcement key

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm/values.yaml
@@ -67,9 +67,6 @@ operator:
   podDisruptionBudget:
     enabled: true
     maxUnavailable: 1
-podDisruptionBudget:
-  enabled: true
-  maxUnavailable: 1
 prometheus:
   enabled: true
   serviceMonitor:
@@ -97,4 +94,4 @@ securityContext:
       - NET_ADMIN
       - SYS_ADMIN
       - SYS_RESOURCE
-policyEnforcement: default
+policyEnforcementMode: default


### PR DESCRIPTION
Clears the two dead values `flate` reports as *"values not used by the chart"* for cilium. **No behavioural change.**

## 1. Duplicate `podDisruptionBudget`

`values.yaml` had a working `operator.podDisruptionBudget` **and** a top-level duplicate immediately after it:

```yaml
operator:
  ...
  podDisruptionBudget:      # <- works, renders the live PDB
    enabled: true
    maxUnavailable: 1
podDisruptionBudget:        # <- dead duplicate, removed
  enabled: true
  maxUnavailable: 1
```

The chart exposes `podDisruptionBudget` only under `operator` and `preflight` — there is **no agent/DaemonSet PDB option** — so the top-level copy rendered nothing.

The live `cilium-operator` PDB (`maxUnavailable: 1`) comes from the operator block and is **unaffected**; I verified it still renders after the change.

## 2. `policyEnforcement` → `policyEnforcementMode`

`policyEnforcement` is not a chart key. The correct one is `policyEnforcementMode`. The value (`default`) equals the chart default, so this was a no-op either way — renaming makes the intent real and pins it should the chart default change.

## Validation

- `flate test all --namespace kube-system` — 38 passed, and the cilium *"values not used by the chart"* warning is **gone**
- rendered output still contains `operator.podDisruptionBudget {enabled: true, maxUnavailable: 1}` and now `policyEnforcementMode: default`
- local super-linter (CI image): YAML pass, no findings in the changed file
