### PR TITLE
fix(security): restrict kopia backup browser to health probes and monitor

### DIFF
--- a/kubernetes/apps/default/homepage/app/resources/services.yaml
+++ b/kubernetes/apps/default/homepage/app/resources/services.yaml
@@ -221,11 +221,6 @@
         href: https://certwarden.${SECRET_DOMAIN}
         siteMonitor: https://certwarden.${SECRET_DOMAIN}
         description: Certificate management
-    - Kopia:
-        icon: kopia.svg
-        href: https://kopia.${SECRET_DOMAIN}
-        siteMonitor: https://kopia.${SECRET_DOMAIN}
-        description: Backups
     - Backrest:
         icon: mdi-backup-restore
         href: https://backrest.${SECRET_DOMAIN}

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -67,17 +67,6 @@ spec:
         ports:
           http:
             port: *port
-    route:
-      app:
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-        hostnames:
-          - kopia.${SECRET_DOMAIN}
-        rules:
-          - backendRefs:
-              - name: kopia
-                port: 80
     configMaps:
       config:
         data:

--- a/kubernetes/apps/volsync-system/kopia/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ./externalsecret.yaml
   - ./gatus.yaml
   - ./helmrelease.yaml
+  - ./networkpolicy.yaml
   - ./ocirepository.yaml

--- a/kubernetes/apps/volsync-system/kopia/app/networkpolicy.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/networkpolicy.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kopia-default-deny-ingress
+spec:
+  # The kopia web UI runs --without-password, so the ClusterIP :80 is an unauthenticated
+  # read/restore path to every app's volsync backup. volsync-system is deliberately
+  # EXCLUDED (NotIn) from every clusterwide baseline policy (allow-kube-apiserver,
+  # allow-same-namespace, allow-prometheus-scraping), so the pod is otherwise
+  # default-ALLOW to every pod cluster-wide. This app-local policy is the ONLY ingress
+  # policy selecting the pod, so it flips it to default-deny and must re-supply the host
+  # ingress itself: the kubelet liveness/readiness probes are httpGet / :80 from
+  # reserved:host, and Cilium's allow-localhost:auto implicit localhost allow is
+  # suppressed by the host-selecting clusterwide rule — without this the pod
+  # CrashLoopBackOffs (silently, since ks.yaml sets wait: false). Admin access to the
+  # web UI is by `kubectl port-forward` only (the LAN-facing HTTPRoute was removed).
+  description: "Default-deny ingress for kopia; allow only host/kube-apiserver health probes and the observability Gatus monitor"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: kopia
+  ingress:
+    - fromEntities:
+        - host
+        - remote-node
+        - kube-apiserver
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "80"
+              protocol: TCP


### PR DESCRIPTION
## What

The `kopia` backup-repository web UI in `volsync-system` runs with `--without-password`, so it served an **unauthenticated, fully-decrypted browse/restore view of every VolSync PVC backup** (database dumps, config, and any secrets captured in PVCs) to anyone who could reach it. It was reachable two ways:

- a LAN-facing `HTTPRoute` on `envoy-internal` (`kopia.${SECRET_DOMAIN}`), and
- the in-cluster ClusterIP `:80` — and because `volsync-system` is deliberately excluded (`NotIn`) from every clusterwide Cilium baseline policy, the pod was **default-allow ingress from every pod in the cluster**.

The repository encryption key (`KOPIA_PASSWORD`) was doing no access-control work, since the server opens the repo with it and then serves the decrypted contents with auth disabled.

## Changes

- **Remove the `route:` block** from the kopia HelmRelease — the UI is no longer LAN-reachable. Admin access is now via `kubectl port-forward`. The Service and Deployment are untouched.
- **Add an app-local `CiliumNetworkPolicy`** (`networkpolicy.yaml`) that flips the pod to default-deny ingress, allowing only:
  - `host` / `remote-node` / `kube-apiserver` — the kubelet health probes on `:80`. This namespace is excluded from the clusterwide `allow-kube-apiserver` policy, so the host allow **must** be re-supplied here or the pod would silently CrashLoopBackOff on failed probes (`ks.yaml` has `wait: false`, so CI/flate would stay green while it crashlooped).
  - the `observability` namespace on `:80` — the existing Gatus uptime monitor.
- **Drop the now-dead kopia homepage tile.**

VolSync's own backup/restore movers use `filesystem:///repository` (a direct NFS mount) and never touch this web deployment, so backups are unaffected.

## How this was produced and verified

This fix came out of a Claude Security scan of `kubernetes/` and was **verified by a panel of agents** — an independent verifier plus a fresh adversarial reviewer of the bare diff. It closes findings F2 (auth-bypass / LAN route) and F3 (info-disclosure / in-cluster ClusterIP), which were the same sink under two lenses.

**One caveat for the reviewer:** the behaviour-unchanged guarantee **rests on review of the Cilium policy model, not a live test** — there is no network-policy enforcement test in this repo, so `flate`/`kustomize` validated rendering only. Worth a sanity check that the kopia pod stays healthy and Gatus still reports it up after apply.

## Validation

- Super-linter (`slim-v8`, the CI image) — clean on all four files (YAML, prettier, editorconfig, codespell).
- `flate test all --namespace volsync-system` — 9 passed; `flate build hr kopia` renders **0 HTTPRoutes**; `flate build hr homepage` renders 0 kopia references.

## Follow-ups (not in this PR)

The same scan surfaced two more findings that need an **owner decision** and were deliberately not auto-patched:

- **Mosquitto MQTT broker allows anonymous access** (`kubernetes/apps/home/mosquitto`) — no manifest-only fix that doesn't break the existing anonymous clients (zigbee2mqtt, Home Assistant); needs a choice between MQTT auth, VLAN segmentation, or cluster-wide policy surgery.
- **OPNsense config-backup sends admin credentials over TLS with `--no-check-certificate`** (`kubernetes/apps/network/opnsense-config-backup`) — OPNsense presents a self-signed cert and no CA is available in-repo, so a fix needs the OPNsense trust anchor provisioned (ExternalSecret-templated CA + `--ca-certificate`) or the cert moved onto a trusted CA.
