### PR TITLE
fix(volsync): repoint satisfactory at sf-gamedata, drop duplicate resources

### DIFF
--- a/kubernetes/apps/games/satisfactory/app/kustomization.yaml
+++ b/kubernetes/apps/games/satisfactory/app/kustomization.yaml
@@ -6,18 +6,19 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
-  # Backups only — see the note in gatus. The full volsync component would also
-  # declare a PVC named ${APP} ("satisfactory"), which is NOT this app's claim:
-  # the save data lives in ./pvc.yaml as "sf-gamedata". Pulling in the component
-  # would create a second, empty volume and leave the real one unprotected.
-  - ../../../../components/volsync/nfs
-  - ../../../../components/volsync/remote
 patches:
-  # The component templates sourcePVC as ${APP}, which resolves to "satisfactory".
-  # This app's claim is named sf-gamedata, so point both ReplicationSources at the
-  # real volume. Patching locally rather than parameterising the shared component
-  # keeps the blast radius at this app — 40+ other apps depend on that component
-  # and their PVC names already match ${APP}.
+  # ks.yaml already pulls in ../../../../components/volsync, so the
+  # ReplicationSources exist — but the component templates sourcePVC as ${APP},
+  # which resolves to "satisfactory". That is the empty 5Gi PVC the component
+  # creates, NOT this app's save data: the helmrelease mounts existingClaim
+  # "sf-gamedata" (30Gi, ./pvc.yaml).
+  #
+  # So the backup has been reporting healthy for 345 days while archiving the
+  # wrong volume, and the actual saves were never covered. Repoint both
+  # ReplicationSources at the real claim.
+  #
+  # Patched here rather than parameterising the shared component: 40+ other apps
+  # use it and their PVC names already match ${APP}.
   - target:
       kind: ReplicationSource
     patch: |-


### PR DESCRIPTION
Two problems — one pre-existing, one mine.

## Pre-existing: the backup was archiving the wrong volume for 345 days

satisfactory's `ks.yaml` **already** pulled in `components/volsync`, so ReplicationSources existed and reported healthy. But the component templates `sourcePVC` as `${APP}` → `satisfactory`, which is the **empty 5Gi PVC the component itself creates** — not the app's data. The helmrelease mounts `existingClaim: sf-gamedata` (30Gi, `./pvc.yaml`).

So the 30Gi of save data was never covered, while the backup looked green. This is exactly the silent failure mode #3878 described — it turned out to be already live here rather than hypothetical.

## Mine: #3878 duplicated resources here

#3878 added `components/volsync/nfs` and `/remote` as resources. Correct for gatus and grafana, whose `ks.yaml` do **not** include the component — but here it duplicated what `ks.yaml` already supplies:

```
may not add resource with an already registered id:
ExternalSecret.v1.external-secrets.io/${APP}-volsync-nfs
```

The Kustomization went `Ready=False` and stopped reconciling. It stuck on the previous revision, so **no running workload was affected**.

## Fix

Drop the duplicate resources, keep only the patch. Verified by simulating what Flux actually builds — appending `components:` to this kustomization the way `spec.components` does — which renders:

```
ReplicationSource  ${APP}-nfs   sourcePVC: sf-gamedata
ReplicationSource  ${APP}-r2    sourcePVC: sf-gamedata
```

with no duplicate-id error.

**Left alone:** the component still creates an unused 5Gi PVC named `satisfactory`. Harmless and already provisioned; removing it is separate cleanup — and it's the same shape as the broader question of whether the component should accept a claim-name override rather than assuming `${APP}`.