### PR TITLE
feat(observability): host metrics for the NUT appliance

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ./kromgo/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./netdata/ks.yaml
+  - ./nut-appliance/ks.yaml
   - ./nut-exporter/ks.yaml
   - ./opnsense-exporter/ks.yaml
   - ./oxidized/ks.yaml

--- a/kubernetes/apps/observability/nut-appliance/app/dashboards/nut-appliance.json
+++ b/kubernetes/apps/observability/nut-appliance/app/dashboards/nut-appliance.json
@@ -1,0 +1,963 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "node-exporter scrape state. Box-down is covered by UPSUnreachable, not here.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "BLIND"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "up{job=\"nut-appliance-node\"}",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Appliance",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Time since last boot. Zincati auto-updates reboot this box, so resets are expected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 0,
+        "w": 4,
+        "h": 4
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "time() - node_boot_time_seconds{job=\"nut-appliance-node\"}",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Uptime",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The real xfs filesystem. FCOS mounts it at four paths and / is a 5 MB composefs that is permanently 100% full, so this pins mountpoint=/var. Alert at 85%.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 0,
+        "w": 4,
+        "h": 8
+      },
+      "id": 3,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "1 - (node_filesystem_avail_bytes{job=\"nut-appliance-node\", mountpoint=\"/var\"} / node_filesystem_size_bytes{job=\"nut-appliance-node\", mountpoint=\"/var\"})",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "/var used",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Why node-exporter runs as root here. POWER.md records a hand-measured idle tuning pass (525 -> 411 mW package); this makes a regression after a CMOS clear or a bios-tune.sh re-run visible. No alert on it yet - the band is not stable enough to threshold.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "watt",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_rapl_package_joules_total{job=\"nut-appliance-node\"}[$__rate_interval])",
+          "legendFormat": "package",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_rapl_core_joules_total{job=\"nut-appliance-node\"}[$__rate_interval])",
+          "legendFormat": "core",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_rapl_dram_joules_total{job=\"nut-appliance-node\"}[$__rate_interval])",
+          "legendFormat": "dram",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "CPU package power (RAPL)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "smartctl_device_percentage_used - endurance consumed. 6% at 2420 power-on hours.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smartctl_device_percentage_used{job=\"nut-appliance-smartctl\"}",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NVMe wear",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Baseline 0. Growth here is what the smartctl exporter exists to catch; the shared smartctl-exporter.rules page on any non-zero value.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 4,
+        "y": 4,
+        "w": 4,
+        "h": 4
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smartctl_device_media_errors{job=\"nut-appliance-smartctl\"}",
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NVMe media errors",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Idle baseline: CPU cores 35-36 C, NVMe 33-35 C. CPU alert at 75 C (fan/intake failure, not load); NVMe is covered by the shared smartctl rules at 65 C.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_hwmon_temp_celsius{job=\"nut-appliance-node\", chip=\"platform_coretemp_0\"}",
+          "legendFormat": "CPU {{sensor}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smartctl_device_temperature{job=\"nut-appliance-smartctl\", temperature_type=\"current\"}",
+          "legendFormat": "NVMe",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Temperatures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-core average. This box idles at roughly 1%; there is deliberately no CPU alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 8,
+        "w": 12,
+        "h": 8
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "avg by (mode) (rate(node_cpu_seconds_total{job=\"nut-appliance-node\"}[$__rate_interval]))",
+          "legendFormat": "{{mode}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "CPU by mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "No swap on this box, so exhaustion means the OOM killer. Alert at <10% available.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemTotal_bytes{job=\"nut-appliance-node\"} - node_memory_MemAvailable_bytes{job=\"nut-appliance-node\"}",
+          "legendFormat": "used",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "node_memory_MemTotal_bytes{job=\"nut-appliance-node\"}",
+          "legendFormat": "total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The LAN interface. SNMP polls, upsd clients, the PeaNUT dashboard and this scrape.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 3,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps",
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_network_receive_bytes_total{job=\"nut-appliance-node\", device=\"eno1\"}[$__rate_interval])",
+          "legendFormat": "receive",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "rate(node_network_transmit_bytes_total{job=\"nut-appliance-node\", device=\"eno1\"}[$__rate_interval])",
+          "legendFormat": "transmit",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "eno1 throughput",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 40,
+  "tags": ["nut", "appliance", "node-exporter"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Datasource",
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "NUT appliance",
+  "uid": "nut-appliance",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/apps/observability/nut-appliance/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/grafanadashboard.yaml
@@ -1,0 +1,26 @@
+---
+# Bespoke dashboard rather than the upstream "Node Exporter Full" (grafana.com
+# 1860). Two reasons: 1860 has no RAPL panel, and RAPL is the reason this box's
+# node-exporter runs as root at all; and its rootfs panels key on mountpoint="/",
+# which on FCOS 44 is a 5 MB composefs overlay reporting a permanent 100% full —
+# so the headline disk panel would be wrong rather than merely empty.
+#
+# Every query here was validated against live data before merge; there are no
+# speculative panels. Same shape as the seedbox and truenas-zfs dashboards.
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: nut-appliance
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: nut-appliance-dashboard
+    key: nut-appliance.json

--- a/kubernetes/apps/observability/nut-appliance/app/kustomization.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/kustomization.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./grafanadashboard.yaml
+  - ./prometheusrule.yaml
+  - ./scrapeconfig.yaml
+configMapGenerator:
+  - name: nut-appliance-dashboard
+    files:
+      - nut-appliance.json=./dashboards/nut-appliance.json
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    # The dashboard JSON uses Grafana's own ${DS_PROMETHEUS}/$__rate_interval
+    # macros; disable Flux postBuild var substitution so they are not clobbered
+    # to empty.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
@@ -1,0 +1,133 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: nut-appliance.rules
+spec:
+  groups:
+    # Host-level alerts for the NUT appliance. Deliberately FOUR rules, and all
+    # four are calibrated against values observed on the box on 2026-07-28 rather
+    # than against textbook defaults:
+    #
+    #   load 0.08 across 6 cores | RAM 836 MB of 7796 MB used, NO SWAP
+    #   /var 8.2 GB of 238 GB (3.4%) | coretemp 35-36 C | NVMe 33-35 C
+    #
+    # Every alert here PAGES. Alertmanager's root route sends all severities to
+    # Pushover, so `warning` is not a quiet tier and `info` is not either — the
+    # seedbox learned this the expensive way (an iowait alert calibrated at the
+    # textbook 0.4 "would have paged perpetually"). Hence a small set with wide
+    # margins, not a comprehensive one.
+    #
+    # NOT SHIPPED — a RAPL power-regression alert, despite the power series being
+    # the reason node-exporter runs as root on that box. POWER.md's tuning delta
+    # is 525 mW -> 411 mW package idle, and POWER.md itself records 394 vs 411 mW
+    # as indistinguishable run-to-run noise, so a threshold separating tuned from
+    # untuned sits inside the noise floor. Worse, a fresh 300s sample on
+    # 2026-07-28 read 261 mW — 36% below the figure recorded five days earlier,
+    # with package C-state residency moved from PC8 65% to PC9 85%. The band is
+    # not stable enough to threshold. It is graphed on the dashboard instead;
+    # revisit with a couple of weeks of history and a real working band. Shipping
+    # a number now would be guessing, which is the specific mistake the seedbox
+    # iowait alert exists to warn about.
+    - name: nut-appliance.rules
+      rules:
+        # Deliberately NOT a "box is down" alert. UPSUnreachable already covers
+        # that, at Pushover EMERGENCY priority with a 3m fuse tuned to the main
+        # UPS's ~13 minute battery — a second critical would only double-page.
+        #
+        # What that alert cannot see is host metrics dying while upsd keeps
+        # serving: a crashed exporter, a docker problem, a bad deploy. Gating on
+        # the nut-exporter scrape still succeeding turns this into exactly that
+        # statement — "the appliance is alive, but we have gone blind on it".
+        #
+        # The gate also keeps FCOS auto-updates quiet. Zincati is enabled on this
+        # box, so it reboots itself; a reboot takes upsd down too, so the gate is
+        # false and nothing fires here. 15m additionally clears the reboot itself
+        # (~2-3 min, including the consistent 50s NIC link-up delay this hardware
+        # shows on every boot).
+        #
+        # max() collapses nut-exporter's two ServiceMonitor endpoints (one per
+        # UPS) to a single scalar so `and on()` has an empty label set to match.
+        - alert: NutApplianceHostMetricsMissing
+          annotations:
+            description: >-
+              node-exporter on the NUT appliance has not been scraped for 15 minutes,
+              but nut-exporter is still reading upsd on the same host — so the box is
+              up and only its host metrics are blind. Check the monitoring stack
+              (nut-apps apps/monitoring) rather than the box itself.
+            summary: NUT appliance host metrics are missing while the box is still up.
+          expr: |-
+            up{job="nut-appliance-node"} == 0
+            and on()
+            (max(up{job="nut-exporter"}) == 1)
+          for: 15m
+          labels:
+            severity: warning
+        # Baseline 3.4% used, so this needs ~202 GB of growth — a runaway-log or
+        # runaway-image safety net, not a routine capacity watch.
+        #
+        # mountpoint="/var" is load-bearing. FCOS 44 mounts the same xfs at four
+        # places (/var, /etc, /sysroot, /sysroot/ostree/deploy/...), all reporting
+        # identical numbers, so an unpinned expression would fire four identical
+        # alerts. And "/" must NOT be used: it is a 5 MB composefs overlay that is
+        # permanently 100% full, which is why the textbook rootfs rule would page
+        # from the moment this target came up.
+        #
+        # /boot is deliberately excluded. It is 350 MB at 48%, and 85% of that is
+        # 52 MB free — already past the point where rpm-ostree can stage a kernel,
+        # so this threshold would be useless there. If /boot ever needs watching it
+        # needs its own rule and its own number, not a share of this one.
+        - alert: NutApplianceDiskFillHigh
+          annotations:
+            description: >-
+              /var on the NUT appliance is {{ $value | humanizePercentage }} full.
+              Baseline is 3.4%, so something is growing that should not be — most
+              likely container logs or unpruned images.
+            summary: NUT appliance /var is above 85% full.
+          expr: |-
+            1 - (
+              node_filesystem_avail_bytes{job="nut-appliance-node", mountpoint="/var"}
+              / node_filesystem_size_bytes{job="nut-appliance-node", mountpoint="/var"}
+            ) > 0.85
+          for: 30m
+          labels:
+            severity: warning
+        # Baseline 36 C against a Tjmax of 100 C. 75 C on a box that idles at ~1%
+        # CPU means a dead fan or a blocked intake, not work — this is a rack
+        # hardware alert wearing a temperature threshold. Set ~40 C above the
+        # working band so it cannot false-fire, and 25 C below Tjmax so it still
+        # arrives before thermal throttling rather than after.
+        #
+        # NVMe temperature is NOT covered here: the shared smartctl-exporter.rules
+        # already alert on smartctl_device_temperature > 65 with no job selector,
+        # so this target inherits it.
+        - alert: NutApplianceCPUTemperatureHigh
+          annotations:
+            description: >-
+              Hottest CPU core on the NUT appliance is {{ $value }}°C, against a
+              35-36°C idle baseline. On a box this idle that means cooling, not load —
+              check the fan and the intake.
+            summary: NUT appliance CPU temperature is high.
+          expr: |-
+            max(node_hwmon_temp_celsius{job="nut-appliance-node", chip="platform_coretemp_0"}) > 75
+          for: 15m
+          labels:
+            severity: warning
+        # Baseline 89% available. This box has NO SWAP, so memory exhaustion does
+        # not degrade — the OOM killer picks a victim, and the candidates include
+        # upsd, which is the one process on this box that must not die quietly.
+        # Only a genuine leak can reach 10%.
+        - alert: NutApplianceMemoryLow
+          annotations:
+            description: >-
+              Available memory on the NUT appliance is {{ $value | humanizePercentage }}
+              of total (baseline 89%). There is no swap on this box, so the next step is
+              the OOM killer — and upsd is a candidate.
+            summary: NUT appliance is low on available memory.
+          expr: |-
+            node_memory_MemAvailable_bytes{job="nut-appliance-node"}
+            / node_memory_MemTotal_bytes{job="nut-appliance-node"} < 0.10
+          for: 30m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
@@ -1,0 +1,78 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name nut-appliance-node
+spec:
+  # node-exporter on the NUT appliance (:9100) — CPU/memory/disk/network, plus
+  # RAPL package power. Same host as the ${NUT_SERVER_ADDR} the nut-exporter
+  # ServiceMonitor already talks to on :3493; the exporters live in nut-apps
+  # under apps/monitoring.
+  #
+  # Plain LAN scrape, no egress Service. This is the truenas-exporter shape, not
+  # the seedbox one — the seedbox needs egress.yaml because it is reached over
+  # the tailnet, and this appliance is not.
+  staticConfigs:
+    - targets:
+        - ${NUT_SERVER_ADDR}:9100
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: nut-appliance
+  metricRelabelings:
+    # Load-bearing, not tidying. Several ceph-mixin alerts are shipped with NO
+    # job selector and therefore adopt every node-exporter target in the cluster.
+    # CephNodeDiskspaceWarning joins through node_uname_info
+    # (`* on(cluster, instance) group_left(nodename) node_uname_info`), so
+    # dropping the metric here breaks that join and keeps a 5-day predict_linear
+    # on an appliance's filesystems from paging. The seedbox does the same for
+    # the same reason. Nothing else reads it — the dashboard deliberately does
+    # not show a kernel-version panel.
+    #
+    # The other two unscoped ceph node alerts were checked against this box
+    # rather than assumed, and are safe as-is:
+    #   CephNodeRootFilesystemFull — keys on mountpoint="/", which FCOS 44 does
+    #     not expose to node-exporter at all (/ is a 5 MB composefs overlay,
+    #     permanently 100% full; the real xfs surfaces as /var, /etc, /sysroot).
+    #   CephNodeInconsistentMTU — compares each device against the cluster-wide
+    #     median for that device name. Verified: eno1 1500, docker0 1500 and
+    #     tailscale0 1280 all match the existing medians, and the br-*/veth*
+    #     names are unique to this host so each is its own median.
+    - action: drop
+      sourceLabels:
+        - __name__
+      regex: node_uname_info
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name nut-appliance-smartctl
+spec:
+  # smartctl-exporter on the NUT appliance (:9633) — NVMe health for the single
+  # boot/data drive. node-exporter cannot see SMART, and smartmontools is not in
+  # the FCOS base image, so on an immutable OS a container is the only route.
+  #
+  # This target needs no rules of its own: the shared smartctl-exporter.rules
+  # carry no job selector, so it inherits smart_status / critical_warning /
+  # media_errors / available_spare / temperature for free.
+  staticConfigs:
+    - targets:
+        - ${NUT_SERVER_ADDR}:9633
+  metricsPath: /metrics
+  # 300s, matching the seedbox: SMART attributes move on a timescale of days, so
+  # a 5x cheaper scrape loses nothing.
+  scrapeInterval: 300s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: nut-appliance

--- a/kubernetes/apps/observability/nut-appliance/ks.yaml
+++ b/kubernetes/apps/observability/nut-appliance/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nut-appliance
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/nut-appliance/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  # CR-only app — the exporters run on the NUT appliance itself (nut-apps
+  # apps/monitoring), so there is nothing in-cluster to health-check. Same shape
+  # as truenas-exporter, and the reason this is NOT folded into nut-exporter/:
+  # that one deploys an actual workload and waits on it.
+  wait: false


### PR DESCRIPTION
Closes the estate's last host-metrics blind spot. The NUT appliance ran no exporters at all — the seedbox and the NAS both run node-exporter — on the one box whose job is to notice power events and outlive the cluster it shuts down. Exporters landed in `nut-apps#33` (private); this is the cluster half.

Two ScrapeConfigs against the existing `${NUT_SERVER_ADDR}`: node-exporter `:9100` at 60s, smartctl-exporter `:9633` at 300s. Plain LAN scrape — the `truenas-exporter/` shape, not the `seedbox/` one, because there is no tailnet egress to plumb.

## Why a new directory rather than extending `nut-exporter/`

Different shape: `nut-exporter` deploys a workload and waits on it (HelmRelease, `wait: true`); this is CR-only with `wait: false`. Keeping the UPS-protocol proxy separate from host metrics means retiring or replacing either does not disturb the other. Named for the **role**, not the host, so nothing here needs a leak-scanner allowlist entry and the new files stay fully scanned.

## `node_uname_info` is dropped, and that is load-bearing

Several **ceph-mixin node alerts ship with no job selector** and therefore adopt every node-exporter target in the cluster. `CephNodeDiskspaceWarning` joins through `node_uname_info`, so dropping the metric breaks that join and keeps a 5-day `predict_linear` over an appliance's filesystems from paging. The seedbox does the same for the same reason.

The other two unscoped ceph node alerts were **checked against the box rather than assumed**:

| Alert | Verdict |
| --- | --- |
| `CephNodeRootFilesystemFull` (critical) | Safe — keys on `mountpoint="/"`, which FCOS 44 does not expose to node-exporter at all. `/` is a 5 MB composefs overlay sitting at a permanent **100% full**; the real xfs surfaces as `/var`, `/etc`, `/sysroot`. Same fact is why the disk alert here pins `/var`. |
| `CephNodeInconsistentMTU` (warning, no `for:`) | Safe — compares each device to the cluster-wide median for that device name. Verified against live Prometheus: `eno1` 1500, `docker0` 1500, `tailscale0` 1280 all match existing medians; the `br-*`/`veth*` names are unique to this host so each is its own median. |

The kube-prometheus-stack node mixin scopes on `job="node-exporter"`, so `nut-appliance-node` is not swept into it.

## Four alerts, calibrated against observed values

Baseline on the box, 2026-07-28: load 0.08 across 6 cores · RAM 836 MB / 7796 MB, **no swap** · `/var` 3.4% · cores 35–36 °C · NVMe 33–35 °C, `percentage_used 6`, `media_errors 0`.

Alertmanager's root route sends **every** severity to Pushover, so `warning` is not a quiet tier. The set is deliberately small.

| Alert | Threshold | `for` | Calibration |
| --- | --- | --- | --- |
| `NutApplianceHostMetricsMissing` | `up==0` **gated on** the nut-exporter scrape still succeeding | 15m | Means "box up, metrics blind", not box-down — `UPSUnreachable` already covers box-down at *emergency* priority with a 3m fuse. The gate also keeps Zincati's auto-reboots quiet, since a reboot takes upsd down too. |
| `NutApplianceDiskFillHigh` | `/var` > 85% | 30m | Baseline 3.4% — needs ~202 GB of growth. `/boot` deliberately excluded: 85% of 350 MB is 52 MB free, already past the point rpm-ostree can stage a kernel, so the threshold would be useless there. |
| `NutApplianceCPUTemperatureHigh` | coretemp > 75 °C | 15m | Baseline 36 °C, Tjmax 100 °C. A fan/intake alert — load cannot heat this box. NVMe temp is inherited from the shared smartctl rules at 65 °C. |
| `NutApplianceMemoryLow` | `MemAvailable` < 10% | 30m | Baseline 89%, no swap, and `upsd` is an OOM candidate. |

Plus **five NVMe alerts for free** — the shared `smartctl-exporter.rules` carry no job selector and are already NVMe-aware.

## No power-regression alert (deliberate)

RAPL is the reason node-exporter runs as root on that box, but it does **not** get a threshold. `POWER.md`'s tuning delta is 525 → 411 mW package idle, and POWER.md itself records 394 vs 411 mW as indistinguishable run-to-run noise — so a threshold separating tuned from untuned sits inside the noise floor. A fresh 300 s sample on 2026-07-28 read **261 mW**, 36% below the figure recorded five days earlier, with package C-state residency moved from PC8 65% to PC9 85%. The band is not stable enough to threshold.

It is graphed instead, to revisit once there is real history. Shipping a number now would be guessing — the specific mistake the seedbox iowait alert exists to warn about.

## Dashboard

Bespoke JSON, not grafana.com 1860: 1860 has no RAPL panel, and its rootfs panels key on the composefs `/`, so its headline disk figure would be **wrong** rather than merely empty.

## Verified

- Leak scanner clean across all 1675 tracked files
- super-linter v8.6.0 run locally with this repo's CI flag set + `filter-regex-exclude`: clean
- `kustomize build` renders
- Box side already live via doco-cd; `nut-upsd` container ID and start time byte-identical before and after the deploy, 0 restarts, both UPSes still `OL` at 100%