### PR TITLE
docs(kb): add KB-028 — Talos upgrade installs but the node boots the old version (BIOS NVRAM wipe)

### DIFF
--- a/docs/docs/troubleshooting/index.md
+++ b/docs/docs/troubleshooting/index.md
@@ -37,7 +37,7 @@ Work down from what you observe to the most likely entry:
     - Apple TV shows one frame of a 4K title then the Plex app freezes (force-quit to recover); the same file plays fine in Infuse → [KB-026](kb/026-plex-apple-tv-app-receive-window-deadlock.md)
 - **Talos upgrades**
     - TUPPR patch rollout stuck after drain; node cordoned and still on the old version → [KB-004](kb/004-talos-patch-rollout-gotchas-tuppr.md)
-    - Upgrade reports success but the node comes back Ready, uncordoned, and still on the old version → [KB-028](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)
+    - Upgrade reports success but the node comes back Ready, uncordoned, and still on the old version (after a BIOS flash) → [KB-028](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)
 - **CI / validation / local dev**
     - `Flate - Test` fails or skips on the `gpu-operator` namespace → [KB-005](kb/005-flate-misresolves-ngc-helmrepository-chart-urls.md)
     - Checkov CKV_K8S_21 flags a namespaced resource as `default` → [KB-006](kb/006-checkov-ckv-k8s-21-namespaced-resources.md)
@@ -72,4 +72,4 @@ Work down from what you observe to the most likely entry:
 - [KB-025: CephFS "Module ceph not found" on Talos Is a Built-in, Not a Missing Module](kb/025-cephfs-modprobe-builtin-misdiagnosis.md)
 - [KB-026: Plex Apple TV App Freezes on One Frame (Client Receive-Window Deadlock)](kb/026-plex-apple-tv-app-receive-window-deadlock.md)
 - [KB-027: A DNS Cleanup Scaled Every NFS-Backed App to Zero](kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md)
-- [KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (`LoaderEntryDefault`)](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)
+- [KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (NVRAM Wipe)](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)

--- a/docs/docs/troubleshooting/index.md
+++ b/docs/docs/troubleshooting/index.md
@@ -37,6 +37,7 @@ Work down from what you observe to the most likely entry:
     - Apple TV shows one frame of a 4K title then the Plex app freezes (force-quit to recover); the same file plays fine in Infuse → [KB-026](kb/026-plex-apple-tv-app-receive-window-deadlock.md)
 - **Talos upgrades**
     - TUPPR patch rollout stuck after drain; node cordoned and still on the old version → [KB-004](kb/004-talos-patch-rollout-gotchas-tuppr.md)
+    - Upgrade reports success but the node comes back Ready, uncordoned, and still on the old version → [KB-028](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)
 - **CI / validation / local dev**
     - `Flate - Test` fails or skips on the `gpu-operator` namespace → [KB-005](kb/005-flate-misresolves-ngc-helmrepository-chart-urls.md)
     - Checkov CKV_K8S_21 flags a namespaced resource as `default` → [KB-006](kb/006-checkov-ckv-k8s-21-namespaced-resources.md)
@@ -71,3 +72,4 @@ Work down from what you observe to the most likely entry:
 - [KB-025: CephFS "Module ceph not found" on Talos Is a Built-in, Not a Missing Module](kb/025-cephfs-modprobe-builtin-misdiagnosis.md)
 - [KB-026: Plex Apple TV App Freezes on One Frame (Client Receive-Window Deadlock)](kb/026-plex-apple-tv-app-receive-window-deadlock.md)
 - [KB-027: A DNS Cleanup Scaled Every NFS-Backed App to Zero](kb/027-dns-cleanup-scaled-nfs-apps-to-zero.md)
+- [KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (`LoaderEntryDefault`)](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)

