### PR TITLE
fix(renovate): make the AI review actually gate auto-merge

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -196,13 +196,18 @@
       minimumReleaseAge: "2 days",
     },
     {
-      description: "Auto-merge GitHub Actions",
+      description: "Auto-merge GitHub Actions — CI-gated PR merge",
       matchManagers: ["github-actions"],
       automerge: true,
-      automergeType: "branch",
+      // PR-automerge, not branch: branch-merge pushes straight to main and
+      // ignoreTests waived the checks, so claude/renovate-review landed its
+      // verdict 76-93s AFTER the commit was already on main (#3821, #3816,
+      // #3812). The review has to gate the merge, not annotate it.
+      automergeType: "pr",
+      platformAutomerge: false,
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "2 days",
-      ignoreTests: true,
+      ignoreTests: false,
     },
     {
       // Was automergeType:branch + ignoreTests:true, i.e. CRD bumps for cluster
@@ -223,22 +228,32 @@
       ignoreTests: false,
     },
     {
-      description: "Auto-merge Mise Tools",
+      description: "Auto-merge Mise Tools — CI-gated PR merge",
       matchManagers: ["mise"],
       automerge: true,
-      automergeType: "branch",
+      // PR-automerge, not branch: branch-merge pushes straight to main and
+      // ignoreTests waived the checks, so claude/renovate-review landed its
+      // verdict 76-93s AFTER the commit was already on main (#3821, #3816,
+      // #3812). The review has to gate the merge, not annotate it.
+      automergeType: "pr",
+      platformAutomerge: false,
       matchUpdateTypes: ["minor", "patch"],
-      ignoreTests: true,
+      ignoreTests: false,
     },
     {
-      description: "Auto-merge trusted GitHub Actions",
+      description: "Auto-merge trusted GitHub Actions — CI-gated PR merge",
       matchManagers: ["github-actions"],
       matchPackageNames: ["/^actions\\//", "/^renovatebot\\//"],
       automerge: true,
-      automergeType: "branch",
+      // PR-automerge, not branch: branch-merge pushes straight to main and
+      // ignoreTests waived the checks, so claude/renovate-review landed its
+      // verdict 76-93s AFTER the commit was already on main (#3821, #3816,
+      // #3812). The review has to gate the merge, not annotate it.
+      automergeType: "pr",
+      platformAutomerge: false,
       matchUpdateTypes: ["minor", "patch", "digest"],
       minimumReleaseAge: "1 day",
-      ignoreTests: true,
+      ignoreTests: false,
     },
 
     // === Changelogs (from changelogs.json5) ===
@@ -254,10 +269,14 @@
     {
       addLabels: ["renovate/grafana-dashboard"],
       automerge: true,
-      automergeType: "branch",
+      // Was branch + ignoreTests:true — a MAJOR dashboard revision went straight
+      // to main with no CI and no AI review at all. Same reasoning as the rules
+      // above: branch-merge bypasses the PR, so the review cannot gate it.
+      automergeType: "pr",
+      platformAutomerge: false,
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
       commitMessageTopic: "dashboard {{depName}}",
-      ignoreTests: true,
+      ignoreTests: false,
       matchDatasources: ["custom.grafana-dashboards"],
       matchUpdateTypes: ["major"],
       semanticCommitScope: "grafana-dashboards",


### PR DESCRIPTION
Follows #3869, which fixed this for GitHub Releases. Four more rules had the same defect.

## `dependencyDashboardApproval` is fine

Checking first, since that was the worry: it is set **once**, scoped to `matchDatasources: ["custom.minecraft-release"]`, deliberately — a human waits for a STABLE Paper build. There is no top-level setting and nothing else uses it. It is not blocking anything else.

## The actual gap

Four rules used `automergeType: branch` with `ignoreTests: true`. Branch-merge pushes straight to `main` without a PR, and `ignoreTests` waives status checks — so `claude/renovate-review` never gated those categories.

Not theoretical. On the three most recent mise bumps the review posted its verdict onto a commit that was **already merged**:

| PR | Merged | Review completed | |
| --- | --- | --- | --- |
| #3821 | 00:46:20 | 00:47:40 | merged **80s before** |
| #3816 | 17:04:20 | 17:05:53 | merged **93s before** |
| #3812 | 05:28:31 | 05:29:47 | merged **76s before** |

The review ran and passed every time. It simply could not have blocked anything.

## Fixed

Converted to `automergeType: pr` + `platformAutomerge: false` + `ignoreTests: false`:

- Auto-merge GitHub Actions
- Auto-merge Mise Tools
- Auto-merge trusted GitHub Actions
- Grafana dashboards — **major** revisions, the worst of the set: a major bump reaching `main` with no CI and no review

## After

| | |
| --- | --- |
| Auto-merge paths | 8, all `pr` + `ignoreTests: false` |
| Ungated paths | **0** |
| Blocked | protected-infra denylist (`automerge: false`), Minecraft (dashboard approval) |

That is the model you asked for: auto-merge on green, unless on the blocked list.

## Cost

None. The review already ran on these PRs — Renovate just did not wait for it. Merges now take roughly 80–90 seconds longer.
