### PR TITLE
docs: align KB with the current estate + humanizer pass

### DIFF
--- a/bootstrap/helmfile.d/01-apps.yaml
+++ b/bootstrap/helmfile.d/01-apps.yaml
@@ -34,7 +34,7 @@ releases:
           - --namespace={{ .Release.Namespace }}
           - --server-side
           - --field-manager=kustomize-controller
-          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/app/networking.yaml
+          - --filename=../../kubernetes/apps/{{ .Release.Namespace }}/{{ .Release.Name }}/app/networks.yaml
         events:
           - postsync
         showlogs: true

--- a/docs/docs/apps/autopulse.md
+++ b/docs/docs/apps/autopulse.md
@@ -7,8 +7,8 @@ web UI on the internal route, no triggers/targets wired yet.
 ## Purpose
 
 - Bring autopulse online on image `v2.0.0` in a deliberately minimal config:
-  - Pod becomes `Ready`; web UI reachable at `autopulse.${SECRET_DOMAIN}` and
-      `autopulse.${SECRET_INTERNAL_DOMAIN}` (both served via `envoy-internal`, internal-only).
+  - Pod becomes `Ready`; web UI reachable at `autopulse.${SECRET_DOMAIN}`,
+      served via `envoy-internal` (internal-only).
   - SQLite database persisted on a VolSync-backed PVC (NFS + remote backups).
   - Triggers/targets intentionally omitted — integrations are added later.
 - Not in scope (for the minimal bring-up): wiring source/target integrations,

--- a/docs/docs/apps/autopulse.md
+++ b/docs/docs/apps/autopulse.md
@@ -10,7 +10,7 @@ web UI on the internal route, no triggers/targets wired yet.
   - Pod becomes `Ready`; web UI reachable at `autopulse.${SECRET_DOMAIN}`,
       served via `envoy-internal` (internal-only).
   - SQLite database persisted on a VolSync-backed PVC (NFS + remote backups).
-  - Triggers/targets intentionally omitted — integrations are added later.
+  - Triggers/targets intentionally omitted. Integrations are added later.
 - Not in scope (for the minimal bring-up): wiring source/target integrations,
   or exposing the app externally.
 
@@ -18,16 +18,16 @@ web UI on the internal route, no triggers/targets wired yet.
 
 - **SQLite, not Postgres.** v2.0.0 changed the default `database_url` from
   PostgreSQL to a SQLite file (`sqlite://data/autopulse.db`, resolving to
-  `/app/data/autopulse.db`). The minimal config embraces this — no database
+  `/app/data/autopulse.db`). The minimal config embraces this: no database
   dependency, just a single file on a small PVC.
 - **Single-file SQLite DB backed up with VolSync.** The whole "database" is one
   file living on a PVC, so the standard VolSync component backs it up exactly
-  like any other app's data dir — no DB-specific dump/restore tooling needed:
+  like any other app's data dir, with no DB-specific dump/restore tooling needed:
   - The `volsync` component (added in `ks.yaml` `spec.components`, never also in
     `app/kustomization.yaml`) auto-creates the PVC `autopulse` (`ceph-block`),
     the NFS + remote `ReplicationSource`s, and the restore `ReplicationDestination`.
   - `VOLSYNC_CAPACITY: 1Gi` because a SQLite DB is tiny (the component default
-    is 5Gi — override it down).
+    is 5Gi, overridden down here).
   - Backup credentials reuse the shared VolSync 1Password items; **no new backup
     secrets** are introduced.
 - **Writable PVC at `/app/data`, root FS stays read-only.** The HelmRelease keeps
@@ -71,27 +71,27 @@ web UI on the internal route, no triggers/targets wired yet.
   and no writable mount at `/app/data`, v2 cannot create the SQLite file. The
   writable `data` PVC (above) is mandatory, not optional.
 - **`existingClaim` must match the VolSync PVC name.** The HelmRelease uses
-  `existingClaim: "{{ .Release.Name }}"`, which resolves to `autopulse` — the
+  `existingClaim: "{{ .Release.Name }}"`, which resolves to `autopulse`, the
   exact name the VolSync component derives from `APP`. PVC name, claim, and
   `ReplicationSource` `sourcePVC` must all agree.
 - **Default credentials must be changed.** v2 ships `admin` / `password`
   defaults. Create the `autopulse` 1Password login item (username `admin` + a
   generated 32-char password) via `op item create` in the operator's signed-in
-  shell — never the UI, never committed. The field labels `username`/`password`
+  shell, never the UI, never committed. The field labels `username`/`password`
   must match the `{{ .username }}` / `{{ .password }}` template vars.
 - **Empty `triggers`/`targets` may be rejected.** The minimal config omits both
   maps (serde should default them to empty). If startup logs complain about
   missing keys, add explicit `triggers: {}` / `targets: {}` to the inline config.
-- **First-deploy restore finds no snapshot.** Standard VolSync bootstrap — the
-  `ReplicationDestination` provisions an empty PVC and the app initializes a
-  fresh DB. No manual action.
+- **First-deploy restore finds no snapshot.** This is standard VolSync
+  bootstrap: the `ReplicationDestination` provisions an empty PVC and the app
+  initializes a fresh DB. No manual action.
 
 ## Operational notes
 
 - **Enable/disable** lives in the namespace `kustomization.yaml`: the app entry
   `- ./autopulse/ks.yaml` is commented out when dormant. Keep it in alphabetical
   position when re-enabling.
-- **Health endpoint** `/health` (port `2875`) is unauthenticated in v2 — handy
+- **Health endpoint** `/health` (port `2875`) is unauthenticated in v2, handy
   for a quick liveness check from inside the pod without credentials.
 - **Verify a healthy deploy** by checking, in order:
   - `Kustomization autopulse` reconciles `Ready=True`.

--- a/docs/docs/apps/isponsorblocktv.md
+++ b/docs/docs/apps/isponsorblocktv.md
@@ -7,8 +7,8 @@ SponsorBlock community database. No web UI, no API.
 ## Purpose
 
 - Skip sponsor (and other community-flagged) segments on YouTube TV-app playback across
-  the household's TVs and streaming boxes — fully automatic, no user interaction during
-  playback.
+  the household's TVs and streaming boxes. It runs fully automatically, with no user
+  interaction during playback.
 - Runs as a long-lived daemon: it watches paired devices over the LAN and issues skip
   commands; there is nothing to browse to.
 
@@ -18,12 +18,12 @@ SponsorBlock community database. No web UI, no API.
   `ocirepository.yaml`, `helmrelease.yaml`, `kustomization.yaml`); single Deployment,
   1 replica.
 - Image is the upstream `ghcr.io/dmunozv04/isponsorblocktv`, pinned by tag plus digest.
-- No `Service` and no `HTTPRoute` — the daemon exposes no ports and has no web UI, so
+- No `Service` and no `HTTPRoute`: the daemon exposes no ports and has no web UI, so
   there is nothing to route. It only needs ordinary pod networking to reach the TVs.
-- No `ExternalSecret` — there are no upstream credentials. The only config
+- No `ExternalSecret`: there are no upstream credentials. The only config
   (`config.json`, including device pairings) is produced by the app's own interactive
   pairing flow, so it is not stored in 1Password.
-- All probes (liveness / readiness / startup) disabled — no HTTP endpoint exists to
+- All probes (liveness / readiness / startup) disabled: no HTTP endpoint exists to
   health-check.
 - VolSync component enabled (config PVC mounted at `/app/data`). Re-pairing every device
   by hand is tedious, so the pairings are backed up and survive cluster rebuilds. This is
@@ -38,12 +38,12 @@ SponsorBlock community database. No web UI, no API.
 ## Deploy gotchas
 
 - The Flux Kustomization `dependsOn` `rook-ceph-cluster` (the VolSync config PVC lands on
-  `ceph-block`); `wait: false`. VolSync substitutes — `APP`, `VOLSYNC_CAPACITY: 1Gi`,
-  `VOLSYNC_CACHE_CAPACITY: 8Gi` — live in `ks.yaml`, and the `volsync` component goes in
+  `ceph-block`); `wait: false`. VolSync substitutes (`APP`, `VOLSYNC_CAPACITY: 1Gi`,
+  `VOLSYNC_CACHE_CAPACITY: 8Gi`) live in `ks.yaml`, and the `volsync` component goes in
   `ks.yaml` `spec.components` only (never also in `app/kustomization.yaml`).
-- The pod `CrashLoopBackOff`s until a valid `config.json` exists — expected on first
-  deploy, before any device is paired. It is not a failure; it clears once pairing is
-  done.
+- The pod `CrashLoopBackOff`s until a valid `config.json` exists. This is expected on
+  first deploy, before any device is paired. It is not a failure; it clears once pairing
+  is done.
 - The config PVC uses `existingClaim` (VolSync owns the claim), mounted at the app's data
   directory `/app/data`. The pairing TUI writes `config.json` there.
 - Register the app in the namespace `kustomization.yaml` in alphabetical order, same as
@@ -60,7 +60,7 @@ SponsorBlock community database. No web UI, no API.
 
   Each device shows a link code in its YouTube app; enter it in the TUI to pair. Repeat
   per device.
