### PR TITLE
fix(todoist-sort): disable model thinking to stop plan-day failures

### DIFF
--- a/kubernetes/apps/custom/todoist-sort/app/resources/config.toml
+++ b/kubernetes/apps/custom/todoist-sort/app/resources/config.toml
@@ -11,7 +11,13 @@ max_per_run = 12
 [llm]
 base_url = "http://litellm.ai.svc.cluster.local:4000/v1"
 model = "self-hosted"
-extra_body = { max_tokens = 16384 }
+# enable_thinking=false: the self-hosted model is a reasoning model that emits
+# thousands of tokens of reasoning_content before answering; on heavy plan-day
+# runs that reasoning overran max_tokens and truncated before the JSON array,
+# failing the job ("no JSON array found"). Qwen's thinking switch (llama.cpp
+# honours chat_template_kwargs, not reasoning_effort) turns it off; verified
+# 2026-07-22 — golden eval still 12/12, plan output valid. Applies to both passes.
+extra_body = { max_tokens = 16384, chat_template_kwargs = { enable_thinking = false } }
 # timeout is seconds per LLM attempt; 2 attempts x 300s must stay under
 # the CronJob activeDeadlineSeconds of 660
 timeout = 300


### PR DESCRIPTION
## Problem

The daily `todoist-sort-plan-day` CronJob (`custom` ns) intermittently fails with `plan failed: no JSON array found in model output`, which fires the netdata `k8s_state_cronjob_last_execution_failed` alert (persists ~24h until the next daily run succeeds).

## Root cause (verified against the live gateway)

- The self-hosted model is a **reasoning model** emitting ~8k tokens of `reasoning_content` before answering, even for a simple plan. On heavier plan days that reasoning overruns `max_tokens` (16384) and the response truncates **before** the JSON array → parse fails.
- The planner's `for _ in range(2)` retry is **inert**: `temperature=0` is deterministic here (8/8 byte-identical outputs), so the retry reproduces the same failure — hence the doubled, identical error.
- Only plan-day alerts because it's `backoffLimit: 0`; sort-inbox (`backoffLimit: 1`, every 15 min) absorbs the same flakiness. Raising backoffLimit would **not** help — the failure is deterministic per day.

## Fix

Set `chat_template_kwargs.enable_thinking = false` in `[llm].extra_body`. llama.cpp honours this Qwen switch (`reasoning_effort` is ignored by this build). Reasoning drops to **zero tokens**, eliminating the truncation cliff; both passes also get faster. ConfigMap-only — no image rebuild.

## Verification (2026-07-22, live `self-hosted` gateway)

- Golden eval **12/12** with thinking off, **cache-defeated** (real 24s generation, not a cache hit).
- Real 14-task plan prompt: valid output — deadlines respected, ≤5 promoted to today, nothing past horizon; 956 tokens vs 8235 with thinking.
- Applies to both passes via the shared provider; classifier accuracy unchanged.