### PR TITLE
feat: point in-cluster mail consumers at smtp2graph

### DIFF
--- a/kubernetes/apps/default/tandoor/app/helmrelease.yaml
+++ b/kubernetes/apps/default/tandoor/app/helmrelease.yaml
@@ -44,8 +44,8 @@ spec:
               DB_ENGINE: django.db.backends.postgresql
               DEBUG: "0"
               DEFAULT_FROM_EMAIL: tandoor@${SECRET_DOMAIN}
-              EMAIL_HOST: smtp-relay.network.svc.cluster.local
-              EMAIL_PORT: "2525"
+              EMAIL_HOST: smtp2graph.infrastructure.svc.cluster.local
+              EMAIL_PORT: "25"
               ENABLE_PDF_EXPORT: "1"
               ENABLE_SIGNUP: "0"
               FRACTION_PREF_DEFAULT: "0"

--- a/kubernetes/apps/games/epicgames/app/helmrelease.yaml
+++ b/kubernetes/apps/games/epicgames/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
               EMAIL_SENDER_NAME: "Epic Games Captchas"
               RUN_ON_STARTUP: "true"
               SEARCH_STRATEGY: all
-              SMTP_HOST: smtp-relay.infrastructure.svc.cluster.local
+              SMTP_HOST: smtp2graph.infrastructure.svc.cluster.local
               SMTP_PORT: "25"
               SMTP_SECURE: "false"
             envFrom:

--- a/kubernetes/apps/infrastructure/netpol.yaml
+++ b/kubernetes/apps/infrastructure/netpol.yaml
@@ -5,11 +5,12 @@ kind: CiliumNetworkPolicy
 metadata:
   name: allow-cross-namespace-ingress
 spec:
-  description: "Allow ingress from gateway and external clients (smtp-relay, vlmcsd)"
+  description: "Allow ingress from gateway, cluster workloads (smtp2graph/smtp-relay consumers) and external clients (vlmcsd, off-cluster smtp)"
   endpointSelector: {}
   ingress:
     - fromEndpoints:
         - matchLabels:
             io.kubernetes.pod.namespace: network
     - fromEntities:
+        - cluster
         - world

--- a/kubernetes/apps/network/scanopy/app/helmrelease.yaml
+++ b/kubernetes/apps/network/scanopy/app/helmrelease.yaml
@@ -48,7 +48,7 @@ spec:
               SCANOPY_PUBLIC_URL: https://scanopy.${SECRET_DOMAIN}
               SCANOPY_WEB_EXTERNAL_PATH: /app/static
               SCANOPY_USE_SECURE_SESSION_COOKIES: "true"
-              SCANOPY_SMTP_RELAY: smtp-relay.infrastructure.svc.cluster.local:25
+              SCANOPY_SMTP_RELAY: smtp2graph.infrastructure.svc.cluster.local:25
               SCANOPY_SMTP_EMAIL: scanopy@${SECRET_DOMAIN}
             envFrom: *envFrom
             probes:

--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -59,8 +59,8 @@ spec:
               # LDAP_ATTRIBUTE_GROUP_NAME: cn
               # LDAP_ATTRIBUTE_ADMIN_GROUP: ID-Admin
               SMTP_FROM: "pocket-id@${SECRET_DOMAIN}"
-              SMTP_HOST: "smtp-relay.infrastructure.svc.cluster.local"
-              SMTP_PORT: "2525"
+              SMTP_HOST: "smtp2graph.infrastructure.svc.cluster.local"
+              SMTP_PORT: "25"
               SESSION_DURATION: "43800"
               TRUST_PROXY: "true"
               UPLOAD_PATH: /app/data/uploads


### PR DESCRIPTION
Repoints the four in-repo relay consumers at `smtp2graph.infrastructure.svc.cluster.local:25` and widens the infrastructure netpol ingress to `cluster` (it already admitted `world`; cross-namespace pods were the only thing blocked). Tenant-side prerequisites already applied and tested: each From is an alias on the relay mailbox, send-from-alias enabled, mismatched-From send verified end-to-end (was `ErrorSendAsDenied` pre-alias, delivers with sender identity intact post-alias).