### PR TITLE
chore(oxidized): stop backing up opnsense config to network-configs

### DIFF
--- a/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/oxidized/app/externalsecret.yaml
@@ -21,8 +21,13 @@ spec:
         # the core switch and the WiFi controller not included:
         # oxidized 0.36.0 has no built-in models for either. Re-add when
         # custom models land or those devices are replaced.
+        # opnsense removed 2026-07-22: its config.xml dump carries plaintext
+        # secrets (ddclient tokens, cert private keys, tailscale pre-auth key)
+        # into network-configs — GitGuardian incidents 32670994/32670995/
+        # 33916995/33991644/34105179. Use OPNsense's own encrypted backup
+        # mechanism instead; RouterOS exports hide sensitive values, so the
+        # MikroTiks stay.
         router.db: |
-          opnsense:{{ .OPNSENSE_HOST }}:opnsense:{{ .OPNSENSE_USERNAME }}:{{ .OPNSENSE_PASSWORD }}
           mikrotik_poe:{{ .MIKROTIK_POE_HOST }}:routeros:{{ .MIKROTIK_POE_USERNAME }}:{{ .MIKROTIK_POE_PASSWORD }}
           mikrotik_nonpoe:{{ .MIKROTIK_NONPOE_HOST }}:routeros:{{ .MIKROTIK_NONPOE_USERNAME }}:{{ .MIKROTIK_NONPOE_PASSWORD }}
   dataFrom:


### PR DESCRIPTION
The opnsense config.xml dump lands plaintext secrets (ddclient Cloudflare token, certificate private keys, tailscale pre-auth key) in the network-configs repo — flagged as GitGuardian incidents 32670994, 32670995, 33916995, 33991644 and 34105179.

RouterOS exports hide sensitive values so the MikroTik devices stay; OPNsense moves to its own encrypted backup mechanism.

Remediation already done alongside this change: the leaked ddclient Cloudflare token was rolled (old value verified dead), and the leaked Tailscale pre-auth key was confirmed expired/absent from the tailnet.
