### PR TITLE
feat(observability): scrape doco-cd on the NUT appliance

### DIFF
--- a/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
@@ -109,6 +109,33 @@ spec:
           for: 5m
           labels:
             severity: warning
+        # ---- GitOps freshness (doco-cd's own metrics) --------------------------
+        # NutApplianceContainerDown catches doco-cd's container exiting; this
+        # catches the worse case, where the container is up and healthy but has
+        # stopped POLLING. Nothing deploys, the box drifts from nut-apps, and
+        # there is no other symptom — the failure this whole job exists for.
+        #
+        # doco_cd_polls_total only counts SUCCESSFUL polls, so a stalled or
+        # erroring poller shows up as the counter not moving; there is no error
+        # counter to key on instead. Poll interval is 3600s (poll-config.yml), so
+        # a 3h window is three consecutive missed polls before this says anything.
+        #
+        # No absent() arm needed: if the scrape itself dies the job stops
+        # reporting and NutApplianceHostMetricsMissing covers it, because that
+        # rule matches job=~"nut-appliance-.*" and this job is one of them.
+        - alert: NutApplianceGitOpsStalled
+          annotations:
+            description: >-
+              doco-cd on the NUT appliance has not completed a successful poll of
+              {{ $labels.repository }} in 3 hours (it polls hourly). The container may
+              be up and healthy while deploying nothing — the box is drifting from
+              nut-apps with no other symptom.
+            summary: NUT appliance GitOps has stalled — no successful doco-cd poll in 3h.
+          expr: |-
+            increase(doco_cd_polls_total{job="nut-appliance-doco-cd"}[3h]) == 0
+          for: 30m
+          labels:
+            severity: warning
         - alert: NutApplianceContainerFlapping
           annotations:
             description: >-

--- a/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
@@ -110,3 +110,35 @@ spec:
     # Same shape as the truenas-docker-exporter job.
     - action: labelkeep
       regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name nut-appliance-doco-cd
+spec:
+  # doco-cd's own metrics (:9120) — GitOps poll and deploy status for the
+  # appliance, matching the seedbox-doco-cd job.
+  #
+  # Strictly better than "the container is running", which docker_state_exporter
+  # already covers: doco_cd_polls_total is the signal that the repo is actually
+  # being polled. A doco-cd that is up but has stopped polling deploys nothing,
+  # and the box drifts from nut-apps with no other symptom.
+  #
+  # The container always served these; they were simply never published. Exposing
+  # them needed a `--publish` on the doco-cd systemd unit, declared in the Butane
+  # config under nut-apps provision/ignition/ — doco-cd deploys compose stacks, it
+  # does not manage its own unit, so that change is NOT GitOps-applied and a live
+  # box needs the unit updated by hand.
+  staticConfigs:
+    - targets:
+        - ${NUT_SERVER_ADDR}:9120
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: nut-appliance


### PR DESCRIPTION
Adds the `nut-appliance-doco-cd` job (`:9120`, published by `nut-apps#35`) and one alert.

`NutApplianceContainerDown` already catches doco-cd's *container* exiting. This catches the worse case: **the container up and healthy while having stopped polling.** Nothing deploys, the box drifts from `nut-apps`, and there is no other symptom — which is the failure this whole job exists for.

## `NutApplianceGitOpsStalled`

```promql
increase(doco_cd_polls_total{job="nut-appliance-doco-cd"}[3h]) == 0
for: 30m
```

`doco_cd_polls_total` counts only **successful** polls, so a stalled or erroring poller shows up as the counter not moving — there is no error counter to key on instead. Poll interval is `3600s` (`poll-config.yml`), so a 3h window is three consecutive missed polls before this says anything.

No `absent()` arm needed: if the scrape itself dies, the job stops reporting and `NutApplianceHostMetricsMissing` covers it — that rule matches `job=~"nut-appliance-.*"` and this is one of them. The generalisation made in #3921 pays for itself here.

## Verified

- `:9120` published on the box and serving; **18 `doco_cd_*` series reachable from a cluster pod**
- Leak scanner clean across all 1680 tracked files
- `kustomize build` renders all four scrape jobs
- super-linter v8.6.0 locally with this repo's CI flag set: clean