### PR TITLE
fix(cronjob): reap finished jobs so a failure cannot pin KubeJobFailed

### DIFF
--- a/kubernetes/apps/infrastructure/nextdns/app/cronjob.yaml
+++ b/kubernetes/apps/infrastructure/nextdns/app/cronjob.yaml
@@ -13,6 +13,9 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      # Reap finished jobs after 24h so a failed run cannot pin KubeJobFailed
+      # (the alert clears only when the Job object is gone)
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           labels:

--- a/kubernetes/apps/network/opnsense-dns/app/restart-cronjob.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/restart-cronjob.yaml
@@ -54,6 +54,9 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      # Reap finished jobs after 24h so a failed run cannot pin KubeJobFailed
+      # (the alert clears only when the Job object is gone)
+      ttlSecondsAfterFinished: 86400
       template:
         metadata:
           labels:


### PR DESCRIPTION
## Problem

`KubeJobFailed` is `kube_job_failed > 0` — it stays true for as long as the failed Job object exists. The rule's own description says so: *"Removing failed job after investigation should clear this alert."*

`nextdns-linkip` failed one run on 2026-07-26 and has completed every hourly run since. But with `failedJobsHistoryLimit: 3` and no TTL, that dead Job sits in the API until two further failures evict it. For a job that fails roughly once every eight months, that is effectively never — so the alert had been firing for three days against a workload that was healthy.

`opnsense-dns-restarter` had the same gap.

## Fix

Set `ttlSecondsAfterFinished: 86400` on both `jobTemplate.spec`. The alert still fires and notifies on a real failure, then resolves on its own once the evidence has aged out after 24h.

`86400` is the value already used by the other five CronJobs in the tree (garage-sync, sabnzbd cleanup x2, exclusion-sync, cnpg r2-backup) — these two were the only ones missing it.

## Validation

- `flate test all` — infrastructure 17 passed, network 33 passed (2 warnings pre-existing and unrelated)
- `flate build ks nextdns` — confirms the field renders onto the CronJob
- `just lint` (super-linter, same image as CI) — all linters clean