### PR TITLE
fix(seedbox): explicit rate window — three panels were silently empty

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
+++ b/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
@@ -290,7 +290,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_network_receive_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[$__rate_interval])",
+          "expr": "rate(node_network_receive_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[5m])",
           "legendFormat": "receive",
           "range": true,
           "refId": "A"
@@ -301,21 +301,22 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_network_transmit_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[$__rate_interval])",
+          "expr": "rate(node_network_transmit_bytes_total{job=\"seedbox-node\",device=\"eno0\"}[5m])",
           "legendFormat": "transmit",
           "range": true,
           "refId": "B"
         }
       ],
       "title": "eno0 throughput",
-      "type": "timeseries"
+      "type": "timeseries",
+      "interval": "1m"
     },
     {
       "datasource": {
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "md4 is the RAID5 data array — healthy is active=4, failed=0, spare=0.",
+      "description": "md4 is the RAID5 data array \u2014 healthy is active=4, failed=0, spare=0.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -556,14 +557,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg by (mode) (rate(node_cpu_seconds_total{job=\"seedbox-node\",mode!=\"idle\"}[$__rate_interval]))",
+          "expr": "avg by (mode) (rate(node_cpu_seconds_total{job=\"seedbox-node\",mode!=\"idle\"}[5m]))",
           "legendFormat": "{{mode}}",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "CPU by mode",
-      "type": "timeseries"
+      "type": "timeseries",
+      "interval": "1m"
     },
     {
       "datasource": {
@@ -692,7 +694,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Fraction of each second the disk spent doing I/O — 1.0 means saturated.",
+      "description": "Fraction of each second the disk spent doing I/O \u2014 1.0 means saturated.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -772,14 +774,15 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "rate(node_disk_io_time_seconds_total{job=\"seedbox-node\",device=~\"sd[a-z]\"}[$__rate_interval])",
+          "expr": "rate(node_disk_io_time_seconds_total{job=\"seedbox-node\",device=~\"sd[a-z]\"}[5m])",
           "legendFormat": "{{device}}",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Disk I/O per device",
-      "type": "timeseries"
+      "type": "timeseries",
+      "interval": "1m"
     },
     {
       "datasource": {
@@ -880,7 +883,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Instantaneous transfer speeds reported by qBittorrent (already gauges — no rate()).",
+      "description": "Instantaneous transfer speeds reported by qBittorrent (already gauges \u2014 no rate()).",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1095,7 +1098,7 @@
           "refId": "C"
         }
       ],
-      "title": "Seedbox availability — box vs scrape path vs qBit",
+      "title": "Seedbox availability \u2014 box vs scrape path vs qBit",
       "type": "timeseries"
     }
   ],

--- a/kubernetes/apps/observability/seedbox/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/seedbox/app/grafanadashboard.yaml
@@ -1,6 +1,18 @@
 ---
 # Hand-built: no public dashboard matches this mixed node/qbittorrent/seedbox
 # schema. DS_PROMETHEUS mapped via spec.datasources (house pattern).
+#
+# The rate() panels use an explicit [5m] window, NOT $__rate_interval. That macro
+# expands to max($__interval + scrape, 4 * scrape) where `scrape` is the
+# DATASOURCE's scrape-interval setting — 15s by default, regardless of what the
+# job actually uses. Every seedbox job here scrapes at 60s (300s for smartctl),
+# so at short time ranges the macro resolved to a window too narrow to hold two
+# samples and "eno0 throughput", "CPU by mode" and "Disk I/O per device"
+# rendered "No data". Diagnosed on nut-appliance (talos-cluster #3919), where
+# Grafana's Query Inspector showed it sending rate(...[1m15s]) against a 60s job.
+# Setting the panel Min step alone does NOT fix it — it raises $__interval but
+# leaves the `scrape` term at the datasource value. The Min step is still set
+# here, correctly, to stop Grafana asking for finer resolution than the scrape.
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard


### PR DESCRIPTION
Same bug diagnosed on `nut-appliance` in #3919, found by checking whether it applied elsewhere. **It did.**

`eno0 throughput`, `CPU by mode` and `Disk I/O per device` all use `rate()` with `$__rate_interval` and no Min step, against jobs that scrape at **60s**.

`$__rate_interval` expands to `max($__interval + scrape, 4 × scrape)` where `scrape` is the **datasource's** scrape-interval setting — 15s by default, not the job's. Grafana was observed sending `rate(...[1m15s])` against a 60s job on `nut-appliance`, and a 75s window rarely holds two samples.

## Verified against live seedbox data, which settles it

| window | result |
| --- | --- |
| `[1m15s]` — what the macro sent | **0 series on all three panels** |
| `[5m]` | `eno0` 1 series (2199 B/s), `CPU by mode` 7 series, `Disk I/O` 4 series |

So these panels have been rendering **"No data"**, not merely being coarse.

Explicit `[5m]` is deterministic and independent of datasource settings. Min step `1m` is also set — it does *not* fix the window (it raises `$__interval`, not the `scrape` term) but it correctly stops Grafana asking for finer resolution than the job is scraped at.

## Note for whoever deploys this

Updating only the dashboard JSON does **not** reach Grafana: the `GrafanaDashboard` CR is unchanged, so grafana-operator waits out its 1h `resyncPeriod` while Flux *and* the CR both report success (`.status.lastResync` is the tell). Annotating the CR doesn't trigger it. `kubectl delete grafanadashboard seedbox` + a Flux reconcile does.