### PR TITLE
fix(garage): sync cluster→NAS over SECRET_DOMAIN (retire the internal-domain endpoint)

### DIFF
--- a/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
@@ -66,8 +66,11 @@ spec:
                 - name: RCLONE_CONFIG_DST_PROVIDER
                   value: Other
                 - name: RCLONE_CONFIG_DST_ENDPOINT
-                  # NAS Garage is now bridge+Traefik (s3-nas), not the old host :3900
-                  value: https://s3-nas.${SECRET_INTERNAL_DOMAIN}
+                  # NAS Garage is now bridge+Traefik (s3-nas), not the old host :3900.
+                  # Public zone (SECRET_DOMAIN), not the internal one: core.codelooks.com
+                  # became a delegated AD zone in the 2026-07-22 rebuild, so its Traefik
+                  # cert can no longer renew via Cloudflare DNS-01 and is being retired.
+                  value: https://s3-nas.${SECRET_DOMAIN}
                 - name: RCLONE_CONFIG_DST_REGION
                   value: us-east-1
                 - name: RCLONE_CONFIG_DST_ACL


### PR DESCRIPTION
One-line repoint of the hourly cluster→NAS Garage backup sync from `s3-nas.${SECRET_INTERNAL_DOMAIN}` to `s3-nas.${SECRET_DOMAIN}`.

**Why:** `${SECRET_INTERNAL_DOMAIN}` is now a delegated internal zone, so lego's Cloudflare DNS-01 zone lookup for its wildcard fails (`zone could not be found`) and the NAS certificate for that name can no longer renew. That wildcard is being retired NAS-side. This sync was the only cluster consumer of the internal name; the remaining consumers already use `${SECRET_DOMAIN}`.

`s3-nas.${SECRET_DOMAIN}` resolves to the same endpoint, is covered by the surviving `${SECRET_DOMAIN}` wildcard certificate, and matches the other Garage hostnames (`s3.${SECRET_DOMAIN}`).

**Verified:** `kustomize build` renders `https://s3-nas.${SECRET_DOMAIN}` for postBuild; the endpoint serves a valid certificate and responds (403, auth-gated). Local super-linter (YAML, v8.6.0) clean.

Merge → wait one hourly sync → confirm green, then the NAS-side wildcard drop lands.