-- Confirm it is working by tailing logs — expect connected-device lines and
+- Confirm it is working by tailing logs. Expect connected-device lines and
   segment-skip activity:
 
   ```bash

--- a/docs/docs/apps/isponsorblocktv.md
+++ b/docs/docs/apps/isponsorblocktv.md
@@ -39,7 +39,7 @@ SponsorBlock community database. No web UI, no API.
 
 - The Flux Kustomization `dependsOn` `rook-ceph-cluster` (the VolSync config PVC lands on
   `ceph-block`); `wait: false`. VolSync substitutes — `APP`, `VOLSYNC_CAPACITY: 1Gi`,
-  `VOLSYNC_CACHE_CAPACITY: 1Gi` — live in `ks.yaml`, and the `volsync` component goes in
+  `VOLSYNC_CACHE_CAPACITY: 8Gi` — live in `ks.yaml`, and the `volsync` component goes in
   `ks.yaml` `spec.components` only (never also in `app/kustomization.yaml`).
 - The pod `CrashLoopBackOff`s until a valid `config.json` exists — expected on first
   deploy, before any device is paired. It is not a failure; it clears once pairing is

--- a/docs/docs/apps/litellm.md
+++ b/docs/docs/apps/litellm.md
@@ -22,7 +22,7 @@ See the [AI / LLM stack](../architecture/ai-llm-stack.md) page for how it fits t
 - Prometheus success/failure callbacks enabled for metrics.
 - Auth is the built-in master key + UI credentials (no external SSO for an internal-only service).
 - Routing is an internal-only HTTPRoute on the `envoy-internal` listener at
-  `litellm.${SECRET_INTERNAL_DOMAIN}`; the API (`/v1/*`) and admin UI (`/ui`) share one port.
+  `litellm.${SECRET_DOMAIN}`; the API (`/v1/*`) and admin UI (`/ui`) share one port.
 - Secrets come from an ExternalSecret pulling the `litellm` 1Password item (Talos vault).
 
 ## Deploy gotchas
@@ -51,7 +51,7 @@ See the [AI / LLM stack](../architecture/ai-llm-stack.md) page for how it fits t
 - API round-trip test:
 
   ```bash
-  curl -sS https://litellm.${SECRET_INTERNAL_DOMAIN}/v1/chat/completions \
+  curl -sS https://litellm.${SECRET_DOMAIN}/v1/chat/completions \
     -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
     -H "Content-Type: application/json" \
     -d '{"model":"<model-group>","messages":[{"role":"user","content":"ping"}]}'

--- a/docs/docs/apps/litellm.md
+++ b/docs/docs/apps/litellm.md
@@ -10,10 +10,10 @@ See the [AI / LLM stack](../architecture/ai-llm-stack.md) page for how it fits t
 ## Design decisions
 
 - Deployed with the bjw-s `app-template` chart via a per-app `OCIRepository`.
-- Single replica with the `Recreate` strategy — avoids rolling-update races against the Prisma
+- Single replica with the `Recreate` strategy: this avoids rolling-update races against the Prisma
   schema migrations that run at startup.
 - State lives in the shared CloudNativePG `postgres18` cluster (its own `litellm` database + role,
-  created idempotently by a `postgres-init` init container) — so the app is PVC-less and needs no
+  created idempotently by a `postgres-init` init container), so the app is PVC-less and needs no
   VolSync.
 - Response cache in the shared Dragonfly over `*.svc.cluster.local`, with a deliberately short TTL so
   usage tracking stays accurate.
@@ -28,15 +28,15 @@ See the [AI / LLM stack](../architecture/ai-llm-stack.md) page for how it fits t
 ## Deploy gotchas
 
 - **Prometheus scrape:** the `/metrics` endpoint needs `require_auth_for_metrics_endpoint: false`,
-  **and** the ServiceMonitor path must be `/metrics/` (trailing slash, with redirect-follow off) —
-  otherwise the scrape silently gets nothing.
+  **and** the ServiceMonitor path must be `/metrics/` (trailing slash, with redirect-follow off).
+  Otherwise the scrape silently gets nothing.
 - The liveness/readiness probe path is `/health/liveliness` (upstream's spelling). `/v1/health`
-  requires auth and runs heavy backend probes — too heavy for kubelet.
-- Never rotate `LITELLM_SALT_KEY` — rotating it makes UI-added provider keys undecipherable
+  requires auth and runs heavy backend probes, too heavy for kubelet.
+- Never rotate `LITELLM_SALT_KEY`: rotating it makes UI-added provider keys undecipherable
   (config-file keys are unaffected). Note this on the 1Password item.
 - Keep provider API keys out of git and out of the rendered ConfigMap by referencing them as
   `os.environ/<NAME>` in `config.yaml`.
-- The Grafana dashboard is fetched from grafana.com via URL in the `GrafanaDashboard` CR — Flux
+- The Grafana dashboard is fetched from grafana.com via URL in the `GrafanaDashboard` CR. Flux
   `postBuild` does not process remotely fetched JSON, so no `$${var}` escaping is needed. If you
   ever vendor the dashboard JSON into a ConfigMap instead, escape Grafana template variables as
   `$${var}` and use `"datasource": null` rather than a hard-coded UID.

--- a/docs/docs/apps/metabase.md
+++ b/docs/docs/apps/metabase.md
@@ -15,23 +15,23 @@ shared `postgres18` CloudNativePG cluster.
 - **CloudNativePG, not embedded H2.** Metabase's own docs warn against H2 in production (corruption
   risk, no concurrent access). Reusing the hardened, replicated, backed-up cluster costs one extra
   database; app data is captured by the existing CNPG backup pipeline (Barman + scheduled remote).
-- **bjw-s `app-template` chart**, like every other app in the namespace — one Deployment + Service +
+- **bjw-s `app-template` chart**, like every other app in the namespace: one Deployment + Service +
   route + `postgres-init` initContainer fits it cleanly. The dedicated `metabase` DB and role are
   bootstrapped idempotently by the `ghcr.io/home-operations/postgres-init` initContainer on first run.
 - **Internal-only ingress.** Inline `route:` on `envoy-internal` for
-  `metabase.${SECRET_DOMAIN}` — the `envoy-internal` attachment is what keeps it internal-only, not
+  `metabase.${SECRET_DOMAIN}`. The `envoy-internal` attachment is what keeps it internal-only, not
   the domain. Cloudflare-fronting can be added later by switching the `parentRef` to
   `envoy-external`.
 - **Native Prometheus exporter, not a JMX sidecar.** Metabase 0.49+ ships a built-in `/metrics`
   endpoint via `MB_PROMETHEUS_SERVER_PORT` (port 9191 here), scraped by a `PodMonitor`; a community
   Grafana dashboard is imported via a `GrafanaDashboard` CR.
-- **Deferred (YAGNI):** SMTP, SSO/LDAP/OIDC (paid edition only on OSS — first run creates a local
+- **Deferred (YAGNI):** SMTP, SSO/LDAP/OIDC (paid edition only on OSS; first run creates a local
   admin), `/plugins` PVC for third-party JDBC drivers, and pre-seeded source DBs/dashboards. All are
   configurable later through the UI without redeploying.
 
 ## Deploy gotchas
 
-- **JVM TLS rejects the CNPG server cert — use `sslmode=disable`.** Java's `X509Factory` rejects
+- **JVM TLS rejects the CNPG server cert: use `sslmode=disable`.** Java's `X509Factory` rejects
   CloudNativePG's empty-issuer-DN server certificate, so a JVM app cannot do `verify-full` TLS to the
   `postgres18` cluster. Point Metabase at the in-cluster service with TLS verification off (the pod →
   `*-rw.svc.cluster.local` network path is already trusted):
@@ -64,11 +64,11 @@ shared `postgres18` CloudNativePG cluster.
 
 - **Never lose or naively rotate `MB_ENCRYPTION_SECRET_KEY`.** It encrypts the source-DB credentials
   stored inside Metabase's app DB; losing it means Metabase can no longer decrypt saved connections.
-  The key's canonical home is 1Password — to rotate, run Metabase's `rotate-encryption-key` admin
+  The key's canonical home is 1Password. To rotate, run Metabase's `rotate-encryption-key` admin
   command first, then update the secret.
 - **Recovery is via CNPG, not the app.** Since all state is in the `metabase` database on
   `postgres18`, a corrupt or failed schema migration is recovered by point-in-time restore of that DB
-  from the CNPG backups — there is no app-side backup.
+  from the CNPG backups. There is no app-side backup.
 - **If `postgres18` is down at startup**, the `postgres-init` initContainer exits non-zero and the pod
   restarts with backoff; once Postgres returns, the next attempt succeeds with no manual intervention.
 - **First-run setup is manual.** Browse to the internal hostname, complete the wizard to create the

--- a/docs/docs/apps/metabase.md
+++ b/docs/docs/apps/metabase.md
@@ -18,9 +18,10 @@ shared `postgres18` CloudNativePG cluster.
 - **bjw-s `app-template` chart**, like every other app in the namespace — one Deployment + Service +
   route + `postgres-init` initContainer fits it cleanly. The dedicated `metabase` DB and role are
   bootstrapped idempotently by the `ghcr.io/home-operations/postgres-init` initContainer on first run.
-- **Internal-only ingress.** Inline `route:` on `envoy-internal` for both
-  `metabase.${SECRET_DOMAIN}` and `metabase.${SECRET_INTERNAL_DOMAIN}`. Cloudflare-fronting can be
-  added later by switching the `parentRef` and adding an external hostname.
+- **Internal-only ingress.** Inline `route:` on `envoy-internal` for
+  `metabase.${SECRET_DOMAIN}` — the `envoy-internal` attachment is what keeps it internal-only, not
+  the domain. Cloudflare-fronting can be added later by switching the `parentRef` to
+  `envoy-external`.
 - **Native Prometheus exporter, not a JMX sidecar.** Metabase 0.49+ ships a built-in `/metrics`
   endpoint via `MB_PROMETHEUS_SERVER_PORT` (port 9191 here), scraped by a `PodMonitor`; a community
   Grafana dashboard is imported via a `GrafanaDashboard` CR.

--- a/docs/docs/apps/netbox.md
+++ b/docs/docs/apps/netbox.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 [NetBox](https://github.com/netbox-community/netbox) provides DCIM (data centre infrastructure
-management) and IPAM (IP address management) — the source of truth for devices, racks, prefixes, and
+management) and IPAM (IP address management): the source of truth for devices, racks, prefixes, and
 IP allocations. It runs internal-only in the `default` namespace: a web frontend, an RQ background
 worker (webhooks, scripts, reports), and a daily housekeeping CronJob.
 
@@ -15,16 +15,16 @@ official **`netbox-chart`** (`oci://ghcr.io/netbox-community/netbox-chart/netbox
 and its `existingSecret` contract are already modelled by the upstream chart.
 
 - **Namespace** `default`, modelled on the in-repo `paperless` app (its closest twin).
-- **PostgreSQL** — shared CNPG cluster (`postgres18-rw.database.svc.cluster.local`, `sslmode=require`);
+- **PostgreSQL**: shared CNPG cluster (`postgres18-rw.database.svc.cluster.local`, `sslmode=require`);
   bundled Postgres disabled. An `init-db` initContainer (using the `postgres-init` image) creates
   the `netbox` role + database using the CNPG superuser before first boot.
-- **Redis** — external **Dragonfly** (`dragonfly.database.svc.cluster.local:6379`); the chart's
+- **Redis**: external **Dragonfly** (`dragonfly.database.svc.cluster.local:6379`); the chart's
   bundled cache (`valkey.enabled`) is disabled. Separate logical DB indices for the tasks queue
   (`0`) vs the cache (`1`).
-- **Media** — a local `ceph-block` PVC consumed via `persistence.existingClaim` and backed up by the
+- **Media**: a local `ceph-block` PVC consumed via `persistence.existingClaim` and backed up by the
   VolSync component (`VOLSYNC_CAPACITY`). NetBox uses no object storage; the cluster's S3 tier is
   Garage (`storage` namespace), not Ceph RGW (which was removed).
-- **Auth / exposure** — superuser-only first pass (pocket-id OIDC is a fast-follow); internal-only
+- **Auth / exposure**: superuser-only first pass (pocket-id OIDC is a fast-follow); internal-only
   HTTPRoute on `envoy-internal`, never publicly exposed.
 - Health monitored automatically by the gatus-sidecar (it auto-discovers the HTTPRoute);
   `reloader.stakater.com/auto` rolls pods on secret/config change; a ServiceMonitor exposes metrics
@@ -37,11 +37,11 @@ and its `existingSecret` contract are already modelled by the upstream chart.
   `tasksDatabase` / `cachingDatabase` `existingSecretName`) point at the single `netbox-secret`, so
   that Secret must contain every key the chart projects, spelled exactly as the chart expects:
   - `secret_key`, `email_password` (the chart's projected `secrets` volume **requires the key to
-    exist** even when email is unused — set it to an empty string).
+    exist** even when email is unused, so set it to an empty string).
   - `password` and `api_token` (superuser).
   - `db_password` (the value of `externalDatabase.existingSecretKey`).
   - `tasks_password` and `cache_password` (the Dragonfly tasks/caching DB keys).
-- These mismatches do **not** show up in a `flate` (local) or Konflate (in-cluster PR render) —
+- These mismatches do **not** show up in a `flate` (local) or Konflate (in-cluster PR render):
     the manifest is valid. They only fail at runtime as pod `FailedMount` (`references
     non-existent secret key`) or `CreateContainerConfigError` (`couldn't find key …`). Before
     wiring the ExternalSecret, render the chart and grep the output for every `secretKeyRef`
@@ -77,12 +77,12 @@ and its `existingSecret` contract are already modelled by the upstream chart.
   ```
 
 - **Hostname** is `netbox.${SECRET_DOMAIN}` (internal DNS via external-dns). The HTTPRoute's only
-  hostname sits on the `envoy-internal` listener, which is what keeps it internal-only — it does
+  hostname sits on the `envoy-internal` listener, which is what keeps it internal-only. It does
   not expose NetBox publicly.
-- **First-boot check** — confirm the `init-db` initContainer reports the `netbox` role/database
+- **First-boot check**: confirm the `init-db` initContainer reports the `netbox` role/database
   created (or already exists), then log in as the superuser (`admin`).
-- **Backups** — the `media` PVC is snapshotted by VolSync. The `netbox` database lives on the shared
+- **Backups**: the `media` PVC is snapshotted by VolSync. The `netbox` database lives on the shared
   CNPG cluster and is backed up by CNPG's own path, not VolSync.
-- **Teardown** — `prune: true` removes NetBox's Kubernetes resources on revert, but the `netbox`
+- **Teardown**: `prune: true` removes NetBox's Kubernetes resources on revert, but the `netbox`
   database on the shared CNPG cluster and the 1Password item persist and must be dropped manually
   for a clean teardown.

--- a/docs/docs/apps/netbox.md
+++ b/docs/docs/apps/netbox.md
@@ -59,9 +59,8 @@ and its `existingSecret` contract are already modelled by the upstream chart.
   `GRANIAN_WORKERS=2` and give the web pod request 512Mi / limit 1.5Gi.
 - **Django host guarding rejects unlisted Host headers, including kubelet probes.** `ALLOWED_HOSTS`
   must include both the route host(s) and the in-cluster service name (the chart's
-  `allowedHostsIncludesPodIP` covers the pod IP), and CSRF trusted origins must list both
-  `https://netbox.${SECRET_DOMAIN}` and `https://netbox.${SECRET_INTERNAL_DOMAIN}`. Miss this and
-  probes (and the UI) get a 400.
+  `allowedHostsIncludesPodIP` covers the pod IP), and CSRF trusted origins must list
+  `https://netbox.${SECRET_DOMAIN}`. Miss this and probes (and the UI) get a 400.
 - **`SECRET_KEY` must be 50+ characters.** Generate it long enough (e.g. `openssl rand -base64 60`)
   or NetBox refuses to start.
 - The 1Password source item lives in the `Talos` vault and is created via the `op` CLI (never the
@@ -77,9 +76,9 @@ and its `existingSecret` contract are already modelled by the upstream chart.
   flux reconcile kustomization netbox -n default
   ```
 
-- **Hostname** is `netbox.${SECRET_INTERNAL_DOMAIN}` (internal DNS via external-dns). Listing the
-  `${SECRET_DOMAIN}` host on the `envoy-internal` listener keeps it internal-only — it does not
-  expose NetBox publicly.
+- **Hostname** is `netbox.${SECRET_DOMAIN}` (internal DNS via external-dns). The HTTPRoute's only
+  hostname sits on the `envoy-internal` listener, which is what keeps it internal-only — it does
+  not expose NetBox publicly.
 - **First-boot check** — confirm the `init-db` initContainer reports the `netbox` role/database
   created (or already exists), then log in as the superuser (`admin`).
 - **Backups** — the `media` PVC is snapshotted by VolSync. The `netbox` database lives on the shared

--- a/docs/docs/apps/oxidized.md
+++ b/docs/docs/apps/oxidized.md
@@ -13,11 +13,12 @@ GUI/SSH edits) that bypass the IaC.
   versioned, diffable, and recoverable.
 - Detect drift between IaC-declared intent and what's actually running on the hardware.
 - Notify on change and on failure, and surface per-device freshness as metrics.
-- Device roles backed up (described generically — this is a public repo):
-  - the perimeter firewall/router
-  - the core switch
-  - the access/PoE switches
-  - the wireless AP controller
+- Device roles backed up (described generically — this is a public repo): the perimeter
+  firewall/router, and the PoE and non-PoE access-switch pair — exactly three devices, wired
+  individually in the ExternalSecret's `router.db` template.
+- Deliberately not included: a core switch and a wireless AP controller, because Oxidized ships no
+  built-in model for either — adding them would mean authoring and maintaining custom device
+  models, which isn't worth it for two devices.
 - Out of scope: SNMP-only gear (PDUs) with no config dump that fits Oxidized, and cloud services
   already managed by external IaC.
 
@@ -79,7 +80,7 @@ GUI/SSH edits) that bypass the IaC.
   (check `SecretSynced` vs `SecretSyncError`).
 - **`rest: 0.0.0.0:8888` is required.** Without the REST listener the HTTPRoute, the exporter
   (`-U http://localhost:8888`), and the readiness probe (`/nodes.json`) all have nothing to talk to.
-- **Pin image digests and confirm the exporter tag exists.** Pin all four images
+- **Pin image digests and confirm the exporter tag exists.** Pin all three images
   (Oxidized, exporter, and the init base image) to `@sha256:` digests. The exporter's "latest"
   release tag on the registry may lag its GitHub release — pull the digest for a tag that actually
   has a published image, or Renovate can't track it.

--- a/docs/docs/apps/oxidized.md
+++ b/docs/docs/apps/oxidized.md
@@ -13,11 +13,11 @@ GUI/SSH edits) that bypass the IaC.
   versioned, diffable, and recoverable.
 - Detect drift between IaC-declared intent and what's actually running on the hardware.
 - Notify on change and on failure, and surface per-device freshness as metrics.
-- Device roles backed up (described generically — this is a public repo): the perimeter
-  firewall/router, and the PoE and non-PoE access-switch pair — exactly three devices, wired
-  individually in the ExternalSecret's `router.db` template.
+- Device roles backed up (kept generic, since this is a public repo): the perimeter
+  firewall/router, and the PoE and non-PoE access-switch pair (exactly three devices, wired
+  individually in the ExternalSecret's `router.db` template).
 - Deliberately not included: a core switch and a wireless AP controller, because Oxidized ships no
-  built-in model for either — adding them would mean authoring and maintaining custom device
+  built-in model for either. Adding them would mean authoring and maintaining custom device
   models, which isn't worth it for two devices.
 - Out of scope: SNMP-only gear (PDUs) with no config dump that fits Oxidized, and cloud services
   already managed by external IaC.
@@ -30,7 +30,7 @@ GUI/SSH edits) that bypass the IaC.
   key onto a memory-backed `emptyDir` before the app starts.
 - **The device inventory/lookup table (`router.db`) and device credentials are rendered INSIDE the
   ExternalSecret `target.template.data` block using Golang template syntax (`{{ .VAR }}`), then
-  mounted directly from the rendered Secret — NEVER stored in a ConfigMap in git.** This is the
+  mounted directly from the rendered Secret, NEVER stored in a ConfigMap in git.** This is the
   repository-wide rule for any device address or credential table. In this app it is realised as:
   - The ExternalSecret renders `router.db` inline in its `target.template.data` block, substituting
     per-device hostnames, usernames, and passwords from the 1Password item using `{{ .VAR }}`
@@ -49,7 +49,7 @@ GUI/SSH edits) that bypass the IaC.
 - **Push target is a private GitHub repo over SSH.** An `exec` hook (not the `githubrepo` hook)
   fires on `post_store` and runs system git over SSH using the ed25519 deploy key staged by the init
   container. The `githubrepo` hook (rugged/libgit2) was abandoned because it fails against current
-  GitHub with `Rugged::SshError: remote rejected authentication`. The repo stays private — even after
+  GitHub with `Rugged::SshError: remote rejected authentication`. The repo stays private: even after
   secret stripping, configs may carry topology/address detail.
 - **Notifications are split.** Drift and poll-failure events fire a direct `exec` hook to the push
   notification provider; longer-horizon staleness is alerted through the existing
@@ -72,8 +72,8 @@ GUI/SSH edits) that bypass the IaC.
   must agree exactly or every device parses wrong.
 - **Per-device, not shared, credentials.** Some device roles that look like a matched pair (e.g. two
   switches) have *separate* credentials in 1Password. Don't collapse them into one
-  username/password — split into per-device secret keys, and make sure the ExternalSecret template
-  and `router.db` rendering all use the same per-device key names.
+  username/password. Split into per-device secret keys instead, and make sure the ExternalSecret
+  template and `router.db` rendering all use the same per-device key names.
 - **Init-container and Secret mount.** The `ssh-setup` init writes the deploy key to a memory
   `emptyDir`; `router.db` is mounted directly from the rendered Secret. A failed init is usually a
   malformed deploy key; if `router.db` is missing or empty, the ExternalSecret hasn't synced yet
@@ -82,7 +82,7 @@ GUI/SSH edits) that bypass the IaC.
   (`-U http://localhost:8888`), and the readiness probe (`/nodes.json`) all have nothing to talk to.
 - **Pin image digests and confirm the exporter tag exists.** Pin all three images
   (Oxidized, exporter, and the init base image) to `@sha256:` digests. The exporter's "latest"
-  release tag on the registry may lag its GitHub release — pull the digest for a tag that actually
+  release tag on the registry may lag its GitHub release: pull the digest for a tag that actually
   has a published image, or Renovate can't track it.
 - **Confirm the AP-controller model string before first poll.** The correct Oxidized model name
   depends on the controller's product variant; an unverified guess just makes that one device's polls
@@ -93,7 +93,7 @@ GUI/SSH edits) that bypass the IaC.
   blocked path is almost always a missing firewall rule from the cluster pod CIDR to the device VLAN;
   if internal DNS doesn't resolve for the pod, fall back to IP addresses in `router.db`.
 - **Notification token vs user key.** The push provider needs a per-application token (created in the
-  provider's UI, not via API) *and* a user key — swapping the two yields silent non-delivery while Git
+  provider's UI, not via API) *and* a user key; swapping the two yields silent non-delivery while Git
   commits still succeed.
 
 ## Operational notes
@@ -113,13 +113,13 @@ GUI/SSH edits) that bypass the IaC.
   - A single unreachable device fires the failure hook and, after 48h, the stale alert; it recovers on
     its own when the device returns.
   - A failed GitHub push just accumulates local commits that flush on the next successful push.
-  - A notification-provider outage loses only the notification — drift commits are still stored in Git.
+  - A notification-provider outage loses only the notification; drift commits are still stored in Git.
   - 1Password Connect being down leaves the already-mounted Secret working for hours.
 - **State recovery.** If the PVC is corrupted, delete it and either restore via VolSync or re-clone
-  from the GitHub backup repo — the remote history is durable and a redeploy picks up where it left
+  from the GitHub backup repo. The remote history is durable, and a redeploy picks up where it left
   off. Uninstall is `just kube delete-ks observability oxidized` (+ optional PVC delete); the 1Password
   item and GitHub repo persist for clean redeploy.
 - **Restart after ConfigMap-only changes.** Editing the Oxidized config in the ConfigMap does not roll
-  the pod automatically — re-apply the Kustomization or restart the deployment so the new content is
+  the pod automatically: re-apply the Kustomization or restart the deployment so the new content is
   picked up. Changes to `router.db` require updating the ExternalSecret template and waiting for the
   Secret to re-sync (or force-syncing via `just kube sync-es`).

--- a/docs/docs/apps/prowler.md
+++ b/docs/docs/apps/prowler.md
@@ -7,7 +7,7 @@ this cluster it runs continuous CIS / compliance scanning against the local
 Kubernetes cluster, with a queryable findings dashboard.
 
 - The upstream project is a Django (REST API) + Next.js (UI) + Celery stack and
-  ships only a `docker-compose.yml` — no Helm chart.
+  ships only a `docker-compose.yml`, no Helm chart.
 - This deployment translates the compose stack into bjw-s `app-template`
   HelmReleases, reusing the cluster's existing building blocks:
   - CloudNativePG (`postgres18`) for the Django database
@@ -21,11 +21,11 @@ Kubernetes cluster, with a queryable findings dashboard.
 
 - **Three HelmReleases under `security/prowler/`** plus one for DozerDB under
   `database/dozerdb/`:
-  - `prowler-api` — one Deployment with **two containers**, `api` (gunicorn) and
+  - `prowler-api`: one Deployment with **two containers**, `api` (gunicorn) and
     `worker` (celery), sharing an `emptyDir` at `/tmp/prowler_api_output`, plus an
     `init-db` initContainer that bootstraps the database and role.
-  - `prowler-ui` — the Next.js frontend (NextAuth lives here).
-  - `prowler-beat` — the celery beat scheduler.
+  - `prowler-ui`: the Next.js frontend (NextAuth lives here).
+  - `prowler-beat`: the celery beat scheduler.
 - **Co-locating API and worker in one Pod.** The worker writes scan artifacts that
   the API serves. The cluster has no RWX StorageClass (only RWO `ceph-block`,
   `miroir-local`, and `ceph-bucket` S3), so the two cannot share a PVC across
@@ -60,7 +60,7 @@ Kubernetes cluster, with a queryable findings dashboard.
     (celery, scans, scan-reports, deletion, backfill, overview, integrations, compliance,
     attack-paths-scans) and `--without-mingle --without-gossip`. Celery 5.6's mingle/gossip
     startup steps kill the worker instantly against Dragonfly's pub/sub emulation, and the
-    entrypoint's own `worker` mode can't pass those flags through — direct invocation is the
+    entrypoint's own `worker` mode can't pass those flags through, so direct invocation is the
     only way to disable them.
   The `command` override is required in the beat and worker cases. Without it, an appended
   `args` value is tacked onto the image's hardcoded `["../docker-entrypoint.sh", "prod"]`,
@@ -76,7 +76,7 @@ Kubernetes cluster, with a queryable findings dashboard.
   Pod by an address that is not in `DJANGO_ALLOWED_HOSTS`, and Django returns
   `400 Bad Request` (`DisallowedHost`), so the probe fails and the Pod never goes
   ready. `DJANGO_ALLOWED_HOSTS` is `prowler-api,prowler.${SECRET_DOMAIN}` (the
-  service name plus the one route hostname) — it does not need to widen for the
+  service name plus the one route hostname). It does not need to widen for the
   probe, because the liveness/readiness probes override the request's `Host` header
   to `prowler-api` instead. Expand the allowed-hosts list if Django still rejects a
   `Host` header (e.g. when traffic arrives under a different service DNS).
@@ -90,7 +90,7 @@ Kubernetes cluster, with a queryable findings dashboard.
   HelmRelease was renamed to `prowler-api` (rather than relying on a `nameOverride`
   that not all chart versions honour) to ensure the Service name matches.
 - **celery beat is a singleton.** Run exactly one `prowler-beat` replica with a
-  `Recreate` strategy — two beat instances cause duplicate task scheduling.
+  `Recreate` strategy: two beat instances cause duplicate task scheduling.
 
 ## Operational notes
 
@@ -99,7 +99,7 @@ Kubernetes cluster, with a queryable findings dashboard.
   immediately after the UI comes up; the first registered user becomes tenant owner.
 - **DozerDB memory ceiling** is conservative for a homelab (1G heap). Watch for Pod
   restarts on the first large scan and bump the heap/limit if needed.
-- **The `view` ClusterRole is broad** — it grants read on Secrets cluster-wide.
+- **The `view` ClusterRole is broad.** It grants read on Secrets cluster-wide.
   Acceptable for v1; swap to a narrower role if that read surface is unwanted.
 - **Adding the Kubernetes provider.** In the UI choose the in-cluster ServiceAccount
   option. If only kubeconfig upload is offered, mint a token for the `prowler`

--- a/docs/docs/apps/prowler.md
+++ b/docs/docs/apps/prowler.md
@@ -35,8 +35,8 @@ Kubernetes cluster, with a queryable findings dashboard.
 - **Database bootstrap** uses the `postgres-init` initContainer pattern to create
   the `prowlerdb` database and `prowler` role on the existing CNPG cluster. Prowler's
   `POSTGRES_ADMIN_*` (used for partition management) is pointed at the same app role.
-- **Path-routed HTTPRoute** on `envoy-internal` only, at `prowler.${SECRET_DOMAIN}`
-  and `prowler.${SECRET_INTERNAL_DOMAIN}`. Only `/api/v1` routes to the API backend;
+- **Path-routed HTTPRoute** on `envoy-internal` only, at `prowler.${SECRET_DOMAIN}`.
+  Only `/api/v1` routes to the API backend;
   everything else (including NextAuth's `/api/auth/*` and `/api/health`) goes to the
   UI. Gateway API longest-prefix matching means `/api/v1` wins over `/`.
 - **RBAC** is a ServiceAccount (`prowler`) bound to the built-in read-only `view`
@@ -54,10 +54,16 @@ Kubernetes cluster, with a queryable findings dashboard.
   depending on how the container is launched:
   - no overrides → the default entrypoint (`../docker-entrypoint.sh prod`) runs
     `migrate` + `pgpartition` + gunicorn
-  - `command: ["../docker-entrypoint.sh"], args: ["worker"]` → celery worker across all queues
   - `command: ["../docker-entrypoint.sh"], args: ["beat"]` → celery beat
-  The `command` override is required. Without it, `args: ["worker"]` is appended to
-  the image's hardcoded `["../docker-entrypoint.sh", "prod"]`, yielding `prod worker`,
+  - the worker container skips the entrypoint entirely: `command: ["/bin/sh", "-c"]` invoking
+    `python -m celery -A config.celery worker` directly with an explicit queue list
+    (celery, scans, scan-reports, deletion, backfill, overview, integrations, compliance,
+    attack-paths-scans) and `--without-mingle --without-gossip`. Celery 5.6's mingle/gossip
+    startup steps kill the worker instantly against Dragonfly's pub/sub emulation, and the
+    entrypoint's own `worker` mode can't pass those flags through — direct invocation is the
+    only way to disable them.
+  The `command` override is required in the beat and worker cases. Without it, an appended
+  `args` value is tacked onto the image's hardcoded `["../docker-entrypoint.sh", "prod"]`,
   which still runs gunicorn and causes a port 8080 collision with the API container.
 - **`NEO4J_AUTH` cannot contain a `/`.** The value is `neo4j/<password>` and DozerDB
   parses it by splitting on the first `/`, so a generated password containing `/`
@@ -69,10 +75,11 @@ Kubernetes cluster, with a queryable findings dashboard.
 - **Django `ALLOWED_HOSTS` rejects kubelet probe requests.** Kubelet probes hit the
   Pod by an address that is not in `DJANGO_ALLOWED_HOSTS`, and Django returns
   `400 Bad Request` (`DisallowedHost`), so the probe fails and the Pod never goes
-  ready. The allowed-hosts list must include every host the app is reached by,
-  including the probe host — set `DJANGO_ALLOWED_HOSTS` to cover the service name,
-  both external domains, and the probe address. Expand the list if Django still
-  rejects a `Host` header (e.g. when traffic arrives under the service DNS).
+  ready. `DJANGO_ALLOWED_HOSTS` is `prowler-api,prowler.${SECRET_DOMAIN}` (the
+  service name plus the one route hostname) — it does not need to widen for the
+  probe, because the liveness/readiness probes override the request's `Host` header
+  to `prowler-api` instead. Expand the allowed-hosts list if Django still rejects a
+  `Host` header (e.g. when traffic arrives under a different service DNS).
 - **gunicorn auto-worker count blows memory.** Left to auto-detect, gunicorn spawns a
   worker per CPU core, which on a multi-core node far exceeds the container memory
   limit and OOMKills the API. Pin the worker count explicitly to a small value so

--- a/docs/docs/apps/reclaimerr.md
+++ b/docs/docs/apps/reclaimerr.md
@@ -22,16 +22,15 @@ bjw-s `app-template` deployment mirroring sibling apps (maintainerr, pulsarr).
   than 1Password management — at the cost that the keys live only in the PVC, so the PVC is the
   source of truth for sessions and encrypted state.
 - **Internal-only ingress.** Inline `route:` on the `envoy-internal` listener (namespace
-  `network`) for both `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}` hostnames. No
-  Cloudflare/external exposure — consistent with maintainerr.
+  `network`) for the single `${SECRET_DOMAIN}` hostname — the `envoy-internal` attachment is
+  what keeps it internal-only. No Cloudflare/external exposure — consistent with maintainerr.
 - **`COOKIE_SECURE: "true"`** because Envoy terminates TLS in front of it, and
-  `CORS_ORIGINS` includes both the external-domain and internal-domain hostnames
-  (`${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}`) so the SPA's API calls are accepted
-  regardless of which hostname the user browses to.
+  `CORS_ORIGINS` is the single origin `https://reclaimerr.${SECRET_DOMAIN}` so the SPA's API
+  calls are accepted.
 - **Components:** `homepage` (dashboard tile under the
   `Media` group, `mdi-broom` icon) and `volsync` (PVC backup). (Gatus monitoring is automatic via
   the gatus-sidecar chart's HTTPRoute auto-discovery — no `gatus/guarded` component.) `VOLSYNC_CAPACITY: 2Gi` and
-  `VOLSYNC_CACHE_CAPACITY: 1Gi` are the required substitutes for the volsync component
+  `VOLSYNC_CACHE_CAPACITY: 8Gi` are the required substitutes for the volsync component
   (overriding the 5Gi/10Gi defaults).
 - **Deferred (out of scope):** external ingress, pre-seeding `JWT_SECRET`/`ENCRYPTION_KEY` via
   1Password, and a `TMDB_API_KEY` override (the bundled upstream key is fine).

--- a/docs/docs/apps/reclaimerr.md
+++ b/docs/docs/apps/reclaimerr.md
@@ -19,17 +19,17 @@ bjw-s `app-template` deployment mirroring sibling apps (maintainerr, pulsarr).
   namespace pattern.
 - **No ExternalSecret.** Reclaimerr auto-generates `JWT_SECRET` and `ENCRYPTION_KEY` on first
   launch and persists them into `/app/data` (the upstream-recommended path). This is simpler
-  than 1Password management — at the cost that the keys live only in the PVC, so the PVC is the
+  than 1Password management; the cost is that the keys live only in the PVC, so the PVC is the
   source of truth for sessions and encrypted state.
 - **Internal-only ingress.** Inline `route:` on the `envoy-internal` listener (namespace
-  `network`) for the single `${SECRET_DOMAIN}` hostname — the `envoy-internal` attachment is
-  what keeps it internal-only. No Cloudflare/external exposure — consistent with maintainerr.
+  `network`) for the single `${SECRET_DOMAIN}` hostname: the `envoy-internal` attachment is
+  what keeps it internal-only. No Cloudflare/external exposure, consistent with maintainerr.
 - **`COOKIE_SECURE: "true"`** because Envoy terminates TLS in front of it, and
   `CORS_ORIGINS` is the single origin `https://reclaimerr.${SECRET_DOMAIN}` so the SPA's API
   calls are accepted.
 - **Components:** `homepage` (dashboard tile under the
   `Media` group, `mdi-broom` icon) and `volsync` (PVC backup). (Gatus monitoring is automatic via
-  the gatus-sidecar chart's HTTPRoute auto-discovery — no `gatus/guarded` component.) `VOLSYNC_CAPACITY: 2Gi` and
+  the gatus-sidecar chart's HTTPRoute auto-discovery, no `gatus/guarded` component.) `VOLSYNC_CAPACITY: 2Gi` and
   `VOLSYNC_CACHE_CAPACITY: 8Gi` are the required substitutes for the volsync component
   (overriding the 5Gi/10Gi defaults).
 - **Deferred (out of scope):** external ingress, pre-seeding `JWT_SECRET`/`ENCRYPTION_KEY` via
@@ -62,7 +62,7 @@ bjw-s `app-template` deployment mirroring sibling apps (maintainerr, pulsarr).
 
 - **The PVC is the only state.** Losing `/app/data` loses the auto-generated `JWT_SECRET` and
   `ENCRYPTION_KEY` (all sessions invalidated, encrypted config unreadable). Recovery is via the
-  VolSync snapshot/backup of the `reclaimerr` PVC — there is no 1Password copy of the keys.
+  VolSync snapshot/backup of the `reclaimerr` PVC. There is no 1Password copy of the keys.
 - **Runs unprivileged.** Pod security context is `runAsNonRoot` as UID/GID `1000` with
   `fsGroup: 1000` and `fsGroupChangePolicy: OnRootMismatch`; the container drops all
   capabilities and disables privilege escalation. Resources are light (`cpu` request `10m`,

--- a/docs/docs/apps/scanopy.md
+++ b/docs/docs/apps/scanopy.md
@@ -6,16 +6,16 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
 ## Purpose
 
 - Rust network-documentation tool (AGPL-3.0) split into two workloads plus a database:
-  - **server** — Rust API + bundled Svelte UI, port `60072` (`ghcr.io/scanopy/scanopy/server`).
-  - **daemon** — Rust scanner (SNMP / LLDP / ARP), port `60073` (`ghcr.io/scanopy/scanopy/daemon`).
-  - **postgres** — upstream compose bundles its own Postgres; here it uses the shared CNPG cluster.
+  - **server**: Rust API + bundled Svelte UI, port `60072` (`ghcr.io/scanopy/scanopy/server`).
+  - **daemon**: Rust scanner (SNMP / LLDP / ARP), port `60073` (`ghcr.io/scanopy/scanopy/daemon`).
+  - **postgres**: upstream compose bundles its own Postgres; here it uses the shared CNPG cluster.
 - Deployed via two HelmReleases (`scanopy` server, `scanopy-daemon` scanner) that share one
   `app-template` `OCIRepository`, both referencing `chartRef.name: scanopy`.
 - Internal-only app: exposed on `envoy-internal` at `scanopy.${SECRET_DOMAIN}`.
 
 ## Design decisions
 
-- **Daemon networking — privileged `hostNetwork` Deployment (single replica).** One scanner total
+- **Daemon networking: privileged `hostNetwork` Deployment (single replica).** One scanner total
   for the flat LAN /24; a per-node DaemonSet was rejected because all nodes share the same /24
   and would scan it three times, and two hostNetwork pods would contend for host port `60073`
   during a rollout. `SCANOPY_NAME: scanopy-codelooks` is a fixed static identity (previously
@@ -25,21 +25,21 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
   `SCANOPY_CONCURRENT_SCANS=5` caps simultaneous host scans. Requires
   `dnsPolicy: ClusterFirstWithHostNet`. Multus was rejected: the only existing NAD is a macvlan
   on the same primary NIC, so it adds nothing over hostNetwork without authoring VLAN-tagged NADs.
-- **Database — shared CNPG `postgres18-rw.database.svc`.** Cluster standard (metabase, netbox). A
+- **Database: shared CNPG `postgres18-rw.database.svc`.** Cluster standard (metabase, netbox). A
   `postgres-init` initContainer provisions the DB + user; the Flux Kustomization `dependsOn`
   `cloudnative-pg-cluster` in `database`.
-- **DB TLS — `?sslmode=require`.** CNPG presents a valid cert-manager cert (`postgres18-tls`, real
+- **DB TLS: `?sslmode=require`.** CNPG presents a valid cert-manager cert (`postgres18-tls`, real
   SANs + issuer DN), so the chain verifies. Matches NetBox. The `sslmode=disable` used by Metabase
   is a JVM-only workaround (Java's strict TLS verifier) and does not apply to Scanopy's Rust client.
-  Hardening path is `verify-full` with a mounted `ca.crt` + `sslrootcert` — never drop to `disable`.
-- **Auth — built-in password login.** No OIDC/SSO in v1; first run creates the admin in the UI.
-- **SMTP — internal relay** at `smtp-relay.infrastructure.svc.cluster.local:25` (unauthenticated).
+  Hardening path is `verify-full` with a mounted `ca.crt` + `sslrootcert`; never drop to `disable`.
+- **Auth: built-in password login.** No OIDC/SSO in v1; first run creates the admin in the UI.
+- **SMTP: internal relay** at `smtp-relay.infrastructure.svc.cluster.local:25` (unauthenticated).
 - **SNMP community via ExternalSecret**, mounted read-only at the neutral path
   `/run/secrets/snmp-community`. The community string lives only in 1Password (repo is PUBLIC); the
   credential is then configured in the UI pointing at that file.
 - **Docker-socket scan source dropped.** Talos runs containerd with no Docker socket, so it is
   disabled explicitly with `SCANOPY_ENABLE_LOCAL_DOCKER_SOCKET=false`.
-- **Components** — `volsync` (`VOLSYNC_CAPACITY: 5Gi`) backing the server `/data` PVC. (Gatus
+- **Components**: `volsync` (`VOLSYNC_CAPACITY: 5Gi`) backing the server `/data` PVC. (Gatus
   monitoring is automatic via the gatus-sidecar chart, which auto-discovers the HTTPRoute; the old
   `gatus/guarded` DNS-check component is gone.) No PodMonitor: Scanopy exposes no Prometheus metrics.
 
@@ -48,10 +48,10 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
 - **Daemon pairing is shared state.** Every daemon and the server read `scanopy-secret` (via
   `envFrom`), sharing `SCANOPY_DAEMON_API_KEY` and `SCANOPY_NETWORK_ID` so each per-node daemon
   registers against the server over `http://scanopy.network.svc.cluster.local:60072`. Daemon
-  registration may require a "network" object to exist first — create the admin + network in the UI.
+  registration may require a "network" object to exist first: create the admin + network in the UI.
 - **ExternalSecret key coverage.** `scanopy-secret` must carry `INIT_POSTGRES_*`,
   `SCANOPY_DATABASE_URL`, `SCANOPY_DAEMON_API_KEY`, `SCANOPY_NETWORK_ID`; `scanopy-snmp-secret`
-  must carry `community`. These are not validated by render-time CI — grep the rendered manifests
+  must carry `community`. These are not validated by render-time CI: grep the rendered manifests
   for every `secretRef`/`secretKeyRef` and projected `items[].key` before applying. The CNPG
   superuser fields (`POSTGRES_SUPER_USER`/`POSTGRES_SUPER_PASS`) come from the existing
   `cloudnative-pg` 1Password item; if `POSTGRES_SUPER_USER` is absent, hardcode
@@ -59,13 +59,13 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
 - **Secrets must live in the `Talos` 1Password vault** (the ClusterSecretStore only reads `Talos`).
   Create the `scanopy` item via the `op` CLI, never the UI; `SCANOPY_NETWORK_ID` is a lowercase
   UUID, and `SNMP_COMMUNITY` is the one value supplied by hand.
-- **`volsync` component lives in `ks.yaml` `spec.components` only** — not also in
+- **`volsync` component lives in `ks.yaml` `spec.components` only**, not also in
   `app/kustomization.yaml`, or it double-applies. The PVC it creates is named `${APP}` (`scanopy`),
   referenced by the server's `persistence.data.existingClaim`.
-- **hostNetwork port `60073`** is bound on every node's host IP — confirm nothing else uses it.
+- **hostNetwork port `60073`** is bound on every node's host IP. Confirm nothing else uses it.
 - **Daemon hostPath `/var/lib/scanopy-daemon`** holds daemon config; it persists across Talos
   reboots (`/var/lib` is writable + persistent).
-- **Privileged is allowed** — the cluster enforces no restricted PodSecurity and the `network`
+- **Privileged is allowed**: the cluster enforces no restricted PodSecurity and the `network`
   namespace has no PSA labels, so the privileged hostNetwork daemon admits cleanly.
 - **Image digests are pinned** for both server and daemon (kept in lockstep by Renovate) and the
   `postgres-init` initContainer.

--- a/docs/docs/apps/scanopy.md
+++ b/docs/docs/apps/scanopy.md
@@ -11,8 +11,7 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
   - **postgres** — upstream compose bundles its own Postgres; here it uses the shared CNPG cluster.
 - Deployed via two HelmReleases (`scanopy` server, `scanopy-daemon` scanner) that share one
   `app-template` `OCIRepository`, both referencing `chartRef.name: scanopy`.
-- Internal-only app: exposed on `envoy-internal` with dual hostnames
-  `scanopy.${SECRET_DOMAIN}` and `scanopy.${SECRET_INTERNAL_DOMAIN}`.
+- Internal-only app: exposed on `envoy-internal` at `scanopy.${SECRET_DOMAIN}`.
 
 ## Design decisions
 
@@ -68,8 +67,8 @@ L2/L3/workload/application diagrams by continuously scanning the infrastructure.
   reboots (`/var/lib` is writable + persistent).
 - **Privileged is allowed** — the cluster enforces no restricted PodSecurity and the `network`
   namespace has no PSA labels, so the privileged hostNetwork daemon admits cleanly.
-- **Image digests are pinned** for both server and daemon (`v0.16.2`) and the `postgres-init`
-  initContainer; Renovate manages bumps afterward.
+- **Image digests are pinned** for both server and daemon (kept in lockstep by Renovate) and the
+  `postgres-init` initContainer.
 
 ## Operational notes
 

--- a/docs/docs/apps/scrypted.md
+++ b/docs/docs/apps/scrypted.md
@@ -15,8 +15,7 @@ Reolink cameras in a later phase.
   is cloud-relayed through the Ring account — expected at this stage.
 - **Phase 1+:** Reolink cameras (Doorbell PoE/WiFi, Duo/Elite Floodlight, Argus
   4 Pro, E1 Pro) via `@scrypted/reolink`. Nothing here blocks local RTSP/ONVIF.
-- Internal-only: `scrypted.${SECRET_DOMAIN}` and
-  `scrypted.${SECRET_INTERNAL_DOMAIN}` on `envoy-internal`.
+- Internal-only: `scrypted.${SECRET_DOMAIN}` on `envoy-internal`.
 
 ## Division of labour with Homebridge
 
@@ -97,7 +96,7 @@ The admin account for the management UI is likewise created on first launch.
 
 ## First-run checklist
 
-1. Reach the UI at `scrypted.${SECRET_INTERNAL_DOMAIN}` and create the admin
+1. Reach the UI at `scrypted.${SECRET_DOMAIN}` and create the admin
    account.
 2. Install the **Ring** plugin; sign in with the Ring account and complete 2FA.
    Confirm all devices appear under Devices.

--- a/docs/docs/apps/scrypted.md
+++ b/docs/docs/apps/scrypted.md
@@ -7,22 +7,22 @@ Reolink cameras in a later phase.
 ## Purpose
 
 - Node/TypeScript camera hub (`ghcr.io/koush/scrypted`) chosen over Frigate or a
-  Home Assistant–only setup because it ships first-party **Ring** *and*
+  Home Assistant-only setup because it ships first-party **Ring** *and*
   **Reolink** plugins plus the strongest HKSV pipeline.
 - **Phase 0 (current):** the official Ring plugin bridges the existing Ring
   fleet (2× Doorbell Pro 2, Doorbell 2nd Gen, Stick Up Cam Battery, Floodlight
   Cam Wired Plus, Spotlight Cam Plus Battery, Indoor Cam) into HomeKit. Traffic
-  is cloud-relayed through the Ring account — expected at this stage.
+  is cloud-relayed through the Ring account, which is expected at this stage.
 - **Phase 1+:** Reolink cameras (Doorbell PoE/WiFi, Duo/Elite Floodlight, Argus
   4 Pro, E1 Pro) via `@scrypted/reolink`. Nothing here blocks local RTSP/ONVIF.
 - Internal-only: `scrypted.${SECRET_DOMAIN}` on `envoy-internal`.
 
 ## Division of labour with Homebridge
 
-Scrypted is **additive** — Homebridge stays.
+Scrypted is **additive**: Homebridge stays.
 
-- **Scrypted** — cameras and doorbells only (HKSV, low-latency streams).
-- **Homebridge** — everything else, and optionally Ring Alarm/sensors/modes via
+- **Scrypted**: cameras and doorbells only (HKSV, low-latency streams).
+- **Homebridge**: everything else, and optionally Ring Alarm/sensors/modes via
   `homebridge-ring`. That plugin has no HKSV by design, so cameras must never
   live there. If `homebridge-ring` is ever enabled, disable its camera support
   to avoid duplicate accessories in Apple Home.
@@ -32,16 +32,16 @@ Scrypted is **additive** — Homebridge stays.
     paired to HomeKit), an empty `cachedAccessories`, only the `homebridge-dummy`
     plugin, and a crash-looping Avahi (`Failed to create runtime directory
     /run/avahi-daemon/`). It is therefore **not** a working reference for
-    HomeKit networking — see the Avahi fix tracked separately. Scrypted does not
+    HomeKit networking. See the Avahi fix tracked separately. Scrypted does not
     depend on it.
 
 ## Design decisions
 
-- **Networking — Multus macvlan on the untagged legacy LAN (`iot-legacy` NAD).**
+- **Networking: Multus macvlan on the untagged legacy LAN (`iot-legacy` NAD).**
   HomeKit pairing (HAP) needs L2 adjacency with the HomeKit hubs, or an mDNS
   reflector. An mDNS probe run on both segments settled it empirically: both
   Apple TVs answered `_airplay._tcp` / `_companion-link._tcp` / `_sleep-proxy._udp`
-  on the **untagged legacy LAN**, while **VLAN 68 returned zero services** — so
+  on the **untagged legacy LAN**, while **VLAN 68 returned zero services**, so
   no reflection exists into the IoT VLAN. Scrypted therefore attaches to
   `iot-legacy` (like `matter-server`), *not* the `iot` NAD used by Home
   Assistant, zigbee2mqtt and mosquitto. Upstream's own compose uses
@@ -49,7 +49,7 @@ Scrypted is **additive** — Homebridge stays.
   equivalent of real LAN presence.
 - **Static IP + MAC.** The NAD uses static IPAM, so the pod carries a fixed
   address and a MAC continuing the `02:00:00:00:00:0X` series used by the other
-  Multus workloads. The chosen address was verified unused before assignment —
+  Multus workloads. The chosen address was verified unused before assignment:
   two neighbouring candidates answered ping. It must sit outside the OPNsense
   DHCP pool.
 - **`strategy: Recreate`.** The pod owns a fixed L2 address and a ReadWriteOnce
@@ -58,7 +58,7 @@ Scrypted is **additive** — Homebridge stays.
 - **UI routed over plain HTTP (`11080`), not HTTPS (`10443`).** Scrypted serves
   the *same* application on both ports (`SCRYPTED_INSECURE_PORT` /
   `SCRYPTED_SECURE_PORT`). Routing the gateway at `11080` avoids introducing a
-  `BackendTLSPolicy` + skip-verify for Scrypted's self-signed cert — the
+  `BackendTLSPolicy` + skip-verify for Scrypted's self-signed cert. The
   repository has no such pattern anywhere today. The HTTPS port stays available on the pod
   for direct access. TLS to the browser is still terminated by the gateway.
 - **Avahi deliberately left off.** `SCRYPTED_DOCKER_AVAHI` is not set: with a
@@ -71,14 +71,14 @@ Scrypted is **additive** — Homebridge stays.
 - **Image variant `-noble-full`.** This is the variant upstream publishes as
   `:latest` (identical digest). Renovate's docker versioning keeps updates
   within the same suffix family. The `-noble-nvidia` variant is the drop-in
-  swap if GPU transcoding is ever wanted — the cluster's NVIDIA L4s and the
+  swap if GPU transcoding is ever wanted: the cluster's NVIDIA L4s and the
   `runtimeClassName: nvidia` pattern are available, but Phase 0 needs no GPU.
 
 ## Storage
 
 - `/server/volume` → a 10Gi `ceph-block` PVC with the standard volsync
   treatment. This holds plugin installs, the device database and **the HomeKit
-  pairing keys** — losing it unpairs every accessory in Apple Home.
+  pairing keys**. Losing it unpairs every accessory in Apple Home.
 - **No NVR volume.** HKSV clips live in iCloud, so Phase 0 provisions no bulk
   storage. A commented TrueNAS NFS mount and the `SCRYPTED_NVR_VOLUME=/nvr`
   variable are left in the HelmRelease for when the Reolink NVR plugin is
@@ -86,7 +86,7 @@ Scrypted is **additive** — Homebridge stays.
 
 ## Secrets
 
-**Nothing secret belongs in Git — this repository is public.** Scrypted has no
+**Nothing secret belongs in Git: this repository is public.** Scrypted has no
 `ExternalSecret`. Ring account credentials and the 2FA code are entered
 **interactively in the Scrypted UI** on first configuration, and Scrypted stores
 the resulting refresh token inside `/server/volume` (which is why that PVC is
@@ -101,8 +101,8 @@ The admin account for the management UI is likewise created on first launch.
 2. Install the **Ring** plugin; sign in with the Ring account and complete 2FA.
    Confirm all devices appear under Devices.
 3. Install the **HomeKit** plugin and pair from the Home app.
-4. Pair the **doorbells as standalone accessories** rather than bridged —
-   per Scrypted's docs this is markedly more reliable for doorbell press
+4. Pair the **doorbells as standalone accessories** rather than bridged.
+   Per Scrypted's docs this is markedly more reliable for doorbell press
    notifications. Cameras can stay bridged.
 5. Enable **HKSV recording** on at least one camera and verify clips play back
    in the Home app.

--- a/docs/docs/architecture/ai-llm-stack.md
+++ b/docs/docs/architecture/ai-llm-stack.md
@@ -2,7 +2,7 @@
 
 Self-hosted LLM stack in the `ai` namespace, fronted by **LiteLLM**. Patterns adapted from
 [joryirving/home-ops](https://github.com/joryirving/home-ops/tree/main/kubernetes/apps/base/llm),
-re-targeted to this cluster — **NVIDIA L4 GPUs + llama.cpp (llmkube)**.
+re-targeted to this cluster: **NVIDIA L4 GPUs + llama.cpp (llmkube)**.
 
 ## Components
 
@@ -36,7 +36,7 @@ Weight files are declared as `hf://` URIs pointing to single-file public GGUFs o
 llmkube downloads and caches them on the shared CephFS RWX `modelCache` PVC (`ceph-filesystem`
 storage class), so a cold start auto-heals without manual staging.
 
-Anti-affinity (`podAntiAffinity`) keeps one resident model per L4 — the cluster has 3 cards but
+Anti-affinity (`podAntiAffinity`) keeps one resident model per L4: the cluster has 3 cards but
 runs 2 models, preserving one card for other GPU workloads (Plex/Jellyfin transcodes, Whisper).
 No model swapping occurs during normal operation. The `gpu-preemptible` PriorityClass is set on
 all llmkube pods so higher-priority workloads can evict them if needed.
@@ -46,15 +46,15 @@ projector alongside the main GGUF. This is the model that `loupe` (image analysi
 LiteLLM.
 
 To add a model: drop a `Model` + `InferenceService` manifest under `llmkube/models/`, add a
-`model_list` entry to `litellm/app/configmap.yaml`, and commit — Flux reconciles both.
+`model_list` entry to `litellm/app/configmap.yaml`, and commit. Flux reconciles both.
 
 ### Model groups
 
 LiteLLM `model_name` groups make the serving tier transparent to clients:
 
-- **`self-hosted`** — `llama-nvidia` (order 1), with a live cloud fallback to `openrouter/auto`
+- **`self-hosted`**: `llama-nvidia` (order 1), with a live cloud fallback to `openrouter/auto`
   via `router_settings.fallbacks` (the OpenRouter key is in the `litellm` ExternalSecret).
-- **`self-hosted-uncensored`** — `llama-uncensored` (order 1); no cloud fallback by design
+- **`self-hosted-uncensored`**: `llama-uncensored` (order 1); no cloud fallback by design
   (a cloud model would reintroduce refusals).
 
 ## In-cluster consumers
@@ -76,14 +76,14 @@ All three consume:
 
 ## Rollout (staged)
 
-1. **LiteLLM uplift** — model-groups + router fallbacks + commented hooks for MCP / embeddings /
+1. **LiteLLM uplift**: model-groups + router fallbacks + commented hooks for MCP / embeddings /
    cloud providers.
-2. **ToolHive + MCP** — operator + curated MCP servers (kubectl, flux, talos, searxng) wired into
+2. **ToolHive + MCP**: operator + curated MCP servers (kubectl, flux, talos, searxng) wired into
    LiteLLM `mcp_servers`.
-3. **memini** — agent memory; embeddings + rerank via tiny CPU llama.cpp servers, consolidation via
+3. **memini**: agent memory; embeddings + rerank via tiny CPU llama.cpp servers, consolidation via
    LiteLLM.
-4. **llmkube** — operator + CephFS modelCache; 2 active models (`self-hosted`, `self-hosted-uncensored`).
-5. **Ollama decommission** — Ollama removed; contracthound/subspy/loupe repointed to LiteLLM.
+4. **llmkube**: operator + CephFS modelCache; 2 active models (`self-hosted`, `self-hosted-uncensored`).
+5. **Ollama decommission**: Ollama removed; contracthound/subspy/loupe repointed to LiteLLM.
 
 Each layer is a separate commit on one branch (one PR). `mcp_servers` and
 `mcp_semantic_tool_filter` are now fully active in `litellm/app/configmap.yaml`, and one cloud
@@ -95,44 +95,44 @@ group's fallback. The remaining cloud-provider stubs are still commented out.
 
 ## How to extend LiteLLM
 
-- **Add a backend to a group** — add a `model_list` entry with an existing `model_name` and the
+- **Add a backend to a group**: add a `model_list` entry with an existing `model_name` and the
   next `order:`. LiteLLM balances / fails over within the group.
-- **Add a cloud provider** — add the key to the `litellm` 1Password item, add a line to
+- **Add a cloud provider**: add the key to the `litellm` 1Password item, add a line to
   `externalsecret.yaml`'s `target.template.data`, then uncomment the matching stub in
-  `configmap.yaml`. Don't reference an `os.environ/KEY` that isn't in the secret — the pod env read
+  `configmap.yaml`. Don't reference an `os.environ/KEY` that isn't in the secret. The pod env read
   fails at startup.
-- **Fallbacks** — `router_settings.fallbacks` is a list of `{model_name: [fallback, …]}`.
+- **Fallbacks**: `router_settings.fallbacks` is a list of `{model_name: [fallback, …]}`.
 
 ## Consuming the stack from a workstation (opencode)
 
-Any OpenAI-compatible client can drive the self-hosted models through the gateway — internal route
+Any OpenAI-compatible client can drive the self-hosted models through the gateway: internal route
 `https://litellm.${SECRET_DOMAIN}/v1`, models `self-hosted` and `self-hosted-uncensored`.
 [opencode](https://opencode.ai) is wired this way as a custom provider:
 
-- **Provider** — `@ai-sdk/openai-compatible`, `baseURL: https://litellm.${SECRET_DOMAIN}/v1`.
+- **Provider**: `@ai-sdk/openai-compatible`, `baseURL: https://litellm.${SECRET_DOMAIN}/v1`.
   Put the LiteLLM key in the client's own credential store (opencode: `opencode auth login` →
   `~/.local/share/opencode/auth.json`), **never** as a literal in a shared or committed config.
-- **MCP tools** — point a remote MCP server at LiteLLM's MCP gateway,
+- **MCP tools**: point a remote MCP server at LiteLLM's MCP gateway,
   `https://litellm.${SECRET_DOMAIN}/mcp/` (the `litellm-mcp-server`), with the LiteLLM key
   as `Authorization: Bearer …`. Curate the server set with the `x-mcp-servers` header (e.g.
-  `kubectl,flux,talos,searxng`) — requesting **all** servers times out, and the full tool list
+  `kubectl,flux,talos,searxng`). Requesting **all** servers times out, and the full tool list
   bloats every request (heavy on the small-context local models, so prefer a frontier model for
   tool-heavy work).
-- **Gotchas** — the self-hosted models are Qwen3 *thinking* models (send `think: false`, or
+- **Gotchas**: the self-hosted models are Qwen3 *thinking* models (send `think: false`, or
   `/no_think` in the prompt, for non-reasoning output); switching between the two local models
   forces a ~17Gi VRAM model-swap (seconds, longer on a cold replica). See the context-budget note
   below for opencode's window requirements.
 
 Prefer a **scoped LiteLLM virtual key** (`/key/generate`, limited to the `self-hosted*` models) over
-the master key for any workstation client — it's revocable on its own.
+the master key for any workstation client: it's revocable on its own.
 
 ### opencode and the context budget
 
-opencode's agent sends **~41k tokens before any user input** — its system prompt plus built-in tool
+opencode's agent sends **~41k tokens before any user input**: its system prompt plus built-in tool
 schemas (measured; LiteLLM is not injecting MCP tools, a plain request is ~18 tokens and one with a
 tool is ~130). That exceeds Qwen3-30B-A3B's native context, so `self-hosted-uncensored` is served at
 **64k via YaRN** specifically to host opencode. `self-hosted` is only ~10.9k usable
-(`contextSize 32768 ÷ 3 slots`), too small for the tool-heavy agent — use the uncensored group for
+(`contextSize 32768 ÷ 3 slots`), too small for the tool-heavy agent. Use the uncensored group for
 opencode. The serving knobs live in `llmkube/models/qwen3-30b-abliterated.yaml`: `contextSize 65536`,
 `parallelSlots 1`, `ropeScaling {yarn, factor 2.0, originalContext 32768}`.
 
@@ -141,13 +141,13 @@ context (this GGUF reports 40960) **even with correct YaRN args**, so the served
 at 40960 ([llama.cpp#22140](https://github.com/ggml-org/llama.cpp/issues/22140)). The fix is the
 extra arg `--override-kv qwen3moe.context_length=int:65536`, which raises the value the server caps
 against (rope interpolation still comes from `ropeScaling`). A `Ready` phase and a clean
-`kustomize build` do **not** prove the served window — confirm with `/props`
+`kustomize build` do **not** prove the served window: confirm with `/props`
 (`.default_generation_settings.n_ctx == 65536`) and the absence of a `capping` log line.
 
 ## MCP tools (ToolHive)
 
 Layer 2 runs the [StackLok ToolHive](https://github.com/stacklok/toolhive) operator (separate
-CRDs + operator charts — see `toolhive/app/ocirepository.yaml` for the current pin) in `ai`, an
+CRDs + operator charts, see `toolhive/app/ocirepository.yaml` for the current pin) in `ai`, an
 `MCPGroup` (`mcp-tools`), and these MCP servers, all wired into LiteLLM's `mcp_servers`:
 
 | Server    | Source                          | Access                                                  |
@@ -162,22 +162,22 @@ CRDs + operator charts — see `toolhive/app/ocirepository.yaml` for the current
 | `seerr`   | overseerr-mcp                   | Overseerr request + discovery tools                     |
 
 kubectl + flux share one read-only `ClusterRole` (`kubectl-mcp-readonly`) built from this cluster's
-API groups with core `secrets` omitted — keep it in sync with `kubectl api-resources` as you add
+API groups with core `secrets` omitted. Keep it in sync with `kubectl api-resources` as you add
 CRDs. The talos MCP mounts a `talos.dev` `ServiceAccount`-minted `os:reader` talosconfig.
 
 The `mcp_semantic_tool_filter` is **on** (top_k 8, embeddings via the `all-minilm` model on the
 CPU `llama-embed` pod): with 8 servers' worth of tools it trims each request to the most
-relevant ones. `github` + `grafana` are read-only — a fine-grained PAT (`toolhive-github`) and a
+relevant ones. `github` + `grafana` are read-only, via a fine-grained PAT (`toolhive-github`) and a
 Grafana Viewer service-account token (`toolhive-grafana`).
 
 Deferred (add later): the `VirtualMCPServer` aggregate + `EmbeddingServer` (a single
-`mcp.<domain>` endpoint for non-LiteLLM clients — it's what pulls in a Dragonfly + embedder).
+`mcp.<domain>` endpoint for non-LiteLLM clients, which is what pulls in a Dragonfly + embedder).
 
 ### Enabling flux-mcp write access
 
-The flux MCP is read-only by default. To let it — and therefore any model behind LiteLLM —
+The flux MCP is read-only by default. To let it (and therefore any model behind LiteLLM)
 reconcile / suspend / resume / apply / delete Flux objects, append to
-`toolhive/mcp-servers/flux/rbac.yaml` (no `kustomization.yaml` change needed — `rbac.yaml` is
+`toolhive/mcp-servers/flux/rbac.yaml` (no `kustomization.yaml` change needed, `rbac.yaml` is
 already listed there):
 
 ```yaml
@@ -211,7 +211,7 @@ subjects:
       namespace: ai
 ```
 
-This grants an LLM mutate access to the cluster's GitOps controller — enable only if you trust the
+This grants an LLM mutate access to the cluster's GitOps controller. Enable only if you trust the
 calling chain.
 
 ### Adding an MCP server
@@ -230,11 +230,11 @@ endpoint to LiteLLM's `mcp_servers`. The service name depends on the transport:
 Layer 3 runs [memini](https://github.com/eleboucher/memini) (SQLite backend) for agent long-term
 memory, plus two tiny CPU `llama.cpp` model servers in `ai`:
 
-- `llama-embed` — all-MiniLM-L6-v2 (384-dim), `--embeddings`, OpenAI `/v1`.
-- `llama-rerank` — Qwen3-Reranker-0.6B, `--rerank`.
+- `llama-embed`: all-MiniLM-L6-v2 (384-dim), `--embeddings`, OpenAI `/v1`.
+- `llama-rerank`: Qwen3-Reranker-0.6B, `--rerank`.
 
-Both run on **CPU** (`ghcr.io/ggml-org/llama.cpp:server`, GPU/Vulkan bits stripped) — the L4s are
-spoken for by llmkube and these models are small (~30 MB / ~600 MB). memini's consolidation LLM is
+Both run on **CPU** (`ghcr.io/ggml-org/llama.cpp:server`, GPU/Vulkan bits stripped). The L4s are
+spoken for by llmkube, and these models are small (~30 MB / ~600 MB). memini's consolidation LLM is
 LiteLLM's `self-hosted` group.
 
 Secrets: a generated `MEMINI_API_KEY` (Talos vault item `memini`) + `LITELLM_MASTER_KEY` (reused
@@ -246,16 +246,16 @@ To move embeddings onto the GPU later, swap `llama-embed`/`llama-rerank` for llm
 
 ## Gotchas
 
-- **Public repository** — no LAN IPs / internal hostnames in Git (see `CLAUDE.md`). Cluster service DNS
+- **Public repository**: no LAN IPs / internal hostnames in Git (see `CLAUDE.md`). Cluster service DNS
   and `${SECRET_*}` placeholders are fine.
-- **Metrics** — `require_auth_for_metrics_endpoint: false` **and** ServiceMonitor path `/metrics/`
+- **Metrics**: `require_auth_for_metrics_endpoint: false` **and** ServiceMonitor path `/metrics/`
   (trailing slash, no redirect-follow) are both required for in-cluster Prometheus scraping.
-- **CephFS dependency** — llmkube's shared `modelCache` PVC requires `ceph-filesystem` (RWX).
+- **CephFS dependency**: llmkube's shared `modelCache` PVC requires `ceph-filesystem` (RWX).
   Without it, multi-replica `InferenceService` pods fail to schedule (only one pod can hold an RWO
   volume at a time). The `ceph-filesystem` storage class is provisioned by Rook-Ceph.
-- **ConfigMap reloads** — the `litellm` controller is annotated `reloader.stakater.com/auto`, so
+- **ConfigMap reloads**: the `litellm` controller is annotated `reloader.stakater.com/auto`, so
   Stakater Reloader restarts it automatically when the configmap changes.
-- **Cross-namespace netpol** — `kubernetes/apps/ai/netpol.yaml` allows ingress to the `ai`
+- **Cross-namespace netpol**: `kubernetes/apps/ai/netpol.yaml` allows ingress to the `ai`
   namespace from the `network` namespace (gateway), plus a second `CiliumNetworkPolicy`
   (`allow-litellm-from-consumers`) that grants the `default` and `custom` namespaces ingress to the
   `litellm` endpoint specifically. A new consumer namespace needs adding to that policy's

--- a/docs/docs/architecture/ai-llm-stack.md
+++ b/docs/docs/architecture/ai-llm-stack.md
@@ -11,11 +11,13 @@ re-targeted to this cluster — **NVIDIA L4 GPUs + llama.cpp (llmkube)**.
 | `litellm`    | OpenAI-compatible gateway: routing, fallbacks, cache, metrics, MCP | live   |
 | `llmkube`    | llama.cpp model-serving operator (CUDA); 2 models active           | live   |
 | `open-webui` | chat UI                                                            | live   |
-| `toolhive`   | MCP servers (kubectl/flux/talos/searxng) wired into LiteLLM        | live   |
+| `toolhive`   | MCP servers (8 read-only servers) wired into LiteLLM               | live   |
 | `memini`     | agent long-term memory (SQLite + CPU embed/rerank)                 | live   |
+| `hermes`     | NousResearch hermes-agent gateway + dashboard (memini-backed)      | live   |
+| `hermeswebui`| chat web frontend for hermes (via its API server)                  | live   |
 
 LiteLLM persists to CNPG `postgres18` (`litellm` db) and caches in Dragonfly. Internal-only route
-(`litellm.${SECRET_INTERNAL_DOMAIN}`, envoy-internal).
+(`litellm.${SECRET_DOMAIN}` on envoy-internal).
 
 ## Model serving (llmkube)
 
@@ -50,7 +52,8 @@ To add a model: drop a `Model` + `InferenceService` manifest under `llmkube/mode
 
 LiteLLM `model_name` groups make the serving tier transparent to clients:
 
-- **`self-hosted`** — `llama-nvidia` (order 1); any future second backend adds as `order: 2`.
+- **`self-hosted`** — `llama-nvidia` (order 1), with a live cloud fallback to `openrouter/auto`
+  via `router_settings.fallbacks` (the OpenRouter key is in the `litellm` ExternalSecret).
 - **`self-hosted-uncensored`** — `llama-uncensored` (order 1); no cloud fallback by design
   (a cloud model would reintroduce refusals).
 
@@ -83,11 +86,12 @@ All three consume:
 5. **Ollama decommission** — Ollama removed; contracthound/subspy/loupe repointed to LiteLLM.
 
 Each layer is a separate commit on one branch (one PR). `mcp_servers` and
-`mcp_semantic_tool_filter` are now fully active in `litellm/app/configmap.yaml`; only the optional
-cloud-provider stubs remain commented out.
+`mcp_semantic_tool_filter` are now fully active in `litellm/app/configmap.yaml`, and one cloud
+provider is live: `openrouter/auto` is an active `model_list` entry serving as the `self-hosted`
+group's fallback. The remaining cloud-provider stubs are still commented out.
 
-> Not ported from Jory's repository: `hermes`, `openclaw` (agent runtimes), and `agentmemory` (whose main
-> consumers are hermes/openclaw).
+> Since ported from Jory's repository: `hermes` (plus a `hermeswebui` chat frontend). Still not
+> ported: `openclaw` (agent runtime) and `agentmemory` (memini covers agent memory here).
 
 ## How to extend LiteLLM
 
@@ -102,14 +106,14 @@ cloud-provider stubs remain commented out.
 ## Consuming the stack from a workstation (opencode)
 
 Any OpenAI-compatible client can drive the self-hosted models through the gateway — internal route
-`https://litellm.${SECRET_INTERNAL_DOMAIN}/v1`, models `self-hosted` and `self-hosted-uncensored`.
+`https://litellm.${SECRET_DOMAIN}/v1`, models `self-hosted` and `self-hosted-uncensored`.
 [opencode](https://opencode.ai) is wired this way as a custom provider:
 
-- **Provider** — `@ai-sdk/openai-compatible`, `baseURL: https://litellm.${SECRET_INTERNAL_DOMAIN}/v1`.
+- **Provider** — `@ai-sdk/openai-compatible`, `baseURL: https://litellm.${SECRET_DOMAIN}/v1`.
   Put the LiteLLM key in the client's own credential store (opencode: `opencode auth login` →
   `~/.local/share/opencode/auth.json`), **never** as a literal in a shared or committed config.
 - **MCP tools** — point a remote MCP server at LiteLLM's MCP gateway,
-  `https://litellm.${SECRET_INTERNAL_DOMAIN}/mcp/` (the `litellm-mcp-server`), with the LiteLLM key
+  `https://litellm.${SECRET_DOMAIN}/mcp/` (the `litellm-mcp-server`), with the LiteLLM key
   as `Authorization: Bearer …`. Curate the server set with the `x-mcp-servers` header (e.g.
   `kubectl,flux,talos,searxng`) — requesting **all** servers times out, and the full tool list
   bloats every request (heavy on the small-context local models, so prefer a frontier model for
@@ -142,9 +146,9 @@ against (rope interpolation still comes from `ropeScaling`). A `Ready` phase and
 
 ## MCP tools (ToolHive)
 
-Layer 2 runs the [StackLok ToolHive](https://github.com/stacklok/toolhive) operator (`0.29.3`,
-separate CRDs + operator charts) in `ai`, an `MCPGroup` (`mcp-tools`), and these MCP servers, all
-wired into LiteLLM's `mcp_servers`:
+Layer 2 runs the [StackLok ToolHive](https://github.com/stacklok/toolhive) operator (separate
+CRDs + operator charts — see `toolhive/app/ocirepository.yaml` for the current pin) in `ai`, an
+`MCPGroup` (`mcp-tools`), and these MCP servers, all wired into LiteLLM's `mcp_servers`:
 
 | Server    | Source                          | Access                                                  |
 | --------- | ------------------------------- | ------------------------------------------------------- |
@@ -154,14 +158,16 @@ wired into LiteLLM's `mcp_servers`:
 | `searxng` | mcp-searxng → `searxng.default` | web search                                              |
 | `github`  | github-mcp-server               | GitHub read-only (`GITHUB_READ_ONLY`, fine-grained PAT) |
 | `grafana` | grafana/mcp-grafana             | Grafana Viewer SA token (read-only)                     |
+| `arr`     | mcp-arr                         | Sonarr / Radarr / Prowlarr tools (per-app API keys)     |
+| `seerr`   | overseerr-mcp                   | Overseerr request + discovery tools                     |
 
 kubectl + flux share one read-only `ClusterRole` (`kubectl-mcp-readonly`) built from this cluster's
 API groups with core `secrets` omitted — keep it in sync with `kubectl api-resources` as you add
 CRDs. The talos MCP mounts a `talos.dev` `ServiceAccount`-minted `os:reader` talosconfig.
 
 The `mcp_semantic_tool_filter` is **on** (top_k 8, embeddings via the `all-minilm` model on the
-CPU `llama-embed` pod): with ~110 tools across 6 servers it trims each request to the most
-relevant tools. `github` + `grafana` are read-only — a fine-grained PAT (`toolhive-github`) and a
+CPU `llama-embed` pod): with 8 servers' worth of tools it trims each request to the most
+relevant ones. `github` + `grafana` are read-only — a fine-grained PAT (`toolhive-github`) and a
 Grafana Viewer service-account token (`toolhive-grafana`).
 
 Deferred (add later): the `VirtualMCPServer` aggregate + `EmbeddingServer` (a single
@@ -233,7 +239,7 @@ LiteLLM's `self-hosted` group.
 
 Secrets: a generated `MEMINI_API_KEY` (Talos vault item `memini`) + `LITELLM_MASTER_KEY` (reused
 from the `litellm` item). Data PVC via the volsync component (10Gi). Route:
-`memini.${SECRET_INTERNAL_DOMAIN}` (internal).
+`memini.${SECRET_DOMAIN}` (envoy-internal).
 
 To move embeddings onto the GPU later, swap `llama-embed`/`llama-rerank` for llmkube
 `InferenceService`s and repoint `MEMINI_EMBED_BASE_URL` / `MEMINI_RERANK`.
@@ -250,8 +256,7 @@ To move embeddings onto the GPU later, swap `llama-embed`/`llama-rerank` for llm
 - **ConfigMap reloads** — the `litellm` controller is annotated `reloader.stakater.com/auto`, so
   Stakater Reloader restarts it automatically when the configmap changes.
 - **Cross-namespace netpol** — `kubernetes/apps/ai/netpol.yaml` allows ingress to the `ai`
-  namespace only from the `network` namespace (gateway). Apps in `default` and `custom` that call
-  `litellm.ai.svc.cluster.local:4000` need a policy allowing ingress from those namespaces. If
-  Cilium is in `default` enforcement mode and the policy is active on all `ai` pods, add an
-  additional `fromEndpoints` rule for `io.kubernetes.pod.namespace: default` and
-  `io.kubernetes.pod.namespace: custom` before merging this change.
+  namespace from the `network` namespace (gateway), plus a second `CiliumNetworkPolicy`
+  (`allow-litellm-from-consumers`) that grants the `default` and `custom` namespaces ingress to the
+  `litellm` endpoint specifically. A new consumer namespace needs adding to that policy's
+  `fromEndpoints` list before its calls to `litellm.ai.svc.cluster.local:4000` will connect.

--- a/docs/docs/architecture/networking.md
+++ b/docs/docs/architecture/networking.md
@@ -15,12 +15,12 @@ exist in the `network` namespace, addressed by role rather than by IP here:
 - **`envoy-external`** (reachable via the Cloudflare tunnel).
 
 Most apps declare an inline `route:` in their HelmRelease values targeting one of the two Gateways.
-Every route uses a single hostname, `${APP}.${SECRET_DOMAIN}`, whichever Gateway it attaches to —
+Every route uses a single hostname, `${APP}.${SECRET_DOMAIN}`, whichever Gateway it attaches to:
 internal-only vs public exposure is decided by the Gateway, not by the domain. Routes do not carry
 `${SECRET_INTERNAL_DOMAIN}` aliases: an alias resolves to the same Gateway as the primary hostname,
 so it buys no extra restriction, and each one costs an OPNsense host-override record against a hard
 ceiling (see [Split DNS](split-dns.md)). "Available under `${SECRET_DOMAIN}`" for a home app
-usually means internal DNS on `envoy-internal` — not public exposure.
+usually means internal DNS on `envoy-internal`, not public exposure.
 
 ## DNS
 

--- a/docs/docs/architecture/networking.md
+++ b/docs/docs/architecture/networking.md
@@ -8,16 +8,19 @@ rules, `ingressDeny`, and egress-to-world).
 
 ## Ingress — Envoy Gateway (Gateway API)
 
-Ingress is Envoy Gateway using the Gateway API (`HTTPRoute`), not classic Ingress. Two listeners
-exist, addressed by role rather than by IP here:
+Ingress is Envoy Gateway using the Gateway API (`HTTPRoute`), not classic Ingress. Two Gateways
+exist in the `network` namespace, addressed by role rather than by IP here:
 
-- an **internal** listener (LAN-only), and
-- an **external** listener (reachable via the Cloudflare tunnel).
+- **`envoy-internal`** (LAN-only), and
+- **`envoy-external`** (reachable via the Cloudflare tunnel).
 
-Most apps declare an inline `route:` in their HelmRelease values targeting the appropriate listener
-in the `network` namespace. Hosts are `${APP}.${SECRET_DOMAIN}` (external) and
-`${APP}.${SECRET_INTERNAL_DOMAIN}` (internal). "Available under `${SECRET_DOMAIN}`" for a home app
-usually means internal DNS on the internal listener — not public exposure.
+Most apps declare an inline `route:` in their HelmRelease values targeting one of the two Gateways.
+Every route uses a single hostname, `${APP}.${SECRET_DOMAIN}`, whichever Gateway it attaches to —
+internal-only vs public exposure is decided by the Gateway, not by the domain. Routes do not carry
+`${SECRET_INTERNAL_DOMAIN}` aliases: an alias resolves to the same Gateway as the primary hostname,
+so it buys no extra restriction, and each one costs an OPNsense host-override record against a hard
+ceiling (see [Split DNS](split-dns.md)). "Available under `${SECRET_DOMAIN}`" for a home app
+usually means internal DNS on `envoy-internal` — not public exposure.
 
 ## DNS
 
@@ -29,6 +32,7 @@ See [Split DNS](split-dns.md) for how the internal and external views are kept s
 
 ## TLS
 
-cert-manager issues certificates via Let's Encrypt ACME; the external domain's certificates are
-visible in certificate-transparency logs (which is why the external domain itself is not treated as
-secret, while internal hostnames are kept out of Git).
+cert-manager issues a single wildcard certificate (`*.${SECRET_DOMAIN}`) via Let's Encrypt ACME,
+and both Gateways serve it. The wildcard entry is visible in certificate-transparency logs (which is
+why the domain itself is not treated as secret), but individual app subdomains are not enumerated
+there, and internal hostnames are kept out of Git.

--- a/docs/docs/architecture/split-dns.md
+++ b/docs/docs/architecture/split-dns.md
@@ -4,8 +4,8 @@
 
 This cluster uses a **split-horizon DNS architecture** with two `external-dns` instances:
 
-1. **cloudflare-dns** — manages public DNS records in Cloudflare (external access through Cloudflare Tunnel, proxied).
-2. **opnsense-dns** — manages internal DNS records in OPNsense Unbound (direct LAN access).
+1. **cloudflare-dns**: manages public DNS records in Cloudflare (external access through Cloudflare Tunnel, proxied).
+2. **opnsense-dns**: manages internal DNS records in OPNsense Unbound (direct LAN access).
 
 Which instance publishes a record is decided by the **gateway** an app's `HTTPRoute` attaches to:
 
@@ -15,7 +15,7 @@ Which instance publishes a record is decided by the **gateway** an app's `HTTPRo
 This means the same name can resolve differently depending on where the query comes from, and internal-only services are never exposed publicly.
 
 !!! note "Records come from HTTPRoutes, not per-app CRDs"
-    Both instances derive their records from `HTTPRoute` resources via external-dns's `gateway-httproute` source. There are **no** per-app `DNSEndpoint` CRDs. An earlier revision of this cluster required a `DNSEndpoint` for every app (~40 `dnsendpoint.yaml` files); that is no longer the case — see [How records are created](#how-records-are-created).
+    Both instances derive their records from `HTTPRoute` resources via external-dns's `gateway-httproute` source. There are **no** per-app `DNSEndpoint` CRDs. An earlier revision of this cluster required a `DNSEndpoint` for every app (~40 `dnsendpoint.yaml` files); that is no longer the case. See [How records are created](#how-records-are-created).
 
 ## Architecture Diagrams
 
@@ -52,7 +52,7 @@ graph TB
     EnvoyInt --> Apps
 ```
 
-> Example IPs only — the gateways' LoadBalancer addresses are static LAN IPs assigned literally in `envoy.yaml` (an allowlisted functional config); `${ENVOY_INTERNAL_IP}` in `cluster-secrets` supplies the internal gateway's external-dns target annotation.
+> Example IPs only. The gateways' LoadBalancer addresses are static LAN IPs assigned literally in `envoy.yaml` (an allowlisted functional config); `${ENVOY_INTERNAL_IP}` in `cluster-secrets` supplies the internal gateway's external-dns target annotation.
 
 ### External DNS Flow (Internet Access)
 
@@ -163,7 +163,7 @@ domainFilters:
 - `external.${SECRET_DOMAIN}` CNAME → `${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com` (from the one `DNSEndpoint` CRD, `cloudflare-tunnel`)
 - `<app>.${SECRET_DOMAIN}` records for apps whose `HTTPRoute` attaches to `envoy-external` (from the `gateway-httproute` source), proxied through Cloudflare
 
-**Key Design Decision**: `--cloudflare-proxied` is **enabled** — see [Why `--cloudflare-proxied` is enabled](#why-cloudflare-proxied-is-enabled).
+**Key Design Decision**: `--cloudflare-proxied` is **enabled**. See [Why `--cloudflare-proxied` is enabled](#why-cloudflare-proxied-is-enabled).
 
 ### opnsense-dns (Internal)
 
@@ -196,7 +196,7 @@ domainFilters:
 
 **What it manages**:
 
-- `<app>.${SECRET_DOMAIN}` A records → `${ENVOY_INTERNAL_IP}` for apps whose `HTTPRoute` attaches to `envoy-internal` (the bulk of the cluster) — from the `gateway-httproute` source
+- `<app>.${SECRET_DOMAIN}` A records → `${ENVOY_INTERNAL_IP}` for apps whose `HTTPRoute` attaches to `envoy-internal` (the bulk of the cluster), from the `gateway-httproute` source
 - A records for LoadBalancer service IPs (the `service` source)
 - The `crd` source is enabled for special cases but currently matches nothing (the only internal-target `DNSEndpoint`, `games/minecraft`, is commented out of its kustomization)
 
@@ -211,8 +211,8 @@ How it works now (this mirrors onedr0p's UniFi pattern, adapted for the OPNsense
 
 - An app declares an `HTTPRoute` (the app-template `route:` key) with `parentRefs` pointing at `envoy-internal` or `envoy-external`.
 - external-dns reads the route via `gateway-httproute`; the `--gateway-label-filter` on each instance decides which gateway (and therefore which DNS provider) owns the record.
-- **Internal routes** (`envoy-internal`): opnsense-dns creates an **A record** targeting the gateway's LAN IP — the gateway carries `external-dns.alpha.kubernetes.io/record-type: A` and `target: ${ENVOY_INTERNAL_IP}` annotations, and an A record is exactly what the OPNsense webhook accepts. No CNAME, no per-app CRD.
-- **External routes** (`envoy-external`): the gateway instead carries `external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}` — a hostname, not an IP — so cloudflare-dns creates a **CNAME** `<app>.${SECRET_DOMAIN}` → `external.${SECRET_DOMAIN}`, which the tunnel `DNSEndpoint` below points at Cloudflare's edge.
+- **Internal routes** (`envoy-internal`): opnsense-dns creates an A record targeting the gateway's LAN IP. The gateway carries `external-dns.alpha.kubernetes.io/record-type: A` and `target: ${ENVOY_INTERNAL_IP}` annotations, and an A record is exactly what the OPNsense webhook accepts. No CNAME, no per-app CRD.
+- **External routes** (`envoy-external`): the gateway instead carries `external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}` (a hostname, not an IP), so cloudflare-dns creates a CNAME `<app>.${SECRET_DOMAIN}` → `external.${SECRET_DOMAIN}`, which the tunnel `DNSEndpoint` below points at Cloudflare's edge.
 
 `DNSEndpoint` CRDs are now reserved for the handful of records an `HTTPRoute` cannot express:
 
@@ -241,15 +241,15 @@ spec:
 
 ### Why `--cloudflare-proxied` is enabled
 
-`--cloudflare-proxied` is enabled, and it is safe **because cloudflare-dns no longer ingests internal records**:
+`--cloudflare-proxied` is enabled, and it is safe because cloudflare-dns no longer ingests internal records:
 
 - It only watches the `type=external` gateway and the single tunnel-CNAME `DNSEndpoint`.
 - None of those are RFC1918 A records, so Cloudflare is never asked to proxy a private IP.
 
 Proxying external apps gives Cloudflare's CDN/WAF/DDoS protection in front of them, in addition to the encryption and access control provided by the Tunnel.
 
-!!! info "Historical note — this used to be the opposite"
-    When every app had a `DNSEndpoint` (including ~35 internal A records pointing at RFC1918 IPs), cloudflare-dns processed all of them. With `--cloudflare-proxied` **on**, Cloudflare rejected the proxied RFC1918 A records and the controller crashed before it could create the external CNAMEs — surfacing as **Cloudflare Error 1016**. The workaround at the time was to *remove* `--cloudflare-proxied`. Moving record creation to the gateway-scoped `gateway-httproute` source removed the internal records from cloudflare-dns entirely, so proxying could be turned back on.
+!!! info "Historical note: this used to be the opposite"
+    When every app had a `DNSEndpoint` (including ~35 internal A records pointing at RFC1918 IPs), cloudflare-dns processed all of them. With `--cloudflare-proxied` **on**, Cloudflare rejected the proxied RFC1918 A records and the controller crashed before it could create the external CNAMEs. The result was **Cloudflare Error 1016**. The workaround at the time was to *remove* `--cloudflare-proxied`. Moving record creation to the gateway-scoped `gateway-httproute` source removed the internal records from cloudflare-dns entirely, so proxying could be turned back on.
 
 ## DNS Record Types by Controller
 
@@ -313,12 +313,12 @@ HTTPRoutes attached to this gateway create **A records in OPNsense Unbound**.
 
 ### Error: "Target 10.0.0.X is not allowed for a proxied record"
 
-With `--cloudflare-proxied` enabled, this error means a **private (RFC1918) A record has leaked into cloudflare-dns** — it should only ever manage the external gateway and the tunnel CNAME. Look for:
+With `--cloudflare-proxied` enabled, this error means a private (RFC1918) A record has leaked into cloudflare-dns; it should only ever manage the external gateway and the tunnel CNAME. Look for:
 
 - a stray `DNSEndpoint` with an RFC1918 target that isn't scoped away from Cloudflare, or
 - an app `HTTPRoute` mistakenly attached to `envoy-external` while targeting an internal IP.
 
-This is the failure mode that historically caused Error 1016. The fix is to keep internal records on opnsense-dns — **not** to disable proxying.
+This is the failure mode that historically caused Error 1016. The fix is to keep internal records on opnsense-dns, **not** to disable proxying.
 
 ### Sites returning "Cloudflare Error 1016: Origin DNS error"
 
@@ -468,7 +468,7 @@ API endpoint, which has an operational ceiling this cluster has already hit once
 !!! warning "Symptom: new apps get no DNS record, existing apps are unaffected"
     Once the ceiling trips, `opnsense-dns` fails **every** reconcile with `failed
     to get records with code 500`, so **no new record can be published anywhere in
-    the cluster** — but records already written to Unbound keep resolving
+    the cluster**, but records already written to Unbound keep resolving
     normally. The failure therefore presents narrowly, as "only new apps are
     broken," rather than as an outage.
 
@@ -476,7 +476,7 @@ API endpoint, which has an operational ceiling this cluster has already hit once
   response and truncates once the payload exceeds 65,528 bytes. Verified
   experimentally against a live host-override table: `rowCount=420` returns
   113,794 bytes cleanly; `rowCount=425` truncates. The trip point sits at roughly
-  421-424 rows — it drifts slightly because row size varies with hostname length,
+  421-424 rows. It drifts slightly because row size varies with hostname length,
   not because there is a fixed byte budget per record.
 - **`opnsense-dns` never deletes records.** It runs `--policy=upsert-only
   --registry=noop`, so removing a hostname from Git stops new records from being
@@ -485,14 +485,14 @@ API endpoint, which has an operational ceiling this cluster has already hit once
   something a Git revert alone fixes.
 - **`upsert-only`/`noop` is a deliberate choice, not a misconfiguration to "fix."**
   A TXT registry adds roughly one bookkeeping row per managed record
-  (external-dns v0.21.0), which would push this domain filter to roughly 433 rows
-  — back over the ~421 ceiling that already tripped once. `policy: sync` with
+  (external-dns v0.21.0), which would push this domain filter to roughly 433 rows,
+  back over the ~421 ceiling that already tripped once. `policy: sync` with
   `registry: noop` is worse: without ownership tracking, a sync policy would
   delete every hand-made OPNsense host override outside external-dns's view,
   including device records and unrelated third-party domains hosted on the same
   OPNsense instance.
 - **`${SECRET_INTERNAL_DOMAIN}` still exists and is still needed.** It was never
-  only an app-hostname alias — it still carries device records that have no
+  only an app-hostname alias; it still carries device records that have no
   `${SECRET_DOMAIN}` equivalent: IPMI probe targets, core switches, the
   Kubernetes API endpoint, VM management interfaces, the NAS S3 endpoint, and a
   handful of media-service aliases. Retiring the redundant *app* hostname aliases

--- a/docs/docs/architecture/split-dns.md
+++ b/docs/docs/architecture/split-dns.md
@@ -52,7 +52,7 @@ graph TB
     EnvoyInt --> Apps
 ```
 
-> Example IPs only — the real gateway addresses come from `${ENVOY_EXTERNAL_IP}` / `${ENVOY_INTERNAL_IP}` in `cluster-secrets`.
+> Example IPs only — the gateways' LoadBalancer addresses are static LAN IPs assigned literally in `envoy.yaml` (an allowlisted functional config); `${ENVOY_INTERNAL_IP}` in `cluster-secrets` supplies the internal gateway's external-dns target annotation.
 
 ### External DNS Flow (Internet Access)
 
@@ -210,8 +210,9 @@ domainFilters:
 How it works now (this mirrors onedr0p's UniFi pattern, adapted for the OPNsense webhook):
 
 - An app declares an `HTTPRoute` (the app-template `route:` key) with `parentRefs` pointing at `envoy-internal` or `envoy-external`.
-- external-dns reads the route via `gateway-httproute` and creates a record whose **target is the gateway's LoadBalancer IP**. Because the Cilium load balancer hands out an IP (not a hostname), the record is an **A record** — exactly what the OPNsense webhook accepts. No CNAME, no per-app CRD.
-- The `--gateway-label-filter` on each instance decides which gateway (and therefore which DNS provider) owns the record.
+- external-dns reads the route via `gateway-httproute`; the `--gateway-label-filter` on each instance decides which gateway (and therefore which DNS provider) owns the record.
+- **Internal routes** (`envoy-internal`): opnsense-dns creates an **A record** targeting the gateway's LAN IP — the gateway carries `external-dns.alpha.kubernetes.io/record-type: A` and `target: ${ENVOY_INTERNAL_IP}` annotations, and an A record is exactly what the OPNsense webhook accepts. No CNAME, no per-app CRD.
+- **External routes** (`envoy-external`): the gateway instead carries `external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}` — a hostname, not an IP — so cloudflare-dns creates a **CNAME** `<app>.${SECRET_DOMAIN}` → `external.${SECRET_DOMAIN}`, which the tunnel `DNSEndpoint` below points at Cloudflare's edge.
 
 `DNSEndpoint` CRDs are now reserved for the handful of records an `HTTPRoute` cannot express:
 
@@ -279,14 +280,16 @@ graph LR
 metadata:
     labels:
         type: external # Matched by cloudflare-dns --gateway-label-filter
+    annotations:
+        external-dns.alpha.kubernetes.io/target: external.${SECRET_DOMAIN}
 
 spec:
     infrastructure:
         annotations:
-            lbipam.cilium.io/ips: ${ENVOY_EXTERNAL_IP}
+            lbipam.cilium.io/ips: <static LAN IP> # literal in envoy.yaml (allowlisted)
 ```
 
-HTTPRoutes attached to this gateway create **proxied records in Cloudflare**.
+HTTPRoutes attached to this gateway create **proxied CNAME records in Cloudflare**.
 
 ### Internal Gateway (`envoy-internal`)
 
@@ -294,11 +297,14 @@ HTTPRoutes attached to this gateway create **proxied records in Cloudflare**.
 metadata:
     labels:
         type: internal # Matched by opnsense-dns --gateway-label-filter
+    annotations:
+        external-dns.alpha.kubernetes.io/record-type: A
+        external-dns.alpha.kubernetes.io/target: ${ENVOY_INTERNAL_IP}
 
 spec:
     infrastructure:
         annotations:
-            lbipam.cilium.io/ips: ${ENVOY_INTERNAL_IP}
+            lbipam.cilium.io/ips: <static LAN IP> # literal in envoy.yaml (allowlisted)
 ```
 
 HTTPRoutes attached to this gateway create **A records in OPNsense Unbound**.

--- a/docs/docs/architecture/storage.md
+++ b/docs/docs/architecture/storage.md
@@ -2,16 +2,16 @@
 
 The cluster uses four storage tiers, chosen per workload:
 
-- **Rook-Ceph** — replicated storage for stateful workloads that need durability and to move
-  between nodes. Two StorageClasses: `ceph-block` (RBD, RWO — the default for app state) and
-  `ceph-filesystem` (CephFS, RWX — for volumes shared across pods/nodes, e.g. the llmkube shared
+- **Rook-Ceph**: replicated storage for stateful workloads that need durability and to move
+  between nodes. Two StorageClasses: `ceph-block` (RBD, RWO: the default for app state) and
+  `ceph-filesystem` (CephFS, RWX: for volumes shared across pods/nodes, e.g. the llmkube shared
   model cache).
-- **miroir** (`miroir-local` StorageClass) — loopfile-backed node-local volumes for workloads that
+- **miroir** (`miroir-local` StorageClass): loopfile-backed node-local volumes for workloads that
   want fast node-local storage and tolerate being pinned to a node. Unlike the retired OpenEBS
   hostpath, miroir enforces the requested PVC size (a real ext4 loopfile), so size volumes and
   VolSync caches deliberately.
-- **NFS** (TrueNAS) — bulk storage (media, etc.) and a backup target.
-- **Garage** (S3) — self-hosted S3-compatible object storage in the `storage` namespace, reached at
+- **NFS** (TrueNAS): bulk storage (media, etc.) and a backup target.
+- **Garage** (S3): self-hosted S3-compatible object storage in the `storage` namespace, reached at
   `http://garage.storage.svc.cluster.local:3900` (region `us-east-1`, path-style). It replaced
   Rook's RGW/`CephObjectStore` and serves object-storage consumers such as CloudNativePG's
   barman-cloud backups and apps needing an S3 bucket.
@@ -22,14 +22,14 @@ The cluster uses four storage tiers, chosen per workload:
   `ceph-filesystem` only when a volume genuinely needs RWX.
 - Use `miroir-local` when the workload is latency-sensitive or explicitly node-local; remember it
   pins the pod and a single RWO claim cannot be mounted by pods on two nodes at once (Multi-Attach
-  deadlocks show up on rollouts — co-locate the consumers).
+  deadlocks show up on rollouts, so co-locate the consumers).
 - Use NFS for large shared datasets and as a VolSync destination.
 - Use Garage when an app wants S3, provisioning the bucket and access key with the `/garage` CLI
   inside `garage-0` first.
 
 ## Backups
 
-PVC backups are handled by VolSync — Kopia to NFS, Restic to a remote (R2) target — see
+PVC backups are handled by VolSync (Kopia to NFS, Restic to a remote R2 target); see
 [Backups](../operations/backups.md) and the
 [VolSync / Kopia migration](../migrations/volsync-kopia.md). A parallel `kopiur` operator trial
 (CSI-snapshot-based Kopia backups on two apps) runs alongside VolSync; see Backups for details.

--- a/docs/docs/architecture/storage.md
+++ b/docs/docs/architecture/storage.md
@@ -1,25 +1,35 @@
 # Storage
 
-The cluster uses three storage tiers, chosen per workload:
+The cluster uses four storage tiers, chosen per workload:
 
-- **Rook-Ceph** (`ceph-block` StorageClass) — replicated block storage for stateful workloads that
-  need durability and to move between nodes.
+- **Rook-Ceph** — replicated storage for stateful workloads that need durability and to move
+  between nodes. Two StorageClasses: `ceph-block` (RBD, RWO — the default for app state) and
+  `ceph-filesystem` (CephFS, RWX — for volumes shared across pods/nodes, e.g. the llmkube shared
+  model cache).
 - **miroir** (`miroir-local` StorageClass) — loopfile-backed node-local volumes for workloads that
   want fast node-local storage and tolerate being pinned to a node. Unlike the retired OpenEBS
   hostpath, miroir enforces the requested PVC size (a real ext4 loopfile), so size volumes and
   VolSync caches deliberately.
 - **NFS** (TrueNAS) — bulk storage (media, etc.) and a backup target.
+- **Garage** (S3) — self-hosted S3-compatible object storage in the `storage` namespace, reached at
+  `http://garage.storage.svc.cluster.local:3900` (region `us-east-1`, path-style). It replaced
+  Rook's RGW/`CephObjectStore` and serves object-storage consumers such as CloudNativePG's
+  barman-cloud backups and apps needing an S3 bucket.
 
 ## Choosing a tier
 
-- Default to `ceph-block` for app state that must survive node loss and reschedule freely.
+- Default to `ceph-block` for app state that must survive node loss and reschedule freely; use
+  `ceph-filesystem` only when a volume genuinely needs RWX.
 - Use `miroir-local` when the workload is latency-sensitive or explicitly node-local; remember it
   pins the pod and a single RWO claim cannot be mounted by pods on two nodes at once (Multi-Attach
   deadlocks show up on rollouts — co-locate the consumers).
 - Use NFS for large shared datasets and as a VolSync destination.
+- Use Garage when an app wants S3, provisioning the bucket and access key with the `/garage` CLI
+  inside `garage-0` first.
 
 ## Backups
 
 PVC backups are handled by VolSync — Kopia to NFS, Restic to a remote (R2) target — see
 [Backups](../operations/backups.md) and the
-[VolSync / Kopia migration](../migrations/volsync-kopia.md).
+[VolSync / Kopia migration](../migrations/volsync-kopia.md). A parallel `kopiur` operator trial
+(CSI-snapshot-based Kopia backups on two apps) runs alongside VolSync; see Backups for details.

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -9,9 +9,9 @@ the conventions below.
 Tool-agnostic agent instructions and skills live under `.agents/` so any assistant (Codex, Copilot,
 Cursor, Claude Code) can apply the same conventions:
 
-- `.agents/instructions/sorting.instructions.md` — YAML sorting conventions (alphabetical defaults
+- `.agents/instructions/sorting.instructions.md`: YAML sorting conventions (alphabetical defaults
   plus app-template-specific ordering). Apply this when asked to sort YAML.
-- `.agents/skills/add-app/SKILL.md` — a skill that scaffolds a new app-template application
+- `.agents/skills/add-app/SKILL.md`: a skill that scaffolds a new app-template application
   following the conventions below. Agent tools that read `.agents/skills/` can invoke it directly.
 
 `AGENTS.md` at the repository root is the canonical, tool-agnostic conventions guide. The local
@@ -28,7 +28,7 @@ Use the `add-app` skill to scaffold, or follow the shape by hand. Every app live
     `targetNamespace: *namespace`.
   - Declare any `components` (`volsync`, `alerts`, `homepage`) here, along with their
     `postBuild.substitute` values (`APP: *app`, `VOLSYNC_CAPACITY`). Do not duplicate components into
-    `app/kustomization.yaml`. (Gatus monitoring is automatic — the gatus-sidecar chart auto-discovers
+    `app/kustomization.yaml`. (Gatus monitoring is automatic: the gatus-sidecar chart auto-discovers
     HTTPRoutes, so there is no per-app `gatus/guarded` component anymore.)
   - Add `dependsOn` `onepassword-connect` in `external-secrets` if the app uses an ExternalSecret.
 - **Inside `app/`**:
@@ -46,7 +46,7 @@ Use the `add-app` skill to scaffold, or follow the shape by hand. Every app live
 
 ### House rules to respect
 
-- `ConfigMap` resources must set `metadata.namespace` explicitly — Checkov (CKV_K8S_21) scans raw YAML
+- `ConfigMap` resources must set `metadata.namespace` explicitly. Checkov (CKV_K8S_21) scans raw YAML
   before Flux applies `targetNamespace` and flags `default`.
 - Escape any literal `${VAR}` you want preserved as `$${VAR}`; Flux substitutes unescaped `${VAR}`
   against `cluster-secrets`/`cluster-settings`, and undefined vars become empty strings.
@@ -81,13 +81,13 @@ flate test all --path kubernetes/flux/cluster --allow-missing-secrets
 Lefthook runs automatically on `git commit`. Per `.lefthook.toml`, it formats YAML (`yamlfmt`,
 `prettier`) and JSON/JSON5 (`prettier`), and lints shell scripts (`shellcheck`), GitHub Actions
 workflows (`actionlint`, `zizmor`). It also mirrors several super-linter checks in report-only
-mode — `yamllint`, `codespell`, `markdownlint`, `editorconfig-checker` — scoped to staged files so
+mode (`yamllint`, `codespell`, `markdownlint`, `editorconfig-checker`), scoped to staged files so
 their findings surface at commit time instead of in CI. `.lefthook.toml` is the source of truth for
 the exact command/glob/exclude for each hook.
 
 ## Where AI planning artifacts go
 
 AI planning artifacts (specs, plans, scratch notes from superpowers-style workflows) live in the
-gitignored `docs/superpowers/` directory — they are not committed. Durable knowledge that future
+gitignored `docs/superpowers/` directory. They are not committed. Durable knowledge that future
 maintainers and agents need is promoted into this knowledge base instead, so the published site stays
 the single source of truth.

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -14,8 +14,9 @@ Cursor, Claude Code) can apply the same conventions:
 - `.agents/skills/add-app/SKILL.md` — a skill that scaffolds a new app-template application
   following the conventions below. Agent tools that read `.agents/skills/` can invoke it directly.
 
-`AGENTS.md` at the repository root is the canonical conventions guide. The local `CLAUDE.md` is a
-standalone file and does not import `AGENTS.md`.
+`AGENTS.md` at the repository root is the canonical, tool-agnostic conventions guide. The local
+`CLAUDE.md` imports it via an `@AGENTS.md` include and adds Claude-Code-specific specifics on top
+(kubeconfig usage, `just` command reference, Flux reconciliation steps).
 
 ## Adding a new app
 
@@ -57,15 +58,32 @@ Use the `add-app` skill to scaffold, or follow the shape by hand. Every app live
 
 PR renders and diffs are posted by the in-cluster Konflate as a native commit status plus a PR comment
 (there is no GitHub Actions render workflow). GitHub Actions still run security scans (Checkov/Trivy) and
-super-linter. Mirror the render locally first with flate:
+super-linter. Mirror the render locally first with flate, preferably via the `just` wrappers defined in
+`kubernetes/mod.just` (the raw `flate` invocations underneath are shown for reference):
 
 ```bash
-# Render a single app's HelmRelease
-flate build hr <app> -n <namespace> --path kubernetes/flux/cluster --allow-missing-secrets
+# Render a single app's HelmRelease / Kustomization
+just kube flate-build-hr <namespace> <app>
+just kube flate-build-ks <namespace> <app>
 
 # Test all Kustomizations + HelmReleases
+just kube flate-test
+```
+
+```bash
+# Underlying flate invocations
+flate build hr <app> -n <namespace> --path kubernetes/flux/cluster --allow-missing-secrets
 flate test all --path kubernetes/flux/cluster --allow-missing-secrets
 ```
+
+### Pre-commit hooks (lefthook)
+
+Lefthook runs automatically on `git commit`. Per `.lefthook.toml`, it formats YAML (`yamlfmt`,
+`prettier`) and JSON/JSON5 (`prettier`), and lints shell scripts (`shellcheck`), GitHub Actions
+workflows (`actionlint`, `zizmor`). It also mirrors several super-linter checks in report-only
+mode — `yamllint`, `codespell`, `markdownlint`, `editorconfig-checker` — scoped to staged files so
+their findings surface at commit time instead of in CI. `.lefthook.toml` is the source of truth for
+the exact command/glob/exclude for each hook.
 
 ## Where AI planning artifacts go
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -18,7 +18,8 @@ See [Secret management](architecture/secrets.md) for the full picture. To add on
     sensitive cluster-wide values such as `${SECRET_DOMAIN}`, `${SECRET_INTERNAL_DOMAIN}`, and
     internal device DNS names.
   - `cluster-settings` — a git-tracked ConfigMap in `components/global-vars/` for non-sensitive
-    cluster-wide values (e.g. the default model name). Anything in here is world-visible.
+    cluster-wide values. Anything in here is world-visible. It is currently empty (`data: {}`) but
+    stays wired into every app's substitution.
 
 ## How does Flux variable substitution work, and why must I escape `$${VAR}`?
 
@@ -33,13 +34,19 @@ tokens against `cluster-secrets`/`cluster-settings` at apply time.
 
 ## What is the difference between `${SECRET_DOMAIN}` and `${SECRET_INTERNAL_DOMAIN}`?
 
-Both are substituted from `cluster-secrets`:
+Both are substituted from `cluster-secrets`, but they are not an external/internal pair for app
+hostnames:
 
-- `${SECRET_DOMAIN}` — the external domain, used for apps reachable through the Cloudflare tunnel.
-- `${SECRET_INTERNAL_DOMAIN}` — the internal domain, used for LAN-only apps on the internal listener.
+- `${SECRET_DOMAIN}` — the domain every app route uses. All routes follow `${APP}.${SECRET_DOMAIN}`;
+  whether an app is LAN-only or publicly reachable is decided by which gateway the route attaches to
+  (`envoy-internal` vs `envoy-external`), not by the domain in its hostname.
+- `${SECRET_INTERNAL_DOMAIN}` — kept for non-route uses only: device records such as IPMI probe
+  targets and the NAS S3 endpoint, plus the opnsense-dns domain filter. Do not add
+  `${SECRET_INTERNAL_DOMAIN}` aliases to app routes — each alias costs an OPNsense host-override
+  record, and the record count has a hard ceiling above which publishing silently stops.
 
-"Available under `${SECRET_DOMAIN}`" for a home app usually means internal DNS on the internal
-listener, not public exposure. See [Networking](architecture/networking.md) and
+"Available under `${SECRET_DOMAIN}`" for a home app therefore means internal DNS on the
+`envoy-internal` gateway, not public exposure. See [Networking](architecture/networking.md) and
 [Split DNS](architecture/split-dns.md).
 
 ## How do I force a reconcile?
@@ -76,8 +83,10 @@ The repository is publicly readable, so anything committed is world-visible. **N
 
 Use the `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` placeholders and let Flux substitute the
 real values at apply time. A CI guard (`check_internal_identifiers.py`, run by the security-scans
-workflow) fails any pull request that introduces one of these identifiers outside a small allowlist.
-See [Secret management](architecture/secrets.md).
+workflow) fails any pull request that introduces a LAN IP, node or device hostname, MAC, or
+`.lan`/`.internal` hostname outside a small allowlist. Disk serials and device models are
+deliberately not pattern-matched by the (public) script, so keeping those out is enforced by review
+rather than CI. See [Secret management](architecture/secrets.md).
 
 ## Where do device addresses for monitoring live?
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -14,10 +14,10 @@ See [Secret management](architecture/secrets.md) for the full picture. To add on
   - Reference the 1Password item by title, and have the app's `ks.yaml` `dependsOn`
     `onepassword-connect` in `external-secrets`.
 - For a **cluster-wide value**, decide which store it belongs in:
-  - `cluster-secrets` — a 1Password item injected into every app's `postBuild.substituteFrom`. Holds
+  - `cluster-secrets`: a 1Password item injected into every app's `postBuild.substituteFrom`. Holds
     sensitive cluster-wide values such as `${SECRET_DOMAIN}`, `${SECRET_INTERNAL_DOMAIN}`, and
     internal device DNS names.
-  - `cluster-settings` — a git-tracked ConfigMap in `components/global-vars/` for non-sensitive
+  - `cluster-settings`: a git-tracked ConfigMap in `components/global-vars/` for non-sensitive
     cluster-wide values. Anything in here is world-visible. It is currently empty (`data: {}`) but
     stays wired into every app's substitution.
 
@@ -26,7 +26,7 @@ See [Secret management](architecture/secrets.md) for the full picture. To add on
 The root Kustomization patches every child with `postBuild.substituteFrom`, so Flux replaces `${VAR}`
 tokens against `cluster-secrets`/`cluster-settings` at apply time.
 
-- **Undefined variables become the empty string** — a typo silently blanks the value rather than
+- **Undefined variables become the empty string.** A typo silently blanks the value rather than
   erroring.
 - Any literal `${VAR}` you want to survive substitution (Grafana dashboard template variables,
   envsubst templates, shell snippets in ConfigMaps) must be escaped as `$${VAR}` so Flux passes
@@ -37,12 +37,12 @@ tokens against `cluster-secrets`/`cluster-settings` at apply time.
 Both are substituted from `cluster-secrets`, but they are not an external/internal pair for app
 hostnames:
 
-- `${SECRET_DOMAIN}` — the domain every app route uses. All routes follow `${APP}.${SECRET_DOMAIN}`;
+- `${SECRET_DOMAIN}`: the domain every app route uses. All routes follow `${APP}.${SECRET_DOMAIN}`;
   whether an app is LAN-only or publicly reachable is decided by which gateway the route attaches to
   (`envoy-internal` vs `envoy-external`), not by the domain in its hostname.
-- `${SECRET_INTERNAL_DOMAIN}` — kept for non-route uses only: device records such as IPMI probe
+- `${SECRET_INTERNAL_DOMAIN}`: kept for non-route uses only, such as device records for IPMI probe
   targets and the NAS S3 endpoint, plus the opnsense-dns domain filter. Do not add
-  `${SECRET_INTERNAL_DOMAIN}` aliases to app routes — each alias costs an OPNsense host-override
+  `${SECRET_INTERNAL_DOMAIN}` aliases to app routes. Each alias costs an OPNsense host-override
   record, and the record count has a hard ceiling above which publishing silently stops.
 
 "Available under `${SECRET_DOMAIN}`" for a home app therefore means internal DNS on the
@@ -96,5 +96,5 @@ from the rendered Secret:
 
 - Internal device DNS names and addresses live in the `cluster-secrets` 1Password item, not in
   `cluster-settings`.
-- Do not render the table at boot via init + envsubst against a ConfigMap — that puts the template in
+- Do not render the table at boot via init + envsubst against a ConfigMap. That puts the template in
   Git. Template the file content inside the ExternalSecret and mount the rendered key directly.

--- a/docs/docs/migrations/envoy-gateway.md
+++ b/docs/docs/migrations/envoy-gateway.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This guide documents the implementation of Envoy Gateway v1.8.1 in the Talos cluster and provides instructions for migrating applications from nginx ingress to Gateway API HTTPRoutes.
+This guide documents the implementation of Envoy Gateway v1.8.x in the Talos cluster and provides instructions for migrating applications from nginx ingress to Gateway API HTTPRoutes.
 
 ## What Was Implemented
 
@@ -13,7 +13,7 @@ This guide documents the implementation of Envoy Gateway v1.8.1 in the Talos clu
 
 **Location:** `kubernetes/apps/network/envoy-gateway/`
 
-- **Chart:** `oci://mirror.gcr.io/envoyproxy/gateway-helm v1.8.1`
+- **Chart:** `oci://mirror.gcr.io/envoyproxy/gateway-helm` v1.8.x (see `app/ocirepository.yaml` for the current pin)
 - **CRDs:** Installed via `just bootstrap crds` for GitOps compatibility
 - **Components:**
   - 1 Envoy Gateway controller pod
@@ -40,7 +40,9 @@ network/
 - Wildcard certificate (`*.${SECRET_DOMAIN}`) imported from 1Password
 - Certificate stored in `network` namespace (same as Gateway)
 - No cross-namespace certificate references needed
-- Existing `cert-manager/tls/` setup remains for nginx compatibility
+- nginx is now fully decommissioned; `kubernetes/apps/cert-manager/cert-manager/tls/` (a
+  `Certificate` + `PushSecret`) is today the live source of the wildcard TLS certificate that the
+  `network/certificates` ExternalSecret above pulls in for Envoy Gateway
 
 ### 3. Gateway Resources
 

--- a/docs/docs/migrations/envoy-gateway.md
+++ b/docs/docs/migrations/envoy-gateway.md
@@ -1,7 +1,7 @@
 # Envoy Gateway Migration Guide
 
 !!! note "Completed migration"
-    This page is a record of a migration that is already complete. The steps below are preserved as history; some current-state paths, names, and commands have since drifted. Commands and paths flagged in review are corrected inline — see the Architecture and Operations sections for the present-day setup.
+    This page is a record of a migration that is already complete. The steps below are preserved as history; some current-state paths, names, and commands have since drifted. Commands and paths flagged in review are corrected inline. See the Architecture and Operations sections for the present-day setup.
 
 ## Overview
 
@@ -39,7 +39,7 @@ network/
 
 - Wildcard certificate (`*.${SECRET_DOMAIN}`) imported from 1Password
 - Certificate stored in `network` namespace (same as Gateway)
-- No cross-namespace certificate references needed
+- This setup requires no cross-namespace certificate references
 - nginx is now fully decommissioned; `kubernetes/apps/cert-manager/cert-manager/tls/` (a
   `Certificate` + `PushSecret`) is today the live source of the wildcard TLS certificate that the
   `network/certificates` ExternalSecret above pulls in for Envoy Gateway
@@ -129,7 +129,7 @@ spec:
         #     hosts: [...]
 ```
 
-**No kustomization.yaml changes needed** - the app-template chart handles HTTPRoute creation automatically.
+**No kustomization.yaml changes are needed** because the app-template chart handles HTTPRoute creation automatically.
 
 #### For apps NOT using app-template
 
@@ -270,7 +270,7 @@ sources:
 
 - HTTPRoutes attached to `envoy-external` Gateway automatically get DNS records
 - Uses `external-dns.alpha.kubernetes.io/target` annotation from Gateway
-- No additional annotations needed on HTTPRoutes
+- HTTPRoutes require no additional annotations
 
 ## Migration Checklist
 

--- a/docs/docs/operations/backups.md
+++ b/docs/docs/operations/backups.md
@@ -1,6 +1,6 @@
 # Backups
 
-PVC data is backed up with **VolSync** — the NFS destination uses the **Kopia** mover and the remote
+PVC data is backed up with **VolSync**: the NFS destination uses the **Kopia** mover and the remote
 (R2) destination uses the **Restic** mover. Backups are opt-in per app via the `volsync` component.
 
 ## kopiur trial
@@ -8,13 +8,13 @@ PVC data is backed up with **VolSync** — the NFS destination uses the **Kopia*
 A parallel backup path is being trialed alongside VolSync: the **kopiur** operator
 (`kubernetes/apps/kopiur-system/kopiur`) takes CSI-snapshot-based, Kopia-native backups directly to a
 dedicated NFS `ClusterRepository`, wired in per-app via the `components/kopiur/backup` component.
-It's currently opted in on two apps — `apprise` and `atuin` — as a trial, running **alongside**, not
+It's currently opted in on two apps (`apprise` and `atuin`) as a trial, running **alongside**, not
 replacing, VolSync for those apps.
 
 ## Enabling backups for an app
 
 - Add the `volsync` component to the app's `ks.yaml` `spec.components` (not also to
-  `app/kustomization.yaml` — Flux applies `ks.yaml` components on top of the path build, so listing
+  `app/kustomization.yaml`: Flux applies `ks.yaml` components on top of the path build, so listing
   it in both double-applies).
 - Set `VOLSYNC_CAPACITY` in the `ks.yaml` `postBuild.substitute` block to size the replication
   volume.
@@ -24,7 +24,7 @@ replacing, VolSync for those apps.
 - NFS backups run every 4 hours (`0 */4 * * *`); remote (R2) backups run nightly (`30 0 * * *`).
   Snapshots should reach a Succeeded state.
 - Trigger snapshots for all PVCs on demand with `just kube snapshot`.
-- For single-file SQLite databases, VolSync backs up the whole volume — see the
+- For single-file SQLite databases, VolSync backs up the whole volume. See the
   [Autopulse](../apps/autopulse.md) page for that pattern.
 
 See the [VolSync / Kopia migration](../migrations/volsync-kopia.md) for the move to the Kopia mover

--- a/docs/docs/operations/backups.md
+++ b/docs/docs/operations/backups.md
@@ -3,6 +3,14 @@
 PVC data is backed up with **VolSync** — the NFS destination uses the **Kopia** mover and the remote
 (R2) destination uses the **Restic** mover. Backups are opt-in per app via the `volsync` component.
 
+## kopiur trial
+
+A parallel backup path is being trialed alongside VolSync: the **kopiur** operator
+(`kubernetes/apps/kopiur-system/kopiur`) takes CSI-snapshot-based, Kopia-native backups directly to a
+dedicated NFS `ClusterRepository`, wired in per-app via the `components/kopiur/backup` component.
+It's currently opted in on two apps — `apprise` and `atuin` — as a trial, running **alongside**, not
+replacing, VolSync for those apps.
+
 ## Enabling backups for an app
 
 - Add the `volsync` component to the app's `ks.yaml` `spec.components` (not also to

--- a/docs/docs/operations/bootstrap.md
+++ b/docs/docs/operations/bootstrap.md
@@ -271,24 +271,35 @@ Deploys bootstrap applications via Helmfile.
 
 ### Full Bootstrap
 
-Run all stages in sequence:
+`just bootstrap` on its own only **lists** the module's recipes (`set default-list`
+in `bootstrap/mod.just`) — it no longer arms a bootstrap by itself. Run the full
+end-to-end flow with the `cluster` recipe:
 
 ```bash
