### PR TITLE
fix(paperless): move DBSSLMODE to DB_OPTIONS for v3

### DIFF
--- a/kubernetes/apps/default/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless/app/externalsecret.yaml
@@ -23,7 +23,12 @@ spec:
         PAPERLESS_DBNAME: &dbname "paperless"
         PAPERLESS_DBUSER: &dbuser "{{ .PAPERLESS_POSTGRES_USER }}"
         PAPERLESS_DBPASS: &dbpass "{{ .PAPERLESS_POSTGRES_PASSWORD }}"
-        PAPERLESS_DBSSLMODE: require
+        # v3 replaced PAPERLESS_DBSSLMODE with PAPERLESS_DB_OPTIONS; the old key is
+        # ignored now and removed outright in v3.2. The running v3.0.3 pod logs:
+        #   HINT: PAPERLESS_DBSSLMODE is no longer supported and will be removed in
+        #   v3.2. Set the equivalent option via PAPERLESS_DB_OPTIONS instead.
+        # https://docs.paperless-ngx.com/migration-v3/
+        PAPERLESS_DB_OPTIONS: '{"sslmode":"require"}'
         POSTGRES_DB: *dbname
         POSTGRES_USER: *dbuser
         POSTGRES_PASSWORD: *dbpass


### PR DESCRIPTION
The running v3.0.3 pod logs this on every worker start:

```
HINT: PAPERLESS_DBSSLMODE is no longer supported and will be removed in v3.2.
Set the equivalent option via PAPERLESS_DB_OPTIONS instead.
Example: PAPERLESS_DB_OPTIONS='{"sslmode": "<value>"}'
```

Worth flagging: **the pre-merge review on #3781 asserted the opposite** — *"deprecated DBSSLMODE / DB_POOLSIZE not used"*, listed under "not applicable to this repo". It was in fact set to `require` on line 26. The live pod logs caught it, not the review — a good argument for checking the pod after a major bump rather than trusting pre-merge analysis alone.

Same semantics, so `sslmode` stays `require`. Value verified to parse as JSON. The single braces are safe in the ExternalSecret Go template — only `{{` opens an action.

Not urgent (v3.0.3 still honours the old key and only warns), but it becomes a hard break at **v3.2**, which Renovate will offer automatically.