### PR TITLE
chore(cloudnative-pg): pin barman ObjectStore CRD to v0.14.0

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/barman-cloud/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/barman-cloud/kustomization.yaml
@@ -4,7 +4,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: database
 resources:
-  - https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/v0.9.0/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
+  # Keep this pinned to the plugin version running in helmrelease.yaml. It had
+  # drifted to v0.9.0 while the plugin ran v0.14.0, which left
+  # useDefaultAzureCredentials, lz4 as a data.compression value, and
+  # restoreAdditionalCommandArgs missing from the installed schema.
+  - https://raw.githubusercontent.com/cloudnative-pg/plugin-barman-cloud/v0.14.0/config/crd/bases/barmancloud.cnpg.io_objectstores.yaml
   - issuer.yaml
   - certificate.yaml
   - rbac.yaml


### PR DESCRIPTION
Follow-up to #3959 (plugin-barman-cloud v0.13.0 → v0.14.0), raised as a pre-existing observation in the review on that PR.

## Why

`barman-cloud/kustomization.yaml` pinned the `ObjectStore` CRD to the **v0.9.0** manifest while the plugin itself runs **v0.14.0**. That gap left three things the plugin understands missing from the installed schema:

- `useDefaultAzureCredentials`
- `lz4` as a `data.compression` value
- `restoreAdditionalCommandArgs`

**Nothing was being silently dropped today.** The ObjectStore sets `data.compression: bzip2` and `wal.compression: zstd`, both valid under the older schema. This just closes the gap before something needs one of the newer fields.

#3959 did not widen the drift — the `v0.13.0...v0.14.0` compare touches no `api/v1` or `config/crd` files, so the CRD was byte-identical across that bump.

## Safe to apply

The v0.9.0 → v0.14.0 CRD diff is **additive only**: three new optional fields, one widened enum (`lz4` added to `data.compression`), and a `controller-gen` version bump. No schema tightening, so it cannot reject the existing object.

## Verified

- `kubectl kustomize kubernetes/apps/database/cloudnative-pg/barman-cloud/` builds
- The new schema fields appear in the build output
- Live plugin confirmed at `plugin-barman-cloud:v0.14.0`
- Scoped super-linter (`VALIDATE_YAML`) clean