### PR TITLE
fix(observability): explicit rate window on the nut-appliance panels

### DIFF
--- a/kubernetes/apps/observability/nut-appliance/app/dashboards/nut-appliance.json
+++ b/kubernetes/apps/observability/nut-appliance/app/dashboards/nut-appliance.json
@@ -350,7 +350,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_rapl_package_joules_total{job=\"nut-appliance-node\"}[$__rate_interval])",
+          "expr": "rate(node_rapl_package_joules_total{job=\"nut-appliance-node\"}[5m])",
           "legendFormat": "package",
           "range": true,
           "refId": "A"
@@ -361,7 +361,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_rapl_core_joules_total{job=\"nut-appliance-node\"}[$__rate_interval])",
+          "expr": "rate(node_rapl_core_joules_total{job=\"nut-appliance-node\"}[5m])",
           "legendFormat": "core",
           "range": true,
           "refId": "B"
@@ -372,7 +372,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_rapl_dram_joules_total{job=\"nut-appliance-node\"}[$__rate_interval])",
+          "expr": "rate(node_rapl_dram_joules_total{job=\"nut-appliance-node\"}[5m])",
           "legendFormat": "dram",
           "range": true,
           "refId": "C"
@@ -711,7 +711,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg by (mode) (rate(node_cpu_seconds_total{job=\"nut-appliance-node\"}[$__rate_interval]))",
+          "expr": "avg by (mode) (rate(node_cpu_seconds_total{job=\"nut-appliance-node\"}[5m]))",
           "legendFormat": "{{mode}}",
           "range": true,
           "refId": "A"
@@ -913,7 +913,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_network_receive_bytes_total{job=\"nut-appliance-node\", device=\"eno1\"}[$__rate_interval])",
+          "expr": "rate(node_network_receive_bytes_total{job=\"nut-appliance-node\", device=\"eno1\"}[5m])",
           "legendFormat": "receive",
           "range": true,
           "refId": "A"
@@ -924,7 +924,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_network_transmit_bytes_total{job=\"nut-appliance-node\", device=\"eno1\"}[$__rate_interval])",
+          "expr": "rate(node_network_transmit_bytes_total{job=\"nut-appliance-node\", device=\"eno1\"}[5m])",
           "legendFormat": "transmit",
           "range": true,
           "refId": "B"

--- a/kubernetes/apps/observability/nut-appliance/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/grafanadashboard.yaml
@@ -7,6 +7,18 @@
 #
 # Every query here was validated against live data before merge; there are no
 # speculative panels. Same shape as the seedbox and truenas-zfs dashboards.
+#
+# The rate() panels use an explicit [5m] window rather than $__rate_interval.
+# That macro is NOT safe for a 60s-scraped job here: it expands to
+# max($__interval + scrape, 4 * scrape) where `scrape` is the DATASOURCE's
+# scrape-interval setting — 15s by default, regardless of what this job actually
+# uses. Grafana was observed sending rate(...[1m15s]) against a 60s scrape, which
+# rarely catches two samples, so all three rate panels rendered "No data" while
+# every other panel was fine. Setting the panel Min step does not fix it: it
+# raises $__interval but leaves the `scrape` term at the datasource value.
+# An explicit window is deterministic and independent of datasource settings.
+# ⚠️ Any other estate dashboard that pairs $__rate_interval with a scrape
+# interval slower than 15s has the same latent problem.
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard


### PR DESCRIPTION
#3918 was based on a **wrong model** of `$__rate_interval` and did not fix the empty panels. Grafana's Query Inspector shows what it actually sent:

```
Expr: rate(node_rapl_package_joules_total{job="nut-appliance-node"}[1m15s])
Step: 1m0s
```

`$__rate_interval` expands to `max($__interval + scrape, 4 × scrape)`, where `scrape` is the **datasource's** scrape-interval setting — 15s by default, regardless of what the job actually uses. Setting the panel Min step raises `$__interval` but leaves that term alone, hence `1m + 15s = 1m15s`. At a 60s scrape a 75s window rarely contains two samples, so `rate()` returned 0 rows and all three rate panels rendered "No data".

Explicit `[5m]` instead: deterministic, independent of datasource settings, and the window already validated against live data (258–265 mW). The Min step from #3918 stays — it correctly stops Grafana asking for finer resolution than the job is scraped at; it just was never the fix.

## Worth knowing beyond this PR

**Any estate dashboard pairing `$__rate_interval` with a scrape interval slower than 15s has the same latent problem.** Noted in the dashboard wrapper. The `seedbox` dashboard is the obvious one to check — its jobs also scrape at 60s.

Also worth knowing for future dashboard work: **updating only the dashboard JSON ConfigMap does not reach Grafana**. The `GrafanaDashboard` CR is unchanged, so the operator does not re-read the ConfigMap until its 1h `resyncPeriod`; annotating the CR did not trigger it either. Deleting the CR and letting Flux recreate it does.