### PR TITLE
fix(todoist-sort): deploy in-process LLM retry backoff (0.2.5)

### DIFF
--- a/kubernetes/apps/custom/todoist-sort/app/helmrelease.yaml
+++ b/kubernetes/apps/custom/todoist-sort/app/helmrelease.yaml
@@ -22,9 +22,9 @@ spec:
           timeZone: &timeZone Europe/London
           concurrencyPolicy: Forbid
           # Kill a wedged run so Forbid doesn't skip every subsequent */5
-          # window; the next tick recovers. 660 = 2 x 300s LLM attempts
-          # ([llm] timeout in config.toml) + Todoist I/O headroom; the old
-          # 300 was calibrated to the previously hard-wired 120s timeout.
+          # window; the next tick recovers. 660 covers 2 x 300s LLM attempts
+          # ([llm] timeout in config.toml) + the [llm] retry_backoff between
+          # them (35s) + Todoist I/O headroom: 300+35+300 = 635 < 660.
           activeDeadlineSeconds: 660
           # One k8s-level retry: a transient Todoist 5xx that outlasts the
           # in-pod retry (seen 2026-07-12: ~6s of 503 on GET /user) fails the
@@ -45,7 +45,7 @@ spec:
             # renovate/pin-dependencies branch (renovate#24942 family).
             image:
               repository: ghcr.io/lukeevanstech/todoist-sort
-              tag: 0.2.4@sha256:96269bb4101592440a45a888cb50d3ac6760d77f6d79378cf95a147ecebd2f5e
+              tag: 0.2.5@sha256:a2d635251728d77b9b73dc8026e4b43233e60b761dbec66324306a46f30d9783
             command:
               - "sort-inbox"
               - "--root"
@@ -71,14 +71,17 @@ spec:
           schedule: "0 7 * * *"
           timeZone: *timeZone
           concurrencyPolicy: Forbid
-          # 660 = 2 x 300s LLM attempts ([llm] timeout in config.toml) +
-          # Todoist I/O headroom; the old 600 was calibrated to the
-          # previously hard-wired 120s timeout.
+          # 660 covers 2 x 300s LLM attempts ([llm] timeout in config.toml) +
+          # the [llm] retry_backoff between them (35s) + Todoist I/O headroom:
+          # 300+35+300 = 635 < 660.
           activeDeadlineSeconds: 660
-          # No retries: the promotion budget (max_today) is per-process, so
-          # a retried plan pass could promote up to 5 MORE tasks — the retry
-          # budget breaks the <=max_today invariant. A missed morning
-          # self-heals tomorrow at 07:00.
+          # backoffLimit STAYS 0 — do not raise it. The promotion budget
+          # (max_today) is per-process, so a k8s job retry (a new process)
+          # could promote up to 5 MORE tasks, breaking the <=max_today
+          # invariant. Transient LLM blips (e.g. the 2026-07-24 07:00 miss: a
+          # LiteLLM cooldown 400) are instead absorbed IN-PROCESS by the [llm]
+          # retry_backoff (todoist-sort >=0.2.5), which shares the one budget.
+          # What the in-pod retry can't recover self-heals at 07:00 tomorrow.
           backoffLimit: 0
           successfulJobsHistory: 1
           failedJobsHistory: 1
@@ -87,7 +90,7 @@ spec:
             # Duplicated from sort-inbox on purpose — see the comment there.
             image:
               repository: ghcr.io/lukeevanstech/todoist-sort
-              tag: 0.2.4@sha256:96269bb4101592440a45a888cb50d3ac6760d77f6d79378cf95a147ecebd2f5e
+              tag: 0.2.5@sha256:a2d635251728d77b9b73dc8026e4b43233e60b761dbec66324306a46f30d9783
             command:
               - "plan-day"
               - "--root"

--- a/kubernetes/apps/custom/todoist-sort/app/resources/config.toml
+++ b/kubernetes/apps/custom/todoist-sort/app/resources/config.toml
@@ -18,9 +18,19 @@ model = "self-hosted"
 # honours chat_template_kwargs, not reasoning_effort) turns it off; verified
 # 2026-07-22 — golden eval still 12/12, plan output valid. Applies to both passes.
 extra_body = { max_tokens = 16384, chat_template_kwargs = { enable_thinking = false } }
-# timeout is seconds per LLM attempt; 2 attempts x 300s must stay under
-# the CronJob activeDeadlineSeconds of 660
+# timeout is seconds per LLM attempt; 2 attempts x 300s (+retry_backoff)
+# must stay under the CronJob activeDeadlineSeconds of 660
 timeout = 300
+# retry_backoff: seconds to wait before retrying a *transient transport*
+# failure so the retry outlasts the blip instead of firing straight back into
+# it. This is the fix for the 2026-07-24 07:00 plan-day miss — LiteLLM briefly
+# cooled down the single self-hosted backend (cooldown_time=30 in the litellm
+# configmap) and returned a 400, and the old back-to-back retry landed inside
+# the same window. Set >30 to clear that cooldown. In-process, so it never
+# resets the plan's per-process max_today budget (why the CronJob keeps
+# backoffLimit: 0). Content (bad-JSON) retries still fire immediately.
+# Budget: 300 + 35 + 300 = 635 < 660 activeDeadlineSeconds.
+retry_backoff = 35
 # api_key: env ANTHROPIC_API_KEY (cluster) or config.local.toml [llm] api_key (dev)
 
 [todoist]


### PR DESCRIPTION
## Why

The `todoist-sort` **plan-day** job failed at **07:00 on 2026-07-24** with:

```
litellm.BadRequestError: model 'self-hosted' not found. Received Model Group=self-hosted
```

LiteLLM briefly cooled down the single self-hosted GPU backend (`cooldown_time: 30` in the litellm configmap) and returned a 400, and the app's two retry attempts fired **back-to-back with no delay** — so both landed inside the same ~30s cooldown window and failed identically. It succeeded the day before; the every-15-min sort pass was unaffected. Rare and self-healing, but the daily plan lost the day.

Found during a routine cluster health check.

## What

Deploys [todoist-sort#21](https://github.com/LukeEvansTech/todoist-sort/pull/21) (v0.2.5), which adds a config-driven `[llm] retry_backoff` that spaces the **transport** retry out past the cooldown (content/bad-JSON retries still fire immediately at escalated temperature).

- Bump both cronjob images `0.2.4` → `0.2.5`.
- Set `[llm] retry_backoff = 35` in the `config.toml` ConfigMap — just over LiteLLM's 30s cooldown so the retry clears it. `300 + 35 + 300 = 635 < 660` (`activeDeadlineSeconds`).
- Update the deadline-math comments and harden the `backoffLimit: 0` comment.

## Why not just raise `backoffLimit`

The plan pass's promotion budget (`max_today`) is **per-process**, so a k8s job retry (a new process) would reset it and could promote up to `max_today` *more* tasks — which is exactly why `backoffLimit: 0` is intentional. The 0.2.5 retry is **in-process**, sharing the one budget, so it adds resilience without touching that invariant.

## Rollout

These are CronJobs — the next scheduled run (`plan-day` 07:00, `sort-inbox` every 15 min) picks up the new image + ConfigMap automatically. No manual rollout.

## Validation

`just kube flate-build-hr custom todoist-sort` renders both cronjobs on 0.2.5 with the ConfigMap wired; super-linter (YAML) and lefthook clean.
