### PR TITLE
feat(observability): alert on TLS certificate expiry for the non-cluster Traefiks

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
@@ -42,6 +42,20 @@ spec:
         tcp_connect:
           prober: tcp
           timeout: 5s
+        # TLS handshake only — deliberately NOT http_2xx. Several of the probed
+        # endpoints are auth-gated and answer 401/403, which http_2xx scores as
+        # probe_success=0 and would spuriously fire the critical LanProbeFailed
+        # alert below. A bare handshake yields probe_ssl_earliest_cert_expiry
+        # without any HTTP semantics to get wrong, and doubles as a genuine
+        # "is TLS answering" signal. The tcp prober sends the target's hostname
+        # as SNI, which matters because these are Traefik instances serving
+        # several hosts from one listener.
+        tls_connect:
+          prober: tcp
+          timeout: 5s
+          tcp:
+            tls: true
+            preferred_ip_protocol: ip4
     serviceMonitor:
       enabled: true
       selfMonitor:
@@ -58,3 +72,54 @@ spec:
           annotations:
             summary: |-
               The probe targeting {{ $labels.instance }} is currently having connectivity issues
+        # ── Why these exist ──────────────────────────────────────────────────
+        # Added 2026-07-29 after an incident that was invisible for weeks. Two
+        # hand-made Cloudflare DNS-01 tokens carried an IP allowlist that no
+        # longer matched the home WAN address, so ACME renewal was dead on both
+        # the cr-nut and TrueNAS Traefik instances. It only came to light
+        # because a cr-nut rebuild destroyed its acme.json and forced an
+        # immediate re-issue; TrueNAS still held a cached certificate valid for
+        # another six weeks and would have failed silently at its renewal, with
+        # nothing in the estate to say so until a browser threw a warning.
+        #
+        # Nothing anywhere alerted on certificate expiry before this. These two
+        # rules are the safety net that makes the whole class of ACME failure
+        # loud, independent of what caused it.
+        #
+        # Let's Encrypt issues for 90d and renews at 30d remaining, so 21d means
+        # renewal has already been failing for about nine days — early enough to
+        # fix calmly, late enough not to fire on a renewal that is merely due.
+        # Bounded at the bottom by the critical threshold below. There are no
+        # inhibit_rules in this Alertmanager, so an unbounded warning would page
+        # a second time alongside the critical for the same certificate.
+        - alert: CertificateExpiringSoon
+          expr: |-
+            (
+              probe_ssl_earliest_cert_expiry{service="blackbox-exporter-lan"}
+                - time()
+            ) / 86400 < 21
+              and
+            (
+              probe_ssl_earliest_cert_expiry{service="blackbox-exporter-lan"}
+                - time()
+            ) / 86400 >= 7
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              TLS certificate for {{ $labels.instance }} expires in
+              {{ $value | humanize }} days — ACME renewal is probably failing
+        - alert: CertificateExpiringCritical
+          expr: |-
+            (
+              probe_ssl_earliest_cert_expiry{service="blackbox-exporter-lan"}
+                - time()
+            ) / 86400 < 7
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              TLS certificate for {{ $labels.instance }} expires in under
+              7 days and ACME renewal has not succeeded

--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -45,3 +45,41 @@ spec:
     - action: replace
       replacement: blackbox-exporter-lan
       targetLabel: service
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: lan-tls-cert
+spec:
+  # Certificate expiry for the two Traefik instances OUTSIDE the cluster, which
+  # issue their own Let's Encrypt certificates over Cloudflare DNS-01 and had no
+  # expiry monitoring of any kind until 2026-07-29. In-cluster certificates are
+  # deliberately not listed: cert-manager owns those and reports on them itself.
+  #
+  # 5m, not 1m — a certificate's expiry does not change minute to minute, and
+  # these are handshakes against boxes whose job is something else.
+  jobName: tls_cert
+  interval: 5m
+  module: tls_connect
+  prober:
+    url: blackbox-exporter-lan.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        # cr-nut — the box whose rebuild exposed the broken token.
+        - peanut.${SECRET_DOMAIN}:443
+        # TrueNAS. Every host here is served by the one Traefik from a single
+        # acme.json, so in principle one target would do — they are listed
+        # individually because a per-host issuance failure is exactly the kind
+        # of partial breakage a single sampled target would hide.
+        - traefik-nas.${SECRET_DOMAIN}:443
+        - dozzle.${SECRET_DOMAIN}:443
+        - garage-nas.${SECRET_DOMAIN}:443
+        - s3-nas.${SECRET_DOMAIN}:443
+        - scrutiny-nas.${SECRET_DOMAIN}:443
+        - syncthing.${SECRET_DOMAIN}:443
+  metricRelabelings:
+    - action: replace
+      replacement: blackbox-exporter-lan
+      targetLabel: service


### PR DESCRIPTION
## Why

Nothing in the estate alerted on TLS certificate expiry. That gap is how a pair of broken Cloudflare DNS-01 tokens went unnoticed.

Both cr-nut's and TrueNAS's Traefik were using hand-made, user-owned Cloudflare tokens carrying an IP allowlist that no longer matched the home WAN address, so ACME renewal was dead on both:

```
9109: Cannot use the access token from location: <home WAN IP>
```

The two failures behaved very differently, and that contrast is the point:

- **cr-nut** — surfaced immediately. A rebuild on 2026-07-29 destroyed its `acme.json`, forcing a fresh issuance that failed at once; `peanut` fell back to `TRAEFIK DEFAULT CERT`.
- **TrueNAS** — surfaced not at all. It still held a cached certificate valid for another six weeks, so the token was never exercised. It would have failed silently at its renewal, roughly five weeks before anyone saw an expiry warning in a browser.

The tokens are now fixed. These rules are the safety net that makes the whole class of ACME failure loud regardless of cause.

## What

- New `tls_connect` blackbox module — a TLS handshake only.
- New `lan-tls-cert` Probe over the seven externally-issued hostnames (cr-nut + TrueNAS), every 5m.
- `CertificateExpiringSoon` (warning, 21d) and `CertificateExpiringCritical` (critical, 7d).

## Notes on the choices

**Not `http_2xx`.** Several probed endpoints are auth-gated and answer 401, which `http_2xx` scores as `probe_success=0` — that would have spuriously fired the existing critical `LanProbeFailed`. A bare handshake still yields `probe_ssl_earliest_cert_expiry` and doubles as a TLS liveness signal. The tcp prober sends the target hostname as SNI, which matters as these are multi-host Traefik listeners.

**21d / 7d.** Let's Encrypt issues for 90d and renews at 30d remaining, so 21d means renewal has already been failing for ~9 days — late enough not to fire on a renewal merely due, early enough to fix calmly.

**The warning is bounded below by the critical threshold** because this Alertmanager has no `inhibit_rules`; unbounded, it would page twice for one certificate.

**In-cluster certificates are excluded** — cert-manager owns and reports on those.

## Verification

- `promtool check rules` → `SUCCESS: 3 rules found`
- super-linter v8 (the pinned CI version), `VALIDATE_YAML` → `Successfully linted YAML`, exit 0
- No hostname leak: `check-internal-identifiers` passed; all targets use `${SECRET_DOMAIN}`
