### PR TITLE
feat(observability): monitor Brother printer fleet via snmp-exporter (SNMPv3)

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/configmap-brother-printer.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/configmap-brother-printer.yaml
@@ -1,0 +1,98 @@
+---
+# Custom snmp_exporter module for Brother network printers — Printer-MIB
+# (RFC 3805) supplies/marker + Host-Resources-MIB (RFC 2790) printer/device
+# status. Covers the estate's 4 Brother units (2 lasers, 2 label printers) on
+# PRINT VLAN 72. Merged with the image's bundled snmp.yml via an extra
+# --config.file (see helmrelease extraArgs). Auths (SNMPv3) live in the
+# snmp-exporter-auth Secret (external-secrets), never here — this ConfigMap is
+# git-tracked in a public repo and carries modules only.
+#
+# Telemetry notes (verified against the live fleet, community-RO walk 2026-07):
+#   - Brother reports toner level as -3 ("present, level unknown"), so a real
+#     percentage only exists for Drum/Belt units (prtMarkerSuppliesMaxCapacity>0).
+#     Alert on the ratio only where MaxCapacity>0 (see prometheusrule).
+#   - hrDeviceStatus (2=running 3=warning 5=down) is the reliable numeric fault
+#     signal — Brother raises it to warning(3) on low-supply/cover/paper. Alert
+#     on that, not on the OCTET-STRING hrPrinterDetectedErrorState bitfield
+#     (kept as a labelled info metric for dashboards).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snmp-exporter-brother-printer
+  namespace: observability
+data:
+  snmp.yml: |-
+    modules:
+      brother_printer:
+        walk:
+          - 1.3.6.1.2.1.1.3            # sysUpTime
+          - 1.3.6.1.2.1.25.3.2.1.5     # hrDeviceStatus
+          - 1.3.6.1.2.1.25.3.5.1.1     # hrPrinterStatus
+          - 1.3.6.1.2.1.25.3.5.1.2     # hrPrinterDetectedErrorState (bitfield)
+          - 1.3.6.1.2.1.43.10.2.1.4    # prtMarkerLifeCount (page counter)
+          - 1.3.6.1.2.1.43.11.1.1.6    # prtMarkerSuppliesDescription
+          - 1.3.6.1.2.1.43.11.1.1.8    # prtMarkerSuppliesMaxCapacity
+          - 1.3.6.1.2.1.43.11.1.1.9    # prtMarkerSuppliesLevel
+        metrics:
+          - name: sysUpTime
+            oid: 1.3.6.1.2.1.1.3
+            type: gauge
+            help: The time since the network management portion of the system was last re-initialized (hundredths of a second)
+          - name: hrDeviceStatus
+            oid: 1.3.6.1.2.1.25.3.2.1.5
+            type: gauge
+            help: HOST-RESOURCES-MIB hrDeviceStatus (1=unknown 2=running 3=warning 4=testing 5=down)
+            indexes:
+              - labelname: hrDeviceIndex
+                type: gauge
+          - name: hrPrinterStatus
+            oid: 1.3.6.1.2.1.25.3.5.1.1
+            type: gauge
+            help: HOST-RESOURCES-MIB hrPrinterStatus (1=other 2=unknown 3=idle 4=printing 5=warmup)
+            indexes:
+              - labelname: hrDeviceIndex
+                type: gauge
+          - name: hrPrinterDetectedErrorState
+            oid: 1.3.6.1.2.1.25.3.5.1.2
+            type: OctetString
+            help: HOST-RESOURCES-MIB hrPrinterDetectedErrorState bitfield (lowPaper/noPaper/lowToner/noToner/doorOpen/jammed/offline/serviceRequested) — 00 == no error
+            indexes:
+              - labelname: hrDeviceIndex
+                type: gauge
+          - name: prtMarkerLifeCount
+            oid: 1.3.6.1.2.1.43.10.2.1.4
+            type: counter
+            help: Printer-MIB prtMarkerLifeCount — total marks (pages) made over the marker's life
+            indexes:
+              - labelname: hrDeviceIndex
+                type: gauge
+              - labelname: prtMarkerIndex
+                type: gauge
+          - name: prtMarkerSuppliesLevel
+            oid: 1.3.6.1.2.1.43.11.1.1.9
+            type: gauge
+            help: Printer-MIB prtMarkerSuppliesLevel (>=0 current level; -2 unknown; -3 present but level unmeasured)
+            indexes:
+              - labelname: hrDeviceIndex
+                type: gauge
+              - labelname: prtMarkerSuppliesIndex
+                type: gauge
+            lookups:
+              - labels: [hrDeviceIndex, prtMarkerSuppliesIndex]
+                labelname: prtMarkerSuppliesDescription
+                oid: 1.3.6.1.2.1.43.11.1.1.6
+                type: DisplayString
+          - name: prtMarkerSuppliesMaxCapacity
+            oid: 1.3.6.1.2.1.43.11.1.1.8
+            type: gauge
+            help: Printer-MIB prtMarkerSuppliesMaxCapacity (>0 max level; -2 unknown/unrestricted) — divide Level by this for a real percentage where >0
+            indexes:
+              - labelname: hrDeviceIndex
+                type: gauge
+              - labelname: prtMarkerSuppliesIndex
+                type: gauge
+            lookups:
+              - labels: [hrDeviceIndex, prtMarkerSuppliesIndex]
+                labelname: prtMarkerSuppliesDescription
+                oid: 1.3.6.1.2.1.43.11.1.1.6
+                type: DisplayString