-just bootstrap
+just bootstrap cluster
 ```
+
+This prompts for confirmation first — `Bootstrap cluster? [y|N]` — before running
+any stage.
 
 This is equivalent to:
 
 ```bash
 just bootstrap talos
 just bootstrap kube
-just bootstrap kubeconfig
+just bootstrap kubeconfig node
 just bootstrap wait
 just bootstrap namespaces
 just bootstrap resources
 just bootstrap crds
 just bootstrap apps
+just bootstrap kubeconfig
 ```
+
+The first `kubeconfig node` call points kubectl directly at a control-plane node
+IP — Cilium's LoadBalancer doesn't exist yet at this point in the bootstrap, so
+there's no LB IP to route through. The final `kubeconfig` call (default `cilium`)
+re-fetches it pointed at the Cilium LB once Cilium is up and running.
 
 ### Partial Bootstrap
 
@@ -337,28 +348,50 @@ graph TD
 
 Certain applications use post-sync hooks to ensure dependent resources are ready:
 
-### Cilium Hook
+### Cilium Hooks
 
-Waits for Cilium CRDs to be available (helmfile `postsync` hook):
+Cilium has two `postsync` hooks in `bootstrap/helmfile.d/01-apps.yaml`:
 
-```bash
-kubectl wait --for=create \
-  crd/ciliumbgpadvertisements.cilium.io \
-  crd/ciliumbgpclusterconfigs.cilium.io \
-  crd/ciliumbgppeerconfigs.cilium.io \
-  crd/ciliumloadbalancerippools.cilium.io \
-  --timeout=2m
-```
+1. Waits for Cilium CRDs to be available:
 
-### OnePassword Connect Hook
+    ```bash
+    kubectl wait --for=create \
+      crd/ciliumbgpadvertisements.cilium.io \
+      crd/ciliumbgpclusterconfigs.cilium.io \
+      crd/ciliumbgppeerconfigs.cilium.io \
+      crd/ciliumloadbalancerippools.cilium.io \
+      --timeout=2m
+    ```
 
-Waits for ClusterSecretStore CRD (helmfile `postsync` hook on `onepassword-connect`):
+2. Server-side applies Cilium's own networking resources, so they exist before Flux
+   takes over management of them:
 
-```bash
-kubectl wait --for=create \
-  crd/clustersecretstores.external-secrets.io \
-  --timeout=2m
-```
+    ```bash
+    kubectl apply --namespace=kube-system --server-side \
+      --field-manager=kustomize-controller \
+      --filename=../../kubernetes/apps/kube-system/cilium/app/networks.yaml
+    ```
+
+### OnePassword Connect Hooks
+
+OnePassword Connect also has two `postsync` hooks:
+
+1. Waits for the ClusterSecretStore CRD to be available:
+
+    ```bash
+    kubectl wait --for=create \
+      crd/clustersecretstores.external-secrets.io \
+      --timeout=2m
+    ```
+
+2. Server-side applies the `ClusterSecretStore` resource itself, so ExternalSecrets
+   can start resolving `onepassword-connect` refs immediately:
+
+    ```bash
+    kubectl apply --server-side \
+      --field-manager=kustomize-controller \
+      --filename=../../kubernetes/apps/external-secrets/onepassword-connect/app/clustersecretstore.yaml
+    ```
 
 ## Values Template (DRY Principle)
 
@@ -367,10 +400,7 @@ The bootstrap uses a Go template to source Helm values from HelmRelease files:
 **File:** `bootstrap/helmfile.d/templates/values.yaml.gotmpl`
 
 ```gotmpl
