### PR TITLE
docs(agents): add Code Review Rules for Codex code review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,73 @@ just kube flate-build-ks <namespace> <app>
 just kube flate-test
 ```
 
+## Code Review Rules
+
+Read by Codex code review, and by any other reviewer that honours this file. A Renovate-facing
+reviewer already runs here: the `claude/renovate-review` commit status is the **gate** on dependency
+PRs (upstream changelog research, breaking-change verdict, required check on `main`). Reviews driven
+by this section are **advisory** — spend them on how the diff wires into _this_ repo rather than on
+re-deriving upstream release notes.
+
+Flag consequential, repository-specific breakage. Prefer silence over style commentary.
+
+### Always flag
+
+- **Internal coordinates in a public repo.** LAN IPs, `.lan` / `.internal` hostnames, device or node
+  names, deployment topology, MACs, disk serials — in files, and equally in the PR title and body,
+  since a squash merge copies the body into `main` permanently. Safe path: the `${SECRET_DOMAIN}` /
+  `${SECRET_INTERNAL_DOMAIN}` placeholders, or a real address templated inside an `ExternalSecret`'s
+  `target.template.data` and mounted from the rendered Secret — never a `ConfigMap` in git.
+- **Plaintext secrets.** Every secret arrives via 1Password → ExternalSecret. A literal token,
+  password, or key in a manifest is a blocker regardless of how narrowly scoped it looks.
+- **A literal `${VAR}` left unescaped.** Flux `postBuild` substitutes `${VAR}` against
+  `cluster-secrets` and **undefined vars become empty strings**. A Grafana dashboard, envsubst
+  template, or shell snippet that needs the literal must escape it as `$${VAR}`. This fails silently
+  — the config deploys blank instead of erroring.
+- **An app removal that prunes data.** The root Kustomization sets `prune: true`, so deleting an
+  app's line from the namespace `kustomization.yaml` makes Flux delete its PVC. Flag unless the PR
+  shows a VolSync snapshot or copy-out happened first.
+
+### Worth flagging
+
+- A `ConfigMap` with no explicit `metadata.namespace` — Checkov CKV_K8S_21 fails the `default`
+  namespace.
+- A quoted anchored port (`PORT: &port "3000"`) reused as a probe `httpGet.port`. Rejected at apply
+  time with "must contain at least one letter"; ports are unquoted integers.
+- A new app whose name contains a hyphen. The route host is `{{ .Release.Name }}.${SECRET_DOMAIN}`,
+  so the hyphen leaks into the URL — name new apps hyphen-free end to end. Existing hyphenated apps
+  predate the rule and are left alone.
+- A second route hostname, or a `${SECRET_INTERNAL_DOMAIN}` alias beside the primary domain. It
+  resolves to the same gateway so it buys no extra restriction, and each alias costs an OPNsense
+  host-override record against a hard ceiling (~421) above which external-dns silently stops
+  publishing anything cluster-wide.
+- An app with an `externalsecret.yaml` that does not `dependsOn` `onepassword-connect` in
+  `external-secrets`.
+- Components (`volsync`, `alerts`, `homepage`, `kopiur`) or their `postBuild.substitute` values
+  declared in `app/kustomization.yaml` instead of `ks.yaml`.
+- A bump to cluster-critical infrastructure — the "Protected infra" `packageRules` entry in
+  `.renovaterc.json5` is the source of truth (Cilium, Rook-Ceph, Flux, Talos, cert-manager,
+  external-secrets, Envoy Gateway, CloudNativePG, …) — that needs a repo-side change the PR does not
+  make: a renamed Helm value, a CRD version the manifests still pin, a required migration step.
+- A GPU workload missing `runtimeClassName: nvidia`.
+
+### Expected patterns — do not flag
+
+- Bare `${VAR}` in manifests. That is the Flux substitution mechanism, not an undefined variable.
+- YAML anchors (`&app`, `&namespace`, `*app`) in `ks.yaml` — the house DRY pattern, not duplication.
+- Digest-pinned container tags (`tag@sha256:…`). Renovate owns them; do not suggest stripping them.
+- Flux `OCIRepository` tags that are **not** digest-pinned. Helm rejects an appended digest, so the
+  carve-out is deliberate rather than drift from the digest-pinning convention.
+- `HTTPRoute` with no `Ingress` anywhere. Routing is Envoy Gateway + Gateway API by design.
+- Schema or kubeconform-style complaints about raw YAML. The source is meaningless until kustomize
+  substitutes vars and merges components; real validation is `just kube flate-test`.
+- Secrets referenced but absent from git (the ExternalSecret is the mechanism), and anything under
+  `.archive/` (kept for reference, never reconciled).
+- Missing PDBs, extra replicas, or other production-grade HA asks. This is one homelab cluster of
+  three control-plane nodes with no separate workers.
+- HelmRelease `spec` key order, formatting, and line width — super-linter, prettier, and yamlfmt own
+  those.
+
 ## Agent tooling
 
 Tool-agnostic agent instructions and skills live under `.agents/`:


### PR DESCRIPTION
## What

Adds a `## Code Review Rules` section to `AGENTS.md` — the section heading Codex code review looks for when it reviews a pull request.

## Why

Piloting Codex code review (included in ChatGPT Plus) as a second, advisory reviewer alongside the existing `claude/renovate-review` gate. Without repository guidance it reviews against generic Kubernetes expectations and reports this repo's deliberate patterns as defects.

The section is inert until the Codex GitHub app is installed on the repository, so this change is safe to land on its own.

## Contents

- **Always flag** — the silent-failure cases: internal coordinates in a public repo, plaintext secrets, an unescaped literal `${VAR}` deploying blank, an app removal pruning its PVC.
- **Worth flagging** — repo-specific wiring: missing `metadata.namespace`, quoted anchored ports, hyphenated app names leaking into route hosts, extra route aliases spending DNS records, missing `dependsOn` on the secret store, components declared in the wrong file, protected-infra bumps needing a repo-side change.
- **Do not flag** — the carve-outs a generic reviewer gets wrong: bare `${VAR}`, YAML anchors, digest-pinned image tags, `OCIRepository` tags that are deliberately *not* digest-pinned, `HTTPRoute` with no `Ingress`, schema complaints about pre-substitution YAML, production-grade HA asks.

Explicitly scoped as advisory so the two reviewers stay complementary: the gate keeps doing upstream changelog research on dependency PRs, these rules aim Codex at repo-side wiring.

## Validation

`super-linter` v8.6.0 (the version pinned in `shared-workflows`) run locally against the changed file with the repository's canonical markdownlint config staged the way CI stages it — clean, exit 0. Lefthook pre-commit and `check-internal-identifiers` both pass.