--- a/docs/docs/troubleshooting/kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md
+++ b/docs/docs/troubleshooting/kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md
@@ -1,0 +1,180 @@
+# KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (`LoaderEntryDefault`)
+
+**Status:** Workaround documented and proven (v1.13.6 → v1.13.7). Root cause is a firmware/installer interaction; not fixed upstream. **Expect this on every future Talos upgrade** until it is.
+
+## Symptom
+
+A tuppr-driven Talos upgrade fails with a version mismatch, even though nothing looks broken:
+
+```text
+ERROR Failed to verify node  node=<node>
+  error="node <node> version mismatch: current=v1.13.6, target=v1.13.7"
+INFO  Node upgrade failed     node=<node>
+```
+
+The `TalosUpgrade` CR lands in `Failed` with `lastError: "Job failed permanently"` and `retries: 0`, and stops the batch so the remaining nodes are never attempted.
+
+What makes this confusing is that every individual step *succeeded*:
+
+- The drain completed.
+- The installer image was pulled and signature-verified.
+- The install reported `exit_code=0`.
+- The node rebooted, came back `Ready`, and was **uncordoned automatically**.
+- `kubectl get nodes` shows it healthy — just still on the **old** `osImage`.
+
+This is not the KB-004 failure mode. There the reboot never happened; here the reboot happens and the node boots the *wrong* image.
+
+## Cause
+
+Three things combine. Only the third is specific to this cluster's hardware.
+
+1. **The installer writes the new UKI and creates a direct EFI boot entry.** From the node's own log (see below), the v1.13.7 installer copies `Talos-v1.13.7.efi` onto the ESP and creates a `Boot0000` entry pointing at it.
+
+2. **The installer also sets the systemd-boot `LoaderEntryDefault` EFI variable to the version that is currently running** — not to the version it just installed. After a v1.13.6 → v1.13.7 upgrade the variable reads `Talos-v1.13.6.efi`. On a machine that boots the entry from step 1 this is invisible and harmless.
+
+3. **This hardware's firmware discards the boot entry Talos creates.** `BootOrder` stays pinned at the pre-existing fallback entry on every node, and the installer log confirms Talos cannot find any boot entry it created on a previous upgrade either:
+
+   ```text
+   Current BootOrder: [2]
+   Existing boot entries: [2]
+   Found existing Talos Linux UKI boot entries: []
+   created Talos Linux UKI boot entry at index 0
+   ```
+
+So the firmware ignores `Boot0000`, falls through to `\EFI\BOOT\BOOTX64.efi` (systemd-boot), and systemd-boot obediently honours `LoaderEntryDefault` — booting the **old** UKI. tuppr then compares the running version against the target, sees a mismatch, and correctly reports failure.
+
+Earlier upgrades worked because the variable was absent, and systemd-boot with no default selects the newest entry. The upgrade *to* v1.13.7 runs the v1.13.7 installer, which is what starts setting it.
+
+### Confirming the diagnosis
+
+Talos persists service logs to `/var/log`, and they **survive the reboot**, so the failed boot's install output is still readable. This is the single most useful command here:
+
+```bash
+export TALOSCONFIG=./talos/clusterconfig/talosconfig
+talosctl -n <node-ip> read /var/log/machined.log.1 | grep -Ei 'upgrade|install|UKI|BootOrder'
+```
+
+A successful install looks like this — note it ends in success, which is the whole point:
+
+```text
+sd-boot: found existing UKIs during upgrade: [Talos-v1.13.5.efi Talos-v1.13.6.efi]
+removing old UKI: /boot/EFI/EFI/Linux/Talos-v1.13.5.efi
+copying /usr/install/amd64/vmlinuz.efi to /boot/EFI/EFI/Linux/Talos-v1.13.7.efi
+updating EFI variables
+Current BootOrder: [2]
+Found existing Talos Linux UKI boot entries: []
+created Talos Linux UKI boot entry at index 0
+installation of v1.13.7 complete
+[talos] upgrade completed successfully: exit_code=0
+```
+
+Then confirm which entry actually booted and why:
+
+```bash
+talosctl -n <node-ip> get bootedentry -o yaml     # -> bootedEntry: talos-v1.13.6.efi
+```
+
+The EFI variables tell the rest of the story. `LoaderEntries` proves the new UKI is present and bootable; `LoaderEntryDefault` is what overrides it:
+
+```bash
+L=4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
+talosctl -n <node-ip> read /sys/firmware/efi/efivars/LoaderEntryDefault-$L |
+  python3 -c "import sys;print(sys.stdin.buffer.read()[4:].decode('utf-16-le').strip(chr(0)))"
+```
+
+If that prints the **old** version while `LoaderEntries` lists the new one, this KB applies.
+
+## Fix
+
+The install is already on disk — **do not re-run the upgrade**. Delete the `LoaderEntryDefault` variable and reboot; systemd-boot then falls back to selecting the newest UKI, which is the new version.
+
+The host mounts `efivarfs` read-only, so this cannot be done with `talosctl` alone:
+
+```text
+none /sys/firmware/efi/efivars efivarfs ro,nosuid,nodev,noexec,relatime 0 0
+```
+
+A privileged pod can mount its **own** `efivarfs` instance read-write instead. Set `nodeName` (not `nodeSelector`) so it bypasses the scheduler and still lands on a cordoned node:
+
+```yaml
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: efivar-fix
+  namespace: default
+spec:
+  nodeName: <node> # must be nodeName: the target is usually cordoned
+  restartPolicy: Never
+  tolerations:
+    - operator: Exists
+  containers:
+    - name: fix
+      image: python:3.13-alpine
+      securityContext:
+        privileged: true
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -e
+          mkdir -p /ev && mount -t efivarfs none /ev
+          python3 - <<'PY'
+          import fcntl, os, struct
+          P = "/ev/LoaderEntryDefault-4a67b082-0a4c-41cf-b6c7-440b29bb8c4f"
+          FS_IOC_GETFLAGS, FS_IOC_SETFLAGS, FS_IMMUTABLE_FL = 0x80086601, 0x40086602, 0x10
+          assert os.path.exists(P), "variable not present - nothing to do"
+          with open(P, "rb") as f:
+              print("current value:", f.read()[4:].decode("utf-16-le").strip("\x00"))
+          fd = os.open(P, os.O_RDONLY)
+          flags = struct.unpack("l", fcntl.ioctl(fd, FS_IOC_GETFLAGS, struct.pack("l", 0)))[0]
+          fcntl.ioctl(fd, FS_IOC_SETFLAGS, struct.pack("l", flags & ~FS_IMMUTABLE_FL))
+          os.close(fd)
+          os.unlink(P)
+          print("deleted:", not os.path.exists(P))
+          PY
+          umount /ev
+```
+
+The `chattr -i` step is required: efivarfs marks variables immutable, so `unlink` fails without clearing the flag first.
+
+Then drain and reboot the node normally. It comes back on the new version:
+
+```bash
+kubectl cordon <node>
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data --force --timeout=7m
+talosctl -n <node-ip> reboot
+# ~6 minutes of POST on this hardware, then:
+talosctl -n <node-ip> get bootedentry -o yaml   # -> talos-v1.13.7.efi
+kubectl uncordon <node>
+```
+
+Wait for `HEALTH_OK` before moving to the next node — see [KB-019](019-cordon-control-plane-breaks-ceph-mon-quorum.md), a cordoned control-plane node parks its affinity-pinned mon and OSDs in `Pending` and holds Ceph in `HEALTH_WARN` for as long as the cordon stands.
+
+Finally, clear the failed CR so tuppr re-plans against reality:
+
+```bash
+kubectl delete talosupgrade talos
+flux reconcile ks tuppr-upgrades -n system-upgrade --with-source=false
+```
+
+### A node may self-correct
+
+If the install happens to evict the old UKI from the ESP (Talos keeps a limited number and removes the oldest), the stale `LoaderEntryDefault` points at a file that no longer exists, systemd-boot finds no match, and it selects the newest entry — so that node boots the new version unaided. One of the three nodes behaved this way. Do not assume from one healthy node that the fleet is fine; check each one.
+
+### Do not fix it by repointing the default
+
+Setting `LoaderEntryDefault` to the *new* version (for example by pressing `d` in the systemd-boot menu over IPMI) boots the node correctly today but leaves the variable set, which recreates exactly this trap on the next upgrade. **Deleting** it restores the state a healthy node is in.
+
+## Open items
+
+1. The installer arguably should not point `LoaderEntryDefault` at the outgoing version, or should clear it once the new entry is in place. Worth raising with upstream.
+2. The firmware discarding Talos's `BootXXXX` entry is the underlying enabler and affects all nodes here. Until that changes, every Talos upgrade needs the workaround above.
+3. Because the workaround is post-hoc, a tuppr-driven upgrade will always report `Failed` for the first node and stop the batch. Budget for driving the remaining nodes by hand, or clear the variable on every node before starting.
+
+## References
+
+- KB-004 — [Talos Patch Rollout Gotchas (TUPPR)](004-talos-patch-rollout-gotchas-tuppr.md), the other reason an upgrade leaves a node on the old version
+- KB-019 — [Cordoning a Control-Plane Node Breaks Ceph Mon Quorum](019-cordon-control-plane-breaks-ceph-mon-quorum.md)
+- systemd-boot variables: <https://systemd.io/BOOT_LOADER_INTERFACE/>
+- tuppr: <https://github.com/home-operations/tuppr>