-{{- $namespace := .Release.Namespace -}}
-{{- $name := .Release.Name -}}
-{{- $path := printf "../../../kubernetes/apps/%s/%s/app/helmrelease.yaml" $namespace $name -}}
-{{ (fromYaml (readFile $path)).spec.values | toYaml }}
+{{ (fromYaml (readFile (printf "../../../kubernetes/apps/%s/%s/app/helmrelease.yaml" .Release.Namespace .Release.Name))).spec.values | toYaml }}
 ```
 
 **How it works:**
@@ -535,7 +565,7 @@ The old bash-based bootstrap system (`scripts/bootstrap-apps.sh`) has been remov
 ### New Command
 
 ```bash
-just bootstrap
+just bootstrap cluster
 ```
 
 ### Key Differences

--- a/docs/docs/operations/bootstrap.md
+++ b/docs/docs/operations/bootstrap.md
@@ -50,7 +50,7 @@ mise install
 - `talosctl` - Talos Linux CLI
 - `kustomize` - Kubernetes configuration management
 - `yq` - YAML processor
-- `op` - 1Password CLI (for secret injection; install separately, e.g. via Homebrew — not in the mise toolchain)
+- `op` - 1Password CLI (for secret injection; install separately, e.g. via Homebrew, not in the mise toolchain)
 
 **Additional Tools:**
 
@@ -272,14 +272,14 @@ Deploys bootstrap applications via Helmfile.
 ### Full Bootstrap
 
 `just bootstrap` on its own only **lists** the module's recipes (`set default-list`
-in `bootstrap/mod.just`) — it no longer arms a bootstrap by itself. Run the full
+in `bootstrap/mod.just`). It no longer arms a bootstrap by itself. Run the full
 end-to-end flow with the `cluster` recipe:
 
 ```bash
 just bootstrap cluster
 ```
 
-This prompts for confirmation first — `Bootstrap cluster? [y|N]` — before running
+This prompts for confirmation first (`Bootstrap cluster? [y|N]`) before running
 any stage.
 
 This is equivalent to:
@@ -297,7 +297,7 @@ just bootstrap kubeconfig
 ```
 
 The first `kubeconfig node` call points kubectl directly at a control-plane node
