### PR TITLE
fix(ai): revert skipModelInit — it blanks --model and kills inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ CLAUDE.md
 # Python bytecode
 __pycache__/
 *.pyc
+
+# Local-only mise config — carries INTERNAL_DOMAIN_RE for the identifier guard.
+# Never commit: the whole point is to keep the internal zone out of git.
+.mise.local.toml

--- a/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3-30b-abliterated.yaml
@@ -28,11 +28,13 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: qwen3-30b-a3b-abliterated
-  # The llmkube controller stages the GGUF into the shared llmkube-model-cache
-  # PVC itself and the runtime mounts it read-only, so the per-pod
-  # model-downloader init container is redundant (it just logs "already
-  # cached"). Drop it — this is the operator's own MissingSkipModelInit advice.
-  skipModelInit: true
+  # Do NOT set skipModelInit here. It looks safe — the controller does stage the
+  # GGUF into the shared cache PVC, so the model-downloader init container only
+  # logs "already cached" — but on llmkube 0.9.7 the flag ALSO blanks the
+  # rendered `--model` arg, because the /models/<cacheKey>/ path is derived from
+  # the init-container staging step. llama.cpp then starts in router mode with
+  # zero models: the pod goes 1/1 Ready and every request fails with
+  # "model not found". See #3792 (which set it) and the revert that followed.
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:f96be8dfd1c1eb533e09f42fc4d92311150dc63ecd568284c9199cacae5a9e26
   replicas: 1

--- a/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3.6-35b-a3b.yaml
@@ -30,11 +30,14 @@ metadata:
     krr/ignore: "true"
 spec:
   modelRef: qwen3.6-35b-a3b
-  # The llmkube controller stages the GGUF (+ mmproj) into the shared
-  # llmkube-model-cache PVC itself and the runtime mounts it read-only, so the
-  # per-pod model-downloader init container is redundant (it just logs "already
-  # cached"). Drop it — this is the operator's own MissingSkipModelInit advice.
-  skipModelInit: true
+  # Do NOT set skipModelInit here. It looks safe — the controller does stage the
+  # GGUF (+ mmproj) into the shared cache PVC, so the model-downloader init
+  # container only logs "already cached" — but on llmkube 0.9.7 the flag ALSO
+  # blanks the rendered `--model` arg, because the /models/<cacheKey>/ path is
+  # derived from the init-container staging step. llama.cpp then starts in
+  # router mode with zero models: the pod goes 1/1 Ready and every request fails
+  # with "model not found". See #3792 (which set it) and the revert that
+  # followed.
   runtime: llamacpp
   image: ghcr.io/ggml-org/llama.cpp:server-cuda@sha256:f96be8dfd1c1eb533e09f42fc4d92311150dc63ecd568284c9199cacae5a9e26
   replicas: 1


### PR DESCRIPTION
Reverts the spec change from #3792. **Self-hosted inference is currently down** — every request through LiteLLM fails.

## Symptom

`litellm` logs, continuously:

```
litellm.BadRequestError: OpenAIException - model 'self-hosted' not found. Received Model Group=self-hosted
Error doing the fallback: AuthenticationError: OpenrouterException - {"error":{"message":"Missing Authentication header","code":401}}
```

Both GPU pods are `1/1 Running`, both `Model` CRs are `Ready` with a valid `status.path`, and both `InferenceService`s are `Ready`. Nothing looked wrong.

## Cause

`skipModelInit: true` on llmkube 0.9.7 does not only drop the redundant `model-downloader` init container. It also blanks the rendered `--model` argument, because the `/models/<cacheKey>/` path is derived from the init-container staging step.

With an empty `--model`, current llama.cpp no longer errors out — it starts in **router mode with zero models**:

```
srv  load_models: Loaded 0 cached model presets
srv  operator(): Available models (0)
srv  llama_server: starting server in router mode. models will be automatically loaded on-demand
```

The server binds, probes pass, the pod reports Ready, and `/v1/models` returns `[]`. The failure only appears at request time.

## Evidence

`llama-uncensored` ReplicaSet history:

| Revision | `--model` | Init containers |
| --- | --- | --- |
| 6–11 | `/models/6d422a89d4bb73c4/…gguf` | `model-cache-prep`, `model-downloader` |
| 12–13 | `""` | none |

Revision 11 → 12 is exactly where #3792 landed. `llama-embed` and `llama-rerank` are unaffected — they are plain HelmReleases with a literal `--model` path, not llmkube-managed.

## Fix

Drop `skipModelInit` from both InferenceServices. Each keeps a comment explaining why it must stay unset, because the operator itself emits a `MissingSkipModelInit` warning advising the opposite — that warning is a trap on 0.9.7.

## Follow-ups, not in this PR

- **The LiteLLM fallback is dead.** `openrouter/auto` returns 401 "Missing Authentication header", so it cannot cover a primary outage. Worth fixing or removing.
- **Nothing alerted.** A Ready pod serving zero models is invisible to the current probes. A check on `/v1/models` returning a non-empty list would have caught this in minutes rather than hours.
- Worth reporting the `skipModelInit` coupling upstream to llmkube.
