### PR TITLE
feat(tuppr): hold Alertmanager silences during Talos upgrade runs

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -20,6 +20,17 @@ spec:
       # resync spike OOMKilled the follower at 512Mi. This headroom absorbs it.
       limits:
         memory: 768Mi
+    # Hold Alertmanager silences while an upgrade run is in flight. This only
+    # configures how the operator reaches Alertmanager; which alerts each run
+    # silences is authored per-resource in upgrades/talosupgrade.yaml.
+    #
+    # The silence is a short lease re-extended on every reconcile, so it lapses
+    # on its own if the controller stops driving the run — a crashed operator
+    # un-silences rather than leaving the estate permanently muted.
+    silences:
+      enabled: true
+      alertmanager:
+        address: http://kube-prometheus-stack-alertmanager.observability.svc.cluster.local:9093
     monitoring:
       serviceMonitor:
         enabled: true

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -18,6 +18,36 @@ spec:
   # this is the "drain-first, one-node-at-a-time" mitigation #2728 identified.
   drain:
     enabled: true
+  # A rolling Talos upgrade reboots each node in turn, and every alert below is
+  # the expected consequence of a node being deliberately absent — not a signal
+  # anyone should be paged for at 1am. Alertmanager's root route sends all
+  # severities to Pushover, so without this each run pages several times per
+  # node. Ceph and node-absence alerts are silenced; anything not listed here
+  # still pages, so a genuine unrelated fault during a run is not masked.
+  #
+  # maxDuration is the safety catch: a run still holding a silence past it
+  # alerts again, so a wedged upgrade re-pages rather than staying quiet. 1h
+  # comfortably covers one node (drain + reboot + Ceph re-converge) while
+  # parallelism is 1, and the budget re-arms once the hold is released.
+  # Every name below was checked against the rules actually loaded in the
+  # cluster — a silence on an alertname that does not exist is a no-op that
+  # looks like it is working.
+  silences:
+    # Ceph: one node down takes its OSDs and a mon with it, degrades PGs and
+    # puts the cluster into HEALTH_WARN until it re-converges. CephHealthError
+    # and the full/near-full alerts are deliberately NOT silenced — those are
+    # not expected consequences of a reboot.
+    - maxDuration: 1h
+      matchers:
+        - name: alertname
+          matchType: =~
+          value: CephMonDown|CephOSDDown|CephOSDHostDown|CephHealthWarning|CephPGsUnclean|CephPGsInactive|CephFilesystemDegraded
+    # Node/kubelet absence and the scrape failures that follow from it.
+    - maxDuration: 1h
+      matchers:
+        - name: alertname
+          matchType: =~
+          value: KubeNodeUnreachable|KubeNodeNotReady|KubeNodeReadinessFlapping|KubeletDown|TargetDown
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -22,8 +22,20 @@ spec:
   # the expected consequence of a node being deliberately absent — not a signal
   # anyone should be paged for at 1am. Alertmanager's root route sends all
   # severities to Pushover, so without this each run pages several times per
-  # node. Ceph and node-absence alerts are silenced; anything not listed here
-  # still pages, so a genuine unrelated fault during a run is not masked.
+  # node. Ceph and node-absence alerts are silenced; an alertname not listed
+  # here still pages.
+  #
+  # Know the scope before adding a name: tuppr's matchers are static, with no
+  # way to bind a silence to the node currently rebooting, so every name below
+  # is silenced CLUSTER-WIDE for the run. A second node failing while the first
+  # is down is therefore masked under these names — deliberately survivable,
+  # because the alerts that say quorum is actually going are not silenced
+  # anywhere here: etcdInsufficientMembers, etcdMembersDown, etcdNoLeader,
+  # CephMonDownQuorumAtRisk, MiroirVolumeQuorumLost. Note CephMonDown IS
+  # silenced below and CephMonDownQuorumAtRisk is not; that pairing is the
+  # whole design, so keep any new name on the "expected consequence" side of
+  # it. TargetDown is the widest of them and has no such backstop — it covers
+  # every scrape target, not just the rebooting node's.
   #
   # maxDuration is the safety catch: a run still holding a silence past it
   # alerts again, so a wedged upgrade re-pages rather than staying quiet. 1h


### PR DESCRIPTION
Follow-up to #3856 (tuppr 0.3.2 → 0.4.3), raised as a "new feature worth adopting" in the review on that PR. Needed #3856 first — the feature landed in chart v0.4.1.

## Why

A rolling Talos upgrade reboots each node in turn, and the Ceph and node-absence alerts that follow are the expected consequence of a node being deliberately absent. Alertmanager's root route sends **every** severity to Pushover, so `warning` is not a quiet tier — each run pages several times per node.

tuppr 0.4.1+ can hold a silence for the duration of a run. The silence is a short lease re-extended on every reconcile, so it **lapses on its own** if the controller stops driving the run — a crashed operator un-silences rather than leaving the estate muted indefinitely.

## Shape

Two halves, both in this PR because they are coupled:

- `app/helmrelease.yaml` — `silences.enabled` plus the Alertmanager address. This only configures how the operator *reaches* Alertmanager.
- `upgrades/talosupgrade.yaml` — `spec.silences`, which is where the alert selection is authored, per-run.

Two silences rather than one broad matcher, so the scopes stay independent (Alertmanager ANDs the matchers within a single silence).

`maxDuration: 1h` is the safety catch: a run still holding a silence past it **alerts again**, so a wedged upgrade re-pages rather than staying quiet. That comfortably covers one node's drain, reboot and Ceph re-converge while `parallelism` is 1, and the budget re-arms when the hold is released.

## What is deliberately NOT silenced

`CephHealthError`, the full/near-full pool and OSD alerts, and everything not listed. Those are not expected consequences of a reboot, so a genuine unrelated fault during an upgrade still pages.

## Verified

- **Every alertname was checked against the rules actually loaded in the cluster.** This caught three names that do not exist here — `CephClusterWarningState`, `CephNodeDown`, `CephPGsDegraded` — which were dropped. A silence naming a non-existent alert is a no-op that looks like it is working.
- `kubectl apply --server-side --dry-run=server` on the TalosUpgrade — accepted by the live CRD. It emits `spec.silences is configured but the operator has no Alertmanager connection`, which is exactly right pre-merge and confirms the two halves are coupled.
- `just kube flate-build-hr system-upgrade tuppr` renders `ALERTMANAGER_ADDRESS` correctly.
- Regex values re-parsed after formatting to confirm prettier did not fold them.
- Scoped super-linter (`VALIDATE_YAML`) clean.