### PR TITLE
fix(imgur-proxy): let gluetun write its public-IP file under drop-ALL caps

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -86,11 +86,21 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: info
+              # Run as root (0) rather than gluetun's default 1000. gluetun
+              # chowns the public-IP status file to PUID:PGID after every
+              # write (internal/publicip/fs.go), and this container drops ALL
+              # capabilities, so a 0 -> 1000 chown fails EPERM without
+              # CAP_CHOWN. Chowning to the existing owner is a permitted
+              # no-op, which keeps the drop-ALL context intact. Only the
+              # unused OpenVPN process user is otherwise derived from PUID
+              # (this tunnel is WireGuard), so nothing else is affected.
+              PGID: 0
               # Public IP check provider. gluetun only accepts "ipinfo" or
               # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
               # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
               PUBLICIP_API: ip2location
+              PUID: 0 # see PGID above
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h
               VERSION_INFORMATION: off
@@ -263,3 +273,21 @@ spec:
           imgur-proxy:
             gluetun:
               - path: /gluetun
+      # gluetun creates its status directory with os.MkdirAll("/tmp/gluetun",
+      # 0644), a directory with no execute bit, so nothing can traverse into
+      # it without CAP_DAC_OVERRIDE (cmd/gluetun/main.go). The other gluetun
+      # sidecars in this namespace only survive that because they keep root's
+      # default capability set; this one drops ALL, so writing the public-IP
+      # file failed with "clearing public IP data: open /tmp/gluetun/ip:
+      # permission denied" on every tunnel teardown. Pre-creating the path as
+      # an emptyDir (mode 1777) makes gluetun's MkdirAll a no-op and keeps the
+      # mode sane, with no capability grant. Nested under the `tmp` mount
+      # above; the kubelet orders nested mounts by path.
+      gluetun-tmp:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Mi
+        advancedMounts:
+          imgur-proxy:
+            gluetun:
+              - path: /tmp/gluetun


### PR DESCRIPTION
## What

gluetun in `imgur-proxy` logs `clearing public IP data: open /tmp/gluetun/ip: permission denied` on every tunnel teardown. Cosmetic, but noisy.

## Root cause

Two upstream behaviours collide with this container's hardened `securityContext`:

- `cmd/gluetun/main.go` creates its status directory with `os.MkdirAll("/tmp/gluetun", 0644)` — a directory with **no execute bit**, so traversing into it requires `CAP_DAC_OVERRIDE`.
- `internal/publicip/fs.go` chowns the written file to `PUID:PGID` (default `1000`), which requires `CAP_CHOWN`.

`imgur-proxy` is the only gluetun sidecar in `downloads` that sets `capabilities.drop: [ALL]`. qbittorrent, sabnzbd and prowlarr keep root's default capability set and silently rely on both caps, which is why only this one surfaces the error.

## Fix

Neither capability is granted back:

- Pre-create `/tmp/gluetun` as an `emptyDir` (mode `1777`), so gluetun's `MkdirAll` is a no-op on an existing directory and the path stays writable.
- Set `PUID`/`PGID` to `0`, so the chown targets the file's existing owner — permitted without `CAP_CHOWN`. `PUID` otherwise only feeds the OpenVPN process user, unused on a WireGuard tunnel.

`PUBLICIP_FILE=""` is **not** a viable alternative: v3.41.1 calls `persistPublicIP` unconditionally from both the fetch loop and `ClearData()`, so an empty path just swaps `EACCES` for `ENOENT`.

## Verification

- Reproduced and fixed against the identical `securityContext` in a throwaway in-cluster pod: a `0644` directory reproduces `EACCES`; with the `emptyDir` mounted, the write succeeds and a same-owner chown is permitted, all with `drop: [ALL]`.
- `flate test all --namespace downloads` — 27 passed.
- `just lint` (super-linter `slim-v8`) — all linters green.
- `check_internal_identifiers.py` — clean.

## Unrelated, but visible on this pod

`imgur-proxy`'s gluetun is currently `CrashLoopBackOff` with 240+ restarts, **`OOMKilled` (exit 137)** roughly 2s after start, at `[dns] downloading hostnames and IP block lists`, against its `256Mi` limit. That is a separate issue from this change and is not addressed here.