### PR TITLE
feat(observability): container lifecycle alerts for the NUT appliance

### DIFF
--- a/kubernetes/apps/infrastructure/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - ./cupdate/ks.yaml
   - ./nextdns/ks.yaml
   - ./smtp-relay/ks.yaml
+  - ./smtp2graph/ks.yaml
   - ./vlmcsd/ks.yaml

--- a/kubernetes/apps/infrastructure/smtp2graph/app/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: smtp2graph
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: smtp2graph-secret
+    template:
+      data:
+        client.key: "{{ .SMTP2GRAPH_CLIENT_KEY_B64 | b64dec }}"
+        # The whole config lives here (not a ConfigMap) so the tenant/client ids
+        # stay out of this public repo. Graph permission note: the identity holds
+        # Mail.Send ONLY as an Exchange RBAC-for-Applications assignment scoped to
+        # the forceMailbox below — it cannot send as any other mailbox.
+        config.yml: |
+          mode: full
+          receive:
+            port: 25
+            maxSize: 25m
+          send:
+            appReg:
+              tenant: "{{ .SMTP2GRAPH_TENANT }}"
+              id: "{{ .SMTP2GRAPH_CLIENT_ID }}"
+              certificate:
+                thumbprint: "{{ .SMTP2GRAPH_CERT_THUMBPRINT }}"
+                privateKeyPath: /secrets/client.key
+            forceMailbox: noreply@${SECRET_DOMAIN}
+  dataFrom:
+    - extract:
+        key: smtp2graph

--- a/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
@@ -1,0 +1,69 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: smtp2graph
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: smtp2graph
+  values:
+    controllers:
+      smtp2graph:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: smtp2graph/smtp2graph
+              tag: v1.1.5
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          smtp:
+            port: 25
+    persistence:
+      # WORKDIR is /data: config.yml is read from here and the disk queue
+      # (queue/ temp/ failed/) is created alongside it. emptyDir matches the
+      # maddy smtp-relay's queue durability — acceptable at estate volume.
+      data:
+        type: emptyDir
+        globalMounts:
+          - path: /data
+      config:
+        type: secret
+        name: smtp2graph-secret
+        globalMounts:
+          - path: /data/config.yml
+            subPath: config.yml
+            readOnly: true
+          - path: /secrets/client.key
+            subPath: client.key
+            readOnly: true
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/infrastructure/smtp2graph/app/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/infrastructure/smtp2graph/app/ocirepository.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: smtp2graph
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/infrastructure/smtp2graph/ks.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app smtp2graph
+  namespace: &namespace infrastructure
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/infrastructure/smtp2graph/app
+  postBuild: {}
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
@@ -49,19 +49,76 @@ spec:
         #
         # max() collapses nut-exporter's two ServiceMonitor endpoints (one per
         # UPS) to a single scalar so `and on()` has an empty label set to match.
+        #
+        # min() over job=~"nut-appliance-.*" covers ALL THREE appliance scrapes
+        # (node, smartctl, docker) in one rule rather than three near-identical
+        # ones — the operator response is the same for any of them, and every
+        # extra rule is another thing that can page. 15m also rides out the
+        # smartctl job's 300s interval (three missed scrapes).
         - alert: NutApplianceHostMetricsMissing
           annotations:
             description: >-
-              node-exporter on the NUT appliance has not been scraped for 15 minutes,
-              but nut-exporter is still reading upsd on the same host — so the box is
-              up and only its host metrics are blind. Check the monitoring stack
-              (nut-apps apps/monitoring) rather than the box itself.
-            summary: NUT appliance host metrics are missing while the box is still up.
+              At least one appliance exporter (node, smartctl or docker-state) has not
+              been scraped for 15 minutes, but nut-exporter is still reading upsd on the
+              same host — so the box is up and only its metrics are blind. Check the
+              monitoring stack (nut-apps apps/monitoring) rather than the box itself.
+            summary: NUT appliance metrics are missing while the box is still up.
           expr: |-
-            up{job="nut-appliance-node"} == 0
+            min(up{job=~"nut-appliance-.*"}) == 0
             and on()
             (max(up{job="nut-exporter"}) == 1)
           for: 15m