--- a/docs/docs/troubleshooting/kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md
+++ b/docs/docs/troubleshooting/kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md
@@ -1,6 +1,6 @@
-# KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (`LoaderEntryDefault`)
+# KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (NVRAM Wipe → `LoaderEntryDefault`)
 
-**Status:** Workaround documented and proven (v1.13.6 → v1.13.7). Root cause is a firmware/installer interaction; not fixed upstream. **Expect this on every future Talos upgrade** until it is.
+**Status:** Fix proven on two nodes (v1.13.6 → v1.13.7). Trigger identified as the BIOS flash off the buggy line, not a Talos regression. Expect a recurrence on the next upgrade until a Talos boot entry is restored to `BootOrder`.
 
 ## Symptom
 
@@ -26,26 +26,44 @@ This is not the KB-004 failure mode. There the reboot never happened; here the r
 
 ## Cause
 
-Three things combine. Only the third is specific to this cluster's hardware.
+**A BIOS flash wiped the NVRAM, including the EFI boot entries Talos relies on.** The upgrade itself is fine; only the boot *selection* is broken.
 
-1. **The installer writes the new UKI and creates a direct EFI boot entry.** From the node's own log (see below), the v1.13.7 installer copies `Talos-v1.13.7.efi` onto the ESP and creates a `Boot0000` entry pointing at it.
+Normally Talos writes the new UKI to the ESP and creates a direct EFI boot entry for it, which the firmware then boots. After an NVRAM wipe that entry is gone and is never re-established in `BootOrder`, so the firmware falls through to the removable-media fallback `\EFI\BOOT\BOOTX64.efi` — systemd-boot — which picks its entry from the `LoaderEntryDefault` EFI variable. That variable named the outgoing version, so the node booted the old UKI.
 
