### PR TITLE
fix(downloads): apply one hardened gluetun pattern to all four sidecars

### DIFF
--- a/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/prowlarr/app/helmrelease.yaml
@@ -37,11 +37,19 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
+              # Run as root (0) rather than gluetun's default 1000: gluetun
+              # chowns its public-IP status file to PUID:PGID after every
+              # write, which needs CAP_CHOWN, and this container drops ALL
+              # capabilities. Chowning to the file's existing owner is a
+              # permitted no-op instead. PUID otherwise only feeds the
+              # OpenVPN process user, unused on a WireGuard tunnel.
+              PGID: 0
               # Public IP check provider. gluetun only accepts "ipinfo" or
               # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
               # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
               PUBLICIP_API: ip2location
+              PUID: 0 # see PGID above
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h
@@ -75,9 +83,13 @@ spec:
                   failureThreshold: 5
             restartPolicy: Always
             securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
               capabilities:
                 add:
                   - NET_ADMIN
+                drop:
+                  - ALL
               allowPrivilegeEscalation: false
             resources:
               limits:
@@ -249,3 +261,17 @@ spec:
         existingClaim: "{{ .Release.Name }}"
       tmp:
         type: emptyDir
+      # gluetun creates its status directory with os.MkdirAll("/tmp/gluetun",
+      # 0644), a directory with no execute bit, so nothing can traverse into
+      # it without CAP_DAC_OVERRIDE (cmd/gluetun/main.go). Pre-creating the
+      # path as an emptyDir (mode 1777) makes that MkdirAll a no-op and keeps
+      # the mode sane, so the public-IP file stays writable with all
+      # capabilities dropped. Paired with PUID/PGID 0 in the gluetun env.
+      gluetun-tmp:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Mi
+        advancedMounts:
+          prowlarr:
+            gluetun:
+              - path: /tmp/gluetun

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -194,11 +194,19 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
+              # Run as root (0) rather than gluetun's default 1000: gluetun
+              # chowns its public-IP status file to PUID:PGID after every
+              # write, which needs CAP_CHOWN, and this container drops ALL
+              # capabilities. Chowning to the file's existing owner is a
+              # permitted no-op instead. PUID otherwise only feeds the
+              # OpenVPN process user, unused on a WireGuard tunnel.
+              PGID: 0
               # Public IP check provider. gluetun only accepts "ipinfo" or
               # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
               # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
               PUBLICIP_API: ip2location
+              PUID: 0 # see PGID above
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h
@@ -237,6 +245,8 @@ spec:
               capabilities:
                 add:
                   - NET_ADMIN
+                drop:
+                  - ALL
               allowPrivilegeEscalation: false
             resources:
               limits:
@@ -326,3 +336,17 @@ spec:
             #   path: /mnt/speed/snatch
             #   globalMounts:
             #     - path: /speed/snatch
+      # gluetun creates its status directory with os.MkdirAll("/tmp/gluetun",
+      # 0644), a directory with no execute bit, so nothing can traverse into
+      # it without CAP_DAC_OVERRIDE (cmd/gluetun/main.go). Pre-creating the
+      # path as an emptyDir (mode 1777) makes that MkdirAll a no-op and keeps
+      # the mode sane, so the public-IP file stays writable with all
+      # capabilities dropped. Paired with PUID/PGID 0 in the gluetun env.
+      gluetun-tmp:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Mi
+        advancedMounts:
+          qbittorrent:
+            gluetun:
+              - path: /tmp/gluetun

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -163,11 +163,19 @@ spec:
               HEALTH_SERVER_DISABLE_LOOP: on
               HEALTH_VPN_DURATION_INITIAL: 60s
               LOG_LEVEL: debug
+              # Run as root (0) rather than gluetun's default 1000: gluetun
+              # chowns its public-IP status file to PUID:PGID after every
+              # write, which needs CAP_CHOWN, and this container drops ALL
+              # capabilities. Chowning to the file's existing owner is a
+              # permitted no-op instead. PUID otherwise only feeds the
+              # OpenVPN process user, unused on a WireGuard tunnel.
+              PGID: 0
               # Public IP check provider. gluetun only accepts "ipinfo" or
               # "ip2location"; ipinfo rate-limits (HTTP 429) on its free monthly
               # tier, so use ip2location for the (cosmetic) public-IP display.
               # https://github.com/qdm12/gluetun-wiki/blob/main/setup/options/others.md
               PUBLICIP_API: ip2location