-IP — Cilium's LoadBalancer doesn't exist yet at this point in the bootstrap, so
+IP. Cilium's LoadBalancer doesn't exist yet at this point in the bootstrap, so
 there's no LB IP to route through. The final `kubeconfig` call (default `cilium`)
 re-fetches it pointed at the Cilium LB once Cilium is up and running.
 

--- a/docs/docs/operations/device-monitoring.md
+++ b/docs/docs/operations/device-monitoring.md
@@ -18,9 +18,18 @@ cross-cutting "what lives where and how to update it" reference.
 | vCenter / ESXi | `pryorda/vmware_exporter`         | `vmware-exporter`                             | `${SECRET_VSPHERE_ENDPOINT}` | `vsphere-monitoring`                   |
 | Firewall       | `AthennaMind/opnsense-exporter`   | `opnsense-exporter`                           | `host` field in item         | `opnsense-exporter`                    |
 | Core switch    | `prometheus/snmp_exporter`        | `snmp-exporter`                               | `${ONYX_ADDR}`               | — (SNMP community `<community>`)       |
+| UPS (NUT)      | `hon95/prometheus-nut-exporter`   | `nut-exporter` (+ `peanut` web UI)            | `${NUT_SERVER_ADDR}`         | — (anonymous NUT protocol read)        |
 
 All of these run on **least-privilege, dedicated read-only accounts**, never an
 admin credential.
