### PR TITLE
fix(home): drop VLAN 68 macvlan from zigbee2mqtt-garage

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -81,7 +81,6 @@ ALLOWLIST: dict[str, str] = {
     "kubernetes/apps/home/mosquitto/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/scrypted/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/home/zigbee2mqtt/app/helmrelease.yaml": "multus static IP + MAC",
-    "kubernetes/apps/home/zigbee2mqtt-garage/app/helmrelease.yaml": "multus static IP + MAC",
     "kubernetes/apps/kube-system/cilium/app/networks.yaml": "LB IP pool / API host",
     "kubernetes/apps/kube-system/etcd-defrag/app/configmap.yaml": "etcd-defrag node targets",
     "kubernetes/apps/network/envoy-gateway/app/envoy.yaml": "Envoy LB listener IPs",

--- a/kubernetes/apps/home/zigbee2mqtt-garage/app/helmrelease.yaml
+++ b/kubernetes/apps/home/zigbee2mqtt-garage/app/helmrelease.yaml
@@ -80,14 +80,25 @@ spec:
               limits:
                 memory: 384Mi
     defaultPodOptions:
-      annotations:
-        k8s.v1.cni.cncf.io/networks: |-
-          [{
-            "name": "iot",
-            "namespace": "kube-system",
-            "ips": ["10.32.68.35/23"],
-            "mac": "02:00:00:00:00:06"
-          }]
+      # NO VLAN 68 macvlan here — deliberate, do not "restore" it to match the
+      # house instance. VLAN 68 is live at L3 but its L2 cutover is incomplete
+      # (network-ops Gate D, the MikroTik trunk, is still pending). A macvlan
+      # only reaches peers that share the same parent NIC on the same node;
+      # anything needing the physical wire — another node, the gateway, or any
+      # wireless client — is unreachable. The garage coordinator is a *Wi-Fi*
+      # client on VLAN 68, so it falls squarely in the broken case.
+      #
+      # Worse, attaching the macvlan installs a link-scope route for the whole
+      # IoT-trusted prefix on net1, which is more specific than the default
+      # route and hijacks coordinator traffic onto that dead L2 path
+      # -> EHOSTUNREACH on :6638.
+      #
+      # Without it the pod routes via eth0 -> OPNsense -> VLAN 68, which is
+      # verified working. z2m only needs outbound TCP to the coordinator; it
+      # has no multicast/mDNS requirement that would justify an L2 presence.
+      # (The house instance survives only because its coordinator is still on
+      # the legacy LAN at 10.32.8.x and is therefore also routed via eth0.)
+      # Once Gate D lands, a macvlan could be reinstated, but isn't required.
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
Follow-up to #3760. The pod crash-looped on `connect EHOSTUNREACH 10.32.68.30:6638`.

## Root cause

**VLAN 68 macvlan L2 does not traverse the physical switch fabric.** VLAN 68 is live at L3, but its L2 cutover is incomplete — network-ops **Gate D** (the MikroTik trunk) is still pending a maintenance window.

A macvlan only reaches peers that share the same parent NIC *on the same node*. Measured from the working house z2m pod (`10.32.68.20`, VLAN 68 macvlan):

| target | result | why |
|---|---|---|
| mosquitto `.25:1883` | **OPEN (0s)** | same node (`cr-talos-03`) — macvlan siblings, never touch the wire |
| home-assistant `.15:8123` | fail (3s) | different node (`cr-talos-02`) |
| gateway `.1:443` | fail (4s) | needs the wire |
| garage coordinator `.30:6638` | fail (3s) | Wi-Fi client |
| shelly `.75`, tado `.71` | fail (3s) | Wi-Fi clients |

From a pod with **no** VLAN 68 macvlan, `10.32.68.30:6638` is **OPEN in 0s**.

The macvlan is not merely useless here, it's harmful: it installs a link-scope route for the IoT-trusted prefix on `net1`, which is more specific than the default route and hijacks coordinator traffic onto the dead L2 path.

## Fix

Remove the macvlan. The pod then routes `eth0 → OPNsense → VLAN 68` — the same path my workstation uses to reach the device, verified working. z2m needs only outbound TCP to the coordinator; it has no multicast/mDNS requirement that would justify an L2 presence.

## Worth knowing

The house instance works **only because its coordinator is still on the legacy LAN** (`10.32.8.151`) and is therefore also routed via `eth0`. When the house MR5U moves to VLAN 68 (`.68.5`), it will hit this exact wall unless Gate D has landed or its macvlan is dropped too.

I left a comment in the manifest explaining why the macvlan is absent, so it doesn't get "restored" for consistency with the house instance.

## Verification

- Identifier guard passes with the allowlist entry **removed** — the annotation was the only literal IP/MAC in the file, so the guard is now tighter than before
- `kubectl kustomize` builds the app and the `home` overlay