### PR TITLE
feat(todoist-sort): deploy 0.2.4 (temperature-escalating retry)

### DIFF
--- a/kubernetes/apps/custom/todoist-sort/app/helmrelease.yaml
+++ b/kubernetes/apps/custom/todoist-sort/app/helmrelease.yaml
@@ -45,7 +45,7 @@ spec:
             # renovate/pin-dependencies branch (renovate#24942 family).
             image:
               repository: ghcr.io/lukeevanstech/todoist-sort
-              tag: 0.2.3@sha256:dc0b55248df0aee8bb1eb720088809d3652014e09846c4bbbc415c4bff18b717
+              tag: 0.2.4@sha256:96269bb4101592440a45a888cb50d3ac6760d77f6d79378cf95a147ecebd2f5e
             command:
               - "sort-inbox"
               - "--root"
@@ -87,7 +87,7 @@ spec:
             # Duplicated from sort-inbox on purpose — see the comment there.
             image:
               repository: ghcr.io/lukeevanstech/todoist-sort
-              tag: 0.2.3@sha256:dc0b55248df0aee8bb1eb720088809d3652014e09846c4bbbc415c4bff18b717
+              tag: 0.2.4@sha256:96269bb4101592440a45a888cb50d3ac6760d77f6d79378cf95a147ecebd2f5e
             command:
               - "plan-day"
               - "--root"


### PR DESCRIPTION
Bumps both `todoist-sort` CronJob containers from 0.2.3 to **0.2.4** (`@sha256:96269bb4…`).

0.2.4 (todoist-sort#19) makes the classify/plan retry escalate temperature: the first attempt stays deterministic (temp 0), the retry samples at 0.5 so a temp-0 parse/format failure isn't reproduced identically. This is defence-in-depth behind the `enable_thinking=false` ConfigMap fix (#3767) — that removed the truncation cause, this makes the retry an actual safety net.

Digest-pinned per house style. Verified: 120 unit tests pass on 0.2.4; image built green after the build-pipeline fix (todoist-sort#20).