--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -24,6 +24,44 @@ spec:
               community: "{{ .ONYX_COMMUNITY }}"
               security_level: noAuthNoPriv
               version: 2
+            # Brother printer fleet — SNMPv3 authPriv, one shared read-only user
+            # with per-device auth+priv passphrases. Brother offers no v3
+            # read-only mode (v3 is always read-write), so containment is: authPriv
+            # encryption + the opt11 firewall ACL (only the collector reaches :161)
+            # + this exporter only ever issuing GETs. HL/MFC/QL do SHA-256/AES-128;
+            # the 2016 PT-P950NW exposes no protocol selector and uses fixed MD5/DES.
+            printer_hl:
+              version: 3
+              security_level: authPriv
+              username: "{{ .PRINTER_SNMPV3_USER }}"
+              password: "{{ .PRINTER_HL_AUTHPASS }}"
+              auth_protocol: SHA256
+              priv_password: "{{ .PRINTER_HL_PRIVPASS }}"
+              priv_protocol: AES
+            printer_mfc:
+              version: 3
+              security_level: authPriv
+              username: "{{ .PRINTER_SNMPV3_USER }}"
+              password: "{{ .PRINTER_MFC_AUTHPASS }}"
+              auth_protocol: SHA256
+              priv_password: "{{ .PRINTER_MFC_PRIVPASS }}"
+              priv_protocol: AES
+            printer_ql:
+              version: 3
+              security_level: authPriv
+              username: "{{ .PRINTER_SNMPV3_USER }}"
+              password: "{{ .PRINTER_QL_AUTHPASS }}"
+              auth_protocol: SHA256
+              priv_password: "{{ .PRINTER_QL_PRIVPASS }}"
+              priv_protocol: AES
+            printer_pt:
+              version: 3
+              security_level: authPriv
+              username: "{{ .PRINTER_SNMPV3_USER }}"
+              password: "{{ .PRINTER_PT_AUTHPASS }}"
+              auth_protocol: MD5
+              priv_password: "{{ .PRINTER_PT_PRIVPASS }}"
+              priv_protocol: DES
   dataFrom:
     - extract:
         key: snmp-exporter

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -20,11 +20,16 @@ spec:
     extraArgs:
       - --config.file=/etc/snmp_exporter/snmp.yml
       - --config.file=/run/snmp-extra/snmp.yml
+      - --config.file=/run/snmp-printer/snmp.yml
       - --config.file=/run/snmp-auth/snmp.yml
     extraConfigmapMounts:
       - name: entity-sensor
         configMap: snmp-exporter-entity-sensor
         mountPath: /run/snmp-extra
+        readOnly: true
+      - name: brother-printer
+        configMap: snmp-exporter-brother-printer
+        mountPath: /run/snmp-printer
         readOnly: true
     # Credentials only (auths:) — templated by the snmp-exporter ExternalSecret
     # so no community string lives in git (public repo).
@@ -59,6 +64,71 @@ spec:
             - sourceLabels:
                 - __param_target
               targetLabel: instance
+        # Brother printer fleet on PRINT VLAN 72. if_mib gives link/oper status;
+        # brother_printer adds supplies/page-count/printer-status. Each carries a
+        # device_class=printer label so the noisy label printers (which power
+        # themselves off) are excluded from the critical SnmpTargetDown alert and
+        # get supply/fault alerts instead. SNMPv3 authPriv per-device auths.
+        - name: printer-hl
+          target: ${PRINTER_HL_ADDR}
+          module:
+            - if_mib
+            - brother_printer
+          auth:
+            - printer_hl
+          interval: 120s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: printer
+        - name: printer-mfc
+          target: ${PRINTER_MFC_ADDR}
+          module:
+            - if_mib
+            - brother_printer
+          auth:
+            - printer_mfc
+          interval: 120s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: printer
+        - name: printer-ql
+          target: ${PRINTER_QL_ADDR}
+          module:
+            - if_mib
+            - brother_printer
+          auth:
+            - printer_ql
+          interval: 120s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: printer
+        - name: printer-pt
+          target: ${PRINTER_PT_ADDR}
+          module:
+            - if_mib
+            - brother_printer
+          auth:
+            - printer_pt
+          interval: 120s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: printer
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./configmap-entity-sensor.yaml
+  - ./configmap-brother-printer.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./grafanadashboard.yaml

