### PR TITLE
feat(infrastructure): move the smtp LB IP and hostname to smtp2graph

### DIFF
--- a/kubernetes/apps/infrastructure/smtp-relay/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/smtp-relay/app/helmrelease.yaml
@@ -47,11 +47,10 @@ spec:
         runAsGroup: 1000
     service:
       app:
-        type: LoadBalancer
-        annotations:
-          external-dns.alpha.kubernetes.io/hostname: smtp.${SECRET_DOMAIN}
-          io.cilium/lb-ipam-ips: ${SVC_SMTP_RELAY_ADDR}
-        externalTrafficPolicy: Local
+        # ClusterIP since 2026-07-28: the LB IP (${SVC_SMTP_RELAY_ADDR}) and the
+        # smtp.${SECRET_DOMAIN} hostname moved to smtp2graph, which now fronts all
+        # off-cluster senders. In-cluster consumers still reach maddy by this
+        # Service's DNS name until they migrate.
         ports:
           smtp:
             port: *port

--- a/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
@@ -42,6 +42,11 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:
+        type: LoadBalancer
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: smtp.${SECRET_DOMAIN}
+          io.cilium/lb-ipam-ips: ${SVC_SMTP_RELAY_ADDR}
+        externalTrafficPolicy: Local
         ports:
           smtp:
             port: 25


### PR DESCRIPTION
Swaps `type: LoadBalancer` + `io.cilium/lb-ipam-ips` + the `smtp.${SECRET_DOMAIN}` external-dns annotation from `smtp-relay` to `smtp2graph` in one change so Cilium releases and re-grants the IP in a single reconcile. maddy becomes ClusterIP — in-cluster consumers unaffected. e2e (internal Delivered + external received) verified earlier today on smtp2graph.