+              PUID: 0 # see PGID above
               # STORAGE_FILEPATH: "" # prevent memory spike and avoid I/O
               TZ: ${TIMEZONE}
               UPDATER_PERIOD: 12h
@@ -206,6 +214,8 @@ spec:
               capabilities:
                 add:
                   - NET_ADMIN
+                drop:
+                  - ALL
               allowPrivilegeEscalation: false
             resources:
               limits:
@@ -290,3 +300,17 @@ spec:
         path: /mnt/pool/media
         globalMounts:
           - path: /media
+      # gluetun creates its status directory with os.MkdirAll("/tmp/gluetun",
+      # 0644), a directory with no execute bit, so nothing can traverse into
+      # it without CAP_DAC_OVERRIDE (cmd/gluetun/main.go). Pre-creating the
+      # path as an emptyDir (mode 1777) makes that MkdirAll a no-op and keeps
+      # the mode sane, so the public-IP file stays writable with all
+      # capabilities dropped. Paired with PUID/PGID 0 in the gluetun env.
+      gluetun-tmp:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Mi
+        advancedMounts:
+          sabnzbd:
+            gluetun:
+              - path: /tmp/gluetun


### PR DESCRIPTION
Follow-up to #3942, which fixed `clearing public IP data: open /tmp/gluetun/ip: permission denied` on `imgur-proxy`.

## Why not just copy the other sidecars

Because there was nothing to copy. `imgur-proxy` was the only gluetun sidecar setting `capabilities.drop: [ALL]`; the other three never hit the bug purely because nobody dropped their capabilities, so gluetun still had `CAP_DAC_OVERRIDE` and `CAP_CHOWN` to paper over two upstream quirks:

- `cmd/gluetun/main.go` creates `/tmp/gluetun` with `os.MkdirAll(path, 0644)` — a directory with **no execute bit**, which nothing can traverse into.
- `internal/publicip/fs.go` chowns the status file to `PUID:PGID` (default `1000`).

That's an absence of a pattern, not a pattern. Levelling the other three **up** rather than relaxing the one internet-facing sidecar down.

## The pattern, now identical on all four

```yaml
securityContext:
  runAsUser: 0
  runAsNonRoot: false
  capabilities:
    add: [NET_ADMIN]
    drop: [ALL]
  allowPrivilegeEscalation: false

env:
  PGID: 0          # chown targets the existing owner -> no CAP_CHOWN needed
  PUID: 0

persistence:
  gluetun-tmp:     # mode 1777 -> gluetun's 0644 MkdirAll becomes a no-op
    type: emptyDir
    medium: Memory
    sizeLimit: 1Mi
    advancedMounts: { <app>: { gluetun: [{ path: /tmp/gluetun }] } }
```

No capability is granted back. `prowlarr`'s gluetun additionally had no `runAsUser` at all and ran as the image default; that is now explicit rather than implied.

## Why `/gluetun` needs no equivalent

`main.go` has the same `0644` bug for `/gluetun`, but it's a no-op there: the directory ships in the image at `0755` root-owned (`qbittorrent`, `prowlarr`) or is already an emptyDir (`sabnzbd`, `imgur-proxy`), so root writes `servers.json` without extra capabilities. `/gluetun/auth` is never created. Confirmed on the live pods.

## Verification

- `imgur-proxy` has been running this exact configuration since #3942 merged: `2/2 Running`, `/tmp/gluetun` is `drwxrwxrwt`, the IP file writes as `root:root`, no permission error.
- `flate test all --namespace downloads` — 27 passed.
- `just lint` (super-linter `slim-v8`) — green.
- `check_internal_identifiers.py` — clean.

## Deliberately not in scope

Memory limits are still inconsistent — only `imgur-proxy` sets one (`256Mi`), which is why it is the only sidecar that has ever been `OOMKilled` on the ~300MB DNS blocklist download. Left alone here rather than bundled into a security change.

These three sidecars will roll on merge, so qBittorrent/SABnzbd/Prowlarr briefly lose their tunnel during the restart.