-2. **The installer also sets the systemd-boot `LoaderEntryDefault` EFI variable to the version that is currently running** — not to the version it just installed. After a v1.13.6 → v1.13.7 upgrade the variable reads `Talos-v1.13.6.efi`. On a machine that boots the entry from step 1 this is invisible and harmless.
+The installer log states it plainly. Note the empty list: Talos cannot find any boot entry it created on a previous upgrade either.
 
-3. **This hardware's firmware discards the boot entry Talos creates.** `BootOrder` stays pinned at the pre-existing fallback entry on every node, and the installer log confirms Talos cannot find any boot entry it created on a previous upgrade either:
+```text
+Current BootOrder: [2]
+Existing boot entries: [2]
+Found existing Talos Linux UKI boot entries: []
+created Talos Linux UKI boot entry at index 0
+```
 
-   ```text
-   Current BootOrder: [2]
-   Existing boot entries: [2]
-   Found existing Talos Linux UKI boot entries: []
-   created Talos Linux UKI boot entry at index 0
-   ```
+`Boot0002` is a firmware-generated fallback entry. The entry Talos creates on each upgrade does not survive into `BootOrder`, so systemd-boot decides every boot.
 
-So the firmware ignores `Boot0000`, falls through to `\EFI\BOOT\BOOTX64.efi` (systemd-boot), and systemd-boot obediently honours `LoaderEntryDefault` — booting the **old** UKI. tuppr then compares the running version against the target, sees a mismatch, and correctly reports failure.
+### Why it started when it did
 
