### PR TITLE
fix(hygiene): purge the internal zone from tracked files, gate it out

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -39,6 +39,7 @@ Run locally:  python3 .github/scripts/check_internal_identifiers.py
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -116,6 +117,26 @@ ALLOWLIST: dict[str, str] = {
 }
 
 
+def internal_domain_pattern() -> dict[str, re.Pattern]:
+    """Return the optional internal-zone pattern, supplied out-of-band.
+
+    PATTERNS above are deliberately generic because this script is PUBLIC --
+    hardcoding the internal zone here would re-disclose exactly what the guard
+    exists to keep out of git. So the regex arrives at runtime instead, via
+    INTERNAL_DOMAIN_RE: a repository secret in CI, a gitignored .mise.local.toml
+    locally. Unset (any fresh clone), the check simply skips -- every other
+    pattern still applies.
+    """
+    raw = os.environ.get("INTERNAL_DOMAIN_RE", "").strip()
+    if not raw:
+        return {}
+    try:
+        return {"internal domain": re.compile(raw, re.IGNORECASE)}
+    except re.error as exc:
+        print(f"INTERNAL_DOMAIN_RE is not a valid regex: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
 def allowlisted(path: str) -> bool:
     """Return True if the path matches an accepted-functional-config glob."""
     return any(fnmatch(path, glob) or path.startswith(glob.rstrip("*")) for glob in ALLOWLIST)
@@ -152,7 +173,7 @@ def scan_text(source: str, strip_git_comments: bool) -> int:
                 kept.append((lineno, line))
         numbered = kept
 
-    patterns = {**PATTERNS, **PROSE_PATTERNS}
+    patterns = {**PATTERNS, **PROSE_PATTERNS, **internal_domain_pattern()}
     violations: list[str] = []
     for lineno, line in numbered:
         for kind, pat in patterns.items():
@@ -202,6 +223,7 @@ def main() -> int:
         return scan_text(args.text_file, args.strip_git_comments)
 
     paths = changed_files(args.diff_base) if args.diff_base else tracked_files()
+    file_patterns = {**PATTERNS, **internal_domain_pattern()}
     violations: list[str] = []
     for path in paths:
         if allowlisted(path) or path == SELF_PATH:
@@ -212,7 +234,7 @@ def main() -> int:
         except OSError:
             continue
         for lineno, line in enumerate(lines, 1):
-            for kind, pat in PATTERNS.items():
+            for kind, pat in file_patterns.items():
                 for match in pat.finditer(line):
                     val = match.group(0)
                     if any(b.search(val) for b in BENIGN):

--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -155,6 +155,19 @@ def changed_files(base: str) -> list[str]:
     return [f for f in out.splitlines() if f in tracked]
 
 
+def format_violation(kind: str, lineno: int, line: str) -> str:
+    """Render one prose violation, withholding the line for the internal domain.
+
+    Echoing the offending line helps the author find it -- except for the
+    internal domain, where a public repo's CI log would republish the very
+    string the check exists to suppress. Secret masking does not help here: it
+    masks the regex, not the domain that regex matched.
+    """
+    if kind == "internal domain":
+        return f"  line {lineno}: {kind} (content withheld -- it is the leak)"
+    return f"  line {lineno}: {kind}\n    {line.strip()[:120]}"
+
+
 def scan_text(source: str, strip_git_comments: bool) -> int:
     """Scan a commit message or PR body and fail (exit 1) on any identifier."""
     if source == "-":
@@ -180,7 +193,7 @@ def scan_text(source: str, strip_git_comments: bool) -> int:
             for match in pat.finditer(line):
                 if any(b.search(match.group(0)) for b in BENIGN):
                     continue
-                violations.append(f"  line {lineno}: {kind}\n    {line.strip()[:120]}")
+                violations.append(format_violation(kind, lineno, line))
                 break
 
     if violations:
@@ -197,6 +210,28 @@ def scan_text(source: str, strip_git_comments: bool) -> int:
 
     print("OK -- no internal identifiers in the supplied text.")
     return 0
+
+
+def scan_files(paths: list[str]) -> list[str]:
+    """Return one 'path:line: kind' string per non-allowlisted identifier found."""
+    patterns = {**PATTERNS, **internal_domain_pattern()}
+    violations: list[str] = []
+    for path in paths:
+        if allowlisted(path) or path == SELF_PATH:
+            continue
+        try:
+            with open(path, encoding="utf-8", errors="ignore") as handle:
+                lines = handle.readlines()
+        except OSError:
+            continue
+        for lineno, line in enumerate(lines, 1):
+            for kind, pat in patterns.items():
+                for match in pat.finditer(line):
+                    if any(b.search(match.group(0)) for b in BENIGN):
+                        continue
+                    violations.append(f"{path}:{lineno}: {kind}")
+                    break
+    return violations
 
 
 def main() -> int:
@@ -223,24 +258,7 @@ def main() -> int:
         return scan_text(args.text_file, args.strip_git_comments)
 
     paths = changed_files(args.diff_base) if args.diff_base else tracked_files()
-    file_patterns = {**PATTERNS, **internal_domain_pattern()}
-    violations: list[str] = []
-    for path in paths:
-        if allowlisted(path) or path == SELF_PATH:
-            continue
-        try:
-            with open(path, encoding="utf-8", errors="ignore") as handle:
-                lines = handle.readlines()
-        except OSError:
-            continue
-        for lineno, line in enumerate(lines, 1):
-            for kind, pat in file_patterns.items():
-                for match in pat.finditer(line):
-                    val = match.group(0)
-                    if any(b.search(val) for b in BENIGN):
-                        continue
-                    violations.append(f"{path}:{lineno}: {kind}")
-                    break
+    violations = scan_files(paths)
 
     if violations:
         print("Internal infrastructure identifiers found in tracked files:\n")

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -49,6 +49,12 @@ jobs:
           # The internal zone regex is NOT hardcoded in the script: that file is
           # public, so a literal there would re-disclose what the guard exists to
           # hide. Unset, the check skips and every other pattern still applies.
+          # zizmor: ignore[secrets-outside-env]
+          # A dedicated GitHub Environment would gate this behind approval
+          # rules, which is wrong for an always-on lint check that must run
+          # unattended on every PR. The value is a low-sensitivity regex, not
+          # a credential, and it is a secret only so it stays out of a public
+          # file -- see the script docstring.
           INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }}
         run: |-
           printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" \

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -49,13 +49,12 @@ jobs:
           # The internal zone regex is NOT hardcoded in the script: that file is
           # public, so a literal there would re-disclose what the guard exists to
           # hide. Unset, the check skips and every other pattern still applies.
