### PR TITLE
docs(nut-exporter): correct the battery-age claim in the runtime-alert rationale

### DIFF
--- a/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
@@ -44,12 +44,18 @@ spec:
         # On battery AND (runtime < 5m OR charge < 50%). by(ups) aggregation also fixes
         # the old UpsLowRuntime, whose `status`-labelled `and` operand never matched.
         #
-        # Threshold was 900s (15m) and had to come down: the main UPS reports only
-        # ~780s runtime on a FULL battery (2008-vintage cells at ~25% load), so a
-        # 15m test was true the instant it went on battery and this alert was an
-        # exact duplicate of UPSOnBattery rather than an escalation of it. 300s is
-        # below any plausible full-charge runtime for either UPS, so it once again
-        # means what it says: the battery is nearly gone.
+        # Threshold was 900s (15m) and had to come down: the main UPS delivers only
+        # ~780s on a FULL battery at ~25% load, so a 15m test was true the instant
+        # it went on battery and this alert was an exact duplicate of UPSOnBattery
+        # rather than an escalation of it. 300s is below any plausible full-charge
+        # runtime for either UPS, so it once again means what it says.
+        #
+        # That 780s is a measured figure, not an estimate — a runtime calibration
+        # discharged the pack 100%->25% in ~10-11min at 27% load. It is roughly 40%
+        # of what this frame should deliver, and the leading theory is a half-seated
+        # battery tray rather than worn cells (the pack is ~17 months old). If that
+        # is found and fixed, runtime roughly doubles and this threshold should be
+        # revisited — 300s would then be too twitchy to be a useful escalation.
         - alert: UPSBatteryRuntimeLow
           annotations:
             description: >-


### PR DESCRIPTION
Follow-up to #3768, which stated the main UPS had "2008-vintage cells". **That is wrong** — 2008 is the *chassis* build date. The SU5000 was bought refurbished in Feb 2025 and shipped with new batteries, so the pack is **~17 months old**.

The misreading came from the UPS itself: `upsBasicBatteryLastReplaceDate` reads `"02/09/08"` — byte-identical to `upsBasicBatteryManufactureDate` — because the replacement date was never reset after the swap. Worth recording, because anything reading `battery.date` off this UPS will reach the same wrong conclusion.

**The threshold and the 780s figure are unchanged and still correct.** 780s is a *measured* result, not an estimate: a runtime calibration discharged the pack 100%→25% in ~10–11 min at 27% load, and stamped the estimator as trustworthy.

What changes is the **diagnosis**: ~40% of spec on a 17-month-old pack points at a half-seated battery tray (a disconnected string neatly halves capacity, and matches an earlier short-runtime incident) rather than worn cells — so the fix is a physical reseat, not a replacement.

Noted inline that a successful reseat roughly doubles runtime, at which point `300s` becomes too twitchy to be a useful escalation and should be revisited.

Comment-only; no rule or expression changes.
