### PR TITLE
docs: purge em/en dashes tree-wide (humanizer follow-up)

### DIFF
--- a/docs/docs/apps/changedetection.md
+++ b/docs/docs/apps/changedetection.md
@@ -3,11 +3,11 @@
 Web-page and feed change monitor in the `default` namespace, internal-only at
 `changedetection.${SECRET_DOMAIN}`. Runs the bjw-s app-template with two containers: the
 changedetection.io app itself and a browserless Chrome sidecar (`PLAYWRIGHT_DRIVER_URL`) for
-JS-heavy pages. Feeds and static pages use the basic HTTP fetcher (`html_requests`) — no browser
+JS-heavy pages. Feeds and static pages use the basic HTTP fetcher (`html_requests`), no browser
 involved.
 
 **Watch configuration lives on the PVC datastore (`/datastore/url-watches.json`), not in Git.**
-This page is the durable record of how the RSS/Atom watches are built and why — the findings below
+This page is the durable record of how the RSS/Atom watches are built and why. The findings below
 were established empirically on v0.55.7 and cost real debugging time.
 
 ## API access
@@ -20,14 +20,14 @@ were established empirically on v0.55.7 and cost real debugging time.
     python3 -c "import json; print(json.load(open('/datastore/url-watches.json'))['settings']['application']['api_access_token'])"
   ```
 
-- Useful endpoints: `POST /api/v1/watch` (create — accepts most watch fields inline),
+- Useful endpoints: `POST /api/v1/watch` (create: accepts most watch fields inline),
   `PUT /api/v1/watch/<uuid>` (partial update), `GET /api/v1/watch/<uuid>?recheck=1` (queue a
-  check), and `GET /api/v1/watch/<uuid>/history/latest` — the rendered snapshot, which is the
+  check), and `GET /api/v1/watch/<uuid>/history/latest`: the rendered snapshot, which is the
   ground truth when debugging filters.
-- **Global application settings have no REST endpoint** (e.g. RSS reader mode) — those are UI-only
+- **Global application settings have no REST endpoint** (e.g. RSS reader mode); those are UI-only
   (`/settings`).
 - Notifications: watches with an empty `notification_urls` inherit the global Apprise target
-  (Pushover). **Set `notification_muted: true` while tuning a watch** — every filter change
+  (Pushover). **Set `notification_muted: true` while tuning a watch**: every filter change
   produces a "change" event and fires a real notification.
 
 ## RSS/Atom watch recipe
@@ -35,14 +35,14 @@ were established empirically on v0.55.7 and cost real debugging time.
 Verified against `https://opentrackers.org/feed/` (WordPress RSS, fixed 20-item window) and
 `https://old.reddit.com/r/OpenSignups/new/.rss` (Atom, fixed 25-item window).
 
-1. Enable **RSS reader mode** globally (UI → Settings → RSS tab). This is the load-bearing step —
+1. Enable **RSS reader mode** globally (UI → Settings → RSS tab). This is the load-bearing step:
    see the findings below for why raw-XML filtering does not work.
 2. Create the watch with `fetch_backend: html_requests` and no `include_filters`.
 3. Reduce the snapshot to stable lines with an extract-text regex:
    `/(?m)^\s*(?:Title|Link): .+/`. The snapshot becomes exactly two lines per feed item; any new
    or edited post changes those lines and triggers a notification whose diff names the post.
 4. Leave the diff-type options (`filter_text_added` / `removed` / `replaced`) at their defaults
-   (all `true`) — see the pipeline-ordering finding below.
+   (all `true`). See the pipeline-ordering finding below.
 5. Verify with `GET /api/v1/watch/<uuid>/history/latest`: expect `2 × items` clean lines and
    `last_error: false` on the watch.
 
