### PR TITLE
fix(infrastructure): smtp2graph etp Cluster — Local dropped all LB traffic

### DIFF
--- a/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
@@ -46,7 +46,9 @@ spec:
         annotations:
           external-dns.alpha.kubernetes.io/hostname: smtp.${SECRET_DOMAIN}
           io.cilium/lb-ipam-ips: ${SVC_SMTP_RELAY_ADDR}
-        externalTrafficPolicy: Local
+        # No externalTrafficPolicy: Local here (unlike maddy): with one replica the
+        # Cilium L2 lease regularly lands on a node without the pod, which drops
+        # every connection. Client source IP is irrelevant on the Graph path.
         ports:
           smtp:
             port: 25


### PR DESCRIPTION
Follow-up to #3934: the first off-cluster connect failed — the L2 announcer node had no local endpoint under `externalTrafficPolicy: Local` with 1 replica. Default (Cluster) policy forwards from any node; source IP doesn't matter for the Graph path.