### PR TITLE
fix(observability): min step on the nut-appliance rate panels

### DIFF
--- a/kubernetes/apps/observability/nut-appliance/app/dashboards/nut-appliance.json
+++ b/kubernetes/apps/observability/nut-appliance/app/dashboards/nut-appliance.json
@@ -379,7 +379,8 @@
         }
       ],
       "title": "CPU package power (RAPL)",
-      "type": "timeseries"
+      "type": "timeseries",
+      "interval": "1m"
     },
     {
       "datasource": {
@@ -717,7 +718,8 @@
         }
       ],
       "title": "CPU by mode",
-      "type": "timeseries"
+      "type": "timeseries",
+      "interval": "1m"
     },
     {
       "datasource": {
@@ -929,7 +931,8 @@
         }
       ],
       "title": "eno1 throughput",
-      "type": "timeseries"
+      "type": "timeseries",
+      "interval": "1m"
     }
   ],
   "refresh": "1m",


### PR DESCRIPTION
Follow-up to #3914, caught by **actually loading the dashboard** rather than trusting that the queries return data.

Three panels rendered **"No data"** while every other panel was fine — `CPU package power (RAPL)`, `CPU by mode`, `eno1 throughput`. All three, and only those three, use `rate()`.

## Cause

Grafana derives `$__rate_interval` from the **datasource's** scrape-interval setting — the 15s default — not from the job's actual interval. Over a 1h range that resolved to `rate(...[1m])`, and this job scrapes at **60s**, so a 1m window holds at most one sample and `rate()` returns nothing.

Confirmed against live data:

| window | result |
| --- | --- |
| `[1m]` | **no data** |
| `[2m]` | 258 mW |
| `[4m]` | 265 mW |
| `[5m]` | 263 mW |

Setting the panel min step to `1m` makes `$__rate_interval` = `max($__interval + 1m, 4m)`, which always spans several samples.

## Why the pre-merge check missed it

The Prometheus-side validation substituted a literal `5m` for the macro — which is precisely the window Grafana was *not* using. Parse-checking and even data-checking a query is not the same as rendering the panel. Worth remembering for the next bespoke dashboard.

Side benefit: this pins down the current RAPL reading at **~258–265 mW package**, independently matching the 261 mW that `pwr.sh` measured on the box.