-Earlier upgrades worked because the variable was absent, and systemd-boot with no default selects the newest entry. The upgrade *to* v1.13.7 runs the v1.13.7 installer, which is what starts setting it.
+[#3552](https://github.com/LukeEvansTech/talos-cluster/pull/3552) recorded all three sleds on **BIOS 1.4** on 2026-07-15, and documented with hardware proof that flashing *from* the buggy line (≤ 1.7) wipes the Secure Boot keys despite `PreserveSECBOOTKEY: true` — because the preservation logic runs in the *outgoing* BIOS. The boards now report **BIOS 1.9**, so that flash happened, and it took the boot entries along with the keys.
 
-### Confirming the diagnosis
+The timeline is the giveaway, and it is worth trusting over any theory about the Talos release:
+
+| Date       | Event                                         | Outcome    |
+| ---------- | --------------------------------------------- | ---------- |
+| 2026-07-11 | Talos v1.13.5 → v1.13.6                       | Success    |
+| 2026-07-15 | #3552 lands; sleds recorded on BIOS 1.4       | —          |
+| after that | BIOS flashed to 1.9 (out of band, not in Git) | —          |
+| 2026-07-26 | Talos v1.13.6 → v1.13.7                       | **Failed** |
+
+This was the first Talos upgrade after the flash.
+
+### Ruled out
+
+Two plausible-sounding explanations the evidence does **not** support. Both were tested.
+
+- **TPM unseal failing and falling back to the slot-1 static key.** `talosctl get volumestatus STATE` and `EPHEMERAL` report `encryptionSlot: 0` (the TPM slot) on all three nodes, so PCR 7 is intact and the sealed policy is valid. The slot-1 fallback added by #3552 is not engaged. It remains the right insurance for a future flash; it is simply not what happened here.
+- **A Talos v1.13.7 installer regression pointing `LoaderEntryDefault` at the outgoing version.** Contradicted twice: one node's variable names the version it *installed*, not the outgoing one, and on another the variable reappeared after a plain reboot with no installer running at all. Something writes it at boot; it is not the installer setting it backwards.
+
+## Confirming it on a node
 
 Talos persists service logs to `/var/log`, and they **survive the reboot**, so the failed boot's install output is still readable. This is the single most useful command here:
 
@@ -54,39 +72,35 @@ export TALOSCONFIG=./talos/clusterconfig/talosconfig
 talosctl -n <node-ip> read /var/log/machined.log.1 | grep -Ei 'upgrade|install|UKI|BootOrder'
 ```
 
-A successful install looks like this — note it ends in success, which is the whole point:
+A successful install ends like this — which is the whole point, the install is not the problem:
 
 ```text
-sd-boot: found existing UKIs during upgrade: [Talos-v1.13.5.efi Talos-v1.13.6.efi]
-removing old UKI: /boot/EFI/EFI/Linux/Talos-v1.13.5.efi
 copying /usr/install/amd64/vmlinuz.efi to /boot/EFI/EFI/Linux/Talos-v1.13.7.efi
 updating EFI variables
 Current BootOrder: [2]
 Found existing Talos Linux UKI boot entries: []
-created Talos Linux UKI boot entry at index 0
 installation of v1.13.7 complete
 [talos] upgrade completed successfully: exit_code=0
 ```
 
-Then confirm which entry actually booted and why:
+Then confirm which entry actually booted, and what steered it:
 
 ```bash
-talosctl -n <node-ip> get bootedentry -o yaml     # -> bootedEntry: talos-v1.13.6.efi
-```
+talosctl -n <node-ip> get bootedentry -o yaml          # -> bootedEntry: talos-v1.13.6.efi
 
-The EFI variables tell the rest of the story. `LoaderEntries` proves the new UKI is present and bootable; `LoaderEntryDefault` is what overrides it:
-
-```bash
 L=4a67b082-0a4c-41cf-b6c7-440b29bb8c4f
-talosctl -n <node-ip> read /sys/firmware/efi/efivars/LoaderEntryDefault-$L |
-  python3 -c "import sys;print(sys.stdin.buffer.read()[4:].decode('utf-16-le').strip(chr(0)))"
+for v in LoaderEntryDefault LoaderEntries; do
+  echo -n "$v = "
+  talosctl -n <node-ip> read /sys/firmware/efi/efivars/$v-$L |
+    python3 -c "import sys;print(', '.join(x for x in sys.stdin.buffer.read()[4:].decode('utf-16-le').split(chr(0)) if x))"
+done
 ```
 
-If that prints the **old** version while `LoaderEntries` lists the new one, this KB applies.
+If `LoaderEntries` contains the new UKI while `LoaderEntryDefault` names the old one, this KB applies. Confirm the trigger with `talosctl -n <node-ip> read /sys/class/dmi/id/bios_version`.
 
 ## Fix
 
-The install is already on disk — **do not re-run the upgrade**. Delete the `LoaderEntryDefault` variable and reboot; systemd-boot then falls back to selecting the newest UKI, which is the new version.
+The install is already on disk — **do not re-run the upgrade**. Delete `LoaderEntryDefault` and reboot; with no default set, systemd-boot selects the newest UKI, which is the new version.
 
 The host mounts `efivarfs` read-only, so this cannot be done with `talosctl` alone:
 
@@ -94,7 +108,7 @@ The host mounts `efivarfs` read-only, so this cannot be done with `talosctl` alo
 none /sys/firmware/efi/efivars efivarfs ro,nosuid,nodev,noexec,relatime 0 0
 ```
 
-A privileged pod can mount its **own** `efivarfs` instance read-write instead. Set `nodeName` (not `nodeSelector`) so it bypasses the scheduler and still lands on a cordoned node:
+A privileged pod can mount its **own** `efivarfs` instance read-write instead. Use `nodeName` (not `nodeSelector`) so it bypasses the scheduler and still lands on a cordoned node:
 
 ```yaml
 ---
@@ -136,9 +150,9 @@ spec:
           umount /ev
 ```
 
-The `chattr -i` step is required: efivarfs marks variables immutable, so `unlink` fails without clearing the flag first.
+Clearing the immutable flag is required: efivarfs marks variables immutable, so `unlink` fails without it.
 
-Then drain and reboot the node normally. It comes back on the new version:
+Then drain and reboot the node normally:
 
 ```bash
 kubectl cordon <node>
@@ -149,32 +163,32 @@ talosctl -n <node-ip> get bootedentry -o yaml   # -> talos-v1.13.7.efi
 kubectl uncordon <node>
 ```
 
-Wait for `HEALTH_OK` before moving to the next node — see [KB-019](019-cordon-control-plane-breaks-ceph-mon-quorum.md), a cordoned control-plane node parks its affinity-pinned mon and OSDs in `Pending` and holds Ceph in `HEALTH_WARN` for as long as the cordon stands.
+Wait for `HEALTH_OK` before starting the next node — see [KB-019](019-cordon-control-plane-breaks-ceph-mon-quorum.md), a cordoned control-plane node parks its affinity-pinned mon and OSDs in `Pending` and holds Ceph in `HEALTH_WARN` for as long as the cordon stands.
 
-Finally, clear the failed CR so tuppr re-plans against reality:
+Finally clear the failed CR so tuppr re-plans against reality:
 
 ```bash
 kubectl delete talosupgrade talos
 flux reconcile ks tuppr-upgrades -n system-upgrade --with-source=false
 ```
 
-### A node may self-correct
+### A node may self-correct, and can mislead you
 
-If the install happens to evict the old UKI from the ESP (Talos keeps a limited number and removes the oldest), the stale `LoaderEntryDefault` points at a file that no longer exists, systemd-boot finds no match, and it selects the newest entry — so that node boots the new version unaided. One of the three nodes behaved this way. Do not assume from one healthy node that the fleet is fine; check each one.
+If the install happens to leave only new-version UKIs on the ESP, the stale default matches nothing, systemd-boot falls back to newest, and that node boots the new version unaided. One of the three did exactly this. Do not conclude from one healthy node that the fleet is fine — check `bootedentry` on every node.
 
 ### Do not fix it by repointing the default
 
-Setting `LoaderEntryDefault` to the *new* version (for example by pressing `d` in the systemd-boot menu over IPMI) boots the node correctly today but leaves the variable set, which recreates exactly this trap on the next upgrade. **Deleting** it restores the state a healthy node is in.
+Setting `LoaderEntryDefault` to the new version — for example by pressing `d` in the systemd-boot menu over IPMI — boots the node correctly today but leaves a default set, which recreates this trap on the next upgrade. **Deleting** it is what restores correct behaviour.
 
 ## Open items
 
-1. The installer arguably should not point `LoaderEntryDefault` at the outgoing version, or should clear it once the new entry is in place. Worth raising with upstream.
-2. The firmware discarding Talos's `BootXXXX` entry is the underlying enabler and affects all nodes here. Until that changes, every Talos upgrade needs the workaround above.
-3. Because the workaround is post-hoc, a tuppr-driven upgrade will always report `Failed` for the first node and stop the batch. Budget for driving the remaining nodes by hand, or clear the variable on every node before starting.
+1. **The real fix is to get a Talos UKI boot entry back into `BootOrder`** so the firmware stops falling through to systemd-boot. Until then every upgrade needs the workaround. Worth doing from the BIOS boot menu in the next maintenance window.
+2. Because the workaround is applied after the fact, a tuppr-driven upgrade will always fail its first node and stop the batch. Budget for driving the rest by hand.
+3. Identify what writes `LoaderEntryDefault` at boot. It reappeared on one node after deletion and a plain reboot, so deleting it is not necessarily permanent.
 
 ## References
 
 - KB-004 — [Talos Patch Rollout Gotchas (TUPPR)](004-talos-patch-rollout-gotchas-tuppr.md), the other reason an upgrade leaves a node on the old version
 - KB-019 — [Cordoning a Control-Plane Node Breaks Ceph Mon Quorum](019-cordon-control-plane-breaks-ceph-mon-quorum.md)
+- #3552 — the LUKS2 slot-1 fallback key, which documents the BIOS key-wipe behaviour that triggers this
 - systemd-boot variables: <https://systemd.io/BOOT_LOADER_INTERFACE/>
-- tuppr: <https://github.com/home-operations/tuppr>


### PR DESCRIPTION
## Why

Today's Talos patch upgrade failed on the first node with a version mismatch even though every step of the upgrade succeeded. Writing it down so the next bump doesn't cost another evening.

## Cause

**A BIOS flash wiped the NVRAM, including the EFI boot entries Talos relies on.** The upgrade is fine; only the boot *selection* is broken.

Talos writes the new UKI and creates a direct EFI boot entry for it. After the wipe that entry is gone and never re-established in `BootOrder`, so the firmware falls through to the removable-media fallback (systemd-boot), which selects on `LoaderEntryDefault`. That named the outgoing version, so the node booted the old image.

#3552 recorded all three sleds on **BIOS 1.4** and proved that flashing off the buggy line wipes the Secure Boot keys, because the preservation logic runs in the *outgoing* BIOS. The boards now report **1.9**. The last upgrade before that flash succeeded; this was the first one after it.

## Correction

The first commit on this branch blamed the v1.13.7 installer for pointing `LoaderEntryDefault` at the outgoing version. That was inferred from before/after state on one node and does not hold up — a second commit corrects it. Two measurements contradict it: one node's variable names the version it *installed*, and on another the variable reappeared after a plain reboot with no installer running. It is written at boot, not set backwards by the installer.

Also records the TPM theory as tested and **excluded**: STATE and EPHEMERAL report `encryptionSlot: 0` on all three nodes, so PCR 7 is intact and the slot-1 static fallback from #3552 is not engaged.

## What it covers

- Distinguishing this from KB-004 (there the reboot never happens; here it happens and boots the wrong image)
- Confirming it from the persisted `/var/log/machined.log.1`, which survives the reboot, plus `bootedentry`, the EFI variables, and `bios_version`
- Clearing the variable: `efivarfs` is read-only on the host, so it needs a privileged pod mounting its own instance read-write and clearing the immutable flag before unlinking
- Traps: a node that self-corrects can mask the problem on its peers, and repointing the default instead of deleting it recreates the failure
- Durable fix: restore a Talos UKI boot entry to `BootOrder` so the firmware stops falling through to systemd-boot

## Notes

Docs-only. `docs/` is owned by the zensical toolchain and excluded from prettier and markdownlint in lefthook, so the index diff is just the two entries.