+          labels:
+            severity: warning
+        # ---- container lifecycle (docker_state_exporter) -----------------------
+        # Deliberately THREE rules, not the five truenas-docker.rules carries. This
+        # box runs six containers, and two of the NAS's five are already covered
+        # here by something better: the exporter-down case is the rule above, and
+        # OOM is NutApplianceMemoryLow plus the down/flapping rules below showing
+        # the aftermath. `container_state_oomkilled` is also sticky until the
+        # container is recreated, so it re-pages every repeatInterval — a poor
+        # trade on a box this small.
+        #
+        # Scoped to the doco-cd-managed fleet so a hand-run throwaway container
+        # (exactly what the exporters were tested as) can never page.
+        #
+        # These overlap UPSUnreachable when nut-upsd itself dies. That is wanted,
+        # not redundant: "container nut-upsd exited" is directly actionable where
+        # "UPS monitoring is blind" is a symptom. Different alertnames, so the
+        # critical->warning inhibit rule does not couple them.
+        - alert: NutApplianceContainerDown
+          annotations:
+            description: >-
+              Container {{ $labels.name }} on the NUT appliance is {{ $labels.status }}.
+              If this is doco-cd, GitOps has stopped and the box is drifting from
+              nut-apps with no other symptom.
+            summary: NUT appliance container {{ $labels.name }} is not running.
+          expr: |-
+            container_state_status{job="nut-appliance-docker", status=~"exited|dead", container_label_cd_doco_metadata_manager="doco-cd"} == 1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: NutApplianceContainerUnhealthy
+          annotations:
+            description: >-
+              Container {{ $labels.name }} on the NUT appliance is failing its
+              healthcheck. traefik, doco-cd and nut-upsd all define one.
+            summary: NUT appliance container {{ $labels.name }} is unhealthy.
+          expr: |-
+            container_state_health_status{job="nut-appliance-docker", status="unhealthy"} == 1
+          for: 5m
+          labels:
+            severity: warning
+        - alert: NutApplianceContainerFlapping
+          annotations:
+            description: >-
+              Container {{ $labels.name }} on the NUT appliance restarted {{ $value }}
+              times in the last hour — a crash loop, which `restart: unless-stopped`
+              will hide indefinitely.
+            summary: NUT appliance container {{ $labels.name }} is crash-looping.
+          expr: |-
+            changes(container_restartcount{job="nut-appliance-docker"}[1h]) > 3
+          for: 5m
           labels:
             severity: warning
         # Baseline 3.4% used, so this needs ~202 GB of growth — a runaway-log or

--- a/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
@@ -76,3 +76,37 @@ spec:
     - action: replace
       targetLabel: instance
       replacement: nut-appliance
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name nut-appliance-docker
+spec:
+  # docker_state_exporter on the appliance (:9419) — per-container state, health,
+  # restart count and OOM-kill, keyed by container NAME.
+  #
+  # Closes a real hole: upsd dying is covered by UPSUnreachable / UPSMetricsMissing
+  # and the two host exporters are covered by their own scrapes failing, but
+  # traefik, peanut and doco-cd dying were invisible. A dead doco-cd is the worst
+  # of those — GitOps silently stops and the box drifts from its repo with no
+  # symptom at all.
+  staticConfigs:
+    - targets:
+        - ${NUT_SERVER_ADDR}:9419
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: nut-appliance
+  metricRelabelings:
+    # Drop the noisy per-container label set (compose/doco-cd digests, image refs,
+    # container ids) but KEEP cd_doco_metadata_manager, so "container down" can be
+    # scoped to the GitOps-managed fleet and a hand-run throwaway never pages.
+    # Same shape as the truenas-docker-exporter job.
+    - action: labelkeep
+      regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager

--- a/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml
@@ -16,6 +16,20 @@ spec:
         #
         # The NUT server is now an appliance OUTSIDE the cluster, so this alert
         # additionally covers the LAN path to it, not just a pod.
