### PR TITLE
fix(imgur-proxy): drop gluetun's DNS blocklist and give the limit headroom

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -74,6 +74,15 @@ spec:
               repository: ghcr.io/qdm12/gluetun
               tag: v3.41.1@sha256:1a5bf4b4820a879cdf8d93d7ef0d2d963af56670c9ebff8981860b6804ebc8ab
             env:
+              # gluetun blocks malicious domains at its DNS layer by default.
+              # That is dead weight here and nowhere else: nginx below runs
+              # `resolver 127.0.0.1` and its SNI map drops anything that is
+              # not .imgur.com before a connection is opened, so the only
+              # lookups this resolver ever sees are imgur hostnames. Turning
+              # it off also removes the blocklist download, the likeliest
+              # cause of the startup memory spike that OOMKilled this
+              # container against its (previously 256Mi) limit.
+              BLOCK_MALICIOUS: off
               DOT: "on"
               DOT_CACHING: "on"
               DOT_IPV6: off
@@ -163,7 +172,16 @@ spec:
                 cpu: 25m
                 memory: 64Mi
               limits:
-                memory: 256Mi
+                # Steady state is ~26Mi and the highest figure cAdvisor ever
+                # sampled in 7 days is ~86Mi, but this container still
+                # OOMKilled 240+ times at 256Mi: the spike lands ~2s into
+                # startup and dies inside one scrape interval, so it is
+                # invisible to sampling and cannot be sized from metrics.
+                # BLOCK_MALICIOUS: off above should remove it; this is the
+                # belt to that pair of braces, since the 7MB servers.json
+                # parse is an unmeasured second candidate. The other three
+                # gluetun sidecars set no memory limit at all.
+                memory: 512Mi
                 kernel.org/tun: 1
         pod:
           labels:


### PR DESCRIPTION
Follow-up to #3942 / #3950. Addresses the `OOMKilled` crashloop those PRs deliberately left out of scope.

## `BLOCK_MALICIOUS` is a live default, not dormant config

It is **not** deprecated in v3.41.1 and **defaults to `true`** (`dnsblacklist.go:31`). The live settings dump confirms `Block malicious: yes` on all four sidecars — so the commented-out line in the manifests was overriding nothing.

## Off on imgur-proxy, on everywhere else

Turning it off here isn't a security trade, it's removing dead weight. nginx runs `resolver 127.0.0.1` and its SNI map drops anything that isn't `.imgur.com` **before a connection is opened**, so the only lookups that resolver ever sees are imgur hostnames. A malicious-domain blocklist inspecting `imgur.com` all day is pure cost.

Deliberately **left on** for `qbittorrent`, `sabnzbd` and `prowlarr`:

| | steady state | 7d sampled peak | limit |
|---|---|---|---|
| qbittorrent | 43Mi | 62Mi | **none** |
| sabnzbd | 36Mi | 61Mi | **none** |
| prowlarr | 37Mi | 59Mi | **none** |
| imgur-proxy | 26Mi | 86Mi | 256Mi → 512Mi |

Those three have no memory limit at all, so the spike costs them nothing, and their resolvers see real tracker/indexer traffic where the blocklist has some value. Switching it off globally would drop a security feature for zero gain on 3 of 4.

## Why also raise the limit

Because the fix is a strong hypothesis, not a measurement. cAdvisor never sampled above ~86Mi in 7 days — including on the pod that OOMKilled 240+ times — because the spike lands ~2s into startup and dies inside one scrape interval. It's invisible to sampling and can't be sized from metrics; the `OOMKilled` (exit 137) is its only evidence.

The 7MB `servers.json` parse is an unmeasured second candidate (the repo's own commented-out `STORAGE_FILEPATH: ""` line names it: _"prevent memory spike and avoid I/O"_). So the headroom stays as insurance rather than resting a 2.5-day outage on one hypothesis. 512Mi is still far tighter than the other three, which are unbounded.

## Verification

- `flate test all --namespace downloads` — 27 passed.
- `just lint` (super-linter `slim-v8`) — green.
- `check_internal_identifiers.py` — clean.
- `off` renders as the literal string `"off"`, matching `VERSION_INFORMATION: off` already working in this same file (settings dump reads `Enabled: no`).