+
+Since PR #3768 (2026-07-21), UPS monitoring follows the same shape as everything
+else in this table: `nut-exporter` scrapes an **external** NUT appliance (a
+dedicated box outside the cluster, so it can keep reporting — and sequencing the
+cluster's own shutdown — through a power event the cluster itself doesn't
+survive) at `${NUT_SERVER_ADDR}`, and `peanut` gives it a web UI. There is no
+in-cluster `upsd` anymore; reading NUT variables is anonymous, so no credential
+is involved.
 
 !!! warning "The two MikroTik CRS354 switches are currently NOT monitored"
 
@@ -56,9 +65,10 @@ whole game:
    `${...}` values the manifests reference (e.g. `OLLAMA_MODEL`).
 3. **`cluster-secrets`** (1Password-backed) — `SECRET_STORAGE_SERVER`,
    `SECRET_VSPHERE_ENDPOINT`, and the device DNS names `ONYX_ADDR`,
-   `MIKROTIK_POE_ADDR`, `MIKROTIK_NONPOE_ADDR` (internal hostnames kept out of
-   this public repo). Flux substitutes `${...}` from this Secret the same way; the
-   real values live in the `cluster-secrets` 1Password item (vault `Talos`).
+   `MIKROTIK_POE_ADDR`, `MIKROTIK_NONPOE_ADDR`, `NUT_SERVER_ADDR` (internal
+   hostnames kept out of this public repo). Flux substitutes `${...}` from this
+   Secret the same way; the real values live in the `cluster-secrets` 1Password
+   item (vault `Talos`).
 4. **Per-app 1Password items** (vault `Talos`, read by External Secrets via the
    `onepassword-connect` ClusterSecretStore) — the device credentials themselves.
 
@@ -89,8 +99,10 @@ Edit the relevant field (e.g. `ONYX_ADDR`) in the `cluster-secrets` 1Password it
 (vault `Talos`). The `cluster-secrets` ExternalSecret is replicated into every
 namespace; it refreshes within 1h, or force-sync the consuming namespace now, e.g.
 `kubectl annotate externalsecret cluster-secrets -n observability force-sync="$(date +%s)" --overwrite`.
-Flux re-substitutes it into the manifests on the next reconcile. For
-`snmp-exporter` you must then restart the pod (see Gotchas).
+Flux re-substitutes it into the manifests on the next reconcile. `snmp-exporter`
+carries a `reloader.stakater.com/auto: "true"` annotation (see Gotchas), so
+Reloader restarts its pod automatically once the rendered config changes — no
+manual rollout needed.
 
 ### Rotate a credential
 
@@ -99,8 +111,8 @@ Flux re-substitutes it into the manifests on the next reconcile. For
    refresh interval):
    `kubectl annotate externalsecret <name> -n observability force-sync="$(date +%s)" --overwrite`
 3. The app's `reloader.stakater.com/auto` annotation restarts the pod when the
-   rendered secret changes. **Exception: `snmp-exporter` has no reloader** —
-   restart it manually (see Gotchas).
+   rendered secret changes. `snmp-exporter` gets this annotation via a
+   `postRenderers` kustomize patch rather than a chart value (see Gotchas).
 
 ### Enable / disable an OPNsense collector
 
@@ -112,7 +124,8 @@ add an env var to `opnsense-exporter/app/helmrelease.yaml`, e.g.
 ### Add a new SNMP device
 
 Add an entry under `serviceMonitor.params` in
-`snmp-exporter/app/helmrelease.yaml` (chart `9.14.0` reads targets there, **not**
+`snmp-exporter/app/helmrelease.yaml` (the chart — 9.x, see
+`app/ocirepository.yaml` for the current pin — reads targets there, **not**
 a top-level `params`):
 
 ```yaml
@@ -165,9 +178,15 @@ kubectl exec -n observability deploy/snmp-exporter -- \
 
 ## Gotchas
 
-- **`snmp-exporter` has no reloader.** A ConfigMap, module, or auth change does
-  **not** restart the pod, so the new config is not loaded. After any change run
-  `kubectl rollout restart deploy/snmp-exporter -n observability`.
+- **`snmp-exporter` restarts on config change via Reloader (fixed by #3572,
+  2026-07-17).** It previously needed a manual `kubectl rollout restart` after
+  every ConfigMap/module/auth change, because it only reads its `--config.file`
+  at startup. The chart's `9.x` line has no Deployment-level annotations value,
+  so the fix is a `postRenderers` kustomize patch in
+  `snmp-exporter/app/helmrelease.yaml` that adds
+  `reloader.stakater.com/auto: "true"` directly to the Deployment — Reloader now
+  restarts the pod automatically whenever the rendered ConfigMap/Secret changes.
+  No manual restart is needed anymore.
 - **Never write a literal `${...}` in a YAML comment** in a manifest. Flux's
   post-build `envsubst` parses it as a variable name and fails the whole
   Kustomization with `unable to parse variable name`.

--- a/docs/docs/operations/device-monitoring.md
+++ b/docs/docs/operations/device-monitoring.md
@@ -1,7 +1,7 @@
 # Device & Infrastructure Monitoring
 
 How the cluster scrapes external infrastructure (storage, hypervisor, firewall,
-switches) into Prometheus, and — the important part — **how to change the
+switches) into Prometheus, and (the important part) **how to change the
 settings later** without hunting through manifests.
 
 For the TrueNAS-specific exporter install steps see
@@ -25,8 +25,8 @@ admin credential.
 
 Since PR #3768 (2026-07-21), UPS monitoring follows the same shape as everything
 else in this table: `nut-exporter` scrapes an **external** NUT appliance (a
-dedicated box outside the cluster, so it can keep reporting — and sequencing the
-cluster's own shutdown — through a power event the cluster itself doesn't
+dedicated box outside the cluster, so it can keep reporting and sequence the
+cluster's own shutdown through a power event the cluster itself doesn't
 survive) at `${NUT_SERVER_ADDR}`, and `peanut` gives it a web UI. There is no
 in-cluster `upsd` anymore; reading NUT variables is anonymous, so no credential
 is involved.
@@ -41,7 +41,7 @@ is involved.
     (`terraform/mikrotik/hardening.tf`, since 2026-04-02). The exporter only ever
     worked because api-ssl had been enabled by hand in June and never codified; a
     `terraform apply` on 2026-07-06 reconciled that drift and the exporter went
-    blind. Re-enabling it by hand is not durable — the next apply reverts it.
+    blind. Re-enabling it by hand is not durable: the next apply reverts it.
 
     Restoring coverage without touching the hardening posture means **SNMP**:
     add the two switches as `serviceMonitor.params[]` entries on `snmp-exporter`
@@ -53,24 +53,24 @@ is involved.
 There are four places a setting can live. Knowing which one a value uses is the
 whole game:
 
-1. **DNS names** — switch/host addresses are DNS records, not raw IP addresses.
+1. **DNS names**: switch/host addresses are DNS records, not raw IP addresses.
    Host-overrides are declared in the `network-ops` repository
    (`ansible/vars/dns.yml`, applied by `ansible/playbooks/opnsense-dns.yml`) and
    served by OPNsense Unbound.
    - `<core-switch>.${SECRET_INTERNAL_DOMAIN}` → the core switch
    - `<access-switch>.${SECRET_INTERNAL_DOMAIN}` → the PoE access switch
    - `<mgmt-switch>.${SECRET_INTERNAL_DOMAIN}` → the management switch
-2. **`cluster-settings`** (non-secret, Git-tracked) —
+2. **`cluster-settings`** (non-secret, Git-tracked):
    `kubernetes/components/global-vars/cluster-settings.yaml`. Holds non-sensitive
    `${...}` values the manifests reference (e.g. `OLLAMA_MODEL`).
-3. **`cluster-secrets`** (1Password-backed) — `SECRET_STORAGE_SERVER`,
+3. **`cluster-secrets`** (1Password-backed): `SECRET_STORAGE_SERVER`,
    `SECRET_VSPHERE_ENDPOINT`, and the device DNS names `ONYX_ADDR`,
    `MIKROTIK_POE_ADDR`, `MIKROTIK_NONPOE_ADDR`, `NUT_SERVER_ADDR` (internal
    hostnames kept out of this public repo). Flux substitutes `${...}` from this
    Secret the same way; the real values live in the `cluster-secrets` 1Password
    item (vault `Talos`).
 4. **Per-app 1Password items** (vault `Talos`, read by External Secrets via the
-   `onepassword-connect` ClusterSecretStore) — the device credentials themselves.
+   `onepassword-connect` ClusterSecretStore): the device credentials themselves.
 
 > Device **admin** credentials (used by `network-ops` to manage the devices)
 > live in the **`Home Operations`** vault (separate per-device admin items). The
@@ -85,11 +85,11 @@ Because monitoring references **DNS names**, this is a one-line change:
 1. Edit the `server:` for that host in `network-ops` `ansible/vars/dns.yml`.
 2. Apply: `op run --env-file=.env -- ansible-playbook ansible/playbooks/opnsense-dns.yml`
    (or `mise run opnsense-dns`). Requires the `ansibleguy.opnsense` collection
-   and `httpx` in the Ansible Python — see Gotchas.
+   and `httpx` in the Ansible Python (see Gotchas).
 3. Nothing in this repository changes; the exporters re-resolve the name on the
    next scrape.
 
-For TrueNAS / vCenter the address is a `cluster-secrets` variable instead — edit
+For TrueNAS / vCenter the address is a `cluster-secrets` variable instead: edit
 `SECRET_STORAGE_SERVER` / `SECRET_VSPHERE_ENDPOINT` in the `cluster-secrets`
 1Password item; ExternalSecrets pick it up on the next refresh.
 
@@ -101,8 +101,8 @@ namespace; it refreshes within 1h, or force-sync the consuming namespace now, e.
 `kubectl annotate externalsecret cluster-secrets -n observability force-sync="$(date +%s)" --overwrite`.
 Flux re-substitutes it into the manifests on the next reconcile. `snmp-exporter`
 carries a `reloader.stakater.com/auto: "true"` annotation (see Gotchas), so
-Reloader restarts its pod automatically once the rendered config changes — no
-manual rollout needed.
+Reloader restarts its pod automatically once the rendered config changes, so
+no manual rollout is needed.
 
 ### Rotate a credential
 
@@ -124,9 +124,8 @@ add an env var to `opnsense-exporter/app/helmrelease.yaml`, e.g.
 ### Add a new SNMP device
 
 Add an entry under `serviceMonitor.params` in
-`snmp-exporter/app/helmrelease.yaml` (the chart — 9.x, see
-`app/ocirepository.yaml` for the current pin — reads targets there, **not**
-a top-level `params`):
+`snmp-exporter/app/helmrelease.yaml` (the chart's 9.x line reads targets there,
+**not** a top-level `params`; see `app/ocirepository.yaml` for the current pin):
 
 ```yaml
 - name: <short-name>
@@ -146,11 +145,11 @@ with the image's bundled `snmp.yml` via the two `--config.file` `extraArgs`.
 ### Add a RouterOS switch to snmp-exporter
 
 The `mktxp` route is retired (see the warning above). Add RouterOS switches the
-same way as the Onyx core switch — a `serviceMonitor.params[]` entry with module
+same way as the Onyx core switch: a `serviceMonitor.params[]` entry with module
 `if_mib` and the read-only SNMP community. SNMP is enabled and source-ACLed on
 both MikroTiks by the network-ops Terraform (`routeros_snmp_community`), so no
 device-side change is needed. Add the host as a `cluster-secrets` DNS var (the
-1Password item, **not** git-tracked `cluster-settings` — device hostnames stay
+1Password item, **not** git-tracked `cluster-settings`: device hostnames stay
 out of this public repo).
 
 ## Validation
@@ -184,9 +183,9 @@ kubectl exec -n observability deploy/snmp-exporter -- \
   at startup. The chart's `9.x` line has no Deployment-level annotations value,
   so the fix is a `postRenderers` kustomize patch in
   `snmp-exporter/app/helmrelease.yaml` that adds
-  `reloader.stakater.com/auto: "true"` directly to the Deployment — Reloader now
-  restarts the pod automatically whenever the rendered ConfigMap/Secret changes.
-  No manual restart is needed anymore.
+  `reloader.stakater.com/auto: "true"` directly to the Deployment. Reloader now
+  restarts the pod automatically whenever the rendered ConfigMap/Secret changes,
+  so no manual restart is needed anymore.
 - **Never write a literal `${...}` in a YAML comment** in a manifest. Flux's
   post-build `envsubst` parses it as a variable name and fails the whole
   Kustomization with `unable to parse variable name`.
@@ -196,7 +195,7 @@ kubectl exec -n observability deploy/snmp-exporter -- \
   fire. Pair every such alert with `absent(metric)`. This blind spot hid a total
   mktxp outage for eight days.
 - **`pryorda/vmware_exporter` uses an API protocol, not REST.** Likewise, a `401`
-  when testing the RouterOS REST API is expected — the read-only user
+  when testing the RouterOS REST API is expected: the read-only user
   intentionally lacks the `web` policy.
 - **The `network-ops` Ansible setup needs one-time steps** the repository does not
   automate: `ansible-galaxy collection install -r ansible/requirements.yml`,

--- a/docs/docs/operations/jory-homeops-adoption.md
+++ b/docs/docs/operations/jory-homeops-adoption.md
@@ -45,7 +45,7 @@ except where noted.
 | B   | ✅ #3481 — Config cherry-picks: SearXNG hardening, litellm `context_window_fallbacks`, add-app SKILL.md wording | none    |
 | C   | ✅ #3482 arr (+ seerr #3491) — MCP servers over existing apps, with netpol rules; **ha still open** | HA token in 1Password |
 | D   | ✅ #3483 — CephFS enablement + comment corrections; RWX smoke test PASSED 2026-07-10 | none                              |
-| E   | ✅ #3484 — hermes (gateway + dashboard baseline, no chat platforms)      | none — item created, defaults applied           |
+| E   | ✅ #3484 — hermes (gateway + dashboard; web chat since added via `hermeswebui`) | none — item created, defaults applied    |
 | F   | (optional) CPU-served ~4B auxiliary model                                | none                                            |
 | G   | ✅ #3489/#3490/#3493 — model-storage de-workaround (shared CephFS cache); both models cache-served, vision verified | none |
 
@@ -123,8 +123,10 @@ test is the insurance before anything real depends on CephFS.
 
 Stand up [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) at
 `kubernetes/apps/ai/hermes/` as a standard app-template app. All dependencies (litellm, memini,
-toolhive) are same-namespace — no new netpol. It idles fine with zero chat platforms, so the
-baseline is gateway + dashboard only.
+toolhive) are same-namespace — no new netpol. It idles fine with zero bot-token chat platforms, so
+the initial baseline was gateway + dashboard only — since superseded: `hermeswebui`
+(`kubernetes/apps/ai/hermeswebui/`), a chat web frontend, is now deployed, and hermes sets
+`API_SERVER_ENABLED: "true"` specifically to serve it.
 
 Shape (validated against the open-webui HelmRelease as the structural analog):
 
