### PR TITLE
fix(observability): repair two broken alert rules (Ceph pool growth, printer TargetDown)

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -176,3 +176,34 @@ spec:
                 expr: node_zfs_zpool_state{state!="online"} > 0
                 labels:
                   severity: critical
+  # Teach the chart's generic TargetDown about the label printers.
+  #
+  # The Brother label printers power themselves off by design, so snmp-exporter's
+  # own SnmpTargetDown already excludes device_class="printer" (see
+  # observability/snmp-exporter). But TargetDown aggregates by job, so one
+  # sleeping printer out of five snmp targets is 20% > 10% and fires anyway —
+  # defeating that deliberate exclusion and training us to ignore TargetDown,
+  # which is the alert that would catch a real switch outage.
+  #
+  # Absent labels satisfy a != matcher in PromQL, so this drops only targets
+  # explicitly labelled device_class="printer" — verified live: 173 up series,
+  # 169 kept, exactly the 4 printers excluded. Every other job still alerts.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: PrometheusRule
+              name: kube-prometheus-stack-general.rules
+            patch: |-
+              # Guard: assert the index still points at TargetDown, so a chart
+              # upgrade that reorders rules fails loudly instead of silently
+              # rewriting a different alert.
+              - op: test
+                path: /spec/groups/0/rules/0/alert
+                value: TargetDown
+              - op: replace
+                path: /spec/groups/0/rules/0/expr
+                value: >-
+                  100 * (count by (cluster, job, namespace, service)
+                  (up{device_class!="printer"} == 0) / count by (cluster, job,
+                  namespace, service) (up{device_class!="printer"})) > 10

--- a/kubernetes/apps/observability/plex-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/plex-exporter/app/helmrelease.yaml
@@ -12,6 +12,16 @@ spec:
   values:
     controllers:
       plex-exporter:
+        # A high restart count on this pod is expected, not a fault to chase.
+        # The exporter treats a Plex websocket read failure as fatal and exits
+        # ("cannot listen to plex server events") rather than reconnecting, so
+        # the Kubernetes restart IS its reconnect. It has no backoff for "Plex
+        # is not there yet", so while Plex is down — a Plex image update, say —
+        # it hot-loops and the count jumps in bursts of 5-12 an hour, then sits
+        # still for days. Measured impact is small: 99.75% scrape availability
+        # over 7 days. Deliberately no extra alert: those bursts are fast enough
+        # to trip CrashLoopBackOff, so KubePodCrashLooping already covers a
+        # recurrence, and PlexServerUnreachable covers the up-but-blind case.
         annotations:
           reloader.stakater.com/auto: "true"
         containers:

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -174,3 +174,39 @@ spec:
       deletionPolicy: Delete
     # Object storage (RGW) removed — migrated to Garage (storage/garage).
     cephObjectStores: []
+  # Fix the chart's CephPoolGrowthWarning rule, which fails to evaluate whenever
+  # the mgr pod has been rescheduled inside its own [2d] lookback.
+  #
+  # predict_linear() emits one series per label-set, so a restarted mgr leaves the
+  # old pod's series in the window alongside the new one. Both share
+  # {cluster, pool_id, instance} but differ in `pod`, so group_right() sees a
+  # duplicate match group and errors:
+  #   found duplicate series for the match group {...} on the left hand-side
+  # Prometheus then raises PrometheusRuleFailures and — the part that matters —
+  # stops evaluating pool-growth prediction entirely, so a pool trending toward
+  # full would go unwarned. It self-heals ~2d after the last restart and breaks
+  # again on the next one; mgr churn is routine here (see the mgr resources note
+  # above, it was OOMKilling ~twice daily until the 3Gi bump).
+  #
+  # `max by(...)` collapses the duplicates before the join, keeping the most
+  # pessimistic prediction. Upstream bug, not a local misconfiguration.
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: PrometheusRule
+              name: prometheus-ceph-rules
+            patch: |-
+              # Guard: the chart controls this ordering, so assert the index still
+              # points at the intended alert. If an upgrade reorders the groups the
+              # test fails and Flux stops loudly, rather than silently rewriting a
+              # different rule's expression.
+              - op: test
+                path: /spec/groups/7/rules/0/alert
+                value: CephPoolGrowthWarning
+              - op: replace
+                path: /spec/groups/7/rules/0/expr
+                value: >-
+                  (max by(cluster, pool_id, instance) (predict_linear(ceph_pool_percent_used[2d],
+                  3600 * 24 * 5)) * on(cluster,pool_id, instance) group_right()
+                  ceph_pool_metadata) >= 95


### PR DESCRIPTION
Three findings from looking at the firing alerts. Two are real rule bugs; the third is a fault that turned out not to be one.

## 1. CephPoolGrowthWarning has been failing to evaluate

The chart rule breaks whenever the mgr pod has been rescheduled inside its own `[2d]` lookback. `predict_linear()` emits one series per label-set, so the old pod's series sits in the window beside the new one; both share `{cluster, pool_id, instance}` but differ in `pod`, so `group_right()` hits a duplicate match group:

```
found duplicate series for the match group {...} on the left hand-side of the operation
```

Prometheus raises `PrometheusRuleFailures` and stops evaluating pool-growth prediction entirely — so a pool trending toward full would go unwarned. It self-heals ~2 days after the last restart and breaks again on the next one, and mgr churn is routine here (it was OOMKilling twice daily until the 3Gi bump).

`max by(...)` collapses the duplicates before the join, keeping the most pessimistic prediction. This is an upstream bug, not local misconfiguration.

## 2. Sleeping label printers fire the chart's TargetDown

snmp-exporter already excludes `device_class="printer"` from its own `SnmpTargetDown`, because the Brother label printers power themselves off by design. But `TargetDown` aggregates by job, so one sleeping printer out of five snmp targets is 20% > 10% and fires anyway — defeating that deliberate exclusion and training us to ignore the alert that would catch a real switch outage.

Absent labels satisfy a `!=` matcher, so the added selector drops only targets explicitly labelled as printers.

## 3. plex-exporter's 23 restarts — documented, not fixed

The exporter treats a Plex websocket read failure as fatal and exits rather than reconnecting, so the Kubernetes restart is its reconnect. With no backoff it hot-loops while Plex is down (the bursts line up with Plex image updates), then sits still for days.

Impact is small — 99.75% scrape availability over 7d, ~25 min of gaps, nothing since 07-21 — and the bursts are fast enough to trip `CrashLoopBackOff`, so `KubePodCrashLooping` already covers a recurrence. Added a comment rather than an alert.

## Both patches are guarded

Applied as `postRenderers` so each chart keeps ownership of its other rules, each with an `op: test` asserting the alert name at that index. If an upgrade reorders the groups, Flux fails loudly instead of silently rewriting a different rule.

## Verification

| Check | Result |
| --- | --- |
| Ceph expr, current | HTTP 422, duplicate series |
| Ceph expr, patched | Evaluates cleanly, 0 results |
| TargetDown, current | 1 firing series (job=snmp-exporter, 20%) |
| TargetDown, patched | 0 firing |
| TargetDown blast radius | 173 `up` series, 169 kept, exactly the 4 printers excluded |
| Both patches | Apply at the expected index against the live rules |
| Guard | Simulating a reorder makes kustomize refuse to build |

## One thing worth knowing

A restart-rate alert for plex-exporter was the obvious addition and I dropped it, because the obvious selector silently matches nothing: the container is named `app`, not `plex-exporter`. That rule would have sat there looking like coverage and never fired — the same empty-vector trap that already bit mktxp. Worth remembering when writing any `kube_pod_container_*` rule against an app-template workload.