@@ -50,7 +50,7 @@ Verified against `https://opentrackers.org/feed/` (WordPress RSS, fixed 20-item 
 
 - **Never XPath raw RSS on this version.** The feed is parsed through lxml's HTML parser, where
   `<title>` and `<link>` are HTML-special elements (`<link>` is void, `<title>` is head-only). The
-  tree comes out mangled — titles vanish, link URL text detaches from its element — and both the
+  tree comes out mangled (titles vanish, link URL text detaches from its element), and both the
   `xpath:` (elementpath) and `xpath1:` (lxml-native) engines see the same garbage. No XPath
   expression fixes a broken parse.
 - **RSS reader mode sidesteps the parser entirely.** It runs the feed through `feedparser` and
@@ -69,7 +69,7 @@ Verified against `https://opentrackers.org/feed/` (WordPress RSS, fixed 20-item 
 - **Fixed-window feeds make "added-only" unnecessary anyway.** A post cannot leave an N-item
   window without a new one entering, so a removal-only change cannot occur.
 - **Never enable "unique lines in history" for re-bumping sites.** Opentrackers re-dates an old
-  post when a tracker's signup reopens — the title/link lines are identical to a previous
+  post when a tracker's signup reopens: the title/link lines are identical to a previous
   appearance, so unique-line suppression would hide exactly the events the watch exists for.
 
 ## Reddit specifics
@@ -79,9 +79,9 @@ Verified against `https://opentrackers.org/feed/` (WordPress RSS, fixed 20-item 
   `changedetection.io/0.55 (self-hosted; r/OpenSignups feed watch)`. With that, fetches are clean.
 - Observed unauthenticated rate limit: roughly one request per 10 seconds per UA+IP
   (`x-ratelimit-*` response headers). One check per minute is comfortably inside it; bursts are
-  not — space manual rechecks more than ~12 seconds apart, and remember the cluster and the
+  not: space manual rechecks more than ~12 seconds apart, and remember the cluster and the
   workstation share the same egress IP.
-- On a throttle the watch flags an error state and retries at the next interval — failures are
+- On a throttle the watch flags an error state and retries at the next interval: failures are
   visible, not silent misses.
 
 ## Current watches

--- a/docs/docs/architecture/image-verification.md
+++ b/docs/docs/architecture/image-verification.md
@@ -32,7 +32,7 @@ Rule semantics (Talos v1.13):
 - **The factory boot path is the point.** The nodes boot from
   `factory.talos.dev/installer-secureboot/<schematic>` (the schematic is pinned in
   `talos/talconfig.yaml`). Since Talos v1.14 drops `ghcr.io/siderolabs/installer` from releases
-  entirely, the factory path is the sole installer route — its signing coverage is what makes this
+  entirely, the factory path is the sole installer route: its signing coverage is what makes this
   config worthwhile.
 - **History.** A first attempt (PR #2315/#2337) was rolled back (#2339) in April 2026 because
   Sidero then signed only three images, with rotating personal-email identities, and did not sign
@@ -54,9 +54,9 @@ On-node pull-test matrix (run against any node with `talosctl image pull -n <nod
 
 | Test image | Expected |
 | --- | --- |
-| `ghcr.io/siderolabs/installer:<current-version>` | pulled — signature verifies |
-| `docker.io/library/busybox:<tag>` | pulled — no matching rule, unaffected |
-| `ghcr.io/siderolabs/installer:v1.0.0` | **rejected** — pre-dates signing, proves enforcement |
+| `ghcr.io/siderolabs/installer:<current-version>` | pulled, signature verifies |
+| `docker.io/library/busybox:<tag>` | pulled, no matching rule, unaffected |
+| `ghcr.io/siderolabs/installer:v1.0.0` | **rejected**, pre-dates signing, proves enforcement |
 
 The rejection looks like:
 
@@ -70,7 +70,7 @@ legacy signature tag not found
 - Applying the config is a **no-reboot** machine-config change (`just talos apply-node <ip>`;
   `--dry-run` first shows the document diff and confirms no reboot).
 - If a Talos upgrade or image pull fails with `image verification failed`, see the
-  [upgrade troubleshooting page](../operations/talos-upgrades.md#image-verification-failures) —
+  [upgrade troubleshooting page](../operations/talos-upgrades.md#image-verification-failures):
   diagnose whether Sidero's signing identity changed before suspecting anything else.
 - **Emergency bypass:** remove
   `"@./patches/global/machine-image-verification.yaml"` from the `patches` list in

--- a/docs/docs/architecture/networking.md
+++ b/docs/docs/architecture/networking.md
@@ -1,12 +1,12 @@
 # Networking
 
-## CNI — Cilium
+## CNI: Cilium
 
 Pod networking is Cilium. Pod and service CIDRs are the standard cluster-internal ranges and are not
 sensitive. Network policy is enforced with `CiliumNetworkPolicy` (mind the gotchas around empty
 rules, `ingressDeny`, and egress-to-world).
 
-## Ingress — Envoy Gateway (Gateway API)
+## Ingress: Envoy Gateway (Gateway API)
 
 Ingress is Envoy Gateway using the Gateway API (`HTTPRoute`), not classic Ingress. Two Gateways
 exist in the `network` namespace, addressed by role rather than by IP here:

--- a/docs/docs/architecture/overview.md
+++ b/docs/docs/architecture/overview.md
@@ -10,7 +10,7 @@ Git push → Flux detects change → reconciles Kustomizations → deploys HelmR
 ```
 
 The top-level Kustomization (`kubernetes/flux/cluster/ks.yaml`) recursively discovers every app under
-`kubernetes/apps/` and applies default patches to each child — notably `postBuild.substituteFrom`
+`kubernetes/apps/` and applies default patches to each child, notably `postBuild.substituteFrom`
 injecting both the `cluster-secrets` Secret and the `cluster-settings` ConfigMap
 (`kubernetes/components/global-vars/cluster-settings.yaml`), and the HelmRelease
 install/upgrade/rollback defaults.
@@ -32,7 +32,7 @@ Every app follows the same shape:
 
 - `ks.yaml` is the Flux entry point. It uses YAML anchors (`&app`, `&namespace`, `*app`), sets
   `targetNamespace`, and lists any `components` (`volsync`, `alerts`, `homepage`) plus their
-  `postBuild.substitute` values. (Gatus monitoring is automatic — the gatus-sidecar chart
+  `postBuild.substitute` values. (Gatus monitoring is automatic: the gatus-sidecar chart
   auto-discovers HTTPRoutes, so there is no per-app `gatus/guarded` component anymore.)
 - Inside `app/`: a per-app chart source (`ocirepository.yaml` pointing at the bjw-s `app-template`
   for most apps), a `helmrelease.yaml`, an optional `externalsecret.yaml`, and usually an inline
@@ -47,5 +47,5 @@ Every app follows the same shape:
 - Flux `postBuild` replaces `${VAR}` against `cluster-secrets`/`cluster-settings`; undefined vars
   become empty strings, so any literal `${VAR}` you want preserved must be escaped as `$${VAR}`.
 - GPU workloads set `runtimeClassName: nvidia`.
-- This repository is public — internal addresses, node and device hostnames, and MACs are kept out of
+- This repository is public: internal addresses, node and device hostnames, and MACs are kept out of
   Git (a CI guard enforces this; see [Secrets](secrets.md)).

--- a/docs/docs/architecture/scaling.md
+++ b/docs/docs/architecture/scaling.md
@@ -1,8 +1,8 @@
 # Scaling
 
-The cluster runs one deliberately narrow autoscaling pattern — **zeroscaler**: an app scales to
+The cluster runs one deliberately narrow autoscaling pattern, **zeroscaler**: an app scales to
 **0 replicas when its NFS backing store is unreachable** and back to **1** when it returns. It is a
-dependency-availability gate, not load-based autoscaling — there are no CPU/memory HPAs, and no
+dependency-availability gate, not load-based autoscaling. There are no CPU/memory HPAs, and no
 KEDA (removed 2026-07 in favour of a native HPA).
 
 The point is to stop NFS-dependent apps from CrashLoopBackOff-ing against a dead mount (e.g. while
@@ -28,7 +28,7 @@ Deployment/<app>   →  metric 1 = 1 replica,  metric 0 = 0 replicas
 - The blackbox `tcp_connect` probe hits the NFS server on `:2049` every 1m. `jobName: nfs_probe`
   gives the series a stable `job="nfs_probe"` label for the HPA selector.
 - `prometheus-adapter` translates that Prometheus series into a Kubernetes external metric. The
-  `max_over_time(...[3m])` wrapper is a **debounce** — a single transient `probe_success=0` (e.g. a
+  `max_over_time(...[3m])` wrapper is a **debounce**: a single transient `probe_success=0` (e.g. a
   blackbox pod reschedule during a Talos drain) no longer trips scale-to-0; the probe must fail
   continuously for ~3 minutes. See [KB-004](../troubleshooting/kb/004-talos-patch-rollout-gotchas-tuppr.md).
 - The HPA (`autoscaling/v2`, min 0 / max 1) tracks the metric: `1` holds one replica, `0` scales to
@@ -36,8 +36,8 @@ Deployment/<app>   →  metric 1 = 1 replica,  metric 0 = 0 replicas
 
 ## Gated apps
 
-Nine NFS-dependent apps are gated: **media** — plex, jellyfin, sonarr, radarr, bazarr, pinchflat,
-wizarr; **downloads** — qbittorrent, sabnzbd.
+Nine NFS-dependent apps are gated: **media**: plex, jellyfin, sonarr, radarr, bazarr, pinchflat,
+wizarr; **downloads**: qbittorrent, sabnzbd.
 
 ## Adding an app to the gate
 
@@ -52,21 +52,21 @@ spec:
 
 Optional per-app overrides via `postBuild.substitute`:
 
-- `ZEROSCALER_JOB_NAME` — gate on a different blackbox probe (e.g. a Zigbee coordinator instead of
+- `ZEROSCALER_JOB_NAME`: gate on a different blackbox probe (e.g. a Zigbee coordinator instead of
   NFS).
-- `ZEROSCALER_CONTROLLER: StatefulSet` — if the app is a StatefulSet rather than a Deployment.
+- `ZEROSCALER_CONTROLLER: StatefulSet`: if the app is a StatefulSet rather than a Deployment.
 
 ## Prerequisites
 
 The `HPAScaleToZero` feature gate must be enabled on **both** `cluster.apiServer.extraArgs` **and**
 `cluster.controllerManager.extraArgs` in `talos/patches/controller/cluster.yaml`. The apiserver
 validates `minReplicas` (and rejects `0` without the gate); the controller-manager does the actual
-scale-to-0. Missing it on the apiserver is the classic failure — see
+scale-to-0. Missing it on the apiserver is the classic failure: see
 [KB-024](../troubleshooting/kb/024-zeroscaler-nfs-hpa.md).
 
 ## Operations
 
-- **Pause during a node drain** — native HPAs have no `paused` annotation, so pin every gated app
+- **Pause during a node drain**: native HPAs have no `paused` annotation, so pin every gated app
   up with the recipe (it patches `minReplicas: 1`):
 
   ```bash
@@ -76,9 +76,9 @@ scale-to-0. Missing it on the apiserver is the classic failure — see
 
   Flux reverts `minReplicas` to `0` on the next reconcile, so pause then act promptly (or
   `flux suspend` the app's Kustomization for a longer hold).
-- **`KubeHpaMaxedOut` is silenced cluster-wide** — every HPA here is `maxReplicas: 1`, permanently
+- **`KubeHpaMaxedOut` is silenced cluster-wide**: every HPA here is `maxReplicas: 1`, permanently
   "maxed" when NFS is up (silence `zeroscaler-hpa-maxed`).
-- **helm-controller drift detection stays off** — a native HPA writes `spec.replicas`, and drift
+- **helm-controller drift detection stays off**: a native HPA writes `spec.replicas`, and drift
   detection would fight it.
 
 ## Why this shape
@@ -87,7 +87,7 @@ scale-to-0. Missing it on the apiserver is the classic failure — see
   isn't needed. The only useful signal is "is the backing store there?".
 - **No KEDA.** It was a whole operator (+ CRDs + metrics server + webhooks) for this one binary
   pattern. A native HPA plus `prometheus-adapter` is lighter and keeps the singleton
-  `external.metrics.k8s.io` APIService free — KEDA's metrics server and the adapter cannot co-own
+  `external.metrics.k8s.io` APIService free. KEDA's metrics server and the adapter cannot co-own
   it.
 
 Deep dive and gotchas: [KB-024](../troubleshooting/kb/024-zeroscaler-nfs-hpa.md).

--- a/docs/docs/architecture/secrets.md
+++ b/docs/docs/architecture/secrets.md
@@ -11,10 +11,10 @@ Secrets never live in Git. They flow:
 - A `ClusterSecretStore` named `onepassword-connect` reads the `Talos` 1Password vault.
 - Per-app `externalsecret.yaml` files reference specific 1Password items by title. Apps that use one
   should `dependsOn` `onepassword-connect` in `external-secrets`.
-- **`cluster-secrets`** — a single 1Password item extracted into a Secret and injected into every
+- **`cluster-secrets`**: a single 1Password item extracted into a Secret and injected into every
   app's `postBuild.substituteFrom`. Holds cluster-wide *sensitive* values, including
   `${SECRET_DOMAIN}`, `${SECRET_INTERNAL_DOMAIN}`, and internal device DNS names.
-- **`cluster-settings`** — a git-tracked ConfigMap (`components/global-vars/`) holding cluster-wide
+- **`cluster-settings`**: a git-tracked ConfigMap (`components/global-vars/`) holding cluster-wide
   *non-sensitive* `${...}` values (non-secret feature flags and the like; currently empty).
 
 ## Rules for a public repo
@@ -25,7 +25,7 @@ Secrets never live in Git. They flow:
   shell snippets) must be escaped as `$${VAR}`.
 - **Device address / lookup tables** (e.g. router backup inventories, SNMP/NUT targets) must be
   templated inside an ExternalSecret's `target.template.data` block and mounted from the rendered
-  Secret — never rendered into a ConfigMap in Git. Internal device DNS names live in the
+  Secret, never rendered into a ConfigMap in Git. Internal device DNS names live in the
   `cluster-secrets` 1Password item, not in `cluster-settings`.
 - A CI guard (`.github/scripts/check_internal_identifiers.py`, run by the security-scans workflow)
   fails any pull request that introduces a LAN IP, node name, site-prefixed device hostname
@@ -36,7 +36,7 @@ Secrets never live in Git. They flow:
 ## Talos machine secrets (talsecret)
 
 The talhelper secrets bundle (cluster CA/PKI, etcd certs, bootstrap tokens) follows the same
-"1Password owns it" rule as everything else. There is **no SOPS anywhere in this repository** —
+"1Password owns it" rule as everything else. There is **no SOPS anywhere in this repository**:
 the historical `talos/talsecret.sops.yaml` was removed in PR #3463 (2026-07) after the age key for
 it was lost; the encrypted blob left in git history is dead ciphertext.
 
@@ -55,5 +55,5 @@ it was lost; the encrypted blob left in git history is dead ciphertext.
     -o /tmp/talsecret.yaml --force
   ```
 
-  This was how the bundle was recovered when the age key disappeared — regenerated configs were
+  This was how the bundle was recovered when the age key disappeared: regenerated configs were
   verified byte-identical before the SOPS file was deleted.

--- a/docs/docs/architecture/split-dns.md
+++ b/docs/docs/architecture/split-dns.md
@@ -218,8 +218,8 @@ How it works now (this mirrors onedr0p's UniFi pattern, adapted for the OPNsense
 
 | CRD | Purpose | State |
 | --- | ------- | ----- |
-| `network/cloudflare-tunnel/app/dnsendpoint.yaml` | `external.${SECRET_DOMAIN}` CNAME → `${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com` — the tunnel target every external CNAME ultimately points at | **active** |
-| `games/minecraft/app/dnsendpoint.yaml` | A record for an L4 (non-HTTP) service exposed via mc-router | **template, commented out** — an RFC1918 A record can't be proxied through Cloudflare, so it needs a public IP/CNAME setup |
+| `network/cloudflare-tunnel/app/dnsendpoint.yaml` | `external.${SECRET_DOMAIN}` CNAME → `${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com` (the tunnel target every external CNAME ultimately points at) | **active** |
+| `games/minecraft/app/dnsendpoint.yaml` | A record for an L4 (non-HTTP) service exposed via mc-router | **template, commented out** (an RFC1918 A record can't be proxied through Cloudflare, so it needs a public IP/CNAME setup) |
 
 Example of a special-case `DNSEndpoint` (the Cloudflare Tunnel target):
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,7 @@
 
 > A single-tenant **home Kubernetes cluster** built on Talos Linux and managed entirely by GitOps
 > (Flux). This site is the knowledge base for how it works, how to operate it, and the gotchas worth
-> remembering — for the maintainer and for AI agents working in the repo.
+> remembering, for the maintainer and for AI agents working in the repo.
 
 ```mermaid
 flowchart LR
@@ -16,20 +16,20 @@ flowchart LR
 Everything that runs in the cluster is declared in this public repository. Secrets never live in Git:
 they flow from 1Password through External Secrets into Kubernetes `Secret`s, and Flux substitutes
 `${SECRET_DOMAIN}` / `${SECRET_INTERNAL_DOMAIN}` placeholders at apply time. Because the repo is
-public, internal addresses, node and device hostnames, and MACs are kept out of it — a CI guard
+public, internal addresses, node and device hostnames, and MACs are kept out of it. A CI guard
 enforces that on every pull request.
 
 ## Navigate the knowledge base
 
-- **Architecture** — how the pieces fit: the GitOps flow, networking (Cilium + Envoy Gateway),
+- **Architecture**, how the pieces fit: the GitOps flow, networking (Cilium + Envoy Gateway),
   storage, secret management, and the AI/LLM stack.
-- **Operations** — runbooks: bootstrapping, Talos and Kubernetes upgrades, backups, and monitoring
+- **Operations**, runbooks: bootstrapping, Talos and Kubernetes upgrades, backups, and monitoring
   the cluster and the infrastructure around it.
-- **Migrations** — playbooks for the larger changes the cluster has been through.
-- **Apps** — per-application notes: why it is set up the way it is, and the traps hit while deploying
+- **Migrations**: playbooks for the larger changes the cluster has been through.
+- **Apps**, per-application notes: why it is set up the way it is, and the traps hit while deploying
   it.
-- **Troubleshooting** — a symptom ladder and a KB of recurring issues with their fixes.
-- **FAQ** — quick answers to the questions that come up most.
+- **Troubleshooting**: a symptom ladder and a KB of recurring issues with their fixes.
+- **FAQ**: quick answers to the questions that come up most.
 
 ## Tech at a glance
 

--- a/docs/docs/migrations/multus-vlan.md
+++ b/docs/docs/migrations/multus-vlan.md
@@ -1,7 +1,7 @@
 # Multus VLAN Migration Guide
 
 !!! note "Completed migration"
-    This page is a record of a migration that is already complete. The steps below are preserved as history; some current-state paths, names, and commands have since drifted. Commands and paths flagged in review are corrected inline — see the Architecture and Operations sections for the present-day setup.
+    This page is a record of a migration that is already complete. The steps below are preserved as history; some current-state paths, names, and commands have since drifted. Commands and paths flagged in review are corrected inline: see the Architecture and Operations sections for the present-day setup.
 
 This guide documents the process of migrating Home Assistant from the management network (<mgmt-net>/24) to a dedicated IoT VLAN for network isolation.
 

--- a/docs/docs/migrations/volsync-kopia.md
+++ b/docs/docs/migrations/volsync-kopia.md
@@ -1,7 +1,7 @@
 # Volsync Kopia Migration Guide
 
 !!! note "Completed migration"
-    This page is a record of a migration that is already complete. The steps below are preserved as history; some current-state paths, names, and commands have since drifted. Commands and paths flagged in review are corrected inline — see the Architecture and Operations sections for the present-day setup.
+    This page is a record of a migration that is already complete. The steps below are preserved as history; some current-state paths, names, and commands have since drifted. Commands and paths flagged in review are corrected inline: see the Architecture and Operations sections for the present-day setup.
 
 ## Overview
 
@@ -24,7 +24,7 @@ This guide documents the migration from restic to kopia as the backup backend fo
 **Changes:**
 
 - Switched from official volsync chart to perfectra1n fork
-- Source is an OCIRepository (not HelmRepository — this was an intermediate step; the current state uses an OCIRepository mirrored via home-operations)
+- Source is an OCIRepository (not HelmRepository: this was an intermediate step; the current state uses an OCIRepository mirrored via home-operations)
 - Updated to version with kopia CRDs (v0.16.13+)
 
 **Before (restic):**
@@ -261,7 +261,7 @@ spec:
         manageCRDs: true
 ```
 
-1. KopiaMaintenance was initially disabled (unstable), then enabled — now live:
+1. KopiaMaintenance was initially disabled (unstable), then enabled, now live:
 
 ```yaml
 # kubernetes/apps/volsync-system/volsync/ks.yaml

--- a/docs/docs/operations/jory-homeops-adoption.md
+++ b/docs/docs/operations/jory-homeops-adoption.md
@@ -41,15 +41,15 @@ except where noted.
 
 | PR  | Contents                                                                | Blockers / prerequisites                        |
 | --- | ----------------------------------------------------------------------- | ----------------------------------------------- |
-| A   | ✅ #3480 — LLM observability: litellm PrometheusRule, ToolHive telemetry, llama.cpp serving dashboard | none              |
-| B   | ✅ #3481 — Config cherry-picks: SearXNG hardening, litellm `context_window_fallbacks`, add-app SKILL.md wording | none    |
-| C   | ✅ #3482 arr (+ seerr #3491) — MCP servers over existing apps, with netpol rules; **ha still open** | HA token in 1Password |
-| D   | ✅ #3483 — CephFS enablement + comment corrections; RWX smoke test PASSED 2026-07-10 | none                              |
-| E   | ✅ #3484 — hermes (gateway + dashboard; web chat since added via `hermeswebui`) | none — item created, defaults applied    |
+| A   | ✅ #3480: LLM observability, litellm PrometheusRule, ToolHive telemetry, llama.cpp serving dashboard | none              |
+| B   | ✅ #3481: Config cherry-picks, SearXNG hardening, litellm `context_window_fallbacks`, add-app SKILL.md wording | none    |
+| C   | ✅ #3482 arr (+ seerr #3491): MCP servers over existing apps, with netpol rules; **ha still open** | HA token in 1Password |
+| D   | ✅ #3483: CephFS enablement + comment corrections; RWX smoke test PASSED 2026-07-10 | none                              |
+| E   | ✅ #3484: hermes (gateway + dashboard; web chat since added via `hermeswebui`) | none; item created, defaults applied    |
 | F   | (optional) CPU-served ~4B auxiliary model                                | none                                            |
-| G   | ✅ #3489/#3490/#3493 — model-storage de-workaround (shared CephFS cache); both models cache-served, vision verified | none |
+| G   | ✅ #3489/#3490/#3493: model-storage de-workaround (shared CephFS cache); both models cache-served, vision verified | none |
 
-### PR A — LLM observability
+### PR A: LLM observability
 
 - `kubernetes/apps/ai/litellm/app/prometheusrule.yaml`: port jory's four alerts
   (`LiteLLMFallbackChainExhausted` critical, `LiteLLMModelFailover`, `LiteLLMDeploymentOutage`,
@@ -68,7 +68,7 @@ except where noted.
   `prometheus` (KB-021). Optionally set `prometheus.inferencePodMonitor.enabled: true` in the
   llmkube HelmRelease (jory has it on; ours is off).
 
-### PR B — config cherry-picks
+### PR B: config cherry-picks
 
 - SearXNG (`toolhive/mcp-servers/searxng`): disable `autocomplete` and `favicon_resolver`
   (per-keystroke upstream calls trip captcha / rate limits on an automation-driven instance;
@@ -80,7 +80,7 @@ except where noted.
 - `.agents/skills/add-app/SKILL.md`: reword the hardcoded `AskUserQuestion` reference to
   host-neutral phrasing (name it as the Claude Code example). Single line.
 
-### PR C — MCP servers over existing apps
+### PR C: MCP servers over existing apps
 
 - **arr**: a ToolHive `MCPServer` wired to sonarr/radarr (media) and prowlarr (downloads),
   API keys extracted from the existing 1Password items. Requires new ingress
@@ -99,7 +99,7 @@ except where noted.
 - Watch the tool budget: litellm's `mcp_semantic_tool_filter` (top_k 8, threshold 0.3) gets
   more low-similarity tools to rank; may need retuning.
 
-### PR D — CephFS enablement
+### PR D: CephFS enablement
 
 Values-only; never touches the in-use `ceph-blockpool` / `ceph-block` StorageClass. Two files:
 
@@ -119,7 +119,7 @@ No Talos, schematic, or operator changes. Validate with
 pods on different nodes. The June attempt failed at a layer never pinned down, so the smoke
 test is the insurance before anything real depends on CephFS.
 
-### PR E — hermes
+### PR E: hermes
 
 Stand up [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) at
 `kubernetes/apps/ai/hermes/` as a standard app-template app. All dependencies (litellm, memini,
@@ -156,7 +156,7 @@ boundary, so no unattended cluster actions until it has earned trust); reuse
 `LITELLM_MASTER_KEY` (open-webui precedent) with a scoped virtual key as later hardening;
 `MEMINI_NAMESPACE: hermes`.
 
-### PR F — (optional) CPU-served auxiliary model
+### PR F: (optional) CPU-served auxiliary model
 
 A ~4B Q4 model (for example Qwen3-4B-Instruct Q4_K_M) served CPU-only to handle
 summaries / classification / drafts without spending an L4 slice. **Mirror the proven
@@ -167,7 +167,7 @@ Fine for latency-tolerant work, not for interactive chat. Register in litellm as
 model name and consider pointing litellm's auxiliary tasks at it. Set explicit requests/limits
 to protect co-tenants.
 
-### PR G — model-storage de-workaround (requires PR D)
+### PR G: model-storage de-workaround (requires PR D)
 
 The RWO pattern in `kubernetes/apps/ai/llmkube/models/` exists **only** because of the wrong
 June diagnosis (KB-025): per-model `ceph-block` PVCs, one-shot curl staging Jobs carrying

--- a/docs/docs/operations/truenas-monitoring.md
+++ b/docs/docs/operations/truenas-monitoring.md
@@ -15,7 +15,7 @@ Four exporters are configured:
 3. **truenas-graphite-exporter** (ingest 9109 / metrics 9108) - TrueNAS/ZFS-native metrics (ZFS ARC, per-dataset and per-disk I/O, temperatures), bridged from the built-in netdata Graphite output via [`Supporterino/truenas-graphite-to-prometheus`](https://github.com/Supporterino/truenas-graphite-to-prometheus)
 4. **docker-state-exporter** (port 9419) - Per-container state, health, restart count, and OOM-killed status; drives the `truenas-docker.rules` alert group
 
-The first two treat TrueNAS as a generic Linux host. The third surfaces the ZFS internals that node-exporter cannot see — ARC size, hit ratio, and per-disk I/O — which are the highest-value storage signals. The fourth enables container lifecycle alerting by name (the graphite bridge's `cgroup_*` series are keyed by container ID and disappear once a container stops).
+The first two treat TrueNAS as a generic Linux host. The third surfaces the ZFS internals that node-exporter cannot see: ARC size, hit ratio, and per-disk I/O, which are the highest-value storage signals. The fourth enables container lifecycle alerting by name (the graphite bridge's `cgroup_*` series are keyed by container ID and disappear once a container stops).
 
 ## TrueNAS Setup
 
@@ -79,8 +79,8 @@ This exporter bundles `prometheus/graphite_exporter` with a TrueNAS-specific map
 
 1. Repeat the Custom App process. Set the image to `ghcr.io/supporterino/truenas-graphite-to-prometheus:latest`.
 2. Add two port mappings (host network or node ports):
-    - Container `9109` → host `9109` (TCP) — Graphite ingest
-    - Container `9108` → host `9108` (TCP) — Prometheus metrics
+    - Container `9109` → host `9109` (TCP): Graphite ingest
+    - Container `9108` → host `9108` (TCP): Prometheus metrics
 3. Click **Install**.
 
 Then point TrueNAS at it:
@@ -94,7 +94,7 @@ Then point TrueNAS at it:
 > The exporter ships with the mapping config baked into the image, so no mapping file mount is required.
 
 **Preferred (no hand-edited config):** create the Reporting exporter via the REST API instead of the
-GUI — it reconfigures the built-in netdata's exporting engine the supported way, with no
+GUI. It reconfigures the built-in netdata's exporting engine the supported way, with no
 `/etc/netdata/netdata.conf` hand-edit (which TrueNAS middleware manages/overwrites):
 
 ```bash
@@ -141,22 +141,22 @@ the full vanilla-netdata metric set the upstream mapping + dashboards assume. Co
 | CPU temp                 | `cpu_temperature`                                   | ✅                                                                                                                                                              |
 | cgroups / k8s            | `cgroup_*`                                          | ✅ full                                                                                                                                                         |
 | NFS / network / services | `nfs_*`, `interface_*`, `services_*`, `system_load` | ✅                                                                                                                                                              |
-| ZFS ARC                  | `truenas_arcstats{type=...}`                        | raw chart — **not** vanilla `zfs.arc_size`; bridged to `zfs_arc_size` / `zfs_arc_free_bytes` / `zfs_arc_hit_ratio` via recording rules in `prometheusrule.yaml` |
-| ZFS pool state           | **absent**                                          | no `zfs_pool`/scrub metric — rely on TrueNAS native ZFS event detection + alerts                                                                                |
-| Disk temperature         | **absent** from graphite                            | use `smartctl_device_temperature` (smartctl-exporter) — the disk-temp alert is repointed there                                                                  |
+| ZFS ARC                  | `truenas_arcstats{type=...}`                        | raw chart, **not** vanilla `zfs.arc_size`; bridged to `zfs_arc_size` / `zfs_arc_free_bytes` / `zfs_arc_hit_ratio` via recording rules in `prometheusrule.yaml` |
+| ZFS pool state           | **absent**                                          | no `zfs_pool`/scrub metric; rely on TrueNAS native ZFS event detection + alerts                                                                                |
+| Disk temperature         | **absent** from graphite                            | use `smartctl_device_temperature` (smartctl-exporter); the disk-temp alert is repointed there                                                                  |
 | Memory / detailed CPU    | **absent**                                          | `physical_memory`/`memory_*`/`cpu_frequency` not emitted                                                                                                        |
 
 Consequence for the bundled dashboards: **cgroups** is fully populated; **disk_insights**,
 **temperatures**, and the main **truenas_scale** dashboard are partial (empty panels for the absent
-metrics); **applications_k3s** was removed (it targets `k3s_pod_*` — this box runs Talos separately).
+metrics); **applications_k3s** was removed (it targets `k3s_pod_*`; this box runs Talos separately).
 A faithful ZFS dashboard needs either the netdata.conf swap (declined above) or a bespoke dashboard.
 
 ## Kubernetes Configuration
 
 ScrapeConfigs are automatically discovered by kube-prometheus-stack. They are split across two locations:
 
-- `kube-prometheus-stack/app/scrapeconfig.yaml` — the host-level exporters
-- `truenas-exporter/app/scrapeconfig.yaml` — the Graphite exporter (this app also carries its dashboards and alert rules)
+- `kube-prometheus-stack/app/scrapeconfig.yaml`: the host-level exporters
+- `truenas-exporter/app/scrapeconfig.yaml`: the Graphite exporter (this app also carries its dashboards and alert rules)
 
 ### ScrapeConfig Resources
 
@@ -169,18 +169,18 @@ These use the `SECRET_STORAGE_SERVER` variable from cluster secrets to dynamical
 
 ### Dashboards and Alerts (GitOps-managed)
 
-Dashboards and alert rules are reconciled by Flux — no manual import. The `truenas-exporter` app provisions:
+Dashboards and alert rules are reconciled by Flux. No manual import. The `truenas-exporter` app provisions:
 
-- **GrafanaDashboard** CRs (`grafanadashboard.yaml`) — two dashboards:
+- **GrafanaDashboard** CRs (`grafanadashboard.yaml`), two dashboards:
   - `truenas-zfs` (bespoke): sourced from local ConfigMap `truenas-zfs-dashboard` / `truenas-zfs.json`, datasource input `DS_PROMETHEUS`. Primary ZFS/storage dashboard consuming the metrics this box actually emits.
-  - `truenas-scale-cgroups`: fetched from upstream v2.2.1 (`truenas_scale_cgroups.json`), with datasource input `DS_MIMIR` remapped onto the cluster `prometheus` datasource. The dashboards `truenas_scale`, `disk_insights`, `temperatures`, and `applications_k3s` are retired — they render partially or fully blank on TrueNAS SCALE 25.10.
+  - `truenas-scale-cgroups`: fetched from upstream v2.2.1 (`truenas_scale_cgroups.json`), with datasource input `DS_MIMIR` remapped onto the cluster `prometheus` datasource. The dashboards `truenas_scale`, `disk_insights`, `temperatures`, and `applications_k3s` are retired. They render partially or fully blank on TrueNAS SCALE 25.10.
 - A **PrometheusRule** (`prometheusrule.yaml`) with two alert groups:
-  - `truenas-exporter.rules`: exporter-down (`TrueNASGraphiteExporterDown`), disk over-temperature (`TrueNASDiskTemperatureHigh`, sourced from smartctl-exporter), and CPU over-temperature (`TrueNASCPUTemperatureHigh`). No ZFS-pool-unhealthy alert — TrueNAS 25.10 exposes no `zfs_pool`/scrub-state metric via the graphite bridge; pool degradation is handled by TrueNAS's own native ZFS event detection.
+  - `truenas-exporter.rules`: exporter-down (`TrueNASGraphiteExporterDown`), disk over-temperature (`TrueNASDiskTemperatureHigh`, sourced from smartctl-exporter), and CPU over-temperature (`TrueNASCPUTemperatureHigh`). No ZFS-pool-unhealthy alert: TrueNAS 25.10 exposes no `zfs_pool`/scrub-state metric via the graphite bridge; pool degradation is handled by TrueNAS's own native ZFS event detection.
   - `truenas-docker.rules`: six container lifecycle alerts fed by docker-state-exporter (`TrueNASDockerStateExporterDown`, `TrueNASContainerDown`, `TrueNASContainerUnhealthy`, `TrueNASContainerRestarting`, `TrueNASContainerOOMKilled`, `TrueNASContainerFlapping`).
 
 ## Grafana Dashboards
 
-All dashboards are provisioned as `GrafanaDashboard` CRs via grafana-operator — do not import by hand, or changes will be overwritten on reconcile.
+All dashboards are provisioned as `GrafanaDashboard` CRs via grafana-operator. Do not import by hand, or changes will be overwritten on reconcile.
 
 | Dashboard                                                    | Source                   | Provisioned by                                                  |
 | ------------------------------------------------------------ | ------------------------ | --------------------------------------------------------------- |

--- a/docs/docs/troubleshooting/index.md
+++ b/docs/docs/troubleshooting/index.md
@@ -67,7 +67,7 @@ Work down from what you observe to the most likely entry:
 - [KB-021: Grafana Dashboard Panels All Blank ("Datasource … was not found")](kb/021-grafana-dashboard-panels-blank-datasource-case.md)
 - [KB-022: Container Won't Start as Non-Root (s6 / LinuxServer Image `CreateContainerConfigError`)](kb/022-s6-image-createcontainerconfigerror-non-root.md)
 - [KB-023: Node Conntrack Table Saturates from a Host-Network Scanner](kb/023-node-conntrack-saturation-host-network-scanner.md)
-- [KB-024: zeroscaler — NFS-Availability Scale-to-Zero via Native HPA](kb/024-zeroscaler-nfs-hpa.md)
+- [KB-024: zeroscaler, NFS-Availability Scale-to-Zero via Native HPA](kb/024-zeroscaler-nfs-hpa.md)
 - [KB-025: CephFS "Module ceph not found" on Talos Is a Built-in, Not a Missing Module](kb/025-cephfs-modprobe-builtin-misdiagnosis.md)
 - [KB-026: Plex Apple TV App Freezes on One Frame (Client Receive-Window Deadlock)](kb/026-plex-apple-tv-app-receive-window-deadlock.md)
 - [KB-027: A DNS Cleanup Scaled Every NFS-Backed App to Zero](kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md)

--- a/docs/docs/troubleshooting/kb/001-1password-connect-pushsecret-false-400-errors.md
+++ b/docs/docs/troubleshooting/kb/001-1password-connect-pushsecret-false-400-errors.md
@@ -1,6 +1,6 @@
 # KB-001: 1Password Connect PushSecret False 400 Errors
 
-**Status:** Pending upstream fix — monitoring [external-secrets#3631](https://github.com/external-secrets/external-secrets/issues/3631) for resolution from the 1Password Connect team.
+**Status:** Pending upstream fix: monitoring [external-secrets#3631](https://github.com/external-secrets/external-secrets/issues/3631) for resolution from the 1Password Connect team.
 
 ## Symptom
 
@@ -35,7 +35,7 @@ This is a known bug in 1Password Connect starting from version 1.7.3+:
 - The External Secrets Operator correctly reports the PushSecret as `Synced: True`.
 - The errors are cosmetic noise from 1Password Connect itself.
 
-There is no functional impact on cert-manager or PushSecret operations — secrets ARE syncing successfully to 1Password, and the 400 errors are false positives that can be safely ignored.
+There is no functional impact on cert-manager or PushSecret operations. Secrets ARE syncing successfully to 1Password, and the 400 errors are false positives that can be safely ignored.
 
 ## Fix
 

--- a/docs/docs/troubleshooting/kb/002-plex-direct-play-buffering-bbr-mtu-probing.md
+++ b/docs/docs/troubleshooting/kb/002-plex-direct-play-buffering-bbr-mtu-probing.md
@@ -1,6 +1,6 @@
 # KB-002: Plex Direct-Play Buffering on LAN Apple TVs (BBR + MTU Probing)
 
-**Status:** Permanent fix applied via Option 1 (Cilium egress annotation, `kubernetes.io/egress-bandwidth: "200M"`). Plex pod stable since — no restarts, no user-reported flaps, no MSS-collapse signal. Option 2 (pod sysctls via `allowed-unsafe-sysctls`) kept documented as a fallback if Cilium's BandwidthManager is ever disabled.
+**Status:** Permanent fix applied via Option 1 (Cilium egress annotation, `kubernetes.io/egress-bandwidth: "200M"`). Plex pod stable since: no restarts, no user-reported flaps, no MSS-collapse signal. Option 2 (pod sysctls via `allowed-unsafe-sysctls`) kept documented as a fallback if Cilium's BandwidthManager is ever disabled.
 
 ## Symptom
 
@@ -8,17 +8,17 @@
 
 From the player's perspective: playback freezes, the client buffer drains, then playback resumes once a new TCP connection has refilled the client buffer.
 
-Distinct from the connection-URL advertisement issue (see KB-003) — this one manifests as periodic mid-stream freezes rather than app-level "unavailable" states.
+Distinct from the connection-URL advertisement issue (see KB-003). This one manifests as periodic mid-stream freezes rather than app-level "unavailable" states.
 
 ## Cause
 
-Captured via `ss -tni` on the Plex pod, from a privileged `kubectl debug` ephemeral container (netshoot + `netadmin` profile). The investigation ruled out the NFS media read path (sustains 1.5 GB/s), Rook-Ceph (`HEALTH_OK`, pgs clean), the node 25G NIC (no errors), the Cilium data plane (no drops), GPU contention with Ollama, and the switch/LAG path — all clean under load.
+Captured via `ss -tni` on the Plex pod, from a privileged `kubectl debug` ephemeral container (netshoot + `netadmin` profile). The investigation ruled out the NFS media read path (sustains 1.5 GB/s), Rook-Ceph (`HEALTH_OK`, pgs clean), the node 25G NIC (no errors), the Cilium data plane (no drops), GPU contention with Ollama, and the switch/LAG path, all clean under load.
 
 The failure sequence on the long-lived video socket:
 
-1. Every ~6 minutes a new TCP video socket opens (`src=:32400 dst=<node-ip>:49xxx`, `rcvmss:1056` — the HLS 4K-segment signature) and starts direct-playing.
+1. Every ~6 minutes a new TCP video socket opens (`src=:32400 dst=<node-ip>:49xxx`, `rcvmss:1056`, the HLS 4K-segment signature) and starts direct-playing.
 2. The Apple TV Plex client drives its receive window down toward zero (`snd_wnd` from `~130000` to `64` to `32`) and enters **persist mode**.
-3. BBR paces at LAN-speed bandwidth estimates (~1 Gbps `pacing_rate` while actual `delivery_rate` is 6-10 Mbps) — bursts into the tiny window and experiences loss.
+3. BBR paces at LAN-speed bandwidth estimates (~1 Gbps `pacing_rate` while actual `delivery_rate` is 6-10 Mbps). It bursts into the tiny window and experiences loss.
 4. The retransmit/timeout bursts trip `tcp_mtu_probing=1` black-hole detection, which collapses the connection's MSS (`1448 → 758 → 128 → 64`).
 5. Once MSS is tiny and `cwnd:1`, RTO backs off to 100+ seconds and the connection is effectively dead even though `ESTABLISHED`.
 6. Apple TV silently opens a new 49xxx socket → playback resumes → cycle repeats at the 6-minute mark.
@@ -36,13 +36,13 @@ ESTAB 0 3034256 :32400 <node-ip>:49359
   snd_wnd:189248 rcv_wnd:68608
 ```
 
-Parallel control-channel sockets to the same Apple TV IP stayed healthy (`mss:1448`, `cwnd:250-320`, zero retrans) — confirming this is workload-specific to the long-lived high-throughput video socket, not a path-level problem.
+Parallel control-channel sockets to the same Apple TV IP stayed healthy (`mss:1448`, `cwnd:250-320`, zero retrans), confirming this is workload-specific to the long-lived high-throughput video socket, not a path-level problem.
 
 Root cause is a two-part interaction:
 
 1. **Plex explicitly sets BBR per-socket** via `setsockopt(TCP_CONGESTION, "bbr")`, overriding any netns-default congestion control.
 2. **BBR on sub-ms LAN RTT** estimates enormous bandwidth (mrtt ~0.15ms, bw ~1Gbps). When the receiver (tvOS Plex client) closes its receive window down to trickle levels, BBR's next probe after the window re-opens bursts at ~1 Gbps into a receiver that cannot consume it. Losses occur at the Apple TV's receive ring buffer / socket buffer.
-3. **`tcp_mtu_probing=1`** (Talos default) reacts to the burst losses by halving the MSS, then halving again — the classic TCP black-hole detection false-positive. Once MSS < 100, throughput collapses.
+3. **`tcp_mtu_probing=1`** (Talos default) reacts to the burst losses by halving the MSS, then halving again: the classic TCP black-hole detection false-positive. Once MSS < 100, throughput collapses.
 
 ## Fix
 
@@ -66,7 +66,7 @@ Requires Cilium's `bandwidth-manager`, which is already enabled in this cluster 
 
 ### Permanent fix Option 2: Pod-level safeSysctls
 
-Set the two sysctls at pod spec level so they survive restarts. Requires adding these to the kubelet's `allowed-unsafe-sysctls` (Talos machine config `.machine.kubelet.extraArgs`) — more invasive.
+Set the two sysctls at pod spec level so they survive restarts. Requires adding these to the kubelet's `allowed-unsafe-sysctls` (Talos machine config `.machine.kubelet.extraArgs`), more invasive.
 
 ```yaml
 spec:

--- a/docs/docs/troubleshooting/kb/003-plex-advertises-broken-connection-urls.md
+++ b/docs/docs/troubleshooting/kb/003-plex-advertises-broken-connection-urls.md
@@ -1,20 +1,20 @@
 # KB-003: Plex Advertises Broken Connection URLs To plex.tv
 
-**Status:** Fix 1 applied and stable — removes the broken `https://<fqdn>:32400` entry. Zero `location=unknown` / `expected MediaContainer element, found html` / `TranscodeUniversalRequest` errors in `Plex Media Server.log` since the pod rolled. Fix 2 (pod-IP suppression) not applied — still in reserve if Apple TVs ever resume stalling on pod-CIDR `:32400` connection attempts.
+**Status:** Fix 1 applied and stable: removes the broken `https://<fqdn>:32400` entry. Zero `location=unknown` / `expected MediaContainer element, found html` / `TranscodeUniversalRequest` errors in `Plex Media Server.log` since the pod rolled. Fix 2 (pod-IP suppression) not applied: still in reserve if Apple TVs ever resume stalling on pod-CIDR `:32400` connection attempts.
 
 ## Symptom
 
 Intermittent "server unavailable" / mid-stream reconnects on LAN clients (notably Apple TV) even though the Plex pod is healthy (0 restarts, 100% readiness, sub-ms `/identity` probe RTT from another node on the LAN). No pod restarts, no LB or HTTPRoute flaps, no node pressure.
 
-Distinct from the BBR/MTU-probing buffering issue (see KB-002) — this one manifests as connection drops and app-level "unavailable" states, typically at session start or at session re-negotiation boundaries rather than mid-stream 60-second freezes.
+Distinct from the BBR/MTU-probing buffering issue (see KB-002). This one manifests as connection drops and app-level "unavailable" states, typically at session start or at session re-negotiation boundaries rather than mid-stream 60-second freezes.
 
 ## Cause
 
 Captured in parallel during a reported flap:
 
 - LAN-side `curl /identity` probe from a hostNetwork pod on a non-pod-host node: **zero failures**, sub-ms response, for the entire window.
-- `talosctl pcap` on both the pod host and the L2 announcer node showed the Apple TV client opening TCP sockets to **two IPs simultaneously**: the Plex LoadBalancer IP (healthy) **and** the gateway LoadBalancer IP on port 32400 (repeated SYN retransmits, no SYN+ACK — the gateway doesn't listen on 32400, only 443).
-- Apple TV pcap showed `RST` bursts against the _healthy_ Plex socket exactly at the moment the user reported the drop. Not caused by server or network — client-side session teardown.
+- `talosctl pcap` on both the pod host and the L2 announcer node showed the Apple TV client opening TCP sockets to **two IPs simultaneously**: the Plex LoadBalancer IP (healthy) **and** the gateway LoadBalancer IP on port 32400 (repeated SYN retransmits, no SYN+ACK: the gateway doesn't listen on 32400, only 443).
+- Apple TV pcap showed `RST` bursts against the _healthy_ Plex socket exactly at the moment the user reported the drop. Not caused by server or network: client-side session teardown.
 - Plex's own `Plex Media Server.log` at the drop timestamp:
 
     ```text
@@ -23,7 +23,7 @@ Captured in parallel during a reported flap:
     ERROR - [Req#…/Transcode] TranscodeUniversalRequest: unable to get container: ///library/metadata/<id>?…
     ```
 
-    Three tells in that trio: `location … unknown` (the client's request URL didn't match any connection it considered LAN or WAN); HTML body where the transcoder expected XML (an internal fetch hit a gateway error page); and the triple slash `///library/metadata/…` — a classic "empty host in URL-join" bug inside Plex's internal transcoder.
+    Three tells in that trio: `location … unknown` (the client's request URL didn't match any connection it considered LAN or WAN); HTML body where the transcoder expected XML (an internal fetch hit a gateway error page); and the triple slash `///library/metadata/…`, a classic "empty host in URL-join" bug inside Plex's internal transcoder.
 
 - Querying plex.tv for what the server is actually publishing:
 
@@ -66,8 +66,8 @@ After Flux rolls the pod, re-run the `/resources.json` query above and confirm t
 
 If Apple TV stalls still occur after Fix 1, options in order of increasing blast radius:
 
-1. Plex preference `advertiseIp=<LAN-LB-IP>` via an extra `PLEX_PREFERENCE_N` env var — forces Plex to publish only the given IP as its local address and skip interface auto-discovery.
-2. `hostNetwork: true` on the Plex pod — Plex then only sees node IPs rather than the pod-CIDR IP. Has wider consequences (host port binding, LoadBalancer semantics, scheduling) so only reach for this if option 1 doesn't take.
+1. Plex preference `advertiseIp=<LAN-LB-IP>` via an extra `PLEX_PREFERENCE_N` env var: forces Plex to publish only the given IP as its local address and skip interface auto-discovery.
+2. `hostNetwork: true` on the Plex pod: Plex then only sees node IPs rather than the pod-CIDR IP. Has wider consequences (host port binding, LoadBalancer semantics, scheduling) so only reach for this if option 1 doesn't take.
 
 ### Verification
 

--- a/docs/docs/troubleshooting/kb/004-talos-patch-rollout-gotchas-tuppr.md
+++ b/docs/docs/troubleshooting/kb/004-talos-patch-rollout-gotchas-tuppr.md
@@ -13,7 +13,7 @@ The node was left:
 - Drained, so 6 pods (mon-c, osd-X, dragonfly-N, postgres18-N, mosquitto-0, per-volume affinity) sat `Pending` indefinitely.
 - Ceph in `HEALTH_WARN` (1 mon + 2 OSDs down) for as long as the cordon stood.
 
-This blocked TUPPR's own health-check (`status.ceph.health in ['HEALTH_OK']`) from passing, so TUPPR refused to create another upgrade Job — a classic chicken-and-egg.
+This blocked TUPPR's own health-check (`status.ceph.health in ['HEALTH_OK']`) from passing, so TUPPR refused to create another upgrade Job, a classic chicken-and-egg.
 
 ## Cause
 
@@ -26,7 +26,7 @@ The Job pod log shows the install/drain succeed, then:
 console logs for nodes ["<node-ip>"]:
 ```
 
-`<talos-svc-clusterip>:50000` is the `default/talos` Service ClusterIP, which proxies to the per-node Talos API. The Service endpoint is hosted on a pod that was itself evicted during the drain — so by the time TUPPR's wrapper tries to issue the powercycle, the Service has no healthy endpoint, the RPC times out, and the wrapper gives up. The node never gets the reboot command.
+`<talos-svc-clusterip>:50000` is the `default/talos` Service ClusterIP, which proxies to the per-node Talos API. The Service endpoint is hosted on a pod that was itself evicted during the drain, so by the time TUPPR's wrapper tries to issue the powercycle, the Service has no healthy endpoint, the RPC times out, and the wrapper gives up. The node never gets the reboot command.
 
 `bootID` confirms no reboot happened. `kubectl get nodes` shows `LastTransitionTime` weeks-old (no Ready=False transition during the attempt). `kernelVersion` and `osImage` stay on v1.13.0.
 
@@ -34,14 +34,14 @@ console logs for nodes ["<node-ip>"]:
 
 ### Option A: Manual `talosctl reboot --mode=powercycle` (recommended)
 
-The install is already staged — `sd-boot: using Talos-v1.13.X.efi as default entry` is already in the META partition. A direct reboot from the operator's host bypasses the broken in-cluster API path:
+The install is already staged: `sd-boot: using Talos-v1.13.X.efi as default entry` is already in the META partition. A direct reboot from the operator's host bypasses the broken in-cluster API path:
 
 ```bash
 export TALOSCONFIG=./talos/clusterconfig/talosconfig
 talosctl --nodes <node-ip> reboot --mode=powercycle
 ```
 
-`talosctl` talks to the node directly (not through the cluster Service), so it survives the drain that broke the in-cluster path. Node boots into the new version, kubelet re-registers, Pending pods schedule back. Run `kubectl uncordon <node>` afterwards — TUPPR's cordon does not auto-clear when bypassed.
+`talosctl` talks to the node directly (not through the cluster Service), so it survives the drain that broke the in-cluster path. Node boots into the new version, kubelet re-registers, Pending pods schedule back. Run `kubectl uncordon <node>` afterwards. TUPPR's cordon does not auto-clear when bypassed.
 
 ### Option B: Break the deadlock with `kubectl uncordon`, then let TUPPR retry
 
@@ -70,7 +70,7 @@ Safe when the originating pod is already gone (the RBD kernel mapping is cleaned
 
 When the `blackbox-exporter-lan` pod gets shuffled by the drain, the fresh pod's blackbox probe to the NFS server on port 2049 can briefly return `probe_success=0` (DNS resolve fails inside the pod even though the same lookup works from `kubectl run --image=netshoot` in the same namespace), driving the `probe_success{job="nfs_probe"}` metric to 0.
 
-Historically this immediately tripped a KEDA `ScaledObject` and scaled NFS-dependent deployments (notably Plex) to `0`. Since the migration to the [`zeroscaler`](024-zeroscaler-nfs-hpa.md) HPA + `prometheus-adapter`, the adapter serves the metric as `max_over_time(probe_success[3m])`, so a single transient blip no longer trips scale-to-0 — the probe must fail continuously for ~3 minutes first.
+Historically this immediately tripped a KEDA `ScaledObject` and scaled NFS-dependent deployments (notably Plex) to `0`. Since the migration to the [`zeroscaler`](024-zeroscaler-nfs-hpa.md) HPA + `prometheus-adapter`, the adapter serves the metric as `max_over_time(probe_success[3m])`, so a single transient blip no longer trips scale-to-0: the probe must fail continuously for ~3 minutes first.
 
 If a blip is slow to clear, restart the blackbox-exporter pod:
 
@@ -78,7 +78,7 @@ If a blip is slow to clear, restart the blackbox-exporter pod:
 kubectl delete pod -n observability -l app.kubernetes.io/name=prometheus-blackbox-exporter
 ```
 
-To pin every NFS-gated app up for the duration of a drain (native HPAs have no `paused` annotation), use the recipe — it patches `minReplicas: 1` on every zeroscaler HPA:
+To pin every NFS-gated app up for the duration of a drain (native HPAs have no `paused` annotation), use the recipe, which patches `minReplicas: 1` on every zeroscaler HPA:
 
 ```bash
 just kube zeroscaler suspend   # pin all NFS-gated apps up (minReplicas=1)
@@ -90,7 +90,7 @@ Note: Flux reverts `minReplicas` to the git value (`0`) on the next reconcile, s
 ### Open items
 
 1. The TUPPR Job should not route its post-drain `reboot` call through a cluster-internal Service whose endpoint may have been evicted by the drain. Worth raising upstream or pinning `rebootMode: kexec` to skip the powercycle path.
-2. The `blackbox-exporter-lan` pod's intermittent DNS-resolve failure on target hostnames needs investigation — likely a `dnsPolicy` / resolv.conf issue post-Cilium-identity-shuffle.
+2. The `blackbox-exporter-lan` pod's intermittent DNS-resolve failure on target hostnames needs investigation, likely a `dnsPolicy` / resolv.conf issue post-Cilium-identity-shuffle.
 3. zeroscaler pause (`just kube zeroscaler suspend`, which patches HPA `minReplicas: 1`) is reverted by Flux on the next reconcile; for a longer hold during a drain, `flux suspend` the affected app Kustomization instead.
 
 ## References

--- a/docs/docs/troubleshooting/kb/005-flate-misresolves-ngc-helmrepository-chart-urls.md
+++ b/docs/docs/troubleshooting/kb/005-flate-misresolves-ngc-helmrepository-chart-urls.md
@@ -37,7 +37,7 @@ urls:
 ```
 
 Per the Helm spec a relative `urls:` entry resolves against the repository base
-URL — i.e. `helm.ngc.nvidia.com/nvidia/charts/gpu-operator-…tgz`. flate instead
+URL, i.e. `helm.ngc.nvidia.com/nvidia/charts/gpu-operator-…tgz`. flate instead
 resolved it against the **host root**, requesting
 `helm.ngc.nvidia.com/charts/gpu-operator-…tgz` → **404**. In-cluster Flux
 source-controller resolved the same `HelmRepository` correctly (so deployments

--- a/docs/docs/troubleshooting/kb/006-checkov-ckv-k8s-21-namespaced-resources.md
+++ b/docs/docs/troubleshooting/kb/006-checkov-ckv-k8s-21-namespaced-resources.md
@@ -1,20 +1,20 @@
 # KB-006: Checkov CKV_K8S_21 Flags Namespaced Resources Without an Explicit Namespace
 
-**Status:** Resolved by convention — set `metadata.namespace` explicitly on every namespaced resource you author.
+**Status:** Resolved by convention: set `metadata.namespace` explicitly on every namespaced resource you author.
 
 ## Symptom
 
-The `security-scans` workflow (Checkov) fails a PR with **CKV_K8S_21** — _"The default namespace should not be used"_ — on namespaced resources under `app/` (ConfigMaps, ServiceAccounts, PVCs, …), even though they deploy into the correct namespace at runtime.
+The `security-scans` workflow (Checkov) fails a PR with **CKV_K8S_21** (_"The default namespace should not be used"_) on namespaced resources under `app/` (ConfigMaps, ServiceAccounts, PVCs, …), even though they deploy into the correct namespace at runtime.
 
 ## Cause
 
-Checkov scans the **raw committed manifests**, _before_ Flux applies the Kustomization's `targetNamespace` (or the parent-dir `kustomization.yaml` `namespace:`). A resource with no explicit `metadata.namespace` looks like it lives in `default` to the scanner, so it gets flagged — even though `targetNamespace` sets it correctly at apply-time.
+Checkov scans the **raw committed manifests**, _before_ Flux applies the Kustomization's `targetNamespace` (or the parent-dir `kustomization.yaml` `namespace:`). A resource with no explicit `metadata.namespace` looks like it lives in `default` to the scanner, so it gets flagged, even though `targetNamespace` sets it correctly at apply-time.
 
-It bites namespaced **core** kinds (ConfigMaps, ServiceAccounts, PVCs, Services). Cluster-scoped kinds (ClusterRole / ClusterRoleBinding) are not flagged, and CRD instances (ExternalSecret, ToolHive `MCPServer`, …) are typically skipped — so it mainly surfaces on the core kinds.
+It bites namespaced **core** kinds (ConfigMaps, ServiceAccounts, PVCs, Services). Cluster-scoped kinds (ClusterRole / ClusterRoleBinding) are not flagged, and CRD instances (ExternalSecret, ToolHive `MCPServer`, …) are typically skipped, so it mainly surfaces on the core kinds.
 
 ## Fix
 
-Two accepted approaches — pick whichever fits the resource's context:
+Two accepted approaches. Pick whichever fits the resource's context:
 
 1. **Set `metadata.namespace` explicitly** (preferred for single-namespace apps). Set `metadata.namespace: <ns>` on every namespaced resource you author, matching the Kustomization's `targetNamespace`. It is redundant with `targetNamespace` at apply-time (and harmless), but it satisfies the raw-YAML scanner.
 

--- a/docs/docs/troubleshooting/kb/007-flux-not-ready-artifact-failed-alert-storms.md
+++ b/docs/docs/troubleshooting/kb/007-flux-not-ready-artifact-failed-alert-storms.md
@@ -3,30 +3,30 @@
 **Status:** Both patterns understood; either can recur under load or an upstream blip.
 
 A sudden flood of Flux alerts almost always traces back to **one** root cause cascading,
-not dozens of independent failures. The workloads themselves usually stay healthy — the
+not dozens of independent failures. The workloads themselves usually stay healthy: the
 break is at the Flux source / health-gate layer. Two distinct triggers produce the storm;
 the alert text tells them apart.
 
 ## Symptom
 
-- **Variant A — `FluxHelmReleaseArtifactFailed` cluster-wide** (informally "flux is OOM").
+- **Variant A: `FluxHelmReleaseArtifactFailed` cluster-wide** (informally "flux is OOM").
   Many HelmReleases report `Could not load chart: GET http://source-controller.../ocirepository/... context deadline exceeded`.
-- **Variant B — ~28 "dependency not ready" / Kustomization `Ready=False` alerts** at once,
+- **Variant B: ~28 "dependency not ready" / Kustomization `Ready=False` alerts** at once,
   each re-firing on every retry.
 
 In both, `kubectl get pods -A` is green, nodes are `Ready`, and the apps keep serving.
 
 ## Cause
 
-### Variant A — source-controller OOMKilled after a merge burst
+### Variant A: source-controller OOMKilled after a merge burst
 
 A burst of merges (e.g. ~14 PRs in quick succession) spikes source-controller: artifact-store
 rebuild, `--helm-cache-max-size`, and `--concurrent` reconciles together push it past its
 memory limit. Once it OOM-crashloops it **cannot serve OCI/git artifacts**, so every
-HelmRelease that needs to (re)load its chart fails — all the ArtifactFailed alerts are
+HelmRelease that needs to (re)load its chart fails: all the ArtifactFailed alerts are
 downstream of the single OOM.
 
-### Variant B — a transient registry outage cascading via `dependsOn`
+### Variant B: a transient registry outage cascading via `dependsOn`
 
 A brief upstream registry blip (e.g. a `quay.io` **504 Gateway Timeout**) breaks the digest
 re-fetch for a source that sits at the **root** of a `dependsOn` chain (cert-manager and
@@ -39,17 +39,17 @@ only the **OCIRepository / HelmChart** source is unready.
 
 ## Fix
 
-### Variant A — raise source-controller memory (and break-glass the deadlock)
+### Variant A: raise source-controller memory (and break-glass the deadlock)
 
 Bump the source-controller resources in the FluxInstance patch at
 `kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml` (under
 `spec.values.instance.kustomize.patches`, `target.name: source-controller`). Steady state is
-~400Mi and a full artifact re-fetch peaks ~474Mi, so 512Mi is too tight — use **1Gi**
+~400Mi and a full artifact re-fetch peaks ~474Mi, so 512Mi is too tight. Use **1Gi**
 (request = limit). Go higher if a bigger burst OOMs it again.
 
 The git fix can't self-apply while source-controller is down (kustomize/helm-controller need
 it to fetch the git artifact and re-render). Break the deadlock by editing the **live**
-FluxInstance CR — **flux-operator**, not source-controller, reconciles it, so it applies
+FluxInstance CR. **flux-operator**, not source-controller, reconciles it, so it applies
 independently:
 
 ```bash
@@ -61,7 +61,7 @@ kubectl replace -f /tmp/fluxinstance.json
 Then land the same value in git and `flux reconcile kustomization flux-instance -n flux-system`
 so live and git converge (otherwise the next re-render reverts the break-glass).
 
-### Variant B — retry the failing root source
+### Variant B: retry the failing root source
 
 The sources self-heal once the registry recovers; just nudge them and let the cascade clear:
 
@@ -75,7 +75,7 @@ Diagnose which variant you have first: `flux get kustomizations -A --status-sele
 trace the `dependsOn` chain to its root, then check that root's **OCIRepository/HelmChart**
 readiness (not its HelmRelease). A secondary aggravator on Variant B: every `cluster-secrets`
 ExternalSecret refresh cancels in-flight health checks and restarts the 15m clock, prolonging
-recovery — inherent to `dependsOn`, no clean config fix.
+recovery: inherent to `dependsOn`, no clean config fix.
 
 ## References
 

--- a/docs/docs/troubleshooting/kb/008-cilium-cross-node-pod-networking-breaks.md
+++ b/docs/docs/troubleshooting/kb/008-cilium-cross-node-pod-networking-breaks.md
@@ -1,12 +1,12 @@
 # KB-008: Cross-Node Pod Networking Breaks (Cilium)
 
-**Status:** Two distinct causes, each with a different fix. Identify the cause before acting —
+**Status:** Two distinct causes, each with a different fix. Identify the cause before acting:
 the fixes do not overlap.
 
 ## Symptom
 
 One node's **pod-to-pod** traffic to pods on the other nodes is intermittently or
-"flippingly" lost (cross-node CoreDNS lookups succeed only 0–50% of the time), while that
+"flippingly" lost (cross-node CoreDNS lookups succeed only 0-50% of the time), while that
 node's **host / underlay** traffic (node-IP pings) is perfect. Paths that don't involve the
 affected node (peer ↔ peer) are fine.
 
@@ -18,22 +18,22 @@ clean (`rx_crc_errors=0`).
 
 Tell the two variants apart by **route stability** and **recent changes**:
 
-| | Variant A — stale peer state | Variant B — Talos version regression |
+| | Variant A: stale peer state | Variant B: Talos version regression |
 |---|---|---|
 | Trigger | A node was **down/cordoned for hours** (e.g. a failed upgrade), then rejoined | A recent **Talos minor/patch bump** |
 | Routes | Peer pod-CIDR routes are wrong but **stable** | Peer pod-CIDR routes **flap** (count oscillates 0↔1↔2) |
 | Where the bad state lives | On the **long-running peer** nodes, about the churned node | On the upgraded node itself, **load-triggered** |
-| agent log | — | spams `"Fallback node addresses updated" ... device=*` ~2–3/min |
+| agent log | — | spams `"Fallback node addresses updated" ... device=*` ~2-3/min |
 
-### Variant A — stale Cilium datapath state on the peers
+### Variant A: stale Cilium datapath state on the peers
 
 After a node sits cordoned for an extended period and its endpoints churn, the long-running
 peer nodes hold **stale cross-node datapath state** about it. Cilium BPF maps (including
 conntrack) **survive agent restarts**, so the affected node's own reboots, `cilium-agent`
 restarts, a full DaemonSet rollout, and even `cilium bpf ct flush` on all nodes do **not**
-clear it — the bad state isn't on the affected node.
+clear it: the bad state isn't on the affected node.
 
-### Variant B — a Talos release regression flapping the routes
+### Variant B: a Talos release regression flapping the routes
 
 A specific Talos release (historically v1.13.3) regressed cross-node routing: the peer
 pod-CIDR direct routes flap in and out, correlated with workload scheduling (the flap returns
@@ -43,20 +43,20 @@ agent restart, plain reboot, and cordon+drain+reboot all fail to hold.
 
 ## Fix
 
-### Variant A — reboot the **other** (peer) nodes, one at a time
+### Variant A: reboot the **other** (peer) nodes, one at a time
 
 A node reboot wipes its BPF maps (tmpfs) and re-registers, clearing the stale per-node state.
 Reboot the long-running peers (graceful `talosctl reboot`, **not** powercycle), one at a time.
 After the peers cycle, the affected node's cross-node DNS returns to stable and its spegel pod
 recovers `1/1`. Do **not** waste time on a version downgrade, single-node Cilium restart, or
-CT flush — none of them clear it.
+CT flush: none of them clear it.
 
-### Variant B — roll the Talos version back
+### Variant B: roll the Talos version back
 
 Revert the version pins in `talos/talenv.yaml`, `talos/talconfig.yaml`, and
 `kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml` to the last good release,
 push, and let TUPPR downgrade the fleet. Recovery is immediate on the good version. Renovate
-won't auto-merge installer bumps, so it will re-open a PR back to the bad version — **don't
+won't auto-merge installer bumps, so it will re-open a PR back to the bad version: **don't
 merge it**; wait for the next release and test cross-node DNS on the previously-affected node
 before trusting it.
 
@@ -67,8 +67,8 @@ before trusting it.
 - **Check the route stability and recent Talos version first.** Flapping routes + a recent
   version bump → Variant B (roll back). Stable-but-wrong routes after a long node outage →
   Variant A (reboot the peers).
-- Diagnostic gotchas: `one.one.one.one` resolves poorly via this cluster's CoreDNS upstream —
-  use `github.com` as the external probe. `cilium-dbg service list | grep <svcIP>` drops the
+- Diagnostic gotchas: `one.one.one.one` resolves poorly via this cluster's CoreDNS upstream.
+  Use `github.com` as the external probe. `cilium-dbg service list | grep <svcIP>` drops the
   indented backend lines, making a 2-backend service look like 1.
 
 ## References

--- a/docs/docs/troubleshooting/kb/009-nfs-mount-failures-host-dns-readonly-export.md
+++ b/docs/docs/troubleshooting/kb/009-nfs-mount-failures-host-dns-readonly-export.md
@@ -1,6 +1,6 @@
 # KB-009: NFS Mount Failures (Host DNS / Read-Only Export)
 
-**Status:** Two distinct causes with different error strings — read the pod event before
+**Status:** Two distinct causes with different error strings: read the pod event before
 acting.
 
 NFS mounts behave differently from in-pod networking, and that trips up triage twice:
@@ -10,29 +10,29 @@ NFS mounts behave differently from in-pod networking, and that trips up triage t
 
 ## Symptom
 
-- **Variant A — stuck `Init:0/1` / `PodInitializing`** for a long time, repeating
+- **Variant A: stuck `Init:0/1` / `PodInitializing`** for a long time, repeating
   `mount.nfs: Failed to resolve server <server>: No address associated with hostname`.
-- **Variant B — `CreateContainerConfigError`** with
+- **Variant B: `CreateContainerConfigError`** with
   `failed to create subPath directory for volumeMount "<name>"`.
 
 ## Cause
 
-### Variant A — node host DNS can't resolve the NFS server for new mounts
+### Variant A: node host DNS can't resolve the NFS server for new mounts
 
 NFS mounts resolve via the **node host resolver** (Talos hostDNS at `127.0.0.53`), **not**
 CoreDNS. When a node's host DNS is failing to resolve the internal split-DNS storage hostname
-for *new* mounts, every fresh NFS mount on that node fails — while **pod-level** DNS (CoreDNS)
+for *new* mounts, every fresh NFS mount on that node fails, while **pod-level** DNS (CoreDNS)
 on the same node resolves the identical name fine, and long-running NFS pods elsewhere are
 unaffected (NFS resolves once at mount time and then persists). This correlates with prior
 node networking turbulence (a CoreDNS reschedule, see
 [KB-008](008-cilium-cross-node-pod-networking-breaks.md)).
 
 A nasty cascade: a backup CronJob with `concurrencyPolicy: Forbid` lets the **one** stuck job
-block *every* subsequent run — a single bad node can stall an entire hourly backup chain for
+block *every* subsequent run: a single bad node can stall an entire hourly backup chain for
 a day. (Data is usually still safe: the primary CNPG barman/S3 base backups + WAL archiving
 and the off-site job keep completing; only the supplementary local NFS dump is stalled.)
 
-### Variant B — the NFS base export is read-only / the subPath child is missing
+### Variant B: the NFS base export is read-only / the subPath child is missing
 
 When a pod mounts an NFS **base** export and relies on kubelet to create a `<app>/` subPath
 under it, kubelet creates that directory **as root**, which NFS **root-squashes to nobody**.
@@ -43,7 +43,7 @@ earlier.
 
 ## Fix
 
-### Variant A — clear the blocked job, then fix the node
+### Variant A: clear the blocked job, then fix the node
 
 ```bash
 kubectl delete job <stuck-job> -n <ns>
@@ -52,23 +52,23 @@ kubectl create job --from=cronjob/<cronjob> <cronjob>-manualfix -n <ns>
 
 The fresh pod lands on a healthy node, mounts NFS, and completes in seconds; alerts
 auto-clear. That also confirms node-specificity. The **root fix to stop recurrence is
-rebooting the affected node** (`talosctl reboot`) to restart its stale host-DNS forwarder —
-otherwise future runs that schedule back onto the bad node re-stick.
+rebooting the affected node** (`talosctl reboot`) to restart its stale host-DNS forwarder.
+Otherwise, future runs that schedule back onto the bad node re-stick.
 
 Quick triage: a backup/NFS pod stuck `PodInitializing` → `kubectl describe pod`, look for
 `mount.nfs: Failed to resolve` and **which node**; compare host DNS vs CoreDNS rather than
 assuming the hostname/config is wrong.
 
-### Variant B — fix the export storage-side (not in the cluster)
+### Variant B: fix the export storage-side (not in the cluster)
 
 Confirm fast with a busybox debug pod mounting the suspect path and `touch`-testing it, both
-as root and as uid 1000 — the tell is **base path `Read-only file system`** (even as the dir
+as root and as uid 1000: the tell is **base path `Read-only file system`** (even as the dir
 owner) while a **sibling child path is writable**. The fix is on the NAS: create a dedicated
 read-write child dataset for the app, owned by the app's uid/gid (e.g. `1000:1000`), cloning
 an existing writable share's allowed-networks/maproot. Optionally then point the manifest at
 the child path directly instead of base + `subPath`.
 
-**Do not `kubectl delete pod` to "force a remount"** on Variant B — the error is a
+**Do not `kubectl delete pod` to "force a remount"** on Variant B: the error is a
 write-permission / missing-directory problem, not a stale mount, and deleting the pod can
 trigger a Multi-Attach on its RWO block PVC for nothing.
 

--- a/docs/docs/troubleshooting/kb/010-rook-ceph-v120-csi-driver-split.md
+++ b/docs/docs/troubleshooting/kb/010-rook-ceph-v120-csi-driver-split.md
@@ -1,7 +1,7 @@
 # KB-010: Rook-Ceph v1.20 CSI Driver Split Gotchas
 
-**Status:** Resolved (PRs landed). Two runtime-only failures that `flate`/CI cannot catch —
-both render fine and only break on a live cluster. Read before any future Rook upgrade or
+**Status:** Resolved (PRs landed). Two runtime-only failures that `flate`/CI cannot catch.
+Both render fine and only break on a live cluster. Read before any future Rook upgrade or
 chart re-point.
 
 ## Background
@@ -14,27 +14,27 @@ missing service accounts. The Kustomization ordering is
 
 ## Symptom
 
-- **Gotcha 1 — in-use RBD storage breaks during the upgrade.** The RBD nodeplugin DaemonSet
+- **Gotcha 1: in-use RBD storage breaks during the upgrade.** The RBD nodeplugin DaemonSet
   fails: `daemonset/rook-ceph.rbd.csi.ceph.com-nodeplugin FailedCreate: serviceaccount "rbd-nodeplugin-sa" not found`.
   New and existing RBD volumes stop attaching.
-- **Gotcha 2 — every VolSync `copyMethod: Snapshot` source goes out of sync.** A flood of
+- **Gotcha 2: every VolSync `copyMethod: Snapshot` source goes out of sync.** A flood of
   `VolSyncVolumeOutOfSync` alerts (every `*-nfs` / `*-r2` ReplicationSource). CSI
   VolumeSnapshots are stuck `READYTOUSE=false` for hours; the VolSync controller logs
-  `waiting for snapshot to be ready`. (NFS reachability is a red herring — `kopia-maint`
+  `waiting for snapshot to be ready`. (NFS reachability is a red herring: `kopia-maint`
   jobs against the same repo keep completing.)
 
 ## Cause
 
-### Gotcha 1 — the charts-mirror driver name is unprefixed
+### Gotcha 1: the charts-mirror driver name is unprefixed
 
 The home-operations charts-mirror packages the **upstream** ceph-csi-operator chart, whose
 `drivers.rbd.name` defaults to the **unprefixed** `rbd.csi.ceph.com`. Rook's own wrapper chart
-defaults to the **namespace-prefixed** `rook-ceph.rbd.csi.ceph.com` — which is what this
+defaults to the **namespace-prefixed** `rook-ceph.rbd.csi.ceph.com`, which is what this
 cluster's `ceph-block` StorageClass and all in-use RBD PVs reference (`PV .spec.csi.driver`
 is **immutable**). Deploying without the override creates a wrong-named driver, and the new
 operator winds down the in-use one.
 
-### Gotcha 2 — `snapshotPolicy` defaults to `none`
+### Gotcha 2: `snapshotPolicy` defaults to `none`
 
 The `ceph-csi-drivers` chart defaults `drivers.rbd.snapshotPolicy: "none"`, which **omits the
 `csi-snapshotter` sidecar** from the RBD `ctrlplugin` deployment entirely. The
@@ -44,7 +44,7 @@ this regresses silently on migration.
 
 ## Fix
 
-### Gotcha 1 — pin the driver name to the prefixed form
+### Gotcha 1: pin the driver name to the prefixed form
 
 Set, in the `ceph-csi-drivers` HelmRelease values:
 
@@ -56,7 +56,7 @@ drivers:
 
 The pre-existing `Driver` CR is already annotated for the `ceph-csi-drivers` release, so it
 adopts in place. After the rollout, the spurious unprefixed driver's SAs/RBAC are Flux-pruned,
-but the cluster-scoped CSIDriver object is **not** GC'd by the operator — delete it manually
+but the cluster-scoped CSIDriver object is **not** GC'd by the operator. Delete it manually
 once nothing references it:
 
 ```bash
@@ -67,7 +67,7 @@ kubectl delete csidriver rbd.csi.ceph.com
 > uses the **prefixed** provisioner, so the override is required; a cluster on the unprefixed
 > form would not set it.
 
-### Gotcha 2 — enable the snapshotter, then clear the stale leader lease
+### Gotcha 2: enable the snapshotter, then clear the stale leader lease
 
 Set, in `kubernetes/apps/rook-ceph/rook-ceph/csi-drivers/helmrelease.yaml`:
 
@@ -80,7 +80,7 @@ drivers:
 Confirm the `ctrlplugin` pod gains a `csi-snapshotter` container. It then often **hangs at
 `Attempting to acquire leader lease...`** because the snapshotter Lease was orphaned by the
 pre-cutover pod that last held it. Delete the stale lease (a runtime leader-lock, **not**
-GitOps-managed — safe):
+GitOps-managed, safe):
 
 ```bash
 kubectl -n rook-ceph delete lease external-snapshotter-leader-rook-ceph-rbd-csi-ceph-com
@@ -89,7 +89,7 @@ kubectl -n rook-ceph delete lease external-snapshotter-leader-rook-ceph-rbd-csi-
 The snapshotter acquires instantly; backlogged source snapshots flip `ReadyToUse=true` within
 minutes, then VolSync fires its movers in a thundering herd (many `Pending`/`Init`, drains
 gradually). Out-of-sync alerts only clear once each mover **completes**. Note: a `v1.20.x`
-operator point-bump does **not** fix Gotcha 2 — `snapshotPolicy` is a chart value, independent
+operator point-bump does **not** fix Gotcha 2: `snapshotPolicy` is a chart value, independent
 of operator version.
 
 ## References

--- a/docs/docs/troubleshooting/kb/011-konflate-render-failures.md
+++ b/docs/docs/troubleshooting/kb/011-konflate-render-failures.md
@@ -10,23 +10,23 @@ hit it.
 
 ## Symptom
 
-- **Variant A — `KubePersistentVolumeInodesFillingUp` (critical)** on `konflate-cache` within
+- **Variant A: `KubePersistentVolumeInodesFillingUp` (critical)** on `konflate-cache` within
   ~a day, with plenty of free **bytes** remaining.
-- **Variant B — every open PR's konflate check fails** with `status: error` ("all my CIs are
+- **Variant B: every open PR's konflate check fails** with `status: error` ("all my CIs are
   failing"). Pod logs show the **same** object SHA across all PRs:
   `gitclone: repack mirror: getting object <SHA> failed: object not found`.
 
 ## Cause
 
-### Variant A — inode density, not size
+### Variant A: inode density, not size
 
 konflate's source/render/stage caches are millions of tiny files at only a few GB, so a
 fixed-inode ceph-block RBD volume **exhausts inodes long before bytes**. The chart bounds
 caches by bytes + TTL but never by inode count.
 
-### Variant B — a phantom (dangling) ref in the git mirror
+### Variant B: a phantom (dangling) ref in the git mirror
 
-The failing SHA is a **phantom** — not in the GitHub repo at all (`git cat-file -t <SHA>` =
+The failing SHA is a **phantom**, not in the GitHub repo at all (`git cat-file -t <SHA>` =
 bad object even after fetch). It's a dangling ref in konflate's in-pod mirror, almost
 certainly a commit that Renovate force-pushed away but the mirror still references.
 `repack mirror` chokes on it, which breaks the **whole** mirror, so every render fails
@@ -34,7 +34,7 @@ globally.
 
 ## Fix
 
-### Variant A — use an emptyDir cache, never `kubectl patch` the PVC
+### Variant A: use an emptyDir cache, never `kubectl patch` the PVC
 
 Set `persistence.enabled: false` (the chart default) so the cache mounts an **emptyDir** on the
 node filesystem (Talos `/var` is xfs with dynamic inodes); helm then deletes the
@@ -43,14 +43,14 @@ merged-PR shelf is lost on restart.
 
 > **Hard-won rule: never grow a GitOps-managed PVC with `kubectl patch`.** An imperative
 > `5Gi → 20Gi` grow clears the alert but **diverges the live volume from git's declared size**.
-> The next chart bump re-applies the PVC at the git size and the helm upgrade fails —
+> The next chart bump re-applies the PVC at the git size and the helm upgrade fails:
 > `spec.resources.requests.storage: Forbidden: field can not be less than status.capacity`
-> (PVCs can't shrink) — which then fails the auto-rollback and leaves the HR stuck
+> (PVCs can't shrink), which then fails the auto-rollback and leaves the HR stuck
 > `Ready=False/RollbackFailed`. Always bump `size:` **in git**. ("Out of inodes" with free
-> bytes is an inode-density mismatch, not a sizing problem — prefer emptyDir on xfs for
+> bytes is an inode-density mismatch, not a sizing problem; prefer emptyDir on xfs for
 > many-tiny-file caches.)
 
-### Variant B — restart the pod to wipe the mirror
+### Variant B: restart the pod to wipe the mirror
 
 Persistence is disabled (emptyDir mirror), so a restart wipes the corrupt mirror and
 re-clones cleanly:
@@ -66,12 +66,12 @@ current `main`.
 
 ## konflate status semantics
 
-konflate is a **lenient** gate, kept advisory (not required) — `flate` remains the strict
+konflate is a **lenient** gate, kept advisory (not required); `flate` remains the strict
 gate. Its render-status header maps to:
 
 - `ok` → pass.
 - `failures` → individual resources couldn't render (e.g. a private source). Made advisory
-  (`::warning`, no failure) — expected on most PRs, not a bug.
+  (`::warning`, no failure), expected on most PRs, not a bug.
 - `error` → the whole render failed with no diff → the real gate. The phantom-object failure
   is this one.
 

--- a/docs/docs/troubleshooting/kb/012-jvm-container-rss-oom-malloc-arena-max.md
+++ b/docs/docs/troubleshooting/kb/012-jvm-container-rss-oom-malloc-arena-max.md
@@ -7,7 +7,7 @@ Java/JRuby/Logstash workload that OOMs on these many-core nodes.
 
 A JVM-based pod (here `sentinel-syslog`, a Logstash → Microsoft Sentinel shipper) is
 **OOMKilled (`exit 137`) on a regular cadence** (e.g. ~every 4h), creeping steadily toward the
-container memory limit — even though the heap is explicitly bounded (`-Xmx512m`) and never near
+container memory limit, even though the heap is explicitly bounded (`-Xmx512m`) and never near
 its cap. Restarting just resets the clock.
 
 ## Cause
@@ -15,9 +15,9 @@ its cap. Restarting just resets the clock.
 The growth is **off-heap / native**, and it scales with the node's core count. Diagnose by
 attributing where RSS actually lives **before** changing anything:
 
-- `kubectl exec ... -- curl -s localhost:9600/_node/stats/jvm` — if **heap and non-heap are
+- `kubectl exec ... -- curl -s localhost:9600/_node/stats/jvm`: if **heap and non-heap are
   both flat** while RSS climbs, the leak is native, not JVM.
-- `/proc/1/smaps` (sum `Rss` per mapping) — the tell here was **six ~64 MB anonymous arenas**
+- `/proc/1/smaps` (sum `Rss` per mapping): the tell here was **six ~64 MB anonymous arenas**
   (~380 MB and growing) on top of the JVM heap.
 
 That pattern is **glibc per-thread malloc arenas**. On a 24-core node glibc spawns up to
@@ -54,7 +54,7 @@ Address the secondary contributors too when relevant: pin `pipeline.workers: 2` 
 - **Attribute where RSS lives *before* fixing.** `/proc/1/smaps` (look for many ~64 MB anon
   arenas) and the JVM stats endpoint (heap vs non-heap flat while RSS climbs = native malloc).
   The first attempt here fixed secondary layers because it skipped this step.
-- **Verify a memory fix by watching the slope flatten** over 30–60 min — not by the low reading
+- **Verify a memory fix by watching the slope flatten** over 30-60 min, not by the low reading
   right after deploy. Distinguish JVM warmup (heap filling toward `-Xmx`, bounded) from a real
   native creep.
 

--- a/docs/docs/troubleshooting/kb/013-go-1264-binary-startup-sigsegv.md
+++ b/docs/docs/troubleshooting/kb/013-go-1264-binary-startup-sigsegv.md
@@ -6,9 +6,9 @@ for recognition and for the repro technique.
 ## Symptom
 
 A pure-Go pod (here `chaski`, a webhook relay) **SIGSEGVs at startup** (`exit 139`) on a
-fraction of fresh pod starts (~60–70%), recovering in ~1s on the kubelet restart. With 2
+fraction of fresh pod starts (~60-70%), recovering in ~1s on the kubelet restart. With 2
 replicas this causes **no downtime**, but a single restart trips a `KubePodCrashLooping`-style
-page on every rollout or restart — which can look like "the app is failing" when the cluster is
+page on every rollout or restart, which can look like "the app is failing" when the cluster is
 otherwise green.
 
 ## Cause
@@ -18,12 +18,12 @@ The crash is a **Go runtime-bootstrap regression**, not an application bug. It h
 
 - `GODEBUG=inittrace=1` prints **nothing** → the crash is before package `init()`.
 - `GOTRACEBACK=crash` prints **nothing** → before the runtime's signal handler installs (hence
-  a raw `139` with **no obtainable stack** — the runtime dies before it can produce one).
+  a raw `139` with **no obtainable stack**: the runtime dies before it can produce one).
 - The binary was built with **Go 1.26.4**, pure-Go, no CGO. cf. golang/go#78822 (Go 1.26.x
   linux/amd64 SIGSEGV regressions).
 
 Ruled out via a throwaway-probe Deployment (one variable at a time): `GOMAXPROCS` 24→2, memory
-limit 128Mi→1Gi, seccomp `RuntimeDefault`→`Unconfined` — none move the rate; not node-specific;
+limit 128Mi→1Gi, seccomp `RuntimeDefault`→`Unconfined`, none move the rate; not node-specific;
 identical on multiple app versions. Circumstantial proof it's the toolchain: hundreds of
 older-Go binaries start fine on the same nodes, and this is one of the first Go-1.26.4 binaries
 deployed.
@@ -33,7 +33,7 @@ deployed.
 No config knob fixes it and no older release of the affected app dodges it (all built on the
 same Go era). Options, in order of preference:
 
-1. **Leave it** if replicas ≥ 2 and recovery is sub-second — impact is a noisy alert, not an
+1. **Leave it** if replicas ≥ 2 and recovery is sub-second: impact is a noisy alert, not an
    outage. (This is what was chosen.)
 2. Rebuild the binary on a **different Go toolchain** once a fixed release exists.
 3. Silence the rollout-time crash-loop alert for the specific workload if it's too noisy.
@@ -51,5 +51,5 @@ If other Go-1.26 binaries start crash-looping the same way, that confirms it's t
 
 ## References
 
-- golang/go#78822 — Go 1.26.x linux/amd64 startup SIGSEGV reports.
+- golang/go#78822: Go 1.26.x linux/amd64 startup SIGSEGV reports.
 - `GODEBUG` runtime knobs: <https://pkg.go.dev/runtime#hdr-Environment_Variables>

--- a/docs/docs/troubleshooting/kb/014-gpu-device-plugin-handover-allocatable-zero.md
+++ b/docs/docs/troubleshooting/kb/014-gpu-device-plugin-handover-allocatable-zero.md
@@ -16,12 +16,12 @@ but on the affected nodes `talosctl ls /var/lib/kubelet/device-plugins/` shows *
 
 A kubelet plugin-manager **handover race**: the old plugin pod's deletion and the new pod's
 startup overlap so closely that kubelet's plugin manager loses track of the registration. The
-**pod logs lie** — they reflect the in-pod view, not the kubelet-side state. Only some nodes
+**pod logs lie**: they reflect the in-pod view, not the kubelet-side state. Only some nodes
 are affected (whichever lost the race).
 
 ## Fix
 
-Restart the device-plugin pod on each affected node — that forces kubelet to observe a fresh
+Restart the device-plugin pod on each affected node. That forces kubelet to observe a fresh
 socket creation and clears the stale state:
 
 ```bash
@@ -39,7 +39,7 @@ node restart needed.**
    `kubectl get nodes -o json | jq '.items[].status.allocatable["nvidia.com/gpu"]'`.
 2. Any node showing `0` for > 2 min: delete its device-plugin pod and confirm
    `nvidia-gpu.sock` appears at `/var/lib/kubelet/device-plugins/` via `talosctl ls`.
-3. **Don't read the plugin pod logs first** — they're misleading. Check the node allocatable
+3. **Don't read the plugin pod logs first**: they're misleading. Check the node allocatable
    and the host socket.
 4. Don't reach for a kubelet/node restart unless the pod restart fails.
 

--- a/docs/docs/troubleshooting/kb/015-slow-image-pulls-exceed-helmrelease-timeout.md
+++ b/docs/docs/troubleshooting/kb/015-slow-image-pulls-exceed-helmrelease-timeout.md
@@ -1,7 +1,7 @@
 # KB-015: Slow Image Pulls Exceed the HelmRelease Timeout (Rollback Loop)
 
 **Status:** Recurring pattern; the `spec.timeout: 15m` fields it leaves behind are
-load-bearing — don't strip them.
+load-bearing. Don't strip them.
 
 ## Symptom
 
@@ -11,7 +11,7 @@ Renovate image bump. The pod is stuck `ContainerCreating` with an active `Pullin
 
 ## Cause
 
-It's not the app — it's the pull. This cluster's link to GHCR sustains roughly **~1 MB/s**, so
+It's not the app. It's the pull. This cluster's link to GHCR sustains roughly **~1 MB/s**, so
 any image in the **250 MB+** range takes longer than Helm's **default 5-minute** upgrade
 timeout to pull. Each failed attempt **restarts the pull from zero** (the partial pull is
 discarded on rollback), so layers never cache and retries don't converge.
@@ -37,10 +37,10 @@ HRs already carrying this for large images include `default/giteamirror` (~244 M
 ## How to apply
 
 1. On any `UpgradeFailed`/`RollbackFailed`/`Stalled` after a bump, first check for a pod stuck
-   `ContainerCreating` with a live `Pulling` event — if so it's this pattern, **not** an app
+   `ContainerCreating` with a live `Pulling` event: if so it's this pattern, **not** an app
    bug.
 2. Add `spec.timeout: 15m` to the HelmRelease.
-3. **Don't strip these `timeout` fields** when refactoring — they are load-bearing.
+3. **Don't strip these `timeout` fields** when refactoring: they are load-bearing.
 4. When onboarding a new app whose image is known to be large (> 250 MB), set `timeout: 15m`
    preemptively.
 

--- a/docs/docs/troubleshooting/kb/016-kopia-repo-server-oom-repo-size.md
+++ b/docs/docs/troubleshooting/kb/016-kopia-repo-server-oom-repo-size.md
@@ -5,7 +5,7 @@
 ## Symptom
 
 The `volsync-system/kopia` repository server **OOMKills in a crashloop** (`exit 137`) at its
-memory limit — even a trivial `kopia maintenance info` exec OOMs. The server log shows
+memory limit, even a trivial `kopia maintenance info` exec OOMs. The server log shows
 `Found too many index blobs ... run kopia maintenance`, which **looks like** maintenance is
 broken.
 
@@ -13,13 +13,13 @@ broken.
 
 It's **repo size**, not maintenance. The VolSync Kopia repo had grown to ~320 GB / **3.4M
 in-use contents** / ~3,462 index blobs. The server loads the **full index into memory on
-start**, which exceeds the limit. The "too many index blobs" message is a **red herring** —
+start**, which exceeds the limit. The "too many index blobs" message is a **red herring**:
 maintenance is actually running fine:
 
 - The `KopiaMaintenance` CR drives the `kopia-maint-daily-*` cronjob every 4h.
 - Its job log shows it owns maintenance, runs quick **then full** maintenance (GC + epoch
   compaction), and reports `MAINTENANCE_STATUS: SUCCESS` in a few minutes.
-- The maintenance job pod has **no resource limits**, so it doesn't OOM — only the long-lived
+- The maintenance job pod has **no resource limits**, so it doesn't OOM, only the long-lived
   server did.
 
 ## Fix
@@ -34,7 +34,7 @@ resources:
     memory: 2Gi
 ```
 
-The repo keeps growing, so if it OOMs again at 2Gi, go 3–4Gi. (Maintenance config lives at
+The repo keeps growing, so if it OOMs again at 2Gi, go 3-4Gi. (Maintenance config lives at
 `kubernetes/apps/volsync-system/volsync/maintenance/`.)
 
 ## References

--- a/docs/docs/troubleshooting/kb/017-mise-lefthook-symlink-race-on-commit.md
+++ b/docs/docs/troubleshooting/kb/017-mise-lefthook-symlink-race-on-commit.md
@@ -16,7 +16,7 @@ failed to rebuild runtime symlinks ... ln -sf ... File exists (os error 17)
 ## Cause
 
 lefthook runs the YAML format hooks (`format-yaml` and `format-yaml-prettier`) **in parallel**.
-Both invoke mise, and both try to install the missing tool **concurrently** — mise's runtime
+Both invoke mise, and both try to install the missing tool **concurrently**: mise's runtime
 symlink rebuild isn't concurrency-safe, so the loser errors on the `ln -sf`. It triggers
 exactly **once per tool bump**; after the tool is installed the hooks are fast.
 

--- a/docs/docs/troubleshooting/kb/018-plex-remote-4k-transcode-decision-crash.md
+++ b/docs/docs/troubleshooting/kb/018-plex-remote-4k-transcode-decision-crash.md
@@ -23,7 +23,7 @@ A **remote** client (via the cloudflared tunnel; the session shows `location=wan
 decision request demanding a full transcode at **4K** (`videoResolution=4096x2160`,
 `videoQuality=100`, `directPlay=0&directStream=0`) while the server clamps remote streams to
 **20 Mbps** (`WanPerStreamMaxUploadRate=20000` = Settings → Network → Limit remote stream
-bitrate). For ultra-high-bitrate 4K HDR HEVC remuxes (~42–49 Mbps average, ~85 Mbps peak,
+bitrate). For ultra-high-bitrate 4K HDR HEVC remuxes (~42-49 Mbps average, ~85 Mbps peak,
 lossless audio) Plex estimates ~84.8 Mbps needed for 4K, **refuses to downscale resolution**,
 and **crashes the decision** instead of falling back.
 
@@ -33,27 +33,27 @@ remote clients that downscale to 1080p succeed under the *same* cap. Only the im
 
 ## Fix
 
-Keep the cap (it's intentional — sized so the home uplink supports ~5 concurrent remote
+Keep the cap (it's intentional, sized so the home uplink supports ~5 concurrent remote
 streams; one uncapped 4K direct-play would eat the whole link). Raising it doesn't even fix the
-crash — only an effectively-unlimited cap would, which defeats the purpose. Fix it on the
+crash: only an effectively-unlimited cap would, which defeats the purpose. Fix it on the
 client or in the library instead:
 
 1. **Client-side (the fix):** on the failing device, set Remote/Internet Streaming Quality to
    a **1080p preset** (not Original/Maximum, which request 4K). The client then asks for
    `1920x1080` and transcodes ≤ 20 Mbps fine.
 2. **Library-side:** produce **1080p versions** of the specific high-bitrate 4K remuxes (e.g.
-   via tdarr) so even Maximum-quality clients direct-play the 1080p copy (~10–15 Mbps) with
+   via tdarr) so even Maximum-quality clients direct-play the 1080p copy (~10-15 Mbps) with
    zero transcode; keep the 4K original for LAN.
 
 The cap itself is declarative in git as `PLEX_PREFERENCE_14: "WanPerStreamMaxUploadRate=20000"`
 in the Plex HelmRelease values (the home-operations image applies any
-`PLEX_PREFERENCE_<n>="Key=Value"` env on start — no live API/UI change needed). There is **no**
+`PLEX_PREFERENCE_<n>="Key=Value"` env on start, no live API/UI change needed). There is **no**
 server-side "limit remote resolution" setting in Plex, only bitrate.
 
 ## Recon notes
 
 - Tautulli listens on `:80` (not the config's `8181`); its on-disk `config.ini` api_key can be
-  stale versus the in-memory one — copy `/config/tautulli.db` out and query sqlite locally.
+  stale versus the in-memory one: copy `/config/tautulli.db` out and query sqlite locally.
 - The Plex token is in `Preferences.xml` (`PlexOnlineToken`); query the local API at
   `http://localhost:32400` inside the pod. Enable `logDebug=1` temporarily to capture the
   decision codes (`Direct Play=3000`, `Transcode=4005`).

--- a/docs/docs/troubleshooting/kb/019-cordon-control-plane-breaks-ceph-mon-quorum.md
+++ b/docs/docs/troubleshooting/kb/019-cordon-control-plane-breaks-ceph-mon-quorum.md
@@ -5,8 +5,8 @@ steer a pod* on this cluster.
 
 ## Symptom
 
-Minutes after `kubectl cordon <node>` on a control-plane node — often done to "steer a single
-unrelated pod elsewhere" — a burst of **critical** Ceph alerts fires:
+Minutes after `kubectl cordon <node>` on a control-plane node (often done to "steer a single
+unrelated pod elsewhere"), a burst of **critical** Ceph alerts fires:
 
 - `CephMonDown`
 - `CephMonDownQuorumAtRisk`
@@ -25,7 +25,7 @@ losing one mon's home node drops the cluster below a 2/3 quorum, hence the *crit
 alert.
 
 The same trap applies to a node left cordoned by a **failed Talos upgrade** (see
-[KB-004](004-talos-patch-rollout-gotchas-tuppr.md)) — the Ceph risk persists for as long as the
+[KB-004](004-talos-patch-rollout-gotchas-tuppr.md)). The Ceph risk persists for as long as the
 node stays cordoned.
 
 ## Fix
@@ -38,7 +38,7 @@ Quorum recovers within **~60s**: the mon reschedules onto its home node, all ini
 containers reach `Started` in ~25s, quorum is restored, all OSDs come back up, and Ceph returns
 to `HEALTH_OK`.
 
-**Don't cordon a control-plane node to move a pod here** — the displaced Ceph daemons matter
+**Don't cordon a control-plane node to move a pod here**: the displaced Ceph daemons matter
 more than the pod you're relocating. To move a *non-Ceph* pod off a node:
 
 - `kubectl delete pod` it and let the scheduler re-pick, **or**
@@ -51,7 +51,7 @@ possible.
 
 - The alert storm starts **right after a `cordon`**, and a `kubectl get pod -n rook-ceph -o wide`
   shows a mon/osd `Pending`/`FailedScheduling` whose required node is the one you just tainted.
-- A control-plane node that "can't start containers" is usually a **red herring** — the nodes
+- A control-plane node that "can't start containers" is usually a **red herring**: the nodes
   start containers fine. Earlier "node can't run pods" suspicions traced to helm-remediation
   thrash killing pods mid-create, not a node defect (see
   [KB-015](015-slow-image-pulls-exceed-helmrelease-timeout.md)).

--- a/docs/docs/troubleshooting/kb/020-httproute-drifts-to-placeholder-hostnames.md
+++ b/docs/docs/troubleshooting/kb/020-httproute-drifts-to-placeholder-hostnames.md
@@ -1,12 +1,12 @@
 # KB-020: App Returns 404 Through the Gateway (HTTPRoute Drifted to Placeholder Hostnames)
 
 **Status:** Rare and self-correcting; fixed per-app with a one-liner. Structural fix
-**deliberately declined** (see end). If it recurs, just remediate — don't re-investigate.
+**deliberately declined** (see end). If it recurs, just remediate. Don't re-investigate.
 
 ## Symptom
 
 An app returns the cluster's custom `error-pages` **404** when reached through the envoy
-gateway at its real `<app>.${SECRET_DOMAIN}` hostname — even though the pod and HelmRelease are
+gateway at its real `<app>.${SECRET_DOMAIN}` hostname, even though the pod and HelmRelease are
 healthy. The app answers **only** on its direct pod/Service IP. Forcing a helm upgrade does
 **not** fix it.
 
@@ -17,11 +17,11 @@ The **live** HTTPRoute's `spec.hostnames` are the placeholder defaults `<app>.ex
 `<app>.${SECRET_DOMAIN}`, so the request falls through to the `*` catch-all route and gets the
 custom 404.
 
-Where the placeholder comes from — the **first-render substitution race**:
+Where the placeholder comes from is the **first-render substitution race**:
 
 - `kubernetes/components/global-vars/` is a Component included by every namespace. It ships
   **both** a placeholder `cluster-secrets` Secret (fake `SECRET_DOMAIN: "example.com"`, fake
-  CIDRs/paths — needed for offline rendering, both `flate` locally and Konflate's in-cluster PR
+  CIDRs/paths, needed for offline rendering, both `flate` locally and Konflate's in-cluster PR
   renders) **and** the real `cluster-secrets` ExternalSecret (`creationPolicy: Owner`,
   1Password).
 - The placeholder applies **instantly**; ESO overwrites it seconds later. Any app whose
@@ -36,15 +36,15 @@ Why a forced upgrade won't self-heal it:
   revision renders the real domain identically, so helm computes **no diff** for the route and
   leaves the drifted live object untouched. `flux reconcile hr --force` bumps the release but
   still won't touch the un-diffed route. (helm-controller `driftDetection` is intentionally
-  **off** — enabling it would fight the zeroscaler HPAs on
+  **off**: enabling it would fight the zeroscaler HPAs on
   `spec.replicas`.)
 
-This is **not** domain-specific — the domain/route is just the most visible victim of the
+This is **not** domain-specific: the domain/route is just the most visible victim of the
 placeholder-then-ESO race; any `${VAR}` rendered in that window can be caught.
 
 ## Fix
 
-Per affected app (no Git change — the HelmRelease is already correct):
+Per affected app (no Git change, the HelmRelease is already correct):
 
 ```sh
 kubectl delete httproute -n <ns> <app>
@@ -65,7 +65,7 @@ kubectl get httproute -A -o json | jq -r '.items[]
 
 ## How to recognise fast
 
-- Verify **end-to-end through the gateway with real SNI** — a bare `Host:` header gives a
+- Verify **end-to-end through the gateway with real SNI**. A bare `Host:` header gives a
   misleading `200` from the catch-all:
 
   ```sh
@@ -78,7 +78,7 @@ kubectl get httproute -A -o json | jq -r '.items[]
 
 Decided not to fix structurally: the race is rare (a handful of apps in the cluster's lifetime,
 only at first render before ESO syncs), well understood, and self-corrects in the HelmRelease
-values — only already-rendered live objects stay drifted, and the delete+recreate one-liner
+values. Only already-rendered live objects stay drifted, and the delete+recreate one-liner
 clears those. Options considered and declined: global `driftDetection.mode: enabled` (would
 fight the zeroscaler HPAs), a self-healing CronJob guard, splitting `cluster-secrets` into its own
 `dependsOn`-gated Kustomization (the only complete fix, too invasive), and hardcoding the domain

--- a/docs/docs/troubleshooting/kb/021-grafana-dashboard-panels-blank-datasource-case.md
+++ b/docs/docs/troubleshooting/kb/021-grafana-dashboard-panels-blank-datasource-case.md
@@ -6,7 +6,7 @@ needs vendoring.
 ## Symptom
 
 Every panel on one `GrafanaDashboard` renders **"No data"** / **"Datasource Prometheus was not
-found"**, and any `label_values()` template variable returns empty — cascading the whole
+found"**, and any `label_values()` template variable returns empty, cascading the whole
 dashboard to blank. Other dashboards on the same Grafana work fine.
 
 ## Cause
@@ -18,7 +18,7 @@ Grafana resolves a panel's datasource ref **by uid first, then falls back to nam
   operator-generated random uid, defined in
   `kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml`.
 - The grafana-operator writes `GrafanaDashboard.spec.datasources[].datasourceName` **literally**
-  as each panel's datasource `uid` — it does **not** look up the real uid. Grafana then matches
+  as each panel's datasource `uid`. It does **not** look up the real uid. Grafana then matches
   that literal against the datasource's **name**.
 
 So `datasourceName: prometheus` resolves by name ✓, but `datasourceName: Prometheus` (capital)
@@ -26,18 +26,18 @@ matches neither a uid nor the name → every panel blanks. (This was the May/Jun
 "blank dashboards" bug across several shipped dashboards; the already-working dashboards proved
 lowercase is the convention.)
 
-**Second variant — `url:`-imported upstream JSON.** Some imported dashboards hardcode a
+**Second variant: `url:`-imported upstream JSON.** Some imported dashboards hardcode a
 `$datasource` **template variable** value (e.g. "Prometheus") *inside the JSON*, which no
 `datasources` remap can override. Those must be **vendored locally** (configMapRef) with the var
 pinned to `prometheus`.
 
 ## Fix
 
-- Set `datasourceName: prometheus` (lowercase) in the CR spec — this reconciles **immediately**
+- Set `datasourceName: prometheus` (lowercase) in the CR spec. This reconciles **immediately**
   via Flux.
 - For url-imported dashboards that pin `$datasource` internally: **vendor** the JSON locally and
   pin the template var to `prometheus`. Also strip the upstream author's **saved variable
-  defaults** — a saved host default like `esxhost=<a LAN IP>` trips the internal-identifier
+  defaults**: a saved host default like `esxhost=<a LAN IP>` trips the internal-identifier
   guard, and codespell may flag real typos plus schema keys (e.g. `showIn` → whitelist in
   `.github/linters/.codespellrc`).
 - Confirm the fix: the browser console shows `Datasource Prometheus was not found`, or
@@ -54,7 +54,7 @@ pinned to `prometheus`.
   kubectl rollout restart deploy/grafana-operator -n observability
   ```
 
-  CR **spec** changes (like the `datasourceName` fix) reconcile immediately via Flux — only raw
+  CR **spec** changes (like the `datasourceName` fix) reconcile immediately via Flux. Only raw
   JSON/configMap edits need the restart.
 - **Multi-value template vars** that cleared to the wrong default (e.g. a cluster picker landing
   on a single-host cluster with no perf metrics → N/A panels): set `includeAll: true` + default

--- a/docs/docs/troubleshooting/kb/022-s6-image-createcontainerconfigerror-non-root.md
+++ b/docs/docs/troubleshooting/kb/022-s6-image-createcontainerconfigerror-non-root.md
@@ -34,7 +34,7 @@ securityContext:
   runAsNonRoot: false   # REQUIRED — the chart blocks runAsUser: 0 without it
 ```
 
-Always set `runAsNonRoot: false` when you intentionally run root on this chart — `runAsUser: 0`
+Always set `runAsNonRoot: false` when you intentionally run root on this chart. `runAsUser: 0`
 alone is not enough.
 
 ## How to recognise fast
@@ -44,7 +44,7 @@ alone is not enough.
 - Related NFS-ownership note (so you don't "fix" the wrong thing): the TrueNAS `pool/*` exports
   use `mapall=…(1000)` + `all_squash`, so **every write over NFS lands as `1000:1000`
   regardless of the pod's runtime UID**. Running these images as root therefore still writes
-  `1000:1000` files — "run the app as 1000 for NFS compatibility" is unnecessary here; the
+  `1000:1000` files: "run the app as 1000 for NFS compatibility" is unnecessary here; the
   export already normalizes ownership. Hardcode `path: /mnt/pool/<dataset>` in the helmrelease
   (only `server: ${SECRET_STORAGE_SERVER}` is a variable).
 

--- a/docs/docs/troubleshooting/kb/023-node-conntrack-saturation-host-network-scanner.md
+++ b/docs/docs/troubleshooting/kb/023-node-conntrack-saturation-host-network-scanner.md
@@ -13,19 +13,19 @@ trigger is deploying a network scanner / sweeper.
 
 A scanner running with **`hostNetwork: true`** in a poll/daemon mode **auto-scans every subnet
 its host has an interface on**. On a Talos/Cilium node that includes the cilium virtual
-interfaces — and therefore the **pod CIDR `10.42.0.0/16` + service CIDR `10.43.0.0/16`**
+interfaces, and therefore the **pod CIDR `10.42.0.0/16` + service CIDR `10.43.0.0/16`**
 (~131k IPs). At the default scan rate it port-scans the **entire internal cluster network**; run
 as a **DaemonSet** across all control-plane nodes, it saturates **every** node's conntrack
 table.
 
-A full conntrack table drops new connections cluster-wide — this is a **whole-cluster hazard**,
+A full conntrack table drops new connections cluster-wide: this is a **whole-cluster hazard**,
 not just a scanner problem. (Stopping the scanner drains conntrack back to <2% within ~3 min,
 which confirms it is the sole cause.)
 
 ## Fix
 
-- **Scope the scanner to the physical LAN NIC** so it never sees the Cilium CIDRs — the big
-  lever:
+- **Scope the scanner to the physical LAN NIC** so it never sees the Cilium CIDRs (the big
+  lever):
 
   ```sh
   SCANOPY_INTERFACES=<lan-nic>   # --interfaces; default = ALL interfaces
@@ -33,16 +33,16 @@ which confirms it is the sole cause.)
 
   Verify the NIC name is **identical on all nodes** before hardcoding it in a workload (different
   hardware can enumerate interfaces differently).
-- Prefer a **single-replica Deployment over a DaemonSet** on a flat LAN — one scanner covers the
+- Prefer a **single-replica Deployment over a DaemonSet** on a flat LAN. One scanner covers the
   whole `/24`; a per-node DaemonSet triples the load scanning the same subnet. (scanopy: use
   `strategy: Recreate` + a stable `SCANOPY_NAME`.)
-- **Cap concurrency** (`SCANOPY_CONCURRENT_SCANS`, default auto ~10–20) and set a conservative
-  per-discovery Speed profile — newer scanopy moved per-scan rate (`scan-rate-pps`, port batch)
+- **Cap concurrency** (`SCANOPY_CONCURRENT_SCANS`, default auto ~10-20) and set a conservative
+  per-discovery Speed profile. Newer scanopy moved per-scan rate (`scan-rate-pps`, port batch)
   to the **UI per-discovery "Speed" tab**; daemon-level rate flags are ignored.
 - **Optional headroom:** raise `net.netfilter.nf_conntrack_max` via Talos `machine.sysctls`.
 
 **General rule:** any hostNetwork scanner/sweeper on this cluster **must** be scoped to the
-physical NIC / real LAN — never let it discover the Cilium pod/service CIDRs.
+physical NIC / real LAN. Never let it discover the Cilium pod/service CIDRs.
 
 ## How to recognise fast
 
@@ -51,7 +51,7 @@ physical NIC / real LAN — never let it discover the Cilium pod/service CIDRs.
   (`nodeSelector` → no nodes) to drain conntrack, then re-deploy scoped.
 - **VLAN caveat:** `SCANOPY_INTERFACES` only scopes **L2 / local-interface** scanning. The
   scanner still **L3-scans remote routable subnets** it discovers via SNMP routing tables, so as
-  new VLANs come online and become routable, conntrack load can climb again — narrow scope
+  new VLANs come online and become routable, conntrack load can climb again. Narrow scope
   per-discovery in the UI and keep `nf_conntrack_max` headroom. Re-check conntrack after a VLAN
   buildout.
 

--- a/docs/docs/troubleshooting/kb/024-zeroscaler-nfs-hpa.md
+++ b/docs/docs/troubleshooting/kb/024-zeroscaler-nfs-hpa.md
@@ -1,4 +1,4 @@
-# KB-024: zeroscaler — NFS-availability scale-to-zero via native HPA
+# KB-024: zeroscaler, NFS-availability scale-to-zero via native HPA
 
 **Status:** Reference. Replaced the KEDA-based `nfs-scaler` (removed 2026-07). Pattern ported from
 onedr0p/joryirving home-ops.
@@ -8,7 +8,7 @@ onedr0p/joryirving home-ops.
 NFS-dependent apps (the *arr stack, Plex, Jellyfin, qBittorrent, SABnzbd, …) are scaled to **0
 replicas when the NFS server is unreachable** and back to **1** when it returns, so they don't
 CrashLoopBackOff against a dead mount. This is done with a stock `autoscaling/v2`
-HorizontalPodAutoscaler fed by `prometheus-adapter` — **no KEDA**.
+HorizontalPodAutoscaler fed by `prometheus-adapter` (**no KEDA**).
 
 ## How it works
 
@@ -17,9 +17,9 @@ The chain is:
 - **`blackbox-exporter` `lan-tcp-nfs` Probe** (`jobName: nfs_probe`) TCP-connects the NFS server on
   `:2049` every 1m, emitting `probe_success{job="nfs_probe"}`.
 - **`prometheus-adapter`** (`observability` namespace) serves that metric on the
-  `external.metrics.k8s.io` API, wrapped as `max_over_time(probe_success[3m])` — the **debounce**
+  `external.metrics.k8s.io` API, wrapped as `max_over_time(probe_success[3m])`: the **debounce**
   (see Gotchas).
-- **`components/zeroscaler`** — a Kustomize component adding one HPA per app: `minReplicas: 0`,
+- **`components/zeroscaler`**, a Kustomize component adding one HPA per app: `minReplicas: 0`,
   `maxReplicas: 1`, external metric `probe_success{job=nfs_probe}` target value `1`. Metric `1`
   → 1 replica; metric `0` → 0 replicas.
 - An app opts in by adding `../../../../components/zeroscaler` to its `ks.yaml`
@@ -31,14 +31,14 @@ The chain is:
 - **`HPAScaleToZero` feature gate is required on BOTH the apiserver and the controller-manager.**
   Set `feature-gates: HPAScaleToZero=true` under **both** `cluster.apiServer.extraArgs` and
   `cluster.controllerManager.extraArgs` in `talos/patches/controller/cluster.yaml`. The apiserver
-  **validates** `minReplicas` — without the gate there it **rejects** the HPA at apply
+  **validates** `minReplicas`. Without the gate there it **rejects** the HPA at apply
   (`spec.minReplicas: Invalid value: 0: must be greater than or equal to 1`), leaving the app's
   Flux Kustomization `Ready=False`; the controller-manager does the actual scale-to-0. flate/CI
-  pass either way — it only surfaces when Flux applies the HPA. Changing either arg is a
+  pass either way. It only surfaces when Flux applies the HPA. Changing either arg is a
   control-plane change (rolling restart); regenerate with `just talos gen-config` and
   `just talos apply-node` on each control-plane node.
 - **`external.metrics.k8s.io` is a cluster singleton.** Only one APIService can back it. KEDA's
-  metrics server and `prometheus-adapter` both claim it, so they **cannot coexist** — this is why
+  metrics server and `prometheus-adapter` both claim it, so they **cannot coexist**. This is why
   the migration removed KEDA before adding the adapter.
 - **The `[3m]` window is the flap fix.** A blackbox-exporter reschedule (e.g. during a Talos drain)
   can make a single scrape return `probe_success=0` from a DNS blip; `max_over_time(...[3m])` holds
@@ -47,13 +47,13 @@ The chain is:
 - **`KubeHpaMaxedOut` is silenced cluster-wide.** Every HPA here is `maxReplicas: 1`, permanently
   "maxed" when NFS is up. The `zeroscaler-hpa-maxed` Silence matches `alertname=KubeHpaMaxedOut`
   (Alertmanager can't match the HPA's `app.kubernetes.io/part-of` label).
-- **Drift detection stays off.** helm-controller `driftDetection` is intentionally disabled — a
+- **Drift detection stays off.** helm-controller `driftDetection` is intentionally disabled: a
   native HPA writes `spec.replicas` exactly as the KEDA HPA did, and enabling drift would fight it.
 
 ## Operations
 
 Pin every NFS-gated app **up** for the duration of a node drain (native HPAs have no `paused`
-annotation — the recipe patches `minReplicas: 1`):
+annotation, the recipe patches `minReplicas: 1`):
 
 ```bash
 just kube zeroscaler suspend   # pin all zeroscaler HPAs up (minReplicas=1)

--- a/docs/docs/troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md
+++ b/docs/docs/troubleshooting/kb/025-cephfs-modprobe-builtin-misdiagnosis.md
@@ -2,7 +2,7 @@
 
 **Status:** Misdiagnosis corrected 2026-07-09. CephFS support **is present** in the Talos kernel;
 the June 2026 "Talos ships no `ceph` kernel module" conclusion (and the comments it left in the
-rook-ceph HelmReleases) was wrong. Re-enablement is planned — see the
+rook-ceph HelmReleases) was wrong. Re-enablement is planned: see the
 [adoption roadmap](../../operations/jory-homeops-adoption.md).
 
 ## Symptom
@@ -28,7 +28,7 @@ workarounds (per-model PVCs plus staging Jobs) as a consequence.
 
 **The CephFS client is compiled directly into the Talos kernel (`CONFIG_CEPH_FS=y`), not built
 as a loadable module.** `modprobe` only searches for loadable `.ko` files, so it reports
-"Module ceph not found" for any built-in — the error is expected and harmless. A built-in
+"Module ceph not found" for any built-in. The error is expected and harmless. A built-in
 filesystem needs no modprobe at all; `mount -t ceph` works directly.
 
 Verified on all three nodes (Talos v1.13.5, kernel 6.18.36):
@@ -45,11 +45,11 @@ nodev   ceph
 The upstream kernel config (`siderolabs/pkgs`, `release-1.13`, `kernel/build/config-amd64`)
 confirms it: `CONFIG_CEPH_FS=y` and `CONFIG_CEPH_FS_POSIX_ACL=y`. Note the adjacent trap for
 anyone grepping that 7,800-line file: `CONFIG_CEPH_LIB=y` (the messenger library used by RBD)
-appears first and is easy to mistake for the only ceph option present — an automated review
+appears first and is easy to mistake for the only ceph option present. An automated review
 pass made exactly that error and "confirmed" the misdiagnosis.
 
 Why the June mounts actually failed was never pinned down (candidates: the ceph-csi mounter's
-modprobe handling at the time, or a CSI configuration detail such as the msgr2-only setting —
+modprobe handling at the time, or a CSI configuration detail such as the msgr2-only setting:
 this cluster sets `requireMsgr2: true`, which kernel CephFS clients need the `ms_mode` mount
 option to negotiate). The kernel itself was never the blocker.
 
@@ -57,11 +57,11 @@ option to negotiate). The kernel itself was never the blocker.
 
 Before concluding a filesystem is unsupported on Talos (or any immutable OS):
 
-1. `talosctl read /proc/filesystems` — a registered filesystem type means the kernel supports
+1. `talosctl read /proc/filesystems`: a registered filesystem type means the kernel supports
    it **right now**, regardless of what modprobe says.
-2. `talosctl read /lib/modules/<kernel>/modules.builtin` — built-ins live here, not under
+2. `talosctl read /lib/modules/<kernel>/modules.builtin`: built-ins live here, not under
    `kernel/fs/`.
-3. Only if both are empty is the "missing module" theory alive — then check the upstream
+3. Only if both are empty is the "missing module" theory alive. Then check the upstream
    kernel config for `=m` vs `=y` vs absent, reading carefully (`CEPH_LIB` ≠ `CEPH_FS`).
 4. A modprobe failure alone proves nothing about built-ins.
 
@@ -73,5 +73,5 @@ Before concluding a filesystem is unsupported on Talos (or any immutable OS):
   `kustomize.toolkit.fluxcd.io/reconcile: disabled`, a disabled llmkube model cache), record
   the *evidence* alongside the conclusion so it can be re-checked cheaply later.
 - Comparable clusters are a signal: joryirving/home-ops kernel-mounts CephFS on the identical
-  Talos v1.13.5 with zero schematic or extension changes — if a peer does the "impossible",
+  Talos v1.13.5 with zero schematic or extension changes, if a peer does the "impossible",
   re-test the premise.

--- a/docs/docs/troubleshooting/kb/026-plex-apple-tv-app-receive-window-deadlock.md
+++ b/docs/docs/troubleshooting/kb/026-plex-apple-tv-app-receive-window-deadlock.md
@@ -1,24 +1,24 @@
 # KB-026: Plex Apple TV App Freezes on One Frame (Client Receive-Window Deadlock)
 
-**Status:** Understood; **server-side clean — this is a Plex-for-Apple-TV client bug**, isolated by an Infuse control (same device/network/server/file plays fine in Infuse). Root cause narrowed same-day to **EAC3 direct play on tvOS 26.5** (see Cause); community-corroborated, no fixed app version as of 2026-07-12. A server-side `Profiles/tvOS.xml` override (transcode EAC3 audio → ac3 for tvOS clients only) is deployed as a workaround — see Fix.
+**Status:** Understood; **server-side clean: this is a Plex-for-Apple-TV client bug**, isolated by an Infuse control (same device/network/server/file plays fine in Infuse). Root cause narrowed same-day to **EAC3 direct play on tvOS 26.5** (see Cause); community-corroborated, no fixed app version as of 2026-07-12. A server-side `Profiles/tvOS.xml` override (transcode EAC3 audio → ac3 for tvOS clients only) is deployed as a workaround: see Fix.
 
 ## Symptom
 
-A LAN Apple TV shows **one still frame of a 4K title, then the Plex app freezes** — the app becomes unresponsive and you must **force-quit and re-open it** (backing out / pressing play again does nothing). Intermittent: the *same* title sometimes plays for minutes, sometimes freezes at 0s. Affects both **Dolby Vision** (e.g. Silo S3 `[DV HDR10Plus]`) and plain **HDR10** 4K titles (e.g. *500 Days of Summer* `4K HDR10`, `DOVIPresent=0`); low-bitrate/1080p content (e.g. a 3 Mbps Pokémon film) is unaffected.
+A LAN Apple TV shows **one still frame of a 4K title, then the Plex app freezes**. The app becomes unresponsive and you must **force-quit and re-open it** (backing out / pressing play again does nothing). Intermittent: the *same* title sometimes plays for minutes, sometimes freezes at 0s. Affects both **Dolby Vision** (e.g. Silo S3 `[DV HDR10Plus]`) and plain **HDR10** 4K titles (e.g. *500 Days of Summer* `4K HDR10`, `DOVIPresent=0`); low-bitrate/1080p content (e.g. a 3 Mbps Pokémon film) is unaffected.
 
 Distinct from the other Plex Apple TV entries:
 
-- Not KB-002 (BBR/MTU) — that's periodic mid-stream freezes that **auto-recover** after ~60s; this one never recovers and starts at 0s.
-- Not KB-003 (broken connection URLs) — none of its tells (`location=unknown`, `found html`, `///library`) appear in the server log.
-- Not KB-018 (remote 4K decision crash) — the client is `local=1 location=lan`, direct-play, no transcode.
+- Not KB-002 (BBR/MTU): that's periodic mid-stream freezes that **auto-recover** after ~60s; this one never recovers and starts at 0s.
+- Not KB-003 (broken connection URLs): none of its tells (`location=unknown`, `found html`, `///library`) appear in the server log.
+- Not KB-018 (remote 4K decision crash): the client is `local=1 location=lan`, direct-play, no transcode.
 
 ## Cause
 
-**A bug in the Plex for Apple TV client** (observed on app **8.45** / **tvOS 26.5**, `AppleTV11,1`). The app's player stalls at playback start, stops draining its TCP socket, and the connection deadlocks in **zero-window persist**. The server is healthy and holds the next segment ready — it simply can't send because the client's receive window is shut.
+**A bug in the Plex for Apple TV client** (observed on app **8.45** / **tvOS 26.5**, `AppleTV11,1`). The app's player stalls at playback start, stops draining its TCP socket, and the connection deadlocks in **zero-window persist**. The server is healthy and holds the next segment ready. It simply can't send because the client's receive window is shut.
 
-**The isolating control:** playing the *same file from the same Plex server on the same Apple TV via **Infuse*** works flawlessly. Same hardware, same tvOS, same TV/receiver + HDR handshake, same network path, same server egress (Cilium BBR + `200M` cap apply to Infuse too), same Dolby-Vision content — the **only** changed variable is the player app. That eliminates the cluster, the network, the A12 hardware, the display/HDR handshake, and the content, leaving the Plex app itself.
+**The isolating control:** playing the *same file from the same Plex server on the same Apple TV via **Infuse*** works flawlessly. Same hardware, same tvOS, same TV/receiver + HDR handshake, same network path, same server egress (Cilium BBR + `200M` cap apply to Infuse too), same Dolby-Vision content. The **only** changed variable is the player app. That eliminates the cluster, the network, the A12 hardware, the display/HDR handshake, and the content, leaving the Plex app itself.
 
-**Server-observable signature** — captured with `ss -tnie` inside the Plex pod netns during a live freeze, on the video socket to the Apple TV (`10.42.1.109:32400 → <apple-tv-ip>:5xxxx`):
+**Server-observable signature**: captured with `ss -tnie` inside the Plex pod netns during a live freeze, on the video socket to the Apple TV (`10.42.1.109:32400 → <apple-tv-ip>:5xxxx`):
 
 ```text
 ESTAB  Send-Q=3899264  timer:(persist,1min13sec,0) backoff:9
@@ -28,9 +28,9 @@ ESTAB  Send-Q=3899264  timer:(persist,1min13sec,0) backoff:9
   rwnd_limited:146880ms(95.7%) notsent:3899264             <-- blocked 95.7% by the receiver's window
 ```
 
-Read it as: the Apple TV **received ~157 MB of video and still had `viewOffset=0`** (nothing played), then drove its receive window to zero and left it there. The sender parked 3.9 MB in `notsent` and entered persist mode; the persist timer backed off nine times (`backoff:9`), so even if the client reopened the window it would take minutes to resume → permanent freeze. Because the client already holds tens of seconds of buffered video, this is **not** starvation, bandwidth, loss, or decode horsepower — it's the app **refusing to start playback** and consequently stopping its reads.
+Read it as: the Apple TV **received ~157 MB of video and still had `viewOffset=0`** (nothing played), then drove its receive window to zero and left it there. The sender parked 3.9 MB in `notsent` and entered persist mode; the persist timer backed off nine times (`backoff:9`), so even if the client reopened the window it would take minutes to resume → permanent freeze. Because the client already holds tens of seconds of buffered video, this is **not** starvation, bandwidth, loss, or decode horsepower. It's the app **refusing to start playback** and consequently stopping its reads.
 
-Why it isn't universal ("wouldn't everyone see this?"): a 24 Mbps 4K HEVC stream is trivial for an A12 — capability is universal, so a hardware limit would be a famous complaint and isn't. A **startup/player bug in one client build on a brand-new tvOS** is version-specific: only users on that Plex-app + tvOS combo hit it; many are on other versions or use Infuse.
+Why it isn't universal ("wouldn't everyone see this?"): a 24 Mbps 4K HEVC stream is trivial for an A12. Capability is universal, so a hardware limit would be a famous complaint and isn't. A **startup/player bug in one client build on a brand-new tvOS** is version-specific: only users on that Plex-app + tvOS combo hit it; many are on other versions or use Infuse.
 
 ### Narrowed root cause: EAC3 direct play on tvOS 26.5
 
@@ -45,22 +45,22 @@ Re-examining the test matrix, the discriminating variable is the **audio codec**
 
 Community reports match exactly: video freezes on a frame during **EAC3 direct play on tvOS 26.5**, with the same files fine on **tvOS 26.4** and on other platforms
 (<https://forums.plex.tv/t/eac3-audio-apple-tv-direct-play-broken-video-freezes-audio-continues-tvos-26-5-synology-ds152/938778>). Plex staff engaged but could not
-reproduce universally; no fixed app version identified as of 2026-07-12 (tvOS app releases moved to year-based versions, e.g. 2026.13.0 on 2026-06-30 — no EAC3 fix in
+reproduce universally; no fixed app version identified as of 2026-07-12 (tvOS app releases moved to year-based versions, e.g. 2026.13.0 on 2026-06-30, no EAC3 fix in
 its notes). Even Plex's bundled `tvOS.xml` profile carries a comment admitting historical tvOS EAC3 quirks ("Since tvOS may have issues direct playing mov/eac3…").
 
 ## Fix
 
 The bug is in the client, but with the cause narrowed to EAC3 there is a **surgical server-side workaround** plus client-side remediations:
 
-1. **Server-side workaround (deployed):** a custom `Profiles/tvOS.xml` override — `kubernetes/apps/media/plex/app/resources/tvOS.xml`, shipped as the `plex-client-profiles` ConfigMap and mounted over the config dir's `Profiles/` — mirrors the Apple TV 4K's real capabilities but **removes `eac3` from every audioCodec list**. EAC3 titles then direct-stream with an **ac3 5.1 audio transcode** (surround preserved, Atmos metadata lost, tvOS clients only); video stays a copy (`hevc` is in the HLS transcode target). Delete the file + mount to restore stock behaviour once Plex ships a fix. Caveat: the app's `X-Plex-Client-Profile-Extra` deltas may re-add capabilities client-side — verify with `/status/sessions` (`videoDecision=copy`, `audioDecision=transcode`) and revert if the decision doesn't change.
-2. **Client:** update the Plex app past 8.45 (App Store; year-versioned builds like 2026.13.x are newer) and fully power-cycle the Apple TV. If freezes persist, toggle the app's **updated audio engine** setting — it switches the exact EAC3 path that broke.
-3. **Fallback:** play via **Infuse** — its own decoder pipeline is unaffected and keeps full Atmos.
+1. **Server-side workaround (deployed):** a custom `Profiles/tvOS.xml` override (`kubernetes/apps/media/plex/app/resources/tvOS.xml`, shipped as the `plex-client-profiles` ConfigMap and mounted over the config dir's `Profiles/`) mirrors the Apple TV 4K's real capabilities but **removes `eac3` from every audioCodec list**. EAC3 titles then direct-stream with an **ac3 5.1 audio transcode** (surround preserved, Atmos metadata lost, tvOS clients only); video stays a copy (`hevc` is in the HLS transcode target). Delete the file + mount to restore stock behaviour once Plex ships a fix. Caveat: the app's `X-Plex-Client-Profile-Extra` deltas may re-add capabilities client-side. Verify with `/status/sessions` (`videoDecision=copy`, `audioDecision=transcode`) and revert if the decision doesn't change.
+2. **Client:** update the Plex app past 8.45 (App Store; year-versioned builds like 2026.13.x are newer) and fully power-cycle the Apple TV. If freezes persist, toggle the app's **updated audio engine** setting. It switches the exact EAC3 path that broke.
+3. **Fallback:** play via **Infuse**: its own decoder pipeline is unaffected and keeps full Atmos.
 
-The server-side TCP levers (lower the `200M` egress cap, force-disable BBR via `allowed-unsafe-sysctls`) are **not** indicated here — the capture shows `retrans:0/1` (no loss) and a receiver-limited window, so the wire and congestion control are not the bottleneck.
+The server-side TCP levers (lower the `200M` egress cap, force-disable BBR via `allowed-unsafe-sysctls`) are **not** indicated here: the capture shows `retrans:0/1` (no loss) and a receiver-limited window, so the wire and congestion control are not the bottleneck.
 
 ## Recon notes
 
-- **Detect the freeze objectively:** poll `/status/sessions` and watch `viewOffset` — a frozen client keeps reporting `state=playing` while `viewOffset` stops advancing (stuck at `0s` here). Don't trust `state` alone.
+- **Detect the freeze objectively:** poll `/status/sessions` and watch `viewOffset`: a frozen client keeps reporting `state=playing` while `viewOffset` stops advancing (stuck at `0s` here). Don't trust `state` alone.
 - **Get into the right netns.** `pgrep -f "Plex Media Server" | head -1` on a `hostPID` debug pod can match a **host-netns** helper (you'll see the node IP `<node-ip>` / `cilium_host` instead of `10.42.1.109`). Iterate all matches and pick the PID whose `nsenter -t $P -n ip -4 -o addr` actually contains the pod IP `10.42.1.109`:
 
     ```bash
@@ -83,11 +83,11 @@ The server-side TCP levers (lower the `200M` egress cap, force-disable BBR via `
       nsenter -t $P -n ss -tnie "( sport = :32400 )"'
     ```
 
-- **Source-IP is SNAT'd.** The Plex Service is `externalTrafficPolicy: Cluster`, so a filter like `ss dst <apple-tv-ip>` finds nothing — client media sockets can appear with node/masquerade peers, though here the Apple TV's real IP `<apple-tv-ip>` did show on the video socket. Filter by `sport = :32400` and look for the socket with a large `Send-Q` / `persist` timer.
-- **Confirm the egress cap is really enforced** (not just annotated): `cilium-dbg bpf bandwidth list` on the node's agent — the Plex endpoint id (from `cilium-dbg endpoint list` matching `10.42.1.109`) should show `Egress … 200M`. It was correctly enforced here (endpoint `1001 → 200M`), which is why this is *not* a KB-002 relapse.
+- **Source-IP is SNAT'd.** The Plex Service is `externalTrafficPolicy: Cluster`, so a filter like `ss dst <apple-tv-ip>` finds nothing. Client media sockets can appear with node/masquerade peers, though here the Apple TV's real IP `<apple-tv-ip>` did show on the video socket. Filter by `sport = :32400` and look for the socket with a large `Send-Q` / `persist` timer.
+- **Confirm the egress cap is really enforced** (not just annotated): `cilium-dbg bpf bandwidth list` on the node's agent. The Plex endpoint id (from `cilium-dbg endpoint list` matching `10.42.1.109`) should show `Egress … 200M`. It was correctly enforced here (endpoint `1001 → 200M`), which is why this is *not* a KB-002 relapse.
 - **Dead-ends ruled out this run (so nobody re-chases them):**
-    - *GPU/libcuda:* the driver moved `libcuda.so.1` from `/usr/local/glibc/usr/lib` (the KB-era `LD_LIBRARY_PATH`) to `/usr/local/lib` after the 570→595 bump, but **musl already searches `/usr/local/lib`**, so `LD_PRELOAD=libcuda.so.1` loads fine on either path — the stale `LD_LIBRARY_PATH` is harmless, not a bug.
-    - *RPU `hevc … RPU validation failed`:* a single unrelated remote transcode session (`iqi9…`), ~136k lines over Jul 11 16:28–18:03, **zero since**; not the Apple TV, not this symptom.
+    - *GPU/libcuda:* the driver moved `libcuda.so.1` from `/usr/local/glibc/usr/lib` (the KB-era `LD_LIBRARY_PATH`) to `/usr/local/lib` after the 570→595 bump, but **musl already searches `/usr/local/lib`**, so `LD_PRELOAD=libcuda.so.1` loads fine on either path. The stale `LD_LIBRARY_PATH` is harmless, not a bug.
+    - *RPU `hevc … RPU validation failed`:* a single unrelated remote transcode session (`iqi9…`), ~136k lines over Jul 11 16:28-18:03, **zero since**; not the Apple TV, not this symptom.
 
 ## References
 

--- a/docs/docs/troubleshooting/kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md
+++ b/docs/docs/troubleshooting/kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md
@@ -3,8 +3,8 @@
 ## Symptom
 
 A dozen Gatus endpoints go red at once, within about sixty seconds of each other.
-Affected apps span the `media` and `downloads` namespaces — Plex, Jellyfin, Sonarr,
-Radarr, Bazarr, Pinchflat, SABnzbd, qBittorrent — plus their `-gluetun` sidecar
+Affected apps span the `media` and `downloads` namespaces (Plex, Jellyfin, Sonarr,
+Radarr, Bazarr, Pinchflat, SABnzbd, qBittorrent) plus their `-gluetun` sidecar
 routes.
 
 Every one returns **HTTP 503** on its normal hostname:
@@ -22,7 +22,7 @@ Three signals point away from the real cause:
 1. **DNS resolves.** The Gatus check reaches something and gets a 503 back, so the
     record clearly exists.
 2. **The gateway is healthy.** Other apps on the same listener are fine.
-3. **The pods are not unhealthy — they are absent.** `kubectl get pods` simply does
+3. **The pods are not unhealthy. They are absent.** `kubectl get pods` simply does
     not list them, which reads like a scheduling problem rather than a DNS one.
 
 A 503 from Envoy means *no healthy upstream*. With the Deployment scaled to zero
@@ -50,7 +50,7 @@ metrics:
 `nfs_probe` is a blackbox TCP probe against `${SECRET_STORAGE_SERVER}:2049`. When
 the NAS becomes unreachable the probe returns `0` and every NFS-backed app is
 deliberately scaled to zero, rather than left with hung mounts. That behaviour is
-working as designed — see [024](024-zeroscaler-nfs-hpa.md).
+working as designed: see [024](024-zeroscaler-nfs-hpa.md).
 
 The failure is that **`SECRET_STORAGE_SERVER` is a hostname on the internal domain,
 and its DNS record had been deleted** during a host-override cleanup.
@@ -59,7 +59,7 @@ and its DNS record had been deleted** during a host-override cleanup.
 
 The cleanup built its keep-list by grepping the repository for
 `${SECRET_INTERNAL_DOMAIN}`. That is structurally incapable of finding the NAS,
-because manifests never contain its hostname — they contain
+because manifests never contain its hostname: they contain
 `${SECRET_STORAGE_SERVER}`, and the hostname lives only in the `cluster-secrets`
 Secret, sourced from 1Password.
 
@@ -68,14 +68,14 @@ the record-count assertion, and the sibling guard all reasoned about Git, so non
 could see the reference.
 
 A scan of `cluster-secrets` afterwards found **five** values carrying internal-domain
-FQDNs — the storage server, the vSphere endpoint, and three network devices. Four
+FQDNs: the storage server, the vSphere endpoint, and three network devices. Four
 survived the cleanup only by luck: they had no primary-domain twin, so the
 "redundant alias" filter skipped them anyway.
 
 ## Fix
 
-Restore the deleted record, then confirm the metric recovers before checking apps —
-the HPAs need a healthy probe before they will scale back up.
+Restore the deleted record, then confirm the metric recovers before checking apps.
+The HPAs need a healthy probe before they will scale back up.
 
 ```bash
 # 1. restore the record (uuid + values come from the cleanup's JSON backup)
@@ -93,8 +93,8 @@ pods rescheduling.
 
 ## Prevention
 
-Use `scripts/reclaim_stale_dns.py`. It derives its keep-list from **two** sources —
-Git manifests *and* the values inside `cluster-secrets` / `cluster-settings` — and
+Use `scripts/reclaim_stale_dns.py`. It derives its keep-list from **two** sources:
+Git manifests *and* the values inside `cluster-secrets` / `cluster-settings`, and
 refuses to delete anything appearing in either. It also prints a full JSON backup
 with UUIDs before acting; capture that output, because it is the only route back
 from a mistake.
@@ -105,6 +105,6 @@ check that only consults the repository will confidently report a clean result.
 
 ## Related
 
-- [024: zeroscaler NFS scale-to-zero via native HPA](024-zeroscaler-nfs-hpa.md) — why the apps scale to zero
-- [Split DNS architecture](../../architecture/split-dns.md) — the host-override ceiling and why
+- [024: zeroscaler NFS scale-to-zero via native HPA](024-zeroscaler-nfs-hpa.md): why the apps scale to zero
+- [Split DNS architecture](../../architecture/split-dns.md): the host-override ceiling and why
   `upsert-only` means cleanups are manual


### PR DESCRIPTION
Follow-up to #3773: the humanizer pass there only covered the 24 pages the drift audit changed, and froze headings/table cells. This sweeps the rest of the KB.

## Scope

- The nine pages the audit didn't touch (overview, scaling, secrets, image-verification, index, truenas-monitoring, changedetection, volsync-kopia, multus-vlan)
- All 27 troubleshooting KB entries (style-only; incident content, versions, and quoted log lines untouched)
- Headings and table cells frozen in the first pass (networking, split-dns, jory PR ladder) — heading ` — ` becomes `: `, which keeps mkdocs slugs identical since slugify strips punctuation; verified no `#anchor` links break. KB-024's H1 and its index link text updated together.

## Deliberately kept (13 remaining dash characters, all justified)

- Inside fenced code blocks / inline code: quoted YAML/shell comments (KB-017, KB-022, truenas-monitoring) and the verbatim `.renovaterc.json5` description strings in renovate-automerge.md
- Lone `—` table-cell placeholders meaning "none" (KB-008, KB-026)
- `device-monitoring.md` — excluded entirely; the in-flight peanut-retirement branch touches it, so its 6 dashes get swept after that lands

## Verification

- `grep '—|–'` across `docs/docs/`: only the 13 justified survivors above
- `markdownlint` (canonical config): no new findings; `zensical build` clean
- Diff is line-for-line (282/282) — no content, ordering, or fact changes