@@ -220,7 +222,9 @@ repositories, and dispatch needs CNPG + an OIDC story.
 
 ## Decision checklist (pick-up point)
 
-- [ ] hermes: which chat surfaces, if any, to enable first (each needs a bot token in 1Password)?
+- [ ] hermes: the web chat surface is already live via `hermeswebui`; the open question is only
+      which bot-token platforms (Discord/Slack/etc.), if any, to enable next (each needs a bot
+      token in 1Password)
 - [ ] hermes: MCP wiring — direct per-proxy entries (default) or litellm's `/mcp` aggregate?
 - [ ] hermes: keep `approvals.mode: manual` (default) or `smart`?
 - [ ] hermes: image tag to pin (jory runs v2026.7.7; newer exists) + digest.

--- a/docs/docs/operations/jory-homeops-adoption.md
+++ b/docs/docs/operations/jory-homeops-adoption.md
@@ -1,12 +1,12 @@
 # joryirving/home-ops Adoption Roadmap
 
-**Status:** Largely SHIPPED 2026-07-10. PRs A–E landed as #3480–#3484 (+ follow-up
+**Status:** Largely SHIPPED 2026-07-10. PRs A-E landed as #3480-#3484 (+ follow-up
 fixes #3488 mcp-searxng bind / arr telemetry, #3492 cache-prep securityContext), seerr
 MCP as #3491, and PR G as the staged #3489 (operator 0.9.3) → #3490 (shared cache +
 abliterated model) → #3493 (vision, first-class mmproj) with both models verified on the shared
 CephFS cache (text + vision end-to-end). The CephFS RWX smoke test passed on 2026-07-10.
 Still open: **ha MCP** (awaiting a user-created read-only Home Assistant token in 1Password),
