### PR TITLE
feat(seedbox): scrape SMART attributes and alert on disk decline

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -6,8 +6,8 @@ metadata:
   name: seedbox.rules
 spec:
   groups:
-    # Combined availability reading. seedbox:up:ratio = fraction of the 5 tailnet
-    # scrape sensors currently reachable (0..1). NB all 5 ride the same tailnet
+    # Combined availability reading. seedbox:up:ratio = fraction of the 6 tailnet
+    # scrape sensors currently reachable (0..1). NB all 6 ride the same tailnet
     # egress, so this measures MONITORING-PATH health, not true box-up — the
     # independent public-IP blackbox probe (probe_success{job="seedbox-public"})
     # is the box-up anchor. Dashboards graph both for the overall picture.
@@ -60,6 +60,48 @@ spec:
           expr: |-
             up{job="seedbox-qbittorrent"} == 0
           for: 20m
+          labels:
+            severity: warning
+        # ---- disk health -------------------------------------------------------
+        # The shared smartctl-exporter.rules already cover overall SMART status and
+        # temperature for every scraped device (no job selector), so they pick the
+        # seedbox up for free. What they do NOT cover is the SATA attribute pair
+        # that actually predicts a spinning disk dying, so those live here.
+        #
+        # `attribute_value_type="raw"` is load-bearing: the exporter emits the same
+        # attribute_name four times (raw/value/worst/thresh) and the normalised
+        # forms count DOWN from 100, so omitting it both double-counts and inverts.
+        #
+        # Baseline 2026-07-27: sda/sdb/sdd 0 reallocated, sdc (ST8000DM002) 8.
+        # sdc's standing 8 is why this is delta() not `> 0` — the alert is for
+        # GROWTH, otherwise it would fire permanently on a stable count.
+        - alert: SeedboxDiskReallocatedSectorsGrowing
+          annotations:
+            summary: "Seedbox disk {{ $labels.device }} reallocated {{ $value }} more sectors in 24h (drive is consuming spares) — plan a replacement."
+          expr: |-
+            delta(
+              smartctl_device_attribute{
+                job="seedbox-smartctl",
+                attribute_name="Reallocated_Sector_Ct",
+                attribute_value_type="raw"
+              }[24h]
+            ) > 0
+          for: 30m
+          labels:
+            severity: warning
+        # Pending sectors are reads the drive could not complete and has not yet
+        # remapped. Unlike the reallocated count there is no acceptable standing
+        # value, so any non-zero reading is the alert.
+        - alert: SeedboxDiskPendingSectors
+          annotations:
+            summary: "Seedbox disk {{ $labels.device }} has {{ $value }} pending sector(s) — unreadable data awaiting remap; RAID5 rebuild risk."
+          expr: |-
+            smartctl_device_attribute{
+              job="seedbox-smartctl",
+              attribute_name="Current_Pending_Sector",
+              attribute_value_type="raw"
+            } > 0
+          for: 15m
           labels:
             severity: warning
         # Prometheus retention is 14d → a calendar-month sum is not computable.

--- a/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
@@ -95,3 +95,29 @@ spec:
     - action: replace
       targetLabel: instance
       replacement: seedbox
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name seedbox-smartctl
+spec:
+  # smartctl-exporter on the seedbox host (:9633) — per-disk SMART attributes.
+  # netdata's mdstat alarms only catch a disk once it has DROPPED OUT of the
+  # array; this is the upstream signal (reallocated/pending sectors) that
+  # precedes that. See seedbox-apps apps/smartctl-exporter.
+  staticConfigs:
+    - targets:
+        - seedbox.observability.svc.cluster.local:9633
+  metricsPath: /metrics
+  # 300s not 60s: smartctl shells out to all four spinning disks per scrape, and
+  # the attributes move on a timescale of days — a 5x cheaper scrape loses nothing.
+  scrapeInterval: 300s
+  scrapeTimeout: 30s # tailnet-egress scrapes are slow; 30s stops false up=0 (see node job)
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: seedbox


### PR DESCRIPTION
Cluster side of the seedbox disk-monitoring gap. Pairs with [seedbox-apps#46](https://github.com/LukeEvansTech/seedbox-apps/pull/46), which adds the exporter itself.

## Why

netdata's `mdstat_disks` alarms fire when a disk has **already dropped out** of the array. Nothing watched per-disk SMART attributes, so the slow decline before that was invisible:

| Disk | Model | Power-on | Realloc | Pending |
|---|---|---|---|---|
| sda | Toshiba MG05ACA800E | 53,885h (6.2y) | 0 | 0 |
| sdb | Toshiba MG05ACA800E | 53,875h (6.2y) | 0 | 0 |
| **sdc** | **Seagate ST8000DM002** | 3,329h | **8** | 0 |
| sdd | Toshiba MG05ACA800E | 53,878h (6.2y) | 0 | 0 |

The array itself is healthy — `[UUUU]`, `State: clean`, and a full 22TB `raid-check` scrub completed 27 Jul 00:53 in 23h53m with no mismatches.

## Changes

- **ScrapeConfig `seedbox-smartctl`** → `:9633` over the existing tailnet egress Service (one Service already covers every seedbox port, so no egress change needed). `scrapeInterval: 300s` rather than 60s — smartctl shells out to four spinning disks per scrape and these attributes move over days.
- **Two alerts** the shared `smartctl-exporter.rules` don't cover. Those rules carry no job selector, so `SmartDeviceTestFailed` and `SmartDeviceHighTemperature` already cover these disks for free; only the SATA attribute pair needed adding.
  - `SeedboxDiskReallocatedSectorsGrowing` — `delta(...[24h]) > 0`, not a threshold. sdc's standing 8 would make a `> 0` rule fire permanently; it's *growth* that means the drive is eating spares.
  - `SeedboxDiskPendingSectors` — any non-zero, since pending sectors have no acceptable standing value.
- Both pin `attribute_value_type="raw"`. The exporter emits each attribute four times (raw/value/worst/thresh) and the normalised forms count **down** from 100, so omitting it would double-count *and* invert the comparison.
- Corrects the `seedbox:up:ratio` comment — six sensors now, not five.

## Verification

- `just lint` clean (exit 0).
- `just kube flate-build-ks observability seedbox` renders; both alerts and the 5th ScrapeConfig present in the output.
- Both PromQL expressions validated against the live Prometheus API — `status: success`, empty vector (correct; the exporter isn't scraped until seedbox-apps#46 lands).
- Label names taken from real v0.14.0 exporter output captured on the box, not assumed.