### PR TITLE
fix(ai): set skipModelInit on llama InferenceServices

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -28,6 +28,11 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: qwen3-30b-a3b-abliterated
+  # The llmkube controller stages the GGUF into the shared llmkube-model-cache
+  # PVC itself and the runtime mounts it read-only, so the per-pod
+  # model-downloader init container is redundant (it just logs "already
+  # cached"). Drop it — this is the operator's own MissingSkipModelInit advice.
+  skipModelInit: true
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:72ca3a0323ec891af9332afc8d501396557a45eca2b1b3712828d5cf57e36743
   replicas: 1

--- a/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
@@ -30,6 +30,11 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: qwen3.6-35b-a3b
+  # The llmkube controller stages the GGUF (+ mmproj) into the shared
+  # llmkube-model-cache PVC itself and the runtime mounts it read-only, so the
+  # per-pod model-downloader init container is redundant (it just logs "already
+  # cached"). Drop it — this is the operator's own MissingSkipModelInit advice.
+  skipModelInit: true
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:72ca3a0323ec891af9332afc8d501396557a45eca2b1b3712828d5cf57e36743
   replicas: 1


### PR DESCRIPTION
## What

Set `skipModelInit: true` on the `llama-nvidia` and `llama-uncensored` InferenceServices, dropping the redundant per-pod `model-downloader` init container and clearing the operator's `MissingSkipModelInit` warning events.

## Why it's safe (investigated, not assumed)

The operator emits `MissingSkipModelInit` on both services. Before acting, I traced the actual model-loading topology on the live pods:

- The **runtime** (`llama-server`) mounts the shared `llmkube-model-cache` PVC (100Gi RWX CephFS) at `/models` **read-only** and loads `--model /models/<cacheKey>/…gguf`.
- The **`llmkube-controller-manager` itself mounts that same PVC read-write** and stages each Model's GGUF (+ mmproj) into it directly — the design documented in the model files' own comments ("the operator stages the GGUF … into the shared llmkube-model-cache PVC itself").
- The per-pod `model-downloader` init curls from HF into the same cache but only ever logs `"already cached, skipping download"` — the controller already put the file there.

So the downloader is genuinely redundant, and the controller (not a one-shot init) owns cache population and re-stages on any Model change. There's **no cache footgun**: bumping a GGUF re-reconciles the Model, the controller re-stages the new `cacheKey`, and the pod (gated on Model `Ready`) mounts the warm cache. This matches the CRD field's intent and the operator's own recommendation.

## Rollout note

Removing an init container changes the pod template, so **both GPU pods roll once** on merge — each reloads its ~17-20Gi model (a few minutes of per-model inference downtime). Merge at a convenient time. Fully reversible (remove the flag).

## Validation

- `flate test all --namespace ai` → 32 passed
- super-linter (`slim-v8`, YAML) on both changed files → clean
