### PR TITLE
feat(home): add zigbee2mqtt-garage — second Zigbee coordinator

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -81,6 +81,7 @@ ALLOWLIST: dict[str, str] = {
     "kubernetes/apps/home/mosquitto/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/scrypted/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml": "multus static IP + MAC",
+    "kubernetes/apps/home/zigbee2mqtt-garage/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/kube-system/cilium/app/networks.yaml": "LB IP pool / API host",
     "kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml": "etcd-defrag node targets",
     "kubernetes/apps/network/envoy-gateway/app/envoy.yaml": "Envoy LB listener IPs",

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -22,4 +22,5 @@ resources:
   - ./shelly-operator/ks.yaml
   - ./shelly-prometheus-exporter/ks.yaml
   - ./zigbee2mqtt/ks.yaml
+  - ./zigbee2mqtt-garage/ks.yaml
   - ./zwave/ks.yaml

--- a/kubernetes/apps/home/zigbee2mqtt-garage/app/externalsecret.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt-garage/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zigbee2mqtt-garage-secret
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: zigbee2mqtt-garage-secret
+    template:
+      engineVersion: v2
+      data:
+        ZIGBEE2MQTT_CONFIG_SERIAL_PORT: "{{ .ZIGBEE_ADAPTER_HOST }}"
+  dataFrom:
+    - extract:
+        key: zigbee2mqtt-garage

--- a/kubernetes/apps/home/zigbee2mqtt-garage/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt-garage/app/helmrelease.yaml
@@ -1,0 +1,120 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zigbee2mqtt-garage
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: zigbee2mqtt-garage
+  values:
+    controllers:
+      zigbee2mqtt-garage:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/koenkk/zigbee2mqtt
+              tag: 2.12.1@sha256:80f7f04f72a99e4c4ef51ef7e98ee736edba6db0ecbb7abc626d0c4b0f1871f1
+            env:
+              TZ: ${TIMEZONE}
+              ZIGBEE2MQTT_DATA: /data
+              ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.home.svc.cluster.local:1883
+              # Distinct base topic — the house instance owns the default
+              # `zigbee2mqtt`. Sharing it would interleave two networks'
+              # device topics on the same broker.
+              ZIGBEE2MQTT_CONFIG_MQTT_BASE_TOPIC: zigbee2mqtt-garage
+              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_ENABLED: "true"
+              ZIGBEE2MQTT_CONFIG_SERIAL_ADAPTER: ember
+              Z2M_ONBOARD_NO_SERVER: "1"
+              # Shared discovery topic with the house instance is fine: z2m
+              # derives device unique_ids from each device's IEEE address, and
+              # the bridge device's id from the coordinator IEEE — which differ
+              # between the two coordinators. No entity collisions in HA.
+              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_DISCOVERY_TOPIC: homeassistant
+              ZIGBEE2MQTT_CONFIG_HOMEASSISTANT_STATUS_TOPIC: homeassistant/status
+              ZIGBEE2MQTT_CONFIG_PERMIT_JOIN: "false"
+              ZIGBEE2MQTT_CONFIG_FRONTEND_ENABLED: "true"
+              ZIGBEE2MQTT_CONFIG_FRONTEND_PORT: &port 80
+              ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_LEVEL: info
+              ZIGBEE2MQTT_CONFIG_ADVANCED_LOG_OUTPUT: '["console"]'
+              ZIGBEE2MQTT_CONFIG_AVAILABILITY_ACTIVE_TIMEOUT: 60
+              ZIGBEE2MQTT_CONFIG_AVAILABILITY_PASSIVE_TIMEOUT: 2000
+              # --- RF plan (garage coordinator) ---------------------------
+              # ch 25: quietest channel in an on-device energy scan taken at
+              # the garage unit's own location (energy 21 vs 42-64 elsewhere),
+              # and a ZLL channel, which z2m recommends for device
+              # compatibility. Clear of WiFi ch 6 — every codelooks SSID sits
+              # there at ~-48dBm, which is what trashes Zigbee ch 14-18 (61-64)
+              # and rules out the usual ch 15 pick. Also 14 channels off the
+              # house Zigbee network (ch 11).
+              ZIGBEE2MQTT_CONFIG_ADVANCED_CHANNEL: 25
+              # Distinct from the house network's PAN (36576) and from z2m's
+              # own default (0x1a62). Mnemonic: VLAN 68, channel 25.
+              ZIGBEE2MQTT_CONFIG_ADVANCED_PAN_ID: 6825
+              # MUST be set. The house instance doesn't set ext_pan_id, so it
+              # runs z2m's default (0xDD x8) — leaving this unset would put two
+              # networks with an identical extended PAN ID in RF range of each
+              # other. Trailing bytes are 0x68 0x25 (VLAN 68, ch 25).
+              ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID: "[221,221,221,221,221,221,104,37]"
+              # network_key is deliberately NOT set here. Setting it to
+              # GENERATE via env would re-evaluate on every pod start and could
+              # re-key the network on each restart, forcing a full re-pair.
+              # z2m generates one on first run and persists it to the PVC.
+            envFrom:
+              - secretRef:
+                  name: zigbee2mqtt-garage-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 384Mi
+    defaultPodOptions:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "iot",
+            "namespace": "kube-system",
+            "ips": ["10.32.68.35/23"],
+            "mac": "02:00:00:00:00:06"
+          }]
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+    service:
+      app:
+        controller: zigbee2mqtt-garage
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/home/zigbee2mqtt-garage/app/kustomization.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt-garage/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/home/zigbee2mqtt-garage/app/ocirepository.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt-garage/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: zigbee2mqtt-garage
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/zigbee2mqtt-garage/ks.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt-garage/ks.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zigbee2mqtt-garage
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/homepage
+    - ../../../../components/volsync
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+    - name: mosquitto
+      namespace: home
+  interval: 1h
+  path: ./kubernetes/apps/home/zigbee2mqtt-garage/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+      HOMEPAGE_NAME: Zigbee2MQTT (Garage)
+      HOMEPAGE_GROUP: Home
+      HOMEPAGE_ICON: zigbee2mqtt.svg
+      HOMEPAGE_DESCRIPTION: Zigbee bridge (garage coordinator)
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
> ⚠️ **Do not merge yet.** Two prerequisites below, and per repo convention this needs explicit confirmation before it reaches the live cluster.

