### PR TITLE
fix(pocket-id): verify email addresses instead of asserting them

### DIFF
--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -41,7 +41,26 @@ spec:
               ANALYTICS_DISABLED: "true"
               APP_URL: "https://id.${SECRET_DOMAIN}"
               DB_PROVIDER: postgres
-              EMAILS_VERIFIED: "true"
+              # Verify email addresses for real rather than asserting them.
+              #
+              # EMAILS_VERIFIED (previously "true") is what a changed or newly
+              # signed-up address is set to, so with it on, a user editing their
+              # own account had any address they typed emitted as
+              # email_verified: true in OIDC claims without ever proving control
+              # of it. AllowOwnAccountEdit defaults to true and we do not
+              # override it, so that path was open to every account.
+              #
+              # EMAIL_VERIFICATION_ENABLED is a SEPARATE setting that also
+              # defaults to false, and it gates the "verify your email" prompt.
+              # Dropping EMAILS_VERIFIED without it would leave new and changed
+              # addresses permanently unverified with no way to verify them.
+              # Both are required; neither is sufficient alone.
+              #
+              # Not a lockout risk: EmailVerified feeds only the OIDC
+              # email_verified claim and is never used to gate login. Existing
+              # rows are untouched — the flag is written only at signup or on an
+              # email change.
+              EMAIL_VERIFICATION_ENABLED: "true"
               KEYS_STORAGE: database
               UI_CONFIG_DISABLED: "true"
               # TODO: Enable LDAP when Active Directory is configured


### PR DESCRIPTION
Follow-up to #3970. While checking whether the critical advisory in v2.12.0 applied to us, I found we reach the same outcome by configuration.

## The problem

`EMAILS_VERIFIED: "true"` is the value a changed or newly signed-up address gets set to. Two usages in the v2.12.0 source, and that is all of them:

```go
// backend/internal/usersignup/service.go:80
EmailVerified: config.EmailsVerified.IsTrue(),

// backend/internal/service/user_service.go:475  — email changed
user.EmailVerified = cfg.EmailsVerified.IsTrue()
```

`AllowOwnAccountEdit` defaults to `"true"` (`appconfig/model.go:108`) and we do not override it, and LDAP is off — so a user editing their own account takes the full-update branch and any address they type is emitted as `email_verified: true` in OIDC claims without ever proving control of it. A relying party linking accounts by verified email rather than the stable `sub` claim would accept it.

This is the same outcome as [GHSA-rm8c-2cv8-jwf6](https://github.com/pocket-id/pocket-id/security/advisories/GHSA-rm8c-2cv8-jwf6), but reached by configuration rather than by the bug — so the v2.12.0 bump did not address it.

## Why two settings, not one

**`EMAIL_VERIFICATION_ENABLED` is a separate setting that also defaults to `false`**, and it is what gates the verification prompt (`frontend/src/lib/components/email-verification-state-box.svelte:62`).

Dropping `EMAILS_VERIFIED` on its own would have left new and changed addresses permanently at `email_verified: false` with **no way to verify them** — not "verify for real", but "never verified". Both are required; neither is sufficient alone.

Env var naming confirmed from the loader: with `UI_CONFIG_DISABLED: "true"` config is read only from the environment via `loadDbConfigFromEnv`, which derives names as `CamelCaseToScreamingSnakeCase(jsonKey)` — so `emailVerificationEnabled` becomes `EMAIL_VERIFICATION_ENABLED`.

## Blast radius: none

- **Nobody can be locked out.** `EmailVerified` is used in exactly one functional place — `oidc/claims_service.go:154`, `claims["email_verified"] = user.EmailVerified`. It never gates login or authorization.
- **Existing rows are untouched.** The flag is written only at signup or on an email change.
- **There is exactly one account today, already at `email_verified: false`** — so there is no state to migrate, and enabling verification actually gives that account a way to become verified.
- SMTP is already configured and reachable (`smtp2graph.infrastructure.svc.cluster.local:25`, service confirmed live).

Exposure in the meantime was bounded: signup is `withToken` rather than open, and the route is on `envoy-internal`.

## Verified

- `just kube flate-build-hr security pocket-id` renders `EMAIL_VERIFICATION_ENABLED=true` with `EMAILS_VERIFIED` gone
- Scoped super-linter (`VALIDATE_YAML`) clean