### PR TITLE
fix(renovate): close the tier-0 gap on github-releases bumps

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -147,8 +147,14 @@
     },
     {
       description: "Protected infra — never auto-merge, manual review only",
-      matchDatasources: ["docker", "helm"],
+      // github-releases is included deliberately: while this guard matched only
+      // docker/helm, a tier-0 component tracked through GitHub releases bypassed
+      // it entirely and the "Auto-merge GitHub Releases" rule below then merged
+      // the bump straight to main with no CI gate. Keeping the datasource list in
+      // step with the automerge rules is what makes the denylist actually total.
+      matchDatasources: ["docker", "helm", "github-releases"],
       matchPackageNames: [
+        "/gateway-api/", // Envoy Gateway CRDs; envoyproxy itself is protected below
         "/cilium/",
         "/cert-manager/",
         "/coredns/",
@@ -199,17 +205,22 @@
       ignoreTests: true,
     },
     {
-      description: "Auto-merge GitHub Releases",
+      // Was automergeType:branch + ignoreTests:true, i.e. CRD bumps for cluster
+      // ingress and monitoring went straight to main with NO CI gate at all.
+      // Branch-merge is also incompatible with the baseline-main-protection
+      // ruleset's pull_request rule ("Unknown error when attempting branch
+      // automerge"), so it bought nothing. Now a CI-gated PR merge like every
+      // other category. gateway-api has moved to the protected-infra guard above:
+      // it ships the Envoy Gateway CRDs and envoyproxy itself is already protected,
+      // so the CRDs should not outrun a manual controller review.
+      description: "Auto-merge GitHub Releases — CI-gated PR merge",
       matchDatasources: ["github-releases"],
       automerge: true,
-      automergeType: "branch",
+      automergeType: "pr",
+      platformAutomerge: false,
       matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: [
-        "/external-dns/",
-        "/gateway-api/",
-        "/prometheus-operator/",
-      ],
-      ignoreTests: true,
+      matchPackageNames: ["/external-dns/", "/prometheus-operator/"],
+      ignoreTests: false,
     },
     {
       description: "Auto-merge Mise Tools",


### PR DESCRIPTION
## Problem

The `Protected infra — never auto-merge` denylist matched only `matchDatasources: ["docker", "helm"]`. Anything tier-0 that Renovate tracks through the **github-releases** datasource therefore bypassed the guard entirely — and the `Auto-merge GitHub Releases` rule then merged it with:

```json5
automergeType: "branch",
ignoreTests: true,
```

That is **straight to main with no CI gate at all**, for `gateway-api`, `prometheus-operator` and `external-dns`. Branch-merge is also incompatible with this repo's `baseline-main-protection` ruleset (its `pull_request` rule blocks direct pushes), so it bought nothing in exchange.

Latent rather than actively firing — no such bump merged recently — but it contradicts the estate policy of "auto-merge minor/patch **unless the package is tier-0**".

## Change

- **Protected infra** now matches `["docker", "helm", "github-releases"]` and gains `/gateway-api/`. It ships the Envoy Gateway CRDs, and `envoyproxy` itself was already protected, so the CRDs shouldn't outrun a manual controller review.
- **GitHub Releases automerge** becomes a CI-gated PR merge (`automergeType: "pr"`, `platformAutomerge: false`, `ignoreTests: false`). `external-dns` and `prometheus-operator` still auto-merge — now gated on CI like every other category.

Majors are unaffected (they never matched these rules, and the shared preset now queues them on the Dependency Dashboard).

## Verification

- `renovate-config-validator --strict` → exit **0**, no warnings
- `prettier --check` → clean (confirmed `HEAD` was clean first, so no pre-existing debt is being smuggled in)