--- a/kubernetes/apps/observability/snmp-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/prometheusrule.yaml
@@ -8,11 +8,14 @@ spec:
   groups:
     - name: snmp-exporter.rules
       rules:
+        # Printers are excluded here: the label printers (QL/PT) power themselves
+        # off by design, so a blanket down-alert on them is pure noise. Printer
+        # health is covered by PrinterFault + PrinterSupplyLow below instead.
         - alert: SnmpTargetDown
           annotations:
             summary: "SNMP target {{ $labels.instance }} is not being scraped."
           expr: |-
-            up{job="snmp-exporter"} == 0
+            up{job="snmp-exporter", device_class!="printer"} == 0
           for: 5m
           labels:
             severity: critical
@@ -26,5 +29,34 @@ spec:
           expr: |-
             entPhySensorOperStatus{job="snmp-exporter"} > 1
           for: 5m
+          labels:
+            severity: warning
+        # Brother raises hrDeviceStatus to warning(3)/down(5) on low-supply, cover
+        # open, paper jam/out etc. — the reliable numeric fault signal (the
+        # hrPrinterDetectedErrorState bitfield is kept as a label only). idle/
+        # printing/sleep all report running(2), so this does not false-fire.
+        - alert: PrinterFault
+          annotations:
+            summary: "Printer {{ $labels.instance }} needs attention (hrDeviceStatus {{ $value }}: 3=warning, 5=down)."
+          expr: |-
+            hrDeviceStatus{job="snmp-exporter", device_class="printer"} >= 3
+          for: 15m
+          labels:
+            severity: warning
+        # Real supply percentage only exists where MaxCapacity>0 and Level>=0 —
+        # this excludes Brother toners (Level -3, "present, unmeasured") and the
+        # label rolls (Level -2, unknown), leaving drum/belt units which report
+        # true ratios. Fires below 10% remaining.
+        - alert: PrinterSupplyLow
+          annotations:
+            summary: "Printer {{ $labels.instance }} supply '{{ $labels.prtMarkerSuppliesDescription }}' at {{ $value | humanizePercentage }} remaining."
+          expr: |-
+            (
+              prtMarkerSuppliesLevel{job="snmp-exporter", device_class="printer"}
+              / prtMarkerSuppliesMaxCapacity{job="snmp-exporter", device_class="printer"}
+            ) < 0.10
+            and prtMarkerSuppliesMaxCapacity{job="snmp-exporter", device_class="printer"} > 0
+            and prtMarkerSuppliesLevel{job="snmp-exporter", device_class="printer"} >= 0
+          for: 1h
           labels:
             severity: warning

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -58,3 +58,11 @@ stringData:
   # unroutable, so a failed ExternalSecret fails the scrape loudly instead of
   # silently pointing UPS monitoring at some other host.
   NUT_SERVER_ADDR: "192.0.2.2"
+  # Brother printer fleet on PRINT VLAN 72, polled by snmp-exporter over SNMPv3.
+  # Real addresses (the .11-.14 DHCP reservations) live in the cluster-secrets
+  # 1Password item; TEST-NET-1 placeholders again fail loudly if the
+  # ExternalSecret ever fails to overwrite them.
+  PRINTER_HL_ADDR: "192.0.2.11"
+  PRINTER_MFC_ADDR: "192.0.2.12"
+  PRINTER_QL_ADDR: "192.0.2.13"
+  PRINTER_PT_ADDR: "192.0.2.14"


### PR DESCRIPTION
Adds the 4 Brother printers (2 lasers, 2 label) on PRINT VLAN 72 as
snmp-exporter targets, folding them into the estate SNMP design.

- configmap-brother-printer.yaml: brother_printer module — Printer-MIB
  (RFC 3805) supplies/page-count + Host-Resources printer/device status.
  Toner reads -3 over SNMP (no %), so real ratios come from drum/belt only.
- externalsecret.yaml: 4 SNMPv3 authPriv auths (shared user, per-device
  passphrases) — the repo's first v3 auth shape. HL/MFC/QL do SHA-256/AES;
  the 2016 PT has fixed MD5/DES. Rendered from the snmp-exporter 1P item.
- helmrelease.yaml: 4 serviceMonitor targets (${PRINTER_*_ADDR} from
  cluster-secrets), each labelled device_class=printer.
- prometheusrule.yaml: PrinterFault (hrDeviceStatus>=3) + PrinterSupplyLow
  (<10%, guarded against Brother -2/-3 sentinels). Printers excluded from the
  critical SnmpTargetDown — the label printers power themselves off by design.
- cluster-secrets.yaml: TEST-NET-1 fail-loud placeholders for the 4 addresses.

Why v2c stays for now: two-phase rollout — v3 runs alongside v2c-read-only
until an end-to-end scrape is verified, then v2c is disabled device-side.