-          # zizmor: ignore[secrets-outside-env]
           # A dedicated GitHub Environment would gate this behind approval
           # rules, which is wrong for an always-on lint check that must run
           # unattended on every PR. The value is a low-sensitivity regex, not
           # a credential, and it is a secret only so it stays out of a public
           # file -- see the script docstring.
-          INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }}
+          INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }} # zizmor: ignore[secrets-outside-env]
         run: |-
           printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" \
             | python3 .github/scripts/check_internal_identifiers.py --text-file -

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -46,6 +46,10 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          # The internal zone regex is NOT hardcoded in the script: that file is
+          # public, so a literal there would re-disclose what the guard exists to
+          # hide. Unset, the check skips and every other pattern still applies.
+          INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }}
         run: |-
           printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" \
             | python3 .github/scripts/check_internal_identifiers.py --text-file -

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -50,6 +50,12 @@ jobs:
         env:
           DIFF_BASE: ${{ github.event_name == 'pull_request' && 'HEAD^1' || '' }}
           # Internal zone regex supplied out-of-band — see the script docstring.
+          # zizmor: ignore[secrets-outside-env]
+          # A dedicated GitHub Environment would gate this behind approval
+          # rules, which is wrong for an always-on lint check that must run
+          # unattended on every PR. The value is a low-sensitivity regex, not
+          # a credential, and it is a secret only so it stays out of a public
+          # file -- see the script docstring.
           INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }}
         run: python3 .github/scripts/check_internal_identifiers.py ${DIFF_BASE:+--diff-base "$DIFF_BASE"}
       # Deleting a ${SECRET_INTERNAL_DOMAIN} route hostname is only safe when the

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -49,6 +49,8 @@ jobs:
       - name: Scan tracked files for internal infrastructure identifiers
         env:
           DIFF_BASE: ${{ github.event_name == 'pull_request' && 'HEAD^1' || '' }}
