### PR TITLE
feat(observability): add Nutify UPS dashboard as a remote NUT client

### DIFF
--- a/docs/docs/apps/nutify.md
+++ b/docs/docs/apps/nutify.md
@@ -1,0 +1,103 @@
+# Nutify
+
+UPS monitoring web UI in the `observability` namespace
+([DartSteven/Nutify](https://github.com/DartSteven/Nutify)) — a Flask + SQLite front end over
+Network UPS Tools, giving dashboards, historical telemetry, and scheduled reports for the UPSes
+served by the external NUT appliance.
+
+## Purpose
+
+- **Human-facing layer, not the alerting path.** Paging still runs through
+  `nut-exporter` → Prometheus → Alertmanager → Pushover (`UPSOutputOff`, `UPSMetricsMissing`,
+  `UPSUnreachable`, the battery/load rules). Nutify adds charts, energy/cost views, and emailed
+  reports on top of the same data. If Nutify is down, nothing about alerting changes — treat it as
+  optional.
+- **NUT client only.** The appliance that talks to the UPS management cards is out of cluster (it
+  has to outlive the cluster it shuts down, see the `nut-exporter` ServiceMonitor). Nutify is
+  configured in "Remote NUT Only" topology and runs no drivers, no `upsd`, and no USB stack.
+- Internal-only: exposed on `envoy-internal` at `nutify.${SECRET_DOMAIN}`.
+
+## Design decisions
+
+- **Root, but no privileges.** Upstream's compose sets `privileged: true` plus `SYS_ADMIN`,
+  `SYS_RAWIO`, `MKNOD`, a `/dev` bind and `device_cgroup_rules` — all of that is the USB-attached-UPS
+  path. As a remote client none of it applies, so the pod only sets `runAsNonRoot: false`. Root is
+  still required: PID 1 is a bash entrypoint that creates and chowns `/var/run/nut`, `/var/log/nut`
+  and `/etc/nut` before starting the Flask app in the foreground, with no privilege drop.
+- **`SKIP_PERMCHECK: "true"`.** Without it the entrypoint `chown -R root:nut /dev/bus/usb` (harmless
+  warning when absent) and sets the suid bit on `upsc`/`upscmd`/`upsrw`. Neither is wanted here.
+- **`ENABLE_LOG_STARTUP` is deliberately left unset.** Setting it to `Y` makes
+  `start-services.sh` dump the whole environment — `SECRET_KEY` included — to stdout, which would
+  put the key in VictoriaLogs. Unset, the startup banner and summary still print and only the
+  post-boot chatter goes to `/dev/null`. Set it temporarily when debugging a boot failure, then
+  remove it.
+- **`UDEV` is not set.** The upstream compose passes `UDEV=1`, but nothing in the image's scripts or
+  Python reads it — it is a leftover from an older base image.
+- **`SSL_ENABLED: "false"`.** TLS terminates at the gateway. This also short-circuits the
+  entrypoint's self-signed certificate generation, so `/app/ssl` needs no volume.
+- **Arch-suffixed image tag.** Upstream publishes `latest-amd64`, `latest-raspberrypi5-arm64` and so
+  on rather than a multi-arch index, so the tag has to name the architecture: `0.2.0-amd64`,
+  digest-pinned as usual. The scheme flipped at 0.2.0 (`amd64-0.1.7.1` → `0.2.0-amd64`), so Renovate
+  only compares forward from here; the older prefix-style tags are invisible to it.
+- **`SECRET_KEY` is data-bearing, not a session salt.** It is the key Nutify encrypts stored
+  credentials with (the remote NUT monitor password, SMTP auth). Rotating it makes everything already
+  in the SQLite DB undecryptable. It lives in the `nutify` item in the `Talos` 1Password vault and
+  reaches the pod through an ExternalSecret + `envFrom`.
+- **Persistence is split by what is worth backing up.** One `ceph-block` PVC (`volsync`, 5Gi) holds
+  `/app/nutify/instance` (the SQLite DB: telemetry history, users, encrypted credentials) and
+  `/etc/nut` (the config the wizard writes; empty in the image, so mounting over it hides nothing).
+  `/app/nutify/logs` is an `emptyDir` — file logs are not worth a snapshot. `/app/nutify/config`
+  needs nothing: `settings.txt` is regenerated from the environment on every start.
+- **VolSync mover UID 1000 matches the image.** The `nut` user is `uid=1000 gid=1000`, and the
+  entrypoint chowns the DB and its directory to it, so the component defaults need no override.
+
+## Deploy gotchas
+
+- **Configuration is wizard-only — it is not GitOps.** There is no documented env var or config file
+  to preseed the topology, the remote NUT host, or the admin account; the setup wizard writes them
+  into the SQLite DB on first boot. That means **the PVC is the configuration**. Two consequences: a
+  restore from VolSync is the only way to recover the setup, and a `SECRET_KEY` change is
+  functionally a rebuild.
+- **The remote NUT address is entered in the UI, never committed.** The appliance address lives in
+  the `cluster-secrets` 1Password item for the ServiceMonitor's benefit; nothing about Nutify puts it
+  in git. Keep it that way — this repository is public.
+- **Reading NUT variables is anonymous, but `upsmon` is not.** If the wizard asks for monitor
+  credentials, they come from the appliance's own `upsd.users`, not from anything in this repo.
+- **0.2.0 is labelled "Internal Testing" upstream.** Its changelog entry carries that marker and it
+  has been the newest tag since 2026-03-28. It is the release that has the multi-UPS runtime and the
+  remote-topology wizard, which is exactly what this deployment needs, so it is the right choice —
+  but treat instability as expected, and remember the alerting path does not depend on it.
+- **Probes are TCP, not HTTP.** After setup, `/` redirects to the login page; a TCP check on 5050
+  sidesteps having to reason about which status the app returns in which state.
+- **First boot needs a long startup budget.** The SQLite schema is created before the listener opens,
+  so the startup probe is widened to `failureThreshold: 30` / `periodSeconds: 10` (the 30s default is
+  not enough).
+
+## Operational notes
+
+- Check the Kustomization, HelmRelease, and ExternalSecret:
+
+  ```bash
+  flux -n observability get kustomization nutify
+  flux -n observability get helmrelease nutify
+  kubectl -n observability get externalsecret nutify
+  ```
+
+- Confirm the pod is up and reached the summary banner:
+
+  ```bash
+  kubectl -n observability get pods -l app.kubernetes.io/name=nutify
+  kubectl -n observability logs deploy/nutify
+  ```
+
+- Complete the setup wizard at `https://nutify.${SECRET_DOMAIN}`: choose the **Remote NUT Only**
+  topology, point it at the external NUT appliance on port `3493`, add both UPSes, and create the
+  admin account. Nothing works before this step, and none of it is reproducible from git.
+- Verify the backup actually captured the configured state after the wizard:
+
+  ```bash
+  kubectl -n observability get replicationsource nutify nutify-r2
+  ```
+
+- Gatus picks the HTTPRoute up automatically. If the uptime check flaps on the login redirect,
+  annotate the route rather than weakening the app.

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -62,6 +62,7 @@ nav = [
     { "iSponsorBlockTV" = "apps/isponsorblocktv.md" },
     { "changedetection.io" = "apps/changedetection.md" },
     { "Scrypted" = "apps/scrypted.md" },
+    { "Nutify" = "apps/nutify.md" },
   ] },
   { "Troubleshooting" = [
     { "Symptom ladder" = "troubleshooting/index.md" },

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ./kube-prometheus-stack/ks.yaml
   - ./netdata/ks.yaml
   - ./nut-exporter/ks.yaml
+  - ./nutify/ks.yaml
   - ./opnsense-exporter/ks.yaml
   - ./oxidized/ks.yaml
   - ./plex-exporter/ks.yaml

--- a/kubernetes/apps/observability/nutify/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/nutify/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: nutify
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: nutify-secret
+    template:
+      data:
+        # Flask session key AND the Fernet-style key Nutify encrypts stored
+        # credentials with (the remote NUT monitor password, SMTP auth). Losing
+        # or rotating it makes everything already stored in the SQLite DB
+        # undecryptable, so treat it as data-bearing, not just a session salt.
+        SECRET_KEY: "{{ .SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: nutify

--- a/kubernetes/apps/observability/nutify/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/nutify/app/helmrelease.yaml
@@ -1,0 +1,111 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app nutify
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  values:
+    controllers:
+      nutify:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              # Arch-suffixed tags: upstream publishes latest-amd64 /
+              # latest-raspberrypi5-arm64 / … rather than a multi-arch index, so
+              # the tag has to name the architecture. All cluster nodes are
+              # amd64. The tag scheme flipped at 0.2.0 (amd64-0.1.7.1 →
+              # 0.2.0-amd64), so Renovate only tracks forward from here.
+              repository: docker.io/dartsteven/nutify
+              tag: 0.2.0-amd64@sha256:9360c038cb889c6809194110e716e22ec9a45787eb7ef3bc918a4c58bb4aac18
+            env:
+              TZ: ${TIMEZONE:=UTC}
+              SERVER_HOST: 0.0.0.0
+              SERVER_PORT: &port 5050
+              # TLS terminates at the gateway; the pod serves plain HTTP. With
+              # this false the entrypoint also skips its self-signed cert
+              # generation into /app/ssl, so that path needs no volume.
+              SSL_ENABLED: "false"
+              # Skips the entrypoint's chown/chmod of /dev/bus/usb and the suid
+              # bit it sets on the NUT client binaries. Both exist for
+              # USB-attached UPSes; this deployment is a NUT *client* against
+              # the external appliance, so /dev is never mounted and the
+              # unguarded chown would just log a warning and set pointless suid.
+              SKIP_PERMCHECK: "true"
+              # ENABLE_LOG_STARTUP is deliberately NOT set to "Y". It makes
+              # start-services.sh dump the full `env` to stdout — SECRET_KEY
+              # included — which would land the key in VictoriaLogs. Left unset,
+              # the startup banner and summary still print and only the
+              # post-boot chatter is silenced. Set it temporarily (and only
+              # temporarily) when debugging a boot failure.
+            envFrom:
+              - secretRef:
+                  name: nutify-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  # First boot creates the SQLite schema before the listener
+                  # opens; the 30s default startup budget is not enough.
+                  failureThreshold: 30
+                  periodSeconds: 10
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        # PID 1 is a bash entrypoint that creates /var/run/nut, /var/log/nut and
+        # /etc/nut and chowns them to the image's nut user before starting the
+        # Flask app in the foreground — all as root, with no privilege drop.
+        # Nothing beyond that is needed: no privileged mode, no SYS_ADMIN /
+        # SYS_RAWIO / MKNOD, no /dev bind (those are the upstream compose's
+        # USB-UPS path, which this deployment does not use).
+        runAsNonRoot: false
+    service:
+      app:
+        controller: *app
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          # SQLite database (nutify.db.sqlite) — the UPS telemetry history, the
+          # user accounts, and the encrypted credentials.
+          - path: /app/nutify/instance
+            subPath: instance
+          # The NUT config the setup wizard writes (nut.conf, upsmon.conf, …).
+          # Empty in the image, so mounting over it hides nothing.
+          - path: /etc/nut
+            subPath: nut
+      # File logs only — the app's stdout is what Kubernetes collects, and these
+      # are not worth a VolSync snapshot.
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/nutify/logs

--- a/kubernetes/apps/observability/nutify/app/kustomization.yaml
+++ b/kubernetes/apps/observability/nutify/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/nutify/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/nutify/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: nutify
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/observability/nutify/ks.yaml
+++ b/kubernetes/apps/observability/nutify/ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nutify
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/homepage
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/observability/nutify/app
+  postBuild:
+    substitute:
+      APP: *app
+      # Small: one SQLite file of UPS telemetry plus the wizard-written NUT
+      # config. Growth is bounded by Nutify's own retention settings, not by
+      # anything here.
+      VOLSYNC_CAPACITY: 5Gi
+      HOMEPAGE_GROUP: Tools
+      HOMEPAGE_ICON: network-ups-tools.svg
+      HOMEPAGE_DESCRIPTION: UPS dashboards and reports
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Adds [Nutify](https://github.com/DartSteven/Nutify) — a Flask + SQLite UI over Network UPS Tools — to the `observability` namespace, alongside `nut-exporter`.

It is the human-facing layer only. Paging still runs `nut-exporter` → Prometheus → Alertmanager → Pushover, so a Nutify outage is cosmetic rather than a loss of coverage.

## Shape

Configured as a NUT **client** in "Remote NUT Only" topology against the external NUT appliance. That drops everything upstream's compose carries for USB-attached UPSes: no `privileged: true`, no `SYS_ADMIN` / `SYS_RAWIO` / `MKNOD`, no `/dev` bind, no `device_cgroup_rules`. The pod sets `runAsNonRoot: false` and nothing else — root is still needed because PID 1 is a bash entrypoint that creates and chowns the NUT runtime directories before starting Flask, with no privilege drop.

## Non-obvious bits

- **`SKIP_PERMCHECK: "true"`** turns off the entrypoint's `/dev/bus/usb` chown and the suid bit it would otherwise set on `upsc` / `upscmd` / `upsrw`.
- **`ENABLE_LOG_STARTUP` deliberately left unset.** Setting it to `Y` makes `start-services.sh` run a bare `env`, which would put `SECRET_KEY` in the log store. The startup banner and summary still print without it.
- **`UDEV` not set** — the upstream compose passes it, but nothing in the image's scripts or Python reads it.
- **`SECRET_KEY` is data-bearing**, not a session salt: it is the key stored credentials are encrypted with. From the `Talos` vault via ExternalSecret. Rotating it is a rebuild.
- **Arch-suffixed image tag.** Upstream publishes `latest-amd64` / `latest-raspberrypi5-arm64` rather than a multi-arch index, so the tag names the architecture. The scheme flipped at 0.2.0 (`amd64-0.1.7.1` → `0.2.0-amd64`), so Renovate only compares forward from here.
- **Startup probe widened** to `failureThreshold: 30` — the SQLite schema is created before the listener opens, and the 30s default is not enough.

## Caveats worth knowing

- **Configuration is wizard-only.** There is no documented way to preseed the topology, the remote host, or the admin account — it all lands in SQLite on first boot. The PVC *is* the configuration, which makes `volsync` load-bearing rather than insurance, and means the wizard has to be run by hand after this merges.
- **0.2.0 is labelled "Internal Testing"** in upstream's changelog and has been the newest tag since 2026-03-28. It is still the right pick (it is the release with the multi-UPS runtime and the remote-topology wizard), but treat instability as expected.

## Validation

- `just kube flate-test` — 670 passed, 2 skipped, no new warnings
- `just lint` — clean across the whole codebase
- `check_internal_identifiers.py` — clean on tracked files and on the commit message
- `markdownlint-cli2` — clean on the new KB page
