### PR TITLE
fix(rook-ceph): raise ceph-mgr memory limit to 3Gi

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -24,12 +24,16 @@ spec:
         # NOTE: mgr resources must live here (spec.resources.mgr) — the CephCluster
         # CRD has no spec.mgr.resources field, so a block there is silently pruned
         # and the chart default (1Gi limit) applies instead.
+        # 3Gi limit: with diskprediction_local/insights/pg_autoscaler/rook modules
+        # plus the prometheus + dashboard endpoints enabled, the active mgr working
+        # set climbs past 2Gi and gets OOMKilled (~twice daily), failing over to the
+        # standby each time. 3Gi holds it with headroom (mon is already 4Gi).
         mgr:
           requests:
             cpu: 100m
             memory: 1Gi
           limits:
-            memory: 2Gi
+            memory: 3Gi
         mon:
           requests:
             cpu: 100m


### PR DESCRIPTION
## What

Raise the Ceph mgr memory **limit from 2Gi to 3Gi** (`spec.resources.mgr.limits.memory`).

## Why

The active `rook-ceph-mgr` has been **OOMKilled ~twice daily** — 7 kills in ~4 days (last at 04:00 today, exit 137). Each kill fails the active mgr over to the standby: no data risk, but it drops the dashboard/metrics briefly and churns the logs.

The limit is already correctly placed at `spec.resources.mgr` (the CephCluster CRD silently prunes a `spec.mgr.resources` block). 2Gi is simply no longer enough: with the `diskprediction_local`, `insights`, `pg_autoscaler` and `rook` mgr modules plus the prometheus + dashboard endpoints all enabled, the mgr working set was observed at **1.4Gi and climbing** into the 2Gi ceiling.

3Gi holds it with headroom — nodes sit at ~20% memory and `mon` is already at 4Gi.

## Validation

- `flate test all --namespace rook-ceph` → 9 passed
- super-linter (`slim-v8`, YAML) on the changed file → clean
