### PR TITLE
fix(rook-ceph): drop the CephPoolGrowthWarning post-renderer

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -174,39 +174,3 @@ spec:
       deletionPolicy: Delete
     # Object storage (RGW) removed — migrated to Garage (storage/garage).
     cephObjectStores: []
-  # Fix the chart's CephPoolGrowthWarning rule, which fails to evaluate whenever
-  # the mgr pod has been rescheduled inside its own [2d] lookback.
-  #
-  # predict_linear() emits one series per label-set, so a restarted mgr leaves the
-  # old pod's series in the window alongside the new one. Both share
-  # {cluster, pool_id, instance} but differ in `pod`, so group_right() sees a
-  # duplicate match group and errors:
-  #   found duplicate series for the match group {...} on the left hand-side
-  # Prometheus then raises PrometheusRuleFailures and — the part that matters —
-  # stops evaluating pool-growth prediction entirely, so a pool trending toward
-  # full would go unwarned. It self-heals ~2d after the last restart and breaks
-  # again on the next one; mgr churn is routine here (see the mgr resources note
-  # above, it was OOMKilling ~twice daily until the 3Gi bump).
-  #
-  # `max by(...)` collapses the duplicates before the join, keeping the most
-  # pessimistic prediction. Upstream bug, not a local misconfiguration.
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: PrometheusRule
-              name: prometheus-ceph-rules
-            patch: |-
-              # Guard: the chart controls this ordering, so assert the index still
-              # points at the intended alert. If an upgrade reorders the groups the
-              # test fails and Flux stops loudly, rather than silently rewriting a
-              # different rule's expression.
-              - op: test
-                path: /spec/groups/7/rules/0/alert
-                value: CephPoolGrowthWarning
-              - op: replace
-                path: /spec/groups/7/rules/0/expr
-                value: >-
-                  (max by(cluster, pool_id, instance) (predict_linear(ceph_pool_percent_used[2d],
-                  3600 * 24 * 5)) * on(cluster,pool_id, instance) group_right()
-                  ceph_pool_metadata) >= 95


### PR DESCRIPTION
Follow-up to #3936 (rook-ceph v1.20.2 → v1.20.3), raised by the review on that PR.

## Why

Rook v1.20.3 fixes `CephPoolGrowthWarning` upstream ([`cf1acb4`](https://github.com/rook/rook/commit/cf1acb42), backport of [#17920](https://github.com/rook/rook/pull/17920)). Our local post-renderer still applies cleanly after the bump — the `op: test` guard passes, `"pools"` is still group index 7 — which is precisely the problem: the `op: replace` now silently reverts upstream's better expression back to our workaround.

Confirmed against the live rule after #3936 merged. Our `expr` had won, while upstream's new `for: 1h` survived alongside it:

```
expr: (max by(cluster, pool_id, instance) (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)) * on(cluster,pool_id, instance) group_right() ceph_pool_metadata) >= 95
for:  1h
```

## Upstream is strictly better

Ours collapsed the mgr-churn duplicates with `max by(cluster, pool_id, instance)` but kept `instance` on **both** sides of the join, so the mgr `pod`/`instance` labels could still reintroduce a duplicate match group. Upstream aggregates with `avg by (cluster,pool_id)` and joins on `(cluster,pool_id)` alone — dropping `instance` entirely, so the failure mode cannot recur — and adds `for: 1h` to damp flapping.

Retiring it also removes a patch keyed to a hardcoded group index (`/spec/groups/7/rules/0`), which otherwise needs re-verifying on every chart bump.

## Verified

- `just kube flate-build-hr rook-ceph rook-ceph-cluster` renders upstream's expression with `for: 1h`
- No `postRenderers` remain in `cluster/helmrelease.yaml`
- Scoped super-linter (`VALIDATE_YAML`) clean