### PR TITLE
ci(claude): move full-depth review tier to Claude Opus 5

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -140,7 +140,7 @@ jobs:
             echo "model=claude-sonnet-5" >> "$GITHUB_OUTPUT"
             echo "depth=light" >> "$GITHUB_OUTPUT"
           else
-            echo "model=claude-opus-4-8" >> "$GITHUB_OUTPUT"
+            echo "model=claude-opus-5" >> "$GITHUB_OUTPUT"
             echo "depth=full" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Moves the **full-depth** Renovate review tier from `claude-opus-4-8` to `claude-opus-5`.

### Why this is a straight string swap

Opus 5 supersedes Opus 4.8 at **identical pricing** ($5/$25 per MTok), the same 1M context window and the same feature set.

Its two API-level breaking changes — thinking is on by default, and `thinking: disabled` is capped at `high` effort — **do not apply here**. The model is passed through to `claude-code-action` as `--model`; this workflow never sets `thinking` or `effort` directly, so the CLI owns that configuration.

### Unchanged

- Light tier stays on `claude-sonnet-5`
- Haiku token preflight stays on `claude-haiku-4-5-20251001`
- Tier-selection logic, blast-radius regex, fingerprint cache and fail-open behaviour all untouched

### What to watch after merge

- **`--max-turns 25`** — Opus 5 self-verifies without being asked and narrates more between tool calls. The prompt targets 12–18 turns for the full tier so there is headroom, but recurring "Claude finished without posting a verdict" statuses would point at the turn budget rather than the model.
- **Review body length** — Opus 5 writes longer user-facing output by default. The structured review template mitigates most of this; if bodies bloat, add a conciseness line to the prompt (lowering effort is *not* the lever — it does not reliably shorten visible output).