### PR TITLE
fix(observability): revive two seedbox alerts that could never fire

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
+++ b/kubernetes/apps/observability/seedbox/app/dashboards/seedbox.json
@@ -316,7 +316,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "md4 is the RAID5 data array \u2014 healthy is active=4, failed=0, spare=0.",
+      "description": "All mdadm arrays, not just the data array. Healthy is failed=0 and spare=0 everywhere, with active equal to the member count. Arrays are deliberately NOT pinned by name: mdadm renumbered them md4 -> md125/md126/md127 at the 2026-07-20 FCOS rebuild, which is exactly what silently emptied this panel and killed SeedboxRAIDDegraded. md125 = 23.8 TB RAID5 data array, md126 = /boot, md127 = OS.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -337,8 +337,8 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "failed"
+              "id": "byRegexp",
+              "options": "/ (failed|spare)$/"
             },
             "properties": [
               {
@@ -391,13 +391,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "node_md_disks{job=\"seedbox-node\",device=\"md4\"}",
-          "legendFormat": "{{state}}",
+          "expr": "node_md_disks{job=\"seedbox-node\"}",
+          "legendFormat": "{{device}} {{state}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "RAID md4 disks by state",
+      "title": "RAID disks by state",
       "type": "stat"
     },
     {
@@ -405,7 +405,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "",
+      "description": "The old query keyed on mountpoint=\"/\", which FCOS never reports (/ is a composefs overlay node-exporter does not surface), so this panel was permanently empty and SeedboxDiskFillHigh could never fire. /var and /var/mnt/seedbox are the real filesystems. /boot is excluded: at 367 MB the same percentage threshold is meaningless. md127 is mounted at four paths reporting identical numbers, so mountpoints are pinned rather than matched loosely.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -463,13 +463,13 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "1 - (node_filesystem_avail_bytes{job=\"seedbox-node\",mountpoint=\"/\"} / node_filesystem_size_bytes{job=\"seedbox-node\",mountpoint=\"/\"})",
-          "legendFormat": "rootfs used",
+          "expr": "1 - (node_filesystem_avail_bytes{job=\"seedbox-node\",mountpoint=~\"/var|/var/mnt/seedbox\"} / node_filesystem_size_bytes{job=\"seedbox-node\",mountpoint=~\"/var|/var/mnt/seedbox\"})",
+          "legendFormat": "{{mountpoint}}",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Rootfs usage",
+      "title": "Filesystem usage",
       "type": "gauge"
     },
     {

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -133,22 +133,89 @@ spec:
           for: 6h
           labels:
             severity: warning
+        # Both rules below were STRUCTURALLY DEAD until 2026-07-30 — they selected
+        # label values that stopped existing at the 2026-07-20 Debian -> FCOS
+        # rebuild, so each matched zero series and could never fire. Neither was a
+        # threshold that was merely never crossed; both were queries returning
+        # nothing. The check that catches this is to invert the comparison and
+        # confirm the expression still returns series: a live rule yields one
+        # series per array/mountpoint, a dead one yields nothing either way.
+        #
+        # Verify after any future change to the box's storage layout:
+        #   node_md_disks{job="seedbox-node",state="failed"} >= 0          -> 3 series
+        #   node_filesystem_avail_bytes{job="seedbox-node",
+        #     mountpoint=~"/var|/var/mnt/seedbox"}                          -> 2 series
+        #
+        # Arrays are deliberately NOT named here. mdadm renumbers arrays it cannot
+        # match to an mdadm.conf entry (md4 -> md125/md126/md127 at the rebuild),
+        # which is precisely what killed the old rule, so pinning md125 today would
+        # only reset the same trap for the next rebuild.
+        #
+        #   md125  23.8 TB xfs  /var/mnt/seedbox   the RAID5 data array
+        #   md126   367 MB ext4 /boot
+        #   md127  68.6 GB xfs  /var (and /etc, /sysroot, /sysroot/ostree/...)
+        #
+        # Aggregated with max by (device) so an unhealthy array pages ONCE rather
+        # than once per signal — the three arms overlap heavily in a real failure.
+        #
+        # Three arms because they are three genuinely different signals, from two
+        # independent kernel sources:
+        #   node_md_degraded   sysfs md/degraded — a COUNT of missing-or-failed
+        #     members, NOT a boolean, so the test is > 0. This is the arm that
+        #     catches a disk that has been REMOVED rather than marked faulty.
+        #     (`== 1` would silently miss a two-disk RAID5 loss — total data loss.)
+        #   node_md_disks{state="failed"}  /proc/mdstat (F) count — a member the
+        #     kernel has marked faulty but not yet removed.
+        #   node_md_state{state="inactive"} — the array failed to assemble at all.
         - alert: SeedboxRAIDDegraded
           annotations:
-            summary: "Seedbox md4 RAID5 is degraded ({{ $labels.state }}={{ $value }} disks)."
+            summary: "Seedbox RAID array {{ $labels.device }} is degraded — a member disk is failed, missing, or the array did not assemble."
+            description: >-
+              Array {{ $labels.device }} is no longer healthy. md125 is the 23.8 TB RAID5
+              data array; md127 holds the OS. Run `cat /proc/mdstat` on the box for which
+              member is affected — a RAID5 rebuild is the highest-risk window, and one
+              seedbox disk already carries a standing 8 reallocated sectors.
           expr: |-
-            node_md_disks{job="seedbox-node",device="md4",state="failed"} > 0
-            or node_md_disks{job="seedbox-node",device="md4",state="active"} < 4
+            max by (device) (
+              node_md_degraded{job="seedbox-node"} > 0
+              or node_md_disks{job="seedbox-node",state="failed"} > 0
+              or node_md_state{job="seedbox-node",state="inactive"} == 1
+            )
           for: 5m
           labels:
             severity: critical
+        # The old rule keyed on mountpoint="/", which FCOS never reports: / is a
+        # small composefs overlay and node-exporter does not surface it at all.
+        # The real filesystems are /var (OS, images, logs) and /var/mnt/seedbox
+        # (the data array).
+        #
+        # Both mountpoints are listed explicitly rather than matched loosely,
+        # for two reasons:
+        #   md127 is mounted at FOUR paths (/var, /etc, /sysroot,
+        #     /sysroot/ostree/deploy/fedora-coreos/var) reporting identical
+        #     numbers, so an unpinned expression would fire four identical alerts.
+        #   /boot is excluded on purpose: at 367 MB, 85% leaves 55 MB, which is
+        #     already past the point where rpm-ostree can stage a kernel. If /boot
+        #     ever needs watching it needs its own rule and its own number.
+        #
+        # 85% suits both despite the 350x size difference — it leaves ~3.5 TB free
+        # on the data array and ~10 GB on /var, both comfortable margins to react
+        # in. Baseline 2026-07-30: /var/mnt/seedbox 1.9% (456 GB of 23.8 TB),
+        # /var 16.1%. The array is near-empty because the rebuild wiped it and
+        # intake is off by choice, so expect the data figure to climb once
+        # autobrr is re-enabled; this is a "start pruning" warning, not an outage.
         - alert: SeedboxDiskFillHigh
           annotations:
-            summary: "Seedbox rootfs above 85% ({{ $value | humanizePercentage }} used)."
+            summary: "Seedbox {{ $labels.mountpoint }} is above 85% full ({{ $value | humanizePercentage }} used)."
+            description: >-
+              {{ $labels.mountpoint }} on the seedbox ({{ $labels.device }}) is
+              {{ $value | humanizePercentage }} full. On /var/mnt/seedbox this means
+              intake is about to stall — prune torrents or empty .RecycleBin. On /var it
+              means container images or logs are growing and the box itself is at risk.
           expr: |-
             1 - (
-              node_filesystem_avail_bytes{job="seedbox-node",mountpoint="/"}
-              / node_filesystem_size_bytes{job="seedbox-node",mountpoint="/"}
+              node_filesystem_avail_bytes{job="seedbox-node",mountpoint=~"/var|/var/mnt/seedbox"}
+              / node_filesystem_size_bytes{job="seedbox-node",mountpoint=~"/var|/var/mnt/seedbox"}
             ) > 0.85
           for: 30m
           labels:


### PR DESCRIPTION
## The defect

`SeedboxRAIDDegraded` and `SeedboxDiskFillHigh` have been **structurally dead** since the 2026-07-20 Debian → FCOS rebuild. Neither was a threshold that merely went uncrossed — both selected label values that stopped existing, so each matched **zero series** and could not fire under any condition.

| Alert | Selected | Reality on the box |
|---|---|---|
| `SeedboxRAIDDegraded` | `device="md4"`, `active < 4` | arrays are `md125` / `md126` / `md127` |
| `SeedboxDiskFillHigh` | `mountpoint="/"` | FCOS never reports `/` (composefs overlay) |

A disk dropping out of the 23.8 TB RAID5, or either filesystem filling, would have paged nobody.

`md4 → md125/126/127` is mdadm renumbering arrays it cannot match to an `mdadm.conf` entry. The seedbox observability handoff predicted exactly this: *"RAID alert hardcodes md4 / active < 4 — revisit if the array is ever rebuilt."*

## The fix

Written so the next storage change cannot silently kill them again.

**RAID** — no array named, no disk count hardcoded. Three signals from two independent kernel sources, aggregated `by (device)` so an unhealthy array pages once rather than once per signal:

- `node_md_degraded > 0` — sysfs `md/degraded`. This is a **count of missing-or-failed members, not a boolean**, so the test must be `> 0`; `== 1` would silently miss a two-disk RAID5 loss (total data loss). This is the arm that catches a *removed* disk.
- `node_md_disks{state="failed"} > 0` — `/proc/mdstat` (F) count: a member marked faulty but not yet removed.
- `node_md_state{state="inactive"} == 1` — array failed to assemble at all.

**Disk fill** — `/var` and `/var/mnt/seedbox` pinned explicitly. `md127` is mounted at four paths reporting identical numbers, so a loose match would fire four duplicate alerts. `/boot` excluded: at 367 MB, 85% leaves 55 MB, already past what `rpm-ostree` needs to stage a kernel.

## Verification

Verified against live Prometheus, not by reading the diff. The test that catches this class of bug is to **invert the comparison** and confirm the expression still returns series — a dead rule returns nothing either way:

| Expression | As shipped | Inverted |
|---|---|---|
| old RAID | 0 series | **0 series** ← dead |
| old fill | 0 series | **0 series** ← dead |
| new RAID | 0 (healthy) | 3 series, one per array |
| new fill | 0 (healthy) | 2 series, `/var` + `/var/mnt/seedbox` |

All 11 expressions in the file re-parsed against the live API; 0 invalid. super-linter v8.6.0 with this repo's CI flags: **exit 0**.

Baseline now: data array **1.9% used** (456 GB of 23.8 TB — near-empty because the rebuild wiped it and intake is off by choice), `/var` 16.1%, all three arrays 4 active / 0 failed.

## Also

The two dashboard panels carrying the same dead queries are fixed alongside — empty panels are how this was found. The `[5m]` rate windows from #3932 are deliberately preserved.