### PR TITLE
chore(lint): mirror CI's docs/ exclusion locally and fix MD007 in certwarden README

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -31,6 +31,12 @@ template file *args:
 # Run super-linter locally with the same env flags as the shared CI workflow.
 # slim-v8 is amd64-only — `--platform linux/amd64` enables Rosetta emulation
 # on Apple Silicon. RUN_LOCAL=true lints the working tree (skips git-diff logic).
+# FILTER_REGEX_EXCLUDE mirrors the `filter-regex-exclude` input in
+# .github/workflows/lint.yml (the shared workflow maps it to this same env var).
+# Keep the two in sync: without it, local lints the docs/ tree that CI excludes
+# — docs/ is owned by the canonical .markdownlint.yml + docs-standard-check.
+# VALIDATE_ALL_CODEBASE stays true here on purpose: CI defaults it to false
+# (changed files only), but locally we want the whole working tree checked.
 lint *args:
     docker run --rm --platform linux/amd64 \
       -e RUN_LOCAL=true \
@@ -43,6 +49,7 @@ lint *args:
       -e VALIDATE_TRIVY=false \
       -e VALIDATE_GITLEAKS=false \
       -e VALIDATE_JSCPD=false \
+      -e FILTER_REGEX_EXCLUDE='(^|/)(node_modules|\.venv|site)/|(^|/)docs/' \
       -e LOG_LEVEL=NOTICE \
       -v "$PWD":/tmp/lint \
       ghcr.io/super-linter/super-linter:slim-v8 {{ args }}

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/CONTAINERIZED-README.md
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/CONTAINERIZED-README.md
@@ -6,11 +6,13 @@ This deployment now uses a **pre-built container** for faster and more reliable 
 
 - **Container**: `ghcr.io/lukeevanstech/supermicro-ipmi-cert:latest`
 - **Script**: `certwarden-supermicro-deploy.sh`
-- **Benefits**:
-  - Faster execution (no runtime dependency installation)
-  - Consistent environment across deployments
-  - Reduced job execution time by ~30-60 seconds
-  - Better security (minimal container, no runtime downloads)
+
+**Benefits**:
+
+- Faster execution (no runtime dependency installation)
+- Consistent environment across deployments
+- Reduced job execution time by ~30-60 seconds
+- Better security (minimal container, no runtime downloads)
 
 ## Files
 


### PR DESCRIPTION
## The problem

`just lint` ran super-linter across the whole tree with no `FILTER_REGEX_EXCLUDE`, while CI passes:

```yaml
filter-regex-exclude: '(^|/)(node_modules|\.venv|site)/|(^|/)docs/'
```

The shared workflow maps that straight to super-linter's `FILTER_REGEX_EXCLUDE` env var. So local was a **stricter superset** of CI, reporting **65 findings in `docs/`** — a tree CI deliberately excludes because it's owned by the canonical `.markdownlint.yml` + the `docs-standard-check` drift workflow.

## Why not just fix the 65

Running `textlint --fix` would have **corrupted the docs**. It wanted:

- **`YaRN` → `Yarn`** — YaRN is *Yet another RoPE extensioN*, the LLM context-extension technique ("64k via YaRN", "with correct YaRN args"). Not the package manager.
- **`github-action`** capitalised — that's a literal Renovate manager name.
- **`git` / `docker` / `curl` / `sqlite`** (19×) title-cased — correct lowercase as command names.

Roughly half the findings were false positives on technical literals.

## What this does

1. **Adds the same exclusion to the `just lint` recipe**, so local == CI: same image, same env var, same regex. Nothing CI checks today stops being checked. The recipe now documents that `VALIDATE_ALL_CODEBASE` stays `true` locally on purpose (CI defaults it to `false`, changed-files-only).

2. **Fixes a real MD007 finding the noise was hiding.** With docs/ excluded, `certwarden/cert-deployment/supermicro/CONTAINERIZED-README.md` surfaced 4 `MD007/ul-indent` errors. CI lints *changed* files with `soft-launch: false`, so this was a latent landmine — touch that file, CI fails. Fixed by **flattening the nested list** rather than re-indenting to 4, which would have tripped the known MD007-vs-prettier conflict in this repo.

## Result

`just lint` now **exits 0** — 29 linters pass, `MARKDOWN` and `MARKDOWN_PRETTIER` both clean.

Before: `✖ 65 problems`, exit 2 · After: no findings, exit 0
