### PR TITLE
fix(volsync): run kopia maintenance hourly instead of every 4h

### DIFF
--- a/docs/docs/migrations/volsync-kopia.md
+++ b/docs/docs/migrations/volsync-kopia.md
@@ -267,7 +267,7 @@ spec:
 # kubernetes/apps/volsync-system/volsync/ks.yaml
 # The volsync-maintenance Kustomization is active and points to ./maintenance
 # kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
-# spec.enabled: true, trigger.schedule: 30 */4 * * *
+# spec.enabled: true, trigger.schedule: 30 * * * *
 ```
 
 ### Step 2: Deploy Kopia Server
@@ -314,7 +314,7 @@ kubectl get replicationsource smokeping-nfs -n default -o yaml
 | **Identity**              | Per-app                                | Configurable via repository.config   |
 | **CRD Field**             | `spec.restic:`                         | `spec.kopia:`                        |
 | **Restore**               | Direct PVC reference                   | Requires `sourceIdentity.sourceName` |
-| **Maintenance**           | Manual                                 | KopiaMaintenance CRD (live, every 4h)|
+| **Maintenance**           | Manual                                 | KopiaMaintenance CRD (live, hourly)  |
 
 ## Web UI Usage
 
@@ -498,7 +498,7 @@ metadata:
 spec:
     enabled: true
     trigger:
-        schedule: 30 */4 * * *
+        schedule: 30 * * * *
     repository:
         repository: volsync-maintenance-secret
 ```

--- a/docs/docs/troubleshooting/kb/016-kopia-repo-server-oom-repo-size.md
+++ b/docs/docs/troubleshooting/kb/016-kopia-repo-server-oom-repo-size.md
@@ -16,7 +16,9 @@ in-use contents** / ~3,462 index blobs. The server loads the **full index into m
 start**, which exceeds the limit. The "too many index blobs" message is a **red herring**:
 maintenance is actually running fine:
 
-- The `KopiaMaintenance` CR drives the `kopia-maint-daily-*` cronjob every 4h.
+- The `KopiaMaintenance` CR drives the `kopia-maint-daily-*` cronjob every 4h. (Raised to
+  hourly after this incident: index blobs were still being created faster than epoch
+  compaction reclaimed them, so the schedule is now `30 * * * *`.)
 - Its job log shows it owns maintenance, runs quick **then full** maintenance (GC + epoch
   compaction), and reports `MAINTENANCE_STATUS: SUCCESS` in a few minutes.
 - The maintenance job pod has **no resource limits**, so it doesn't OOM, only the long-lived

--- a/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/kopiamaintenance.yaml
@@ -8,6 +8,24 @@ metadata:
 spec:
   enabled: true
   trigger:
-    schedule: 30 */4 * * *
+    # Hourly, not every 4h: ~100 kopia ReplicationSources share this one
+    # filesystem repository and each snapshots every 4h, so index blobs are
+    # created faster than epoch compaction reclaims them. Measured on
+    # 2026-07-30 at the 4h cadence: 2803 -> 3112 -> 3424 across three
+    # consecutive runs, roughly +310 per run and monotonic, with kopia
+    # warning "too many index blobs" on every operation.
+    #
+    # Maintenance was already running and succeeding — the problem was rate,
+    # not failure — and each run compacts only a bounded number of epochs, so
+    # more runs is the lever that does not touch backup retention. Runs take
+    # 125-456s, so they fit inside an hourly window with wide margin
+    # (activeDeadlineSeconds is 10800).
+    #
+    # Kept at :30 so maintenance never starts alongside the sources, which
+    # trigger on the hour.
+    #
+    # If the count still climbs after a day or two, the next lever is
+    # retention (hourly: 168 in components/volsync/nfs) rather than frequency.
+    schedule: 30 * * * *
   repository:
     repository: volsync-maintenance-secret


### PR DESCRIPTION
## Why

Kopia index blobs in the shared filesystem repository are being created faster than epoch compaction reclaims them. Measured across the three retained maintenance runs on 2026-07-30:

| run | index blobs |
|---|---|
| 00:30 | 2,803 |
| 04:30 | 3,112 |
| 08:30 | 3,424 |

Roughly **+310 per run, monotonic** — about +1,860/day — with kopia emitting `Found too many index blobs (…), this may result in degraded performance` on every repository operation, including inside each app's backup.

## This was a rate problem, not a failure

Worth stating plainly, because the kopia warning text (`Please ensure periodic repository maintenance is enabled or run 'kopia maintenance'`) reads like maintenance is off. It is not:

- `KopiaMaintenance/daily` reports `MaintenanceHealthy: OperatingNormally`
- Each run does quick **and** full maintenance and exits 0 (`MAINTENANCE_RESULT: SUCCESS`)
- It is actively compacting — `Compacting an eligible uncompacted epoch`, `Attempting to compact a range of epoch indexes`, `Cleaned up 288 logs`

The issue is throughput: ~100 kopia ReplicationSources share this one repository and each snapshots every 4h (~600 snapshots/day), while a single maintenance run compacts only a bounded number of epochs. The repository is at 3.76M in-use contents / 443.5 GB.

## Why frequency first

It is the only lever that does not change backup policy. Retention (`hourly: 168` in `components/volsync/nfs`) and source frequency both reduce index pressure too, but they change what we can restore.

Feasibility checked — recent run durations were **456s, 125s, 434s**, so an hourly cadence fits with wide margin against the `activeDeadlineSeconds: 10800` cap. Kept at `:30` so maintenance never starts alongside the sources, which trigger on the hour.

If the count still climbs after a day or two, the next lever is retention rather than more frequency.

## Not affected

The offsite copies are **restic**, not kopia (`components/volsync/remote` uses `spec.restic` with `pruneIntervalDays: 14`), so `KopiaMaintenance` never applied to them and there is no equivalent gap there. I checked this specifically before assuming a missing maintenance job.

## Unrelated observation, no action needed

`kubectl get kopiamaintenance` displays `SCHEDULE 0 2 * * *`, which is **not** what runs. The printer column reads `.spec.schedule`, a field the CRD marks `DEPRECATED: Use Trigger.Schedule instead` and **defaults** to `0 2 * * *`. We correctly set `trigger.schedule`, which is what the CronJob and `status.nextScheduledMaintenance` follow. Nothing to fix in git — noting it so the misleading column does not send someone down the wrong path later.

## Verified

- `kubectl kustomize` on the maintenance dir renders `schedule: 30 * * * *`
- Scoped super-linter (`VALIDATE_YAML`) clean