## What

A second zigbee2mqtt instance driving the new garage SLZB-MR5U, forming its **own** Zigbee network to extend coverage. z2m is single-network per instance, so a second coordinator means a second instance — not another adapter on the existing one.

## RF plan

An on-device Zigbee energy scan run at the garage unit's own location (ch 11→26):

| ch | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | **25** | 26 |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| energy | 45 | 46 | 43 | 61 | 61 | 61 | 64 | 63 | 52 | 42 | 35 | 41 | 30 | 35 | **21** | 46 |

**Channel 25** — quietest by a wide margin, and a ZLL channel (z2m recommends 11/15/20/25 for device compatibility), so the empirical result and the documented safe list agree.

The 61–64 spike across ch 14–18 is **WiFi channel 6** — every `codelooks` SSID sits there at ~−48 dBm — which is what rules out the textbook ch 15 pick. Ch 25 is also 14 channels clear of the house network (ch 11).

## Two settings worth reviewing closely

- **`ext_pan_id` is set explicitly, and needs to stay that way.** The house instance doesn't set it, so it runs z2m's default (`0xDD`×8). Leaving it unset here would put two networks with an *identical extended PAN ID* within RF range of each other.
- **`network_key` is deliberately NOT set.** Setting it to `GENERATE` via env var would re-evaluate on every pod start and risks re-keying the network on each restart — which forces a full device re-pair. z2m generates one on first run and persists it to the PVC.

`pan_id` is `6825` — distinct from the house PAN (36576) and from z2m's own default (`0x1a62`).

Shared HA discovery topic with the house instance is intentional and safe: z2m derives device `unique_id`s from each device's IEEE address and the bridge device from the coordinator IEEE, both of which differ between coordinators.

## Prerequisites (both blocking)

1. **1Password item `zigbee2mqtt-garage`** with `ZIGBEE_ADAPTER_HOST` = `tcp://10.32.68.30:6638`. The ExternalSecret won't resolve without it.
2. **LukeEvansTech/network-ops#119** — pins the coordinator to `10.32.68.30`. It's on a pool lease right now, so merging this first would pin z2m to an address that drifts.

## Verification

- `check_internal_identifiers.py` → OK across all 1672 tracked files (allowlist entry added alongside the other multus apps)
- `check_route_hostname_pairs.py` → OK
- `kubectl kustomize` builds both the new app and the `home` overlay
- Multus `10.32.68.35/23` + MAC `02:00:00:00:00:06` confirmed unique across the repo (next free slots after `.25`/`:05`)

Not deployed — no cluster changes applied.