### PR TITLE
feat(volsync): back up gatus, grafana and satisfactory save data

### DIFF
--- a/kubernetes/apps/games/satisfactory/app/kustomization.yaml
+++ b/kubernetes/apps/games/satisfactory/app/kustomization.yaml
@@ -6,3 +6,21 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  # Backups only — see the note in gatus. The full volsync component would also
+  # declare a PVC named ${APP} ("satisfactory"), which is NOT this app's claim:
+  # the save data lives in ./pvc.yaml as "sf-gamedata". Pulling in the component
+  # would create a second, empty volume and leave the real one unprotected.
+  - ../../../../components/volsync/nfs
+  - ../../../../components/volsync/remote
+patches:
+  # The component templates sourcePVC as ${APP}, which resolves to "satisfactory".
+  # This app's claim is named sf-gamedata, so point both ReplicationSources at the
+  # real volume. Patching locally rather than parameterising the shared component
+  # keeps the blast radius at this app — 40+ other apps depend on that component
+  # and their PVC names already match ${APP}.
+  - target:
+      kind: ReplicationSource
+    patch: |-
+      - op: replace
+        path: /spec/sourcePVC
+        value: sf-gamedata

--- a/kubernetes/apps/observability/gatus/app/kustomization.yaml
+++ b/kubernetes/apps/observability/gatus/app/kustomization.yaml
@@ -6,6 +6,18 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./prometheusrule.yaml
+  # Backups only — deliberately NOT the ../../../../components/volsync component.
+  # That component also ships pvc.yaml, which declares a PVC named ${APP} with a
+  # dataSourceRef pointing at ${APP}-dst. Here the gatus PVC already exists and is
+  # created by the gatus-sidecar Helm chart (persistence.enabled), so pulling in
+  # the whole component would collide on the same PVC name and try to re-provision
+  # it from a ReplicationDestination that has no snapshot yet. Referencing the two
+  # halves directly gives ReplicationSource + ReplicationDestination + the kopia
+  # repository ExternalSecret, and leaves the live volume untouched.
+  # sourcePVC is ${APP} = "gatus", which is exactly the chart's claim name, so no
+  # patch is needed here (unlike grafana/satisfactory).
+  - ../../../../components/volsync/nfs
+  - ../../../../components/volsync/remote
 configMapGenerator:
   - name: gatus-configmap
     files:

--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -6,3 +6,22 @@ resources:
   - ./grafanadatasource.yaml
   - ./grafana.yaml
   - ./servicemonitor.yaml
+  # Backups only — see the note in gatus. Grafana's volume is declared inline in
+  # the Grafana CR (grafana.yaml: persistentVolumeClaim -> grafana-pvc), not via
+  # the app-template persistence pattern, so the component's own pvc.yaml would
+  # fight the operator for ownership.
+  # Scope: the 33 dashboards in this repo are GrafanaDashboard CRs and are already
+  # safe in Git. What this protects is the operator's SQLite state — local users,
+  # preferences, annotations, alert-rule state and any dashboard created ad hoc in
+  # the UI — none of which is reconstructable from Git.
+  - ../../../../components/volsync/nfs
+  - ../../../../components/volsync/remote
+patches:
+  # sourcePVC templates to ${APP} = "grafana"; the operator names the claim
+  # grafana-pvc. Patched locally to avoid touching the shared component.
+  - target:
+      kind: ReplicationSource
+    patch: |-
+      - op: replace
+        path: /spec/sourcePVC
+        value: grafana-pvc


### PR DESCRIPTION
Audit of live PVCs vs ReplicationSources found **99 sources already covering the estate** and only ten unprotected volumes. Most are caches or regenerable metrics (netdata TSDB, llama model caches, plex-auto-languages). These three hold state that can't be rebuilt:

| PVC | Size | What it holds |
|---|---|---|
| `gatus` | 5Gi | uptime / status history |
| `grafana-pvc` | 10Gi | operator SQLite — local users, preferences, annotations, alert-rule state, ad-hoc UI dashboards |
| `sf-gamedata` | 30Gi | Satisfactory save games |

On Grafana specifically: the **33 `GrafanaDashboard` CRs in this repo are already safe in Git** — this covers only what *isn't*.

## Why not the volsync component

Deliberately **not** using `../../../../components/volsync`. That component also ships `pvc.yaml`, which declares a PVC named `${APP}` with a `dataSourceRef` to `${APP}-dst`. All three apps already have a live volume created by something else:

- gatus → the `gatus-sidecar` Helm chart (`persistence.enabled`)
- grafana → the Grafana operator, inline in the `Grafana` CR
- satisfactory → its own `pvc.yaml` as `sf-gamedata`

Pulling in the whole component would either collide on the PVC name or — worse for satisfactory and grafana, where the names differ — **provision a second empty volume and leave the real one unprotected while appearing to succeed.**

Referencing `components/volsync/nfs` and `/remote` directly gives exactly the three resources needed (ReplicationSource, ReplicationDestination, repository ExternalSecret) and touches no existing volume.

## sourcePVC patching

`sourcePVC` templates to `${APP}`, which is only correct for gatus. grafana and satisfactory get a local kustomize patch pointing at their real claims. **Patching per-app rather than parameterising the shared component keeps the blast radius here** — 40+ other apps depend on that component and their PVC names already match `${APP}`.

No new secrets: both ExternalSecrets pull from shared 1Password items (`volsync-template`, `volsync-r2-template`), and the R2 repository path is already suffixed per app.

## Verification

`kubectl kustomize` on all three directories — each renders two ReplicationSources with the intended `sourcePVC`:

| app | rendered sourcePVC |
|---|---|
| gatus | `${APP}` (→ `gatus`) |
| satisfactory | `sf-gamedata` |
| grafana | `grafana-pvc` |

and critically **no `PersistentVolumeClaim` named `${APP}`** in any of them — satisfactory still renders only its own `sf-gamedata` claim.