-**PR F** (optional CPU auxiliary model), and **foreman** (parked — re-evaluate now CephFS is
+**PR F** (optional CPU auxiliary model), and **foreman** (parked; re-evaluate now CephFS is
 proven). Planned 2026-07-09 via multi-agent gap analysis + adversarial review.
 
 A survey of [joryirving/home-ops](https://github.com/joryirving/home-ops) (`kubernetes/apps/base/llm`
@@ -17,7 +17,7 @@ that came out of verification, and the plan to unwind workarounds built on a wro
 ## Load-bearing findings
 
 1. **CephFS was never blocked on this cluster.** The June 2026 "Talos ships no ceph kernel
-   module" diagnosis was a modprobe-vs-builtin trap — `CONFIG_CEPH_FS=y` is compiled into the
+   module" diagnosis was a modprobe-vs-builtin trap: `CONFIG_CEPH_FS=y` is compiled into the
    Talos v1.13.5 kernel and `/proc/filesystems` registers `ceph` on all three nodes today.
    See [KB-025](../troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md). This
    invalidates the premise behind the RWO model-storage workarounds (PR G below) and un-blocks
@@ -28,10 +28,10 @@ that came out of verification, and the plan to unwind workarounds built on a wro
    a new ingress rule on each target namespace (precedent: `allow-litellm-from-consumers` in
    `kubernetes/apps/ai/netpol.yaml`).
 3. **Hardware verdict for the "ryzen" question:** the nodes' AMD Ryzen 7000-class CPUs carry a
-   2-CU display-class iGPU sharing the CPUs' DDR5 — nothing like the Strix-Halo-class AMD
+   2-CU display-class iGPU sharing the CPUs' DDR5: nothing like the Strix-Halo-class AMD
    hardware jory serves models on (and his `llama-ryzen` runs on a separate utility cluster
    anyway). The iGPU path is rejected. The useful Ryzen angle is **CPU serving of small
-   auxiliary models** (Zen 4 AVX-512, large RAM, nodes at 6–8% utilisation), which the cluster
+   auxiliary models** (Zen 4 AVX-512, large RAM, nodes at 6-8% utilisation), which the cluster
    already proves with `llama-embed` / `llama-rerank` on the plain CPU `llama.cpp:server` image.
 
 ## The PR ladder
@@ -55,12 +55,12 @@ except where noted.
   (`LiteLLMFallbackChainExhausted` critical, `LiteLLMModelFailover`, `LiteLLMDeploymentOutage`,
   `LiteLLMAuthOrQuotaFailures`) onto the `litellm_deployment_*` series the existing
   ServiceMonitor already scrapes. Tune thresholds for a single replica, and use
-  `absent()` / `for:` windows — several series only appear after a first failure. Consider
+  `absent()` / `for:` windows: several series only appear after a first failure. Consider
   folding in a direct InferenceService-down alert (pod availability on metrics already
-  scraped) — the review pass flagged it as a comparable cheap win.
+  scraped); the review pass flagged it as a comparable cheap win.
 - ToolHive telemetry: an `MCPTelemetryConfig` CR (`prometheus.enabled: true`) in `ai`, plus a
   PodMonitor for the MCP server pods. **Drop jory's `release: kube-prometheus-stack` selector
-  label** — this cluster's Prometheus selects monitors without it, and copying it could
+  label**: this cluster's Prometheus selects monitors without it, and copying it could
   silently break selection.
 - llama.cpp serving dashboard (jory's `llama-server.json`) as a GrafanaDashboard, plus
   `targetLabels: [app.kubernetes.io/instance, app.kubernetes.io/name]` on the `llmkube-models`
@@ -71,7 +71,7 @@ except where noted.
 ### PR B — config cherry-picks
 
 - SearXNG (`toolhive/mcp-servers/searxng`): disable `autocomplete` and `favicon_resolver`
-  (per-keystroke upstream calls trip captcha / rate limits on an automation-driven instance —
+  (per-keystroke upstream calls trip captcha / rate limits on an automation-driven instance;
   ours is driven by the MCP server and open-webui RAG), add jory's `enabled_plugins` set and
   hostname priority boosting, add a `limiter.toml` with RFC1918 `pass_ip`. Skip the
   Redis-backed limiter, `replicas: 2`, and the Brave API engine.
@@ -85,12 +85,12 @@ except where noted.
 - **arr**: a ToolHive `MCPServer` wired to sonarr/radarr (media) and prowlarr (downloads),
   API keys extracted from the existing 1Password items. Requires new ingress
   CiliumNetworkPolicy rules on **both** `media` and `downloads` (finding 2). Gate: source a
-  digest-pinnable image — jory runs it via `npx` at runtime, which violates the image-pinning
+  digest-pinnable image: jory runs it via `npx` at runtime, which violates the image-pinning
   convention here. Register in the `mcp-tools` group and litellm `mcp_servers`.
 - **ha**: `MCPServer` for Home Assistant with a **read-only scoped long-lived token** (new
-  1Password item) and a new ingress rule on `home`. Treat read-only scoping as mandatory —
+  1Password item) and a new ingress rule on `home`. Treat read-only scoping as mandatory:
   LLM-driven home control is the highest blast radius in this batch.
-- **seerr** (optional): the review pass called this the weakest "skip" — same
+- **seerr** (optional): the review pass called this the weakest "skip": same
   exploit-an-existing-app class as arr, nearly free once the `media` netpol rule exists. Add
   read-only as a follow-on if wanted.
 - Alternative to all netpol edits: point the MCP servers at the apps' `envoy-internal` gateway
@@ -104,18 +104,18 @@ except where noted.
 Values-only; never touches the in-use `ceph-blockpool` / `ceph-block` StorageClass. Two files:
 
 1. `kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml`: `drivers.cephfs.enabled: true`,
-   mirror the RBD block's snapshotter settings, and set `kernelMountOptions: ms_mode=prefer-crc`
-   — this cluster sets `requireMsgr2: true`, and the kernel client needs `ms_mode` to negotiate
+   mirror the RBD block's snapshotter settings, and set `kernelMountOptions: ms_mode=prefer-crc`:
+   this cluster sets `requireMsgr2: true`, and the kernel client needs `ms_mode` to negotiate
    msgr2. Rewrite the stale "no ceph kernel module" comment (KB-025).
 2. `kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml`: replace `cephFileSystems: []`
-   with a `ceph-filesystem` entry — distinct metadata + `data0` pools (replicated size 3,
+   with a `ceph-filesystem` entry: distinct metadata + `data0` pools (replicated size 3,
    `failureDomain: host`), MDS `activeCount: 1` + `activeStandby: true` (requests ~100m/1Gi,
-   limit 4Gi — decide the ceiling), and the `ceph-filesystem` StorageClass. Rewrite the comment
+   limit 4Gi; decide the ceiling), and the `ceph-filesystem` StorageClass. Rewrite the comment
    block. Optionally uncomment the `cephFileSystemVolumeSnapshotClass` (`csi-ceph-filesystem`).
 
 No Talos, schematic, or operator changes. Validate with
 `just kube flate-build-hr rook-ceph rook-ceph-cluster`, then after merge: MDS pods Ready,
-`ceph -s` HEALTH_OK, and the **gate for PR G** — a throwaway RWX PVC mounted read-write by two
+`ceph -s` HEALTH_OK, and the **gate for PR G**: a throwaway RWX PVC mounted read-write by two
 pods on different nodes. The June attempt failed at a layer never pinned down, so the smoke
 test is the insurance before anything real depends on CephFS.
 
@@ -123,22 +123,22 @@ test is the insurance before anything real depends on CephFS.
 
 Stand up [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) at
 `kubernetes/apps/ai/hermes/` as a standard app-template app. All dependencies (litellm, memini,
-toolhive) are same-namespace — no new netpol. It idles fine with zero bot-token chat platforms, so
-the initial baseline was gateway + dashboard only — since superseded: `hermeswebui`
+toolhive) are same-namespace: no new netpol. It idles fine with zero bot-token chat platforms, so
+the initial baseline was gateway + dashboard only. That has since been superseded: `hermeswebui`
 (`kubernetes/apps/ai/hermeswebui/`), a chat web frontend, is now deployed, and hermes sets
 `API_SERVER_ENABLED: "true"` specifically to serve it.
 
 Shape (validated against the open-webui HelmRelease as the structural analog):
 
 - `ks.yaml`: components `volsync`, `dependsOn` litellm + memini + **onepassword-connect**
-  (review catch — the ExternalSecret convention), `VOLSYNC_CAPACITY: 10Gi`.
+  (review catch: the ExternalSecret convention), `VOLSYNC_CAPACITY: 10Gi`.
 - `app/configmap.yaml` (`hermes-config`): default model `self-hosted` via a `litellm` provider
   (`http://litellm.ai.svc.cluster.local:4000/v1`), memory provider `memini`
   (`MEMINI_URL` pointing at the memini Service, distinct `MEMINI_NAMESPACE`), terminal backend
   `local` with `/opt/data/workspace`, `security.redact_secrets` + `privacy.redact_pii` on.
 - `app/externalsecret.yaml`: extract `litellm`, `memini`, and a new `hermes-agent` 1Password
   item (dashboard basic-auth credentials + session secret; bot tokens later).
-- `app/helmrelease.yaml`: `fsGroup: 10000` (image-baked UID — not the usual 1000), init
+- `app/helmrelease.yaml`: `fsGroup: 10000` (image-baked UID, not the usual 1000), init
   container bootstraps the pinned memini plugin, gateway + dashboard containers, route on
   `envoy-internal` for `{{ .Release.Name }}.${SECRET_DOMAIN}`, persistence `existingClaim` on
   `/opt/data`. Strip everything jory-specific: Authentik OIDC, the NAS mount, Discord persona,
@@ -149,9 +149,9 @@ Verify before applying (review-pass gaps): the image tag + sha256 digest and con
 actual Service port; the real ToolHive MCP proxy Service names (the live litellm ConfigMap
 disagrees with research snapshots on ports).
 
-Proposed defaults, changeable later — see the decision checklist below for the open ones:
+Proposed defaults, changeable later; see the decision checklist below for the open ones:
 no chat platforms at first boot; MCP wired directly per ToolHive proxy; `approvals.mode:
-manual` (hermes gets kubectl/flux/talos tools and a local terminal — the Pod is the only
+manual` (hermes gets kubectl/flux/talos tools and a local terminal, the Pod is the only
 boundary, so no unattended cluster actions until it has earned trust); reuse
 `LITELLM_MASTER_KEY` (open-webui precedent) with a scoped virtual key as later hardening;
 `MEMINI_NAMESPACE: hermes`.
@@ -161,9 +161,9 @@ boundary, so no unattended cluster actions until it has earned trust); reuse
 A ~4B Q4 model (for example Qwen3-4B-Instruct Q4_K_M) served CPU-only to handle
 summaries / classification / drafts without spending an L4 slice. **Mirror the proven
 app-template pattern of `llama-embed` / `llama-rerank`** (plain `ghcr.io/ggml-org/llama.cpp`
-`server` tag — the CPU build; there is no `server-cpu` tag) rather than the unverified llmkube
-`hardware.accelerator: cpu` path. Expect ~10–18 tok/s generation (dual-channel DDR5 bound) —
-fine for latency-tolerant work, not for interactive chat. Register in litellm as a distinct
+`server` tag: the CPU build; there is no `server-cpu` tag) rather than the unverified llmkube
+`hardware.accelerator: cpu` path. Expect ~10-18 tok/s generation (dual-channel DDR5 bound).
+Fine for latency-tolerant work, not for interactive chat. Register in litellm as a distinct
 model name and consider pointing litellm's auxiliary tasks at it. Set explicit requests/limits
 to protect co-tenants.
 
@@ -190,20 +190,20 @@ Steps:
    and rewrite its comment.
 2. Convert the two Model CRs (`qwen3.6-35b-a3b`, `qwen3-30b-abliterated`) from
    `source: pvc://…` to operator-managed upstream sources so llmkube stages weights into the
-   shared cache itself (mirror the Model source syntax in jory's manifests — his
+   shared cache itself (mirror the Model source syntax in jory's manifests, his
    `memini-summary` Model pulls `unsloth/Qwen3.5-4B-GGUF` directly; verify the exact scheme
    against the chart's CRD docs).
-3. Delete the staging Jobs, their `reconcile: disabled` + Checkov-skip annotations, and — after
-   cutover is verified — the per-model PVCs. Do **one model at a time**: suspend risk is real
+3. Delete the staging Jobs, their `reconcile: disabled` + Checkov-skip annotations, and (after
+   cutover is verified) the per-model PVCs. Do **one model at a time**: suspend risk is real
    (KB-015-style HelmRelease timeout thrash if a Recreate rollout wedges), and the old PVC is
    the instant rollback until the cache-served pod is healthy.
-4. Keep `--no-mmap` (jory keeps it on CephFS too — cold-fault avoidance). The `--mmproj
-   /model-source/mmproj-F16.gguf` path will change with the cache mount — **verify vision still
+4. Keep `--no-mmap` (jory keeps it on CephFS too: cold-fault avoidance). The `--mmproj
+   /model-source/mmproj-F16.gguf` path will change with the cache mount: **verify vision still
    works end-to-end** (the loupe app depends on `self-hosted` carrying the mmproj projector).
-5. No VolSync on the cache — weights are re-downloadable by design.
+5. No VolSync on the cache: weights are re-downloadable by design.
 
 What it buys: no staging Jobs or immutability hacks, operator-managed model lifecycle, one
-shared weights copy, and any node can serve any model without re-staging — model switching and
+shared weights copy, and any node can serve any model without re-staging: model switching and
 failover stop being a re-download event. The `llm-gpu-model` anti-affinity spread stays.
 
 ## Foreman: unblocked, parked
@@ -214,7 +214,7 @@ CronJob claims one ready issue per lane and creates a foreman `Workload`, and fo
 pods (per-language coders → deterministic lint/test gate → read-only reviewer, all inferencing
 through litellm) open the PR, with a big-context cloud model as the escalation lane.
 
-Its hard blocker here was the `gateCache` RWX volume — gone once PR D lands. The remaining
+Its hard blocker here was the `gateCache` RWX volume, gone once PR D lands. The remaining
 question is a soft one: whether local-model coding PRs earn their GPU slices when Claude Code
 is the primary agent. Re-evaluate after PRs D + G have proven CephFS in anger. If pursued, his
 `GATEPROFILE_MAP` (per-repository lint/build/test commands) must be rebuilt for this account's
@@ -225,7 +225,7 @@ repositories, and dispatch needs CNPG + an OIDC story.
 - [ ] hermes: the web chat surface is already live via `hermeswebui`; the open question is only
       which bot-token platforms (Discord/Slack/etc.), if any, to enable next (each needs a bot
       token in 1Password)
-- [ ] hermes: MCP wiring — direct per-proxy entries (default) or litellm's `/mcp` aggregate?
+- [ ] hermes: MCP wiring: direct per-proxy entries (default) or litellm's `/mcp` aggregate?
 - [ ] hermes: keep `approvals.mode: manual` (default) or `smart`?
 - [ ] hermes: image tag to pin (jory runs v2026.7.7; newer exists) + digest.
 - [ ] CephFS: StorageClass name (`ceph-filesystem` proposed), MDS memory limit, snapshot class now or later?
@@ -237,7 +237,7 @@ repositories, and dispatch needs CNPG + an OIDC story.
 ## Deferred / skipped registry
 
 Deferred (right idea, wrong time): ToolHive `VirtualMCPServer` aggregate (litellm already
-aggregates + semantically filters; revisit if external agents need one URL — hermes could be
+aggregates + semantically filters; revisit if external agents need one URL: hermes could be
 that trigger), litellm complexity auto-router + cost economics (need a paid cloud roster),
 `memini-summary` dedicated model (GPU pressure; PR F could host it on CPU instead), repo-wiki,
 speculative decoding, HF-token ExternalSecret.
@@ -248,4 +248,4 @@ llama-strix / llama-ryzen / llama-vision serving (AMD/Vulkan + DRA on hardware w
 toolhive-embed (redundant with all-minilm), memory-mcp (fragments memini), litellm
 HA/public/OIDC/ChatGPT deltas (his conventions, not ours), `.agents` foreman + pr-review
 instructions (document infrastructure we don't run; our sorting + add-app files verified
-better than his), dispatch (pointless without foreman — revisit only together).
+better than his), dispatch (pointless without foreman; revisit only together).

--- a/docs/docs/operations/renovate-automerge.md
+++ b/docs/docs/operations/renovate-automerge.md
@@ -7,38 +7,59 @@ protected set of cluster-critical infrastructure stays on manual review. The who
 
 ## How it works
 
-Renovate evaluates `packageRules` top to bottom, **last match wins per field**. Two rules implement
+Renovate evaluates `packageRules` top to bottom, **last match wins per field**. Three rules implement
 the policy, in this order:
 
-1. A broad **catch-all** enables auto-merge for every container image and Helm chart.
-2. A **protected-infra guard**, placed immediately after, sets `automerge: false` again for the
-   cluster-critical components — so it overrides the catch-all for those packages only.
+1. A broad **catch-all for minor/patch** enables auto-merge for every container image and Helm
+   chart, gated by a cooldown.
+2. A second broad **catch-all for digest + pins** enables auto-merge for the same datasources with
+   no cooldown.
+3. A **protected-infra guard**, placed immediately after both, sets `automerge: false` again for the
+   cluster-critical components — so it overrides both catch-alls for those packages only.
 
-`major` updates are never listed in either rule, so they always open a PR and wait for a human.
+`major` updates are never listed in any rule, so they always open a PR and wait for a human.
 
 ## What auto-merges
 
-Application container images and Helm charts auto-merge for `minor`, `patch`, and `digest` updates:
+Application container images and Helm charts auto-merge under **two** rules, split by update type:
 
 ```json5
 {
-  description: "Auto-merge apps — minor/patch/digest (denylist model; protected guard below)",
+  description: "Auto-merge apps — minor/patch (denylist model; protected guard below)",
   matchDatasources: ["docker", "helm"],
-  matchUpdateTypes: ["minor", "patch", "digest"],
+  matchUpdateTypes: ["minor", "patch"],
   automerge: true,
   automergeType: "pr",
   platformAutomerge: false,
   ignoreTests: false,
-  minimumReleaseAge: "3 days",
+  minimumReleaseAge: "2 days",
+},
+{
+  description: "Auto-merge apps — digest + pins, no age gate (denylist model; protected guard below)",
+  matchDatasources: ["docker", "helm"],
+  matchUpdateTypes: ["digest", "pin", "pinDigest"],
+  automerge: true,
+  automergeType: "pr",
+  platformAutomerge: false,
+  ignoreTests: false,
 }
 ```
 
 - `automergeType: "pr"` opens a normal PR so CI runs against the change.
 - `ignoreTests: false` together with `platformAutomerge: false` mean **Renovate self-gates on CI** —
-  it holds the merge until the branch's checks (flate, security-scans) are green, rather than relying
-  on GitHub-native auto-merge (the repo has no required-status-check rulesets).
-- `minimumReleaseAge: "3 days"` is a cooldown: a release must be three days old before it can merge,
-  giving yanked tags, broken `.0` releases, and runtime regressions a window to surface first.
+  it holds the merge until the PR's checks are green (the `Lint` and `security-scans` GitHub Actions
+  workflows, the Konflate commit status, and the `claude/renovate-review` commit status — see
+  [AI review of Renovate PRs](#ai-review-of-renovate-prs) below), rather than relying on GitHub-native
+  auto-merge (the repo has no required-status-check rulesets).
+- `minimumReleaseAge: "2 days"` on the **minor/patch** rule is a cooldown: a release must be two days
+  old before it can merge, giving yanked tags, broken `.0` releases, and runtime regressions a window
+  to surface first.
+- The **digest/pin/pinDigest** rule deliberately has **no** `minimumReleaseAge` (removed by #3608).
+  Digest bumps track mutable tags that upstream rebuilds every few days (e.g. `nginx:1.31-alpine`,
+  `llama.cpp` `server-cuda`), so a fixed age gate perpetually resets and never clears — PRs sat
+  pending for up to 19 days before the fix. GHCR also often has no retrievable per-digest timestamp
+  at all, which pends forever too. Digest bumps stay CI-gated (`ignoreTests: false`) like everything
+  else, and the protected-infra guard still applies to them.
 
 ## What stays manual
 
@@ -50,6 +71,8 @@ The protected-infra guard keeps these on manual review for all update types (inc
 | Control plane | `kube-apiserver`, `kube-controller-manager`, `kube-proxy`, `kube-scheduler` |
 | CNI | `cilium` |
 | Storage | `rook-ceph`, `rook-ceph-cluster`, `miroir` |
+| Node upgrades | `tuppr` (drives Talos + Kubernetes node upgrades) |
+| Backups | `volsync` (backup mover), `snapshot-controller` (CSI VolumeSnapshot controller) |
 | GitOps | `fluxcd/` (controllers), `controlplaneio-fluxcd` (operator + instance) |
 | Certs / DNS / secrets | `cert-manager`, `coredns`, `external-secrets`, `1password` (onepassword-connect) |
 | Image mirror | `spegel` |
@@ -70,17 +93,24 @@ independent.
 
 ## Safety levers
 
-- **Cooldown** — `minimumReleaseAge: "3 days"` on every app merge.
-- **CI gate** — each app merge waits for flate + security-scans to pass before Renovate merges it.
-- **Kill switch** — set the catch-all rule's `automerge: false` (one line) to pause *all* app
-  auto-merge and fall back to hand-merging, without touching the protected list.
+- **Cooldown** — `minimumReleaseAge: "2 days"` on the minor/patch app rule only; the digest/pin/
+  pinDigest rule has no cooldown at all (removed by #3608, see [What
+  auto-merges](#what-auto-merges) above).
+- **CI gate** — each app merge waits for the `Lint` and `security-scans` GitHub Actions workflows,
+  the Konflate commit status, and the `claude/renovate-review` commit status to pass before Renovate
+  merges it.
+- **Kill switch** — set **both** app catch-all rules' `automerge: false` (the minor/patch rule and the
+  digest/pin/pinDigest rule) to pause *all* app auto-merge and fall back to hand-merging, without
+  touching the protected list. Flipping only one still leaves the other update-type category
+  auto-merging.
 
 ## Maintaining the protected set
 
 To move a component between auto-merge and manual review:
 
 - **Protect a new component** — add a substring pattern to the guard rule's `matchPackageNames`.
-- **Unprotect** — remove its pattern; it then auto-merges under the catch-all.
+- **Unprotect** — remove its pattern; it then auto-merges under whichever catch-all rule matches its
+  update type.
 
 When adding a pattern, confirm it does not accidentally match an unrelated application image (the
 patterns are unanchored substrings).
@@ -98,9 +128,11 @@ The goal is for Renovate to email **only** the PRs that need a human. The mechan
   default, pinned). Manual PRs (the protected-infra guard + any `major`) get assigned at creation,
   which reaches the *Participating* notification stream; clean auto-merge PRs stay unassigned and
   silent.
-- `.github/workflows/renovate-assign-on-failure.yaml` runs on the `Flate` / `security-scans` /
-  `Lint` `workflow_run`. When a check **fails** on a Renovate PR, it assigns the PR — a failed check
-  means Renovate won't merge it (it self-gates on CI), so the PR needs a human.
+- `.github/workflows/renovate-assign-on-failure.yaml` runs on the `security-scans` / `Lint`
+  `workflow_run` (there is no Flate GitHub Actions check anymore — it was deleted in #3375; render
+  validation moved to the in-cluster Konflate, which posts its own commit status). When a check
+  **fails** on a Renovate PR, it assigns the PR — a failed check means Renovate won't merge it (it
+  self-gates on CI), so the PR needs a human.
 
 > **Load-bearing non-git dependency:** the quiet inbox also depends on the repository's GitHub
 > **Watch** level being **"Participating and @mentions"** (not "All Activity"). Assignment reaches
@@ -145,5 +177,6 @@ Renovate's [Merge Confidence](https://docs.renovatebot.com/merge-confidence/) ca
 an **Adoption** score — the percentage of a package's Renovate users already on the new release — via
 `matchConfidence`. It only covers seven language ecosystems (Go, JavaScript, Java, Python, .NET, PHP,
 Ruby), **not Docker images or Helm charts**, which is effectively the entire cluster. So
-`minimumReleaseAge` is the deliberate time-based substitute: "survived three days in the wild" stands
-in for "widely adopted".
+`minimumReleaseAge` is the deliberate time-based substitute for versioned (minor/patch) updates:
+"survived two days in the wild" stands in for "widely adopted". Digest/pin updates get no such
+substitute — see [What auto-merges](#what-auto-merges) for why a cooldown doesn't work for them.

--- a/docs/docs/operations/renovate-automerge.md
+++ b/docs/docs/operations/renovate-automerge.md
@@ -15,7 +15,7 @@ the policy, in this order:
 2. A second broad **catch-all for digest + pins** enables auto-merge for the same datasources with
    no cooldown.
 3. A **protected-infra guard**, placed immediately after both, sets `automerge: false` again for the
-   cluster-critical components — so it overrides both catch-alls for those packages only.
+   cluster-critical components, so it overrides both catch-alls for those packages only.
 
 `major` updates are never listed in any rule, so they always open a PR and wait for a human.
 
@@ -46,9 +46,9 @@ Application container images and Helm charts auto-merge under **two** rules, spl
 ```
 
 - `automergeType: "pr"` opens a normal PR so CI runs against the change.
-- `ignoreTests: false` together with `platformAutomerge: false` mean **Renovate self-gates on CI** —
+- `ignoreTests: false` together with `platformAutomerge: false` mean **Renovate self-gates on CI**:
   it holds the merge until the PR's checks are green (the `Lint` and `security-scans` GitHub Actions
-  workflows, the Konflate commit status, and the `claude/renovate-review` commit status — see
+  workflows, the Konflate commit status, and the `claude/renovate-review` commit status; see
   [AI review of Renovate PRs](#ai-review-of-renovate-prs) below), rather than relying on GitHub-native
   auto-merge (the repo has no required-status-check rulesets).
 - `minimumReleaseAge: "2 days"` on the **minor/patch** rule is a cooldown: a release must be two days
@@ -56,7 +56,7 @@ Application container images and Helm charts auto-merge under **two** rules, spl
   to surface first.
 - The **digest/pin/pinDigest** rule deliberately has **no** `minimumReleaseAge` (removed by #3608).
   Digest bumps track mutable tags that upstream rebuilds every few days (e.g. `nginx:1.31-alpine`,
-  `llama.cpp` `server-cuda`), so a fixed age gate perpetually resets and never clears — PRs sat
+  `llama.cpp` `server-cuda`), so a fixed age gate perpetually resets and never clears. PRs sat
   pending for up to 19 days before the fix. GHCR also often has no retrievable per-digest timestamp
   at all, which pends forever too. Digest bumps stay CI-gated (`ignoreTests: false`) like everything
   else, and the protected-infra guard still applies to them.
@@ -93,13 +93,13 @@ independent.
 
 ## Safety levers
 
-- **Cooldown** — `minimumReleaseAge: "2 days"` on the minor/patch app rule only; the digest/pin/
+- **Cooldown**: `minimumReleaseAge: "2 days"` on the minor/patch app rule only; the digest/pin/
   pinDigest rule has no cooldown at all (removed by #3608, see [What
   auto-merges](#what-auto-merges) above).
-- **CI gate** — each app merge waits for the `Lint` and `security-scans` GitHub Actions workflows,
+- **CI gate**: each app merge waits for the `Lint` and `security-scans` GitHub Actions workflows,
   the Konflate commit status, and the `claude/renovate-review` commit status to pass before Renovate
   merges it.
-- **Kill switch** — set **both** app catch-all rules' `automerge: false` (the minor/patch rule and the
+- **Kill switch**: set **both** app catch-all rules' `automerge: false` (the minor/patch rule and the
   digest/pin/pinDigest rule) to pause *all* app auto-merge and fall back to hand-merging, without
   touching the protected list. Flipping only one still leaves the other update-type category
   auto-merging.
@@ -108,8 +108,8 @@ independent.
 
 To move a component between auto-merge and manual review:
 
-- **Protect a new component** — add a substring pattern to the guard rule's `matchPackageNames`.
-- **Unprotect** — remove its pattern; it then auto-merges under whichever catch-all rule matches its
+- **Protect a new component**: add a substring pattern to the guard rule's `matchPackageNames`.
+- **Unprotect**: remove its pattern; it then auto-merges under whichever catch-all rule matches its
   update type.
 
 When adding a pattern, confirm it does not accidentally match an unrelated application image (the
@@ -129,9 +129,9 @@ The goal is for Renovate to email **only** the PRs that need a human. The mechan
   which reaches the *Participating* notification stream; clean auto-merge PRs stay unassigned and
   silent.
 - `.github/workflows/renovate-assign-on-failure.yaml` runs on the `security-scans` / `Lint`
-  `workflow_run` (there is no Flate GitHub Actions check anymore — it was deleted in #3375; render
+  `workflow_run` (there is no Flate GitHub Actions check anymore: it was deleted in #3375; render
   validation moved to the in-cluster Konflate, which posts its own commit status). When a check
-  **fails** on a Renovate PR, it assigns the PR — a failed check means Renovate won't merge it (it
+  **fails** on a Renovate PR, it assigns the PR: a failed check means Renovate won't merge it (it
   self-gates on CI), so the PR needs a human.
 
 > **Load-bearing non-git dependency:** the quiet inbox also depends on the repository's GitHub
@@ -147,16 +147,16 @@ signature of getting this wrong is open Renovate PRs piling up dozens of CI re-r
 wall of `github-actions` comments. The cause: with `automerge: true`, an unset `rebaseWhen` inherits
 `behind-base-branch`, so **every merge to `main` re-rebases every open PR and re-runs the full CI
 suite** (N open PRs × M merges/day of wasted runs). `conflicted` rebases only on a genuine textual
-conflict — ~80–95 % fewer runs. It's safe here because `platformAutomerge: false` self-merges via
+conflict: ~80-95 % fewer runs. It's safe here because `platformAutomerge: false` self-merges via
 the Renovate API and there's no branch-protection ruleset requiring up-to-date branches, so a
-behind-base-but-green PR merges fine. (The fix is **not** pruning workflows — the per-PR suite is
+behind-base-but-green PR merges fine. (The fix is **not** pruning workflows: the per-PR suite is
 each justified; the waste was re-run *frequency*.)
 
 ### AI review of Renovate PRs
 
 `.github/workflows/renovate-review.yaml` reviews Renovate PRs with `anthropics/claude-code-action`
 (Claude via OAuth, sidestepping the internal-only LiteLLM). It is gated to `renovate[bot]` PRs,
-skips digest-only and github-action bumps, and tiers the model — a cheaper model for routine patch
+skips digest-only and github-action bumps, and tiers the model: a cheaper model for routine patch
 container bumps, a stronger one for minor/major/chart or high-blast-radius components. It posts a
 `claude/renovate-review` commit status that gates auto-merge via all-checks-green.
 
@@ -174,9 +174,9 @@ so a transient blip doesn't wedge auto-merge.
 ## Why not adoption-based confidence?
 
 Renovate's [Merge Confidence](https://docs.renovatebot.com/merge-confidence/) can gate auto-merge on
-an **Adoption** score — the percentage of a package's Renovate users already on the new release — via
+an **Adoption** score (the percentage of a package's Renovate users already on the new release) via
 `matchConfidence`. It only covers seven language ecosystems (Go, JavaScript, Java, Python, .NET, PHP,
 Ruby), **not Docker images or Helm charts**, which is effectively the entire cluster. So
 `minimumReleaseAge` is the deliberate time-based substitute for versioned (minor/patch) updates:
 "survived two days in the wild" stands in for "widely adopted". Digest/pin updates get no such
-substitute — see [What auto-merges](#what-auto-merges) for why a cooldown doesn't work for them.
+substitute. See [What auto-merges](#what-auto-merges) for why a cooldown doesn't work for them.

--- a/docs/docs/operations/talos-upgrades.md
+++ b/docs/docs/operations/talos-upgrades.md
@@ -120,8 +120,8 @@ field: "talosVersion"
 
 **Cause:** talhelper carries a hardcoded list of supported Talos versions via its
 `github.com/siderolabs/talos/pkg/machinery` dependency. A new Talos **minor** needs a talhelper
-release that bumps that dependency, which typically lags Talos GA by **1–2 days**. (Patch bumps
-within a minor — v1.13.0 → v1.13.1 — don't need a talhelper update.)
+release that bumps that dependency, which typically lags Talos GA by **1-2 days**. (Patch bumps
+within a minor, v1.13.0 → v1.13.1, don't need a talhelper update.)
 
 **Resolution:**
 
@@ -145,8 +145,8 @@ within a minor — v1.13.0 → v1.13.1 — don't need a talhelper update.)
 image verification failed: no valid signature found
 ```
 
-Every node cosign-verifies `ghcr.io/siderolabs/*` and `factory.talos.dev/*` images at pull time —
-see [image verification](../architecture/image-verification.md) for the rules and identities.
+Every node cosign-verifies `ghcr.io/siderolabs/*` and `factory.talos.dev/*` images at pull time.
+See [image verification](../architecture/image-verification.md) for the rules and identities.
 Upgrades pull the factory installer image through this check, so a verification failure blocks the
 upgrade before anything is written to disk.
 
@@ -161,7 +161,7 @@ upgrade before anything is written to disk.
      "factory.talos.dev/installer-secureboot/<schematic>:<version>"
    ```
 
-2. If cosign fails too, Sidero likely rotated its signing identity or changed signature format —
+2. If cosign fails too, Sidero likely rotated its signing identity or changed signature format:
    check recent `siderolabs/talos` and `siderolabs/image-factory` releases, update the identities
    in `talos/patches/global/machine-image-verification.yaml`, regenerate and re-apply.
 3. If cosign succeeds but the node still rejects, suspect the Talos-side verifier (the
@@ -191,8 +191,8 @@ kubectl get nodes -o custom-columns=NAME:.metadata.name,VERSION:.status.nodeInfo
 
 Tuppr's `TalosUpgrade` spec does not have a `force` field. To bypass a blocked upgrade, address the blocking condition directly or use `talosctl` to upgrade a node out-of-band:
 
-1. **Fix the blocking condition** — archive Ceph crash reports, wait for VolSync to finish, or resolve the health check failure.
-2. **Manual per-node upgrade** — bypasses tuppr entirely. Prefer the existing `just talos upgrade-node <node-ip>` recipe (`talos/mod.just`): it derives the correct installer image and version from `talconfig.yaml`/`talenv.yaml` via talhelper, so you don't have to hand-assemble the flags. The raw form it wraps is:
+1. **Fix the blocking condition**: archive Ceph crash reports, wait for VolSync to finish, or resolve the health check failure.
+2. **Manual per-node upgrade**: bypasses tuppr entirely. Prefer the existing `just talos upgrade-node <node-ip>` recipe (`talos/mod.just`): it derives the correct installer image and version from `talconfig.yaml`/`talenv.yaml` via talhelper, so you don't have to hand-assemble the flags. The raw form it wraps is:
 
    ```bash
    talosctl upgrade --nodes <node-ip> --image <talos-installer-image>:<version> --timeout=10m

--- a/docs/docs/operations/talos-upgrades.md
+++ b/docs/docs/operations/talos-upgrades.md
@@ -192,7 +192,7 @@ kubectl get nodes -o custom-columns=NAME:.metadata.name,VERSION:.status.nodeInfo
 Tuppr's `TalosUpgrade` spec does not have a `force` field. To bypass a blocked upgrade, address the blocking condition directly or use `talosctl` to upgrade a node out-of-band:
 
 1. **Fix the blocking condition** — archive Ceph crash reports, wait for VolSync to finish, or resolve the health check failure.
-2. **Manual per-node upgrade** — bypasses tuppr entirely:
+2. **Manual per-node upgrade** — bypasses tuppr entirely. Prefer the existing `just talos upgrade-node <node-ip>` recipe (`talos/mod.just`): it derives the correct installer image and version from `talconfig.yaml`/`talenv.yaml` via talhelper, so you don't have to hand-assemble the flags. The raw form it wraps is:
 
    ```bash
    talosctl upgrade --nodes <node-ip> --image <talos-installer-image>:<version> --timeout=10m

--- a/docs/docs/troubleshooting/index.md
+++ b/docs/docs/troubleshooting/index.md
@@ -16,6 +16,7 @@ Work down from what you observe to the most likely entry:
     - One node's cross-node pod traffic flips/breaks while its host traffic is fine; its spegel pod goes `0/1` → [KB-008](kb/008-cilium-cross-node-pod-networking-breaks.md)
     - An app 404s through the gateway on its real hostname but works on its pod IP (live HTTPRoute drifted to `*.example.com`) → [KB-020](kb/020-httproute-drifts-to-placeholder-hostnames.md)
     - `NodeHighNumberConntrackEntriesUsed` on every node at once right after deploying a scanner → [KB-023](kb/023-node-conntrack-saturation-host-network-scanner.md)
+    - A dozen Gatus endpoints across `media`/`downloads` go red at once with HTTP 503, DNS still resolves, pods are simply absent (zeroscaler at 0/1) → [KB-027](kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md)
 - **Storage / backups**
     - Backup pod stuck `PodInitializing` (`mount.nfs: Failed to resolve`), or `CreateContainerConfigError` on a subPath → [KB-009](kb/009-nfs-mount-failures-host-dns-readonly-export.md)
     - After a Rook v1.20 upgrade: RBD nodeplugin `FailedCreate`, or ~88 `VolSyncVolumeOutOfSync` alerts → [KB-010](kb/010-rook-ceph-v120-csi-driver-split.md)
@@ -69,3 +70,4 @@ Work down from what you observe to the most likely entry:
 - [KB-024: zeroscaler — NFS-Availability Scale-to-Zero via Native HPA](kb/024-zeroscaler-nfs-hpa.md)
 - [KB-025: CephFS "Module ceph not found" on Talos Is a Built-in, Not a Missing Module](kb/025-cephfs-modprobe-builtin-misdiagnosis.md)
 - [KB-026: Plex Apple TV App Freezes on One Frame (Client Receive-Window Deadlock)](kb/026-plex-apple-tv-app-receive-window-deadlock.md)
+- [KB-027: A DNS Cleanup Scaled Every NFS-Backed App to Zero](kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md)

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -91,6 +91,7 @@ nav = [
       { "023: Node conntrack saturation (scanner)" = "troubleshooting/kb/023-node-conntrack-saturation-host-network-scanner.md" },
       { "024: zeroscaler NFS scale-to-zero via native HPA" = "troubleshooting/kb/024-zeroscaler-nfs-hpa.md" },
       { "025: CephFS modprobe built-in misdiagnosis" = "troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md" },
+      { "026: Plex Apple TV receive-window deadlock" = "troubleshooting/kb/026-plex-apple-tv-app-receive-window-deadlock.md" },
       { "027: DNS cleanup scaled NFS apps to zero" = "troubleshooting/kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md" },
     ] },
   ] },


### PR DESCRIPTION
## What

Full drift audit of the KB (`docs/docs/`) against the live manifests, prompted by the stale FAQ answer on `${SECRET_DOMAIN}` vs `${SECRET_INTERNAL_DOMAIN}`, followed by a humanizer style pass over the updated pages.

### Commit 1 — bootstrap bug fix (functional, one word)

The helmfile Cilium postsync hook has applied `app/networking.yaml` since the initial commit, but the file is `networks.yaml` — the hook would fail on any fresh bootstrap.

### Commit 2 — docs alignment (25 files)

- **Dual-hostname convention retired everywhere.** Every route is `${APP}.${SECRET_DOMAIN}`; exposure is decided by which gateway the route attaches to. Fixed in the FAQ, networking.md, ai-llm-stack.md, and 8 app pages that still documented `${SECRET_INTERNAL_DOMAIN}` aliases.
- **split-dns.md**: external routes get CNAMEs via the gateway target annotation (not A records); the `lbipam.cilium.io/ips` values are literals in `envoy.yaml`, not cluster-secrets vars (`ENVOY_EXTERNAL_IP` is dead).
- **renovate-automerge.md**: two catch-all rules (minor/patch @ 2 days; digest/pin with no age gate per #3608), real CI gates (Flate workflow deleted in #3375 — gates are Lint, security-scans, Konflate, claude/renovate-review), protected list gains tuppr/volsync/snapshot-controller.
- **bootstrap.md**: `just bootstrap` → `just bootstrap cluster` (bare invocation only lists recipes since the just-1.55 modernization); both `kubeconfig` calls and both postsync hooks documented.
- **device-monitoring.md**: snmp-exporter auto-restarts via Reloader since #3572 (doc said the opposite); adds the external NUT appliance row (#3768).
- **storage.md / backups.md**: Garage S3 tier (replaced RGW), `ceph-filesystem` RWX, kopiur trial.
- **ai-llm-stack.md**: hermes/hermeswebui deployed, 8 MCP servers (adds arr, seerr), OpenRouter fallback live, netpol consumer rule already merged.
- **contributing.md**: CLAUDE.md *does* import AGENTS.md; documents lefthook hooks and the `just` flate wrappers.
- **Indexes**: KB-026 added to the zensical nav, KB-027 to the troubleshooting symptom ladder + list.
- Assorted stale values: envoy-gateway cert-manager/tls note, `VOLSYNC_CACHE_CAPACITY` 8Gi, oxidized device inventory, prowler worker invocation, jory hermes status.

### Commit 3 — humanizer pass (style only)

Em/en dashes in prose replaced with plain punctuation, subjectless fragments given subjects, redundant bold trimmed. No headings, anchors, code blocks, tables, facts, or technical values changed.

## Verification

- `check_internal_identifiers.py`: clean (no new identifiers; CLAUDE.md's literal gateway IPs also removed locally)
- `zensical build`: clean
- `markdownlint` (canonical config): no new findings (pre-existing MD007/MD046/MD051 left as-is)
- Audit claims each verified against manifests by six parallel read-only agents; edits reviewed against the evidence
