### PR TITLE
refactor(renovate): drop seven rules the shared preset already provides

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -87,71 +87,32 @@
     },
   ],
 
-  // --- Package rules (order preserved from the former extends sequence:
-  //     autoMerge → changelogs → grafanaDashboards → groups → labels → overrides) ---
+  // --- Package rules ---
+  //
+  // There are deliberately NO auto-merge rules here. The shared preset
+  // (github>LukeEvansTech/renovate-config) already auto-merges every
+  // minor/patch/digest on green CI, as a CI-gated PR merge, with the release-age
+  // soak opted out for the docker datasource. This file adds only what is
+  // specific to THIS repository: the protected denylist below, plus custom
+  // datasources, groups and labels.
+  //
+  // DO NOT re-state a setting the preset already sets. packageRules are
+  // last-match-wins and preset rules evaluate FIRST, so a local restatement
+  // silently overrides the shared decision with no error and no visible diff.
+  // Every Renovate incident in this repo came from exactly that:
+  //   - a local minimumReleaseAge:"2 days" reverted the preset's docker opt-out,
+  //     and because GHCR exposes no release timestamp the gate never turned
+  //     green — 38 of 39 open PRs were permanently stuck (#3866);
+  //   - local automergeType:"branch" + ignoreTests:true reverted the preset's
+  //     CI-gated PR merge, so claude/renovate-review landed its verdict 76-93s
+  //     AFTER the commit was already on main and could never gate it (#3871).
+  // To change auto-merge behaviour, change the preset — every repo benefits.
   packageRules: [
-    // === Auto-merge (from autoMerge.json5) ===
-    // === App auto-merge (denylist model) ===
-    // Broad enabler: every container image + Helm chart auto-merges for
-    // minor/patch/digest and first-time digest pins. The guard immediately below
-    // re-disables automerge for cluster-critical components (last-match-wins).
-    // `major` is never listed anywhere, so it always stays manual.
-    // platformAutomerge:false => Renovate self-gates on CI (flate, security-scans)
-    // rather than GitHub-native auto-merge, so no branch-protection ruleset is needed.
-    {
-      description: "Auto-merge apps — minor/patch (denylist model; protected guard below)",
-      matchDatasources: ["docker", "helm"],
-      matchUpdateTypes: ["minor", "patch"],
-      automerge: true,
-      automergeType: "pr",
-      platformAutomerge: false,
-      ignoreTests: false,
-      // No release-age soak, and do not put one back. The shared preset had
-      // already opted the docker datasource out; re-stating minimumReleaseAge
-      // here silently reverted that, because preset rules evaluate first and
-      // last-match-wins.
-      //
-      // GHCR/quay expose no reliable release timestamp, so the gate never turns
-      // green — it is a permanent block, not a two-day soak. Measured
-      // 2026-07-26: 38 of 39 open PRs pending on renovate/stability-days, the
-      // one exception a mirror.gcr.io image; the Talos v1.13.7 PR had sat five
-      // days against a two-day gate. It looked healthy only because the
-      // categories with a working gate (digest bumps, Docker Hub) kept merging.
-      //
-      // Explicitly null rather than merely absent: without it the preset's own
-      // 2-day soak still applies to the helm datasource. That would leave a
-      // separate policy for the two HelmRepository charts here (coder,
-      // netdata) out of ~440 dependencies — not worth the extra rule.
-      //
-      // Trust model is unchanged: images are digest-pinned via
-      // docker:pinDigests, CI still gates the merge (ignoreTests:false), and
-      // the protected denylist below still forces manual review for Talos,
-      // Cilium, Flux and Rook-Ceph.
-      minimumReleaseAge: null,
-    },
-    {
-      // No minimumReleaseAge here: digest bumps track mutable tags that upstream
-      // rebuilds every few days (nginx:1.31-alpine, llama.cpp server-cuda …), so
-      // a 3-day age gate perpetually resets and renovate/stability-days never
-      // clears — 11 digest PRs sat pending up to 19 days. GHCR also often has no
-      // retrievable per-digest timestamp at all, which pends forever too. Digest
-      // bumps of an already-trusted tag stay CI-gated (ignoreTests: false) like
-      // everything else, and the protected-infra guard below still applies.
-      description: "Auto-merge apps — digest + pins, no age gate (denylist model; protected guard below)",
-      matchDatasources: ["docker", "helm"],
-      matchUpdateTypes: ["digest", "pin", "pinDigest"],
-      automerge: true,
-      automergeType: "pr",
-      platformAutomerge: false,
-      ignoreTests: false,
-    },
     {
       description: "Protected infra — never auto-merge, manual review only",
-      // github-releases is included deliberately: while this guard matched only
-      // docker/helm, a tier-0 component tracked through GitHub releases bypassed
-      // it entirely and the "Auto-merge GitHub Releases" rule below then merged
-      // the bump straight to main with no CI gate. Keeping the datasource list in
-      // step with the automerge rules is what makes the denylist actually total.
+      // The datasource list must cover every datasource the preset auto-merges,
+      // or a tier-0 component tracked through another one slips past the guard
+      // entirely. github-releases was exactly that gap (#3869).
       matchDatasources: ["docker", "helm", "github-releases"],
       matchPackageNames: [
         "/gateway-api/", // Envoy Gateway CRDs; envoyproxy itself is protected below
@@ -182,79 +143,6 @@
       ],
       automerge: false,
     },
-    {
-      // Docs toolchain lives in docs/requirements.txt (zensical). Same CI-gated
-      // pattern as the container/chart rule above: self-merge minor/patch/digest
-      // after the 2-day age gate, gating on CI (docs build + drift check).
-      description: "Auto-merge Python deps — minor/patch/digest, CI-gated",
-      matchDatasources: ["pypi"],
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      automerge: true,
-      automergeType: "pr",
-      platformAutomerge: false,
-      ignoreTests: false,
-      minimumReleaseAge: "2 days",
-    },
-    {
-      description: "Auto-merge GitHub Actions — CI-gated PR merge",
-      matchManagers: ["github-actions"],
-      automerge: true,
-      // PR-automerge, not branch: branch-merge pushes straight to main and
-      // ignoreTests waived the checks, so claude/renovate-review landed its
-      // verdict 76-93s AFTER the commit was already on main (#3821, #3816,
-      // #3812). The review has to gate the merge, not annotate it.
-      automergeType: "pr",
-      platformAutomerge: false,
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      minimumReleaseAge: "2 days",
-      ignoreTests: false,
-    },
-    {
-      // Was automergeType:branch + ignoreTests:true, i.e. CRD bumps for cluster
-      // ingress and monitoring went straight to main with NO CI gate at all.
-      // Branch-merge is also incompatible with the baseline-main-protection
-      // ruleset's pull_request rule ("Unknown error when attempting branch
-      // automerge"), so it bought nothing. Now a CI-gated PR merge like every
-      // other category. gateway-api has moved to the protected-infra guard above:
-      // it ships the Envoy Gateway CRDs and envoyproxy itself is already protected,
-      // so the CRDs should not outrun a manual controller review.
-      description: "Auto-merge GitHub Releases — CI-gated PR merge",
-      matchDatasources: ["github-releases"],
-      automerge: true,
-      automergeType: "pr",
-      platformAutomerge: false,
-      matchUpdateTypes: ["minor", "patch"],
-      matchPackageNames: ["/external-dns/", "/prometheus-operator/"],
-      ignoreTests: false,
-    },
-    {
-      description: "Auto-merge Mise Tools — CI-gated PR merge",
-      matchManagers: ["mise"],
-      automerge: true,
-      // PR-automerge, not branch: branch-merge pushes straight to main and
-      // ignoreTests waived the checks, so claude/renovate-review landed its
-      // verdict 76-93s AFTER the commit was already on main (#3821, #3816,
-      // #3812). The review has to gate the merge, not annotate it.
-      automergeType: "pr",
-      platformAutomerge: false,
-      matchUpdateTypes: ["minor", "patch"],
-      ignoreTests: false,
-    },
-    {
-      description: "Auto-merge trusted GitHub Actions — CI-gated PR merge",
-      matchManagers: ["github-actions"],
-      matchPackageNames: ["/^actions\\//", "/^renovatebot\\//"],
-      automerge: true,
-      // PR-automerge, not branch: branch-merge pushes straight to main and
-      // ignoreTests waived the checks, so claude/renovate-review landed its
-      // verdict 76-93s AFTER the commit was already on main (#3821, #3816,
-      // #3812). The review has to gate the merge, not annotate it.
-      automergeType: "pr",
-      platformAutomerge: false,
-      matchUpdateTypes: ["minor", "patch", "digest"],
-      minimumReleaseAge: "1 day",
-      ignoreTests: false,
-    },
 
     // === Changelogs (from changelogs.json5) ===
     // 1Password Connect + cloudflared changelog URLs come from the preset's
@@ -268,15 +156,15 @@
     // === Grafana dashboards (from grafanaDashboards.json5) ===
     {
       addLabels: ["renovate/grafana-dashboard"],
+      // A dashboard "major" is just a revision bump, not a breaking change, so
+      // this opts them back into auto-merge — the preset leaves majors with no
+      // automerge rule, and separately queues them behind a dashboard checkbox.
+      // automergeType/ignoreTests are deliberately NOT set: Renovate already
+      // defaults to a CI-gated PR merge, and restating them here is what caused
+      // the branch-merge incident (see the note at the top of packageRules).
       automerge: true,
-      // Was branch + ignoreTests:true — a MAJOR dashboard revision went straight
-      // to main with no CI and no AI review at all. Same reasoning as the rules
-      // above: branch-merge bypasses the PR, so the review cannot gate it.
-      automergeType: "pr",
-      platformAutomerge: false,
       commitMessageExtra: "({{currentVersion}} → {{newVersion}})",
       commitMessageTopic: "dashboard {{depName}}",
-      ignoreTests: false,
       matchDatasources: ["custom.grafana-dashboards"],
       matchUpdateTypes: ["major"],
       semanticCommitScope: "grafana-dashboards",


### PR DESCRIPTION
Every auto-merge rule in this file duplicated the shared preset. The preset's rule [0] matches `minor`/`patch` with **no datasource filter**, so it already covered all seven: apps minor/patch, apps digest+pins, pypi, github-actions, github-releases, mise, and trusted github-actions.

## The duplication was the bug

`packageRules` are last-match-wins and preset rules evaluate **first**, so each local restatement silently reverted a shared decision — no error, no warning, nothing visible in a diff:

| Restated locally | Reverted | Result |
| --- | --- | --- |
| `minimumReleaseAge: "2 days"` | the preset's docker soak opt-out | GHCR publishes no release timestamp, so the gate never turned green — 38 of 39 open PRs permanently stuck (#3866) |
| `automergeType: "branch"` + `ignoreTests: true` | the preset's CI-gated PR merge | `claude/renovate-review` posted its verdict 76–93s **after** the commit was already on `main` (#3871) |

Removing the duplicates removes the whole class of failure.

## What's left

Only what is specific to this repository: the protected denylist, custom datasources, groups and labels. A header comment on `packageRules` records why there are no auto-merge rules here, so they don't get helpfully re-added.

The Grafana dashboard rule also loses its `automergeType`/`ignoreTests` — Renovate already defaults to a CI-gated PR merge, so stating them was the same mistake in miniature. Its `automerge: true` stays, because that *is* a genuine local exception: the preset gives majors no automerge rule at all.

## Audit after

| Local rules setting | Count |
| --- | --- |
| `minimumReleaseAge` | 0 |
| `ignoreTests` | 0 |
| `automergeType` | 0 |
| `platformAutomerge` | 0 |
| `automerge` | 2 — the denylist, and Grafana |

Net **-112 lines**. Config validates via `renovate-config-validator`.

## Two behaviour changes to expect

- **helm minor/patch regains the 2-day soak.** The preset opts out `docker` only. That is correct rather than a regression: `index.yaml` carries a real `created` timestamp, so the gate actually expires — unlike GHCR. Affects two charts here (`coder`, `netdata`).
- **Trusted GitHub Actions move from a 1-day to the standard 2-day soak.**

If either should change, the right place is the preset, so every repo benefits — see LukeEvansTech/renovate-config#10, which documents this pattern for rollout.