+        #
+        # 3m was checked against real history 2026-07-28 rather than left on trust,
+        # because the appliance runs FCOS with Zincati auto-updates and therefore
+        # reboots itself. Every routine reboot in the 14d retention window measured
+        # 45-120s of up==0 (07-27 60s, 07-26 60s/90s, 07-23 120s, 07-22 105s,
+        # 07-21 105s/45s), so 180s clears them all with ~50% margin and this has
+        # NOT been false-firing on reboots. Raising it to 5m was considered and
+        # rejected: it would buy nothing measurable and cost 2 of the ~13 battery
+        # minutes before anyone learns UPS monitoring has gone blind.
+        # Caveat: no Zincati UPGRADE reboot has occurred since the appliance became
+        # the only NUT server (last upgrade 07-20, Phase C landed 07-22), so that
+        # case is unmeasured. On FCOS the new deployment is staged before reboot,
+        # so it should be comparable — but if this ever does false-fire, measure
+        # the actual window before changing the number.
         - alert: UPSUnreachable
           annotations:
             description: >-


### PR DESCRIPTION
Adds the `nut-appliance-docker` scrape job (docker_state_exporter `:9419`, `nut-apps#34`) and three alerts.

Closes a real hole: `nut-upsd` dying is covered by `UPSUnreachable`/`UPSMetricsMissing` and the two host exporters by their own scrapes failing — but **`traefik`, `peanut` and `doco-cd` dying were invisible**. A dead doco-cd is the worst: GitOps silently stops and the box drifts from its repo with no symptom.

## Three rules, not the five `truenas-docker.rules` carries

Two of the NAS's five are already covered here by something better:

| NAS rule | Why not here |
| --- | --- |
| `DockerStateExporterDown` | `NutApplianceHostMetricsMissing`, now generalised to cover all three appliance scrapes |
| `ContainerOOMKilled` | `NutApplianceMemoryLow` plus the down/flapping rules show the aftermath. `container_state_oomkilled` is also **sticky** until the container is recreated, so it re-pages every `repeatInterval` — a poor trade on a six-container box where every alert goes to Pushover |

The three that remain — down, unhealthy, flapping — are scoped to the doco-cd-managed fleet via `container_label_cd_doco_metadata_manager`, so a hand-run throwaway container (exactly how these exporters were tested) can never page.

They deliberately overlap `UPSUnreachable` when `nut-upsd` itself dies. That's wanted: "container nut-upsd exited" is directly actionable where "UPS monitoring is blind" is a symptom. Different alertnames, so the critical→warning inhibit rule doesn't couple them.

## Also: `NutApplianceHostMetricsMissing` generalised

From `job="nut-appliance-node"` to `min(up{job=~"nut-appliance-.*"})` — covering all three appliance scrapes in one rule rather than adding a third near-identical exporter-down alert. The operator response is the same for any of them, and the existing `for: 15m` already rides out the smartctl job's 300s interval.

## Also: `UPSUnreachable` stays at `for: 3m`, and now says why

I'd flagged that FCOS auto-updates might make a routine reboot page at emergency priority. **Measured against 14 days of real history, that was wrong** — every routine reboot showed 45–120 s of `up==0`:

| Reboot | `up==0` duration |
| --- | --- |
| 07-27 17:40 | 60 s |
| 07-26 19:20 | 60 s / 90 s |
| 07-23 13:04 | 120 s |
| 07-22 12:44 | 105 s |
| 07-21 16:00 | 105 s / 45 s |

180 s clears them all with ~50% margin, so it has not been false-firing. Raising it to 5m was considered and **rejected**: it buys nothing measurable and costs 2 of the ~13 battery minutes before anyone learns UPS monitoring has gone blind. The measurement is now recorded in the rule so the next person doesn't re-litigate it from a guess, as I did.

Caveat recorded too: no Zincati *upgrade* reboot has happened since the appliance became the only NUT server (last upgrade 07-20, Phase C landed 07-22), so that case is unmeasured.

## Verified

- Leak scanner clean across all 1680 tracked files
- `kustomize build` renders all 5 resources
- super-linter v8.6.0 locally with this repo's CI flag set: clean