+          # Internal zone regex supplied out-of-band — see the script docstring.
+          INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }}
         run: python3 .github/scripts/check_internal_identifiers.py ${DIFF_BASE:+--diff-base "$DIFF_BASE"}
       # Deleting a ${SECRET_INTERNAL_DOMAIN} route hostname is only safe when the
       # same route also publishes ${SECRET_DOMAIN} -- catches an app going fully

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -50,13 +50,12 @@ jobs:
         env:
           DIFF_BASE: ${{ github.event_name == 'pull_request' && 'HEAD^1' || '' }}
           # Internal zone regex supplied out-of-band — see the script docstring.
-          # zizmor: ignore[secrets-outside-env]
           # A dedicated GitHub Environment would gate this behind approval
           # rules, which is wrong for an always-on lint check that must run
           # unattended on every PR. The value is a low-sensitivity regex, not
           # a credential, and it is a secret only so it stays out of a public
           # file -- see the script docstring.
-          INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }}
+          INTERNAL_DOMAIN_RE: ${{ secrets.INTERNAL_DOMAIN_RE }} # zizmor: ignore[secrets-outside-env]
         run: python3 .github/scripts/check_internal_identifiers.py ${DIFF_BASE:+--diff-base "$DIFF_BASE"}
       # Deleting a ${SECRET_INTERNAL_DOMAIN} route hostname is only safe when the
       # same route also publishes ${SECRET_DOMAIN} -- catches an app going fully

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ CLAUDE.md
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Local-only mise config — carries INTERNAL_DOMAIN_RE for the identifier guard.
+# Never commit: the whole point is to keep the internal zone out of git.
+.mise.local.toml

--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -14,7 +14,9 @@
 [commit-msg]
 
 [commit-msg.commands.check-internal-identifiers]
-run = "python3 .github/scripts/check_internal_identifiers.py --strip-git-comments --text-file {1}"
+# Via `mise x` so the gitignored .mise.local.toml [env] reaches the script: a
+# git hook does not inherit an activated mise shell.
+run = "mise x -- python3 .github/scripts/check_internal_identifiers.py --strip-git-comments --text-file {1}"
 
 [pre-commit]
 parallel = true

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,9 @@
 # Pin exact tool versions + checksums + provenance in mise.lock for
 # reproducible, verified installs across machines and CI.
 lockfile = true
+# Required by the [hooks] block below — mise gates hooks behind experimental.
+# Scoped to this config, so it does not change mise behaviour in other repos.
+experimental = true
 
 [env]
 BOOTSTRAP_DIR = "{{config_root}}/bootstrap"
@@ -12,6 +15,14 @@ ROOT_DIR = "{{config_root}}"
 TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 TALOS_DIR = "{{config_root}}/talos"
 _.python.venv = {path = "{{config_root}}/.venv", create = true}
+
+[hooks]
+# `mise install` fetches the lefthook binary but does NOT materialise
+# .git/hooks — which is how this repo ran for months with an empty hooks dir
+# and none of the documented pre-commit checks firing (see #3804). Wiring the
+# install here closes the fresh-clone gap: one `mise install` and the hooks are
+# live. lefthook install is idempotent, so re-running costs nothing.
+postinstall = "lefthook install"
 
 [tasks.deps]
 description = "Install Python dependencies"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ etc.). Claude Code loads it via an `@AGENTS.md` import in the repository's local
 > rebuild that caused it. Do not append AI session links or co-author trailers.
 > `.github/scripts/check_internal_identifiers.py --text-file` enforces this at `commit-msg` via
 > lefthook and on PR title/body via `.github/workflows/pr-hygiene.yml`, reusing the same patterns as
-> the tracked-file scan so prose and files cannot drift apart.
+> the tracked-file scan so prose and files cannot drift apart. The internal-zone regex is fed in
+> at runtime via `INTERNAL_DOMAIN_RE` (a repository secret in CI, a gitignored `.mise.local.toml`
+> locally) rather than hardcoded, since the script itself is public.
 
 ## Repository structure
 

--- a/kubernetes/apps/media/exclusion-sync/app/cronjob.yaml
+++ b/kubernetes/apps/media/exclusion-sync/app/cronjob.yaml
@@ -28,9 +28,9 @@ spec:
                 - "/scripts/sync_exclusions.py"
               env:
                 - name: RADARR_URL
-                  value: "https://radarr.codelooks.com"
+                  value: "https://radarr.${SECRET_DOMAIN}"
                 - name: SONARR_URL
-                  value: "https://sonarr.codelooks.com"
+                  value: "https://sonarr.${SECRET_DOMAIN}"
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts

--- a/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
@@ -66,10 +66,10 @@ spec:
                 - name: RCLONE_CONFIG_DST_PROVIDER
                   value: Other
                 - name: RCLONE_CONFIG_DST_ENDPOINT
-                  # NAS Garage is now bridge+Traefik (s3-nas), not the old host :3900.
-                  # Public zone (SECRET_DOMAIN), not the internal one: core.codelooks.com
-                  # became a delegated AD zone in the 2026-07-22 rebuild, so its Traefik
-                  # cert can no longer renew via Cloudflare DNS-01 and is being retired.
+                  # NAS Garage is now reverse-proxied (s3-nas), not the old host :3900.
+                  # Deliberately SECRET_DOMAIN, not SECRET_INTERNAL_DOMAIN: the internal
+                  # zone is delegated to an internal resolver, so its wildcard cert can
+                  # no longer renew via Cloudflare DNS-01 and is being retired.
                   value: https://s3-nas.${SECRET_DOMAIN}
                 - name: RCLONE_CONFIG_DST_REGION
                   value: us-east-1


### PR DESCRIPTION
Follow-up to #3804. Answers the domain question left open there, and fixes two live leaks found while answering it.

## Two leaks in tracked files

Sanitizing the #3803 PR body did not touch the repository itself:

- **`garage/app/sync-cronjob.yaml`** carried a comment reproducing the whole #3803 narrative verbatim — the internal zone, the rebuild date, the certificate story. The PR body was cleaned; this was not.
- **`exclusion-sync/app/cronjob.yaml`** hardcoded two internal app hostnames instead of `${SECRET_DOMAIN}`. Both still render correctly — verified with `kustomize build`.

Neither was catchable before, because `check_internal_identifiers.py` keeps its patterns generic on purpose.

## Gating the internal zone without publishing it

Adds an optional `INTERNAL_DOMAIN_RE`, applied to **both** the tracked-file scan and prose. It is supplied at runtime rather than hardcoded — the script is public, so a literal regex there would re-disclose exactly what the guard exists to hide.

| Context | Source |
| --- | --- |
| CI | `INTERNAL_DOMAIN_RE` repository secret (already set) |
| Local | Gitignored `.mise.local.toml`, newly added to `.gitignore` |

The `commit-msg` hook now runs under `mise x` so a git hook actually inherits that env. Unset — any fresh clone, any contributor — the check skips cleanly and every other pattern still applies, so nobody is blocked by a missing secret.

## Fresh-clone gap closed

A mise `[hooks] postinstall` now runs `lefthook install`, so `mise install` alone materialises `.git/hooks`. This is the gap that left the hooks directory empty for months. Needs `experimental = true`, scoped to this config only.

Verified by deleting both hooks and re-running `mise install` — they came back.

## Verification

- Full scan of **all 1669 tracked files** passes with the new pattern active, confirming the two fixes removed the only non-allowlisted occurrences.
- The removed comment is rejected when replayed through the scanner, so the guard would have caught it.
- `kustomize build` renders both changed manifests with placeholders intact.
- `ruff check`, `ruff format`, `actionlint`, `zizmor --offline` all clean.
