### PR TITLE
feat(observability): scrape the fleet endpoints the doco-cd convergence exposed

### DIFF
--- a/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
@@ -50,11 +50,11 @@ spec:
         # max() collapses nut-exporter's two ServiceMonitor endpoints (one per
         # UPS) to a single scalar so `and on()` has an empty label set to match.
         #
-        # min() over job=~"nut-appliance-.*" covers ALL THREE appliance scrapes
-        # (node, smartctl, docker) in one rule rather than three near-identical
-        # ones — the operator response is the same for any of them, and every
-        # extra rule is another thing that can page. 15m also rides out the
-        # smartctl job's 300s interval (three missed scrapes).
+        # min() over job=~"nut-appliance-.*" covers EVERY appliance scrape (node,
+        # smartctl, docker, doco-cd, traefik) in one rule rather than five
+        # near-identical ones — the operator response is the same for any of
+        # them, and every extra rule is another thing that can page. 15m also
+        # rides out the smartctl job's 300s interval (three missed scrapes).
         - alert: NutApplianceHostMetricsMissing
           annotations:
             description: >-

--- a/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/scrapeconfig.yaml
@@ -142,3 +142,26 @@ spec:
     - action: replace
       targetLabel: instance
       replacement: nut-appliance
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name nut-appliance-traefik
+spec:
+  # Traefik metrics entrypoint (:8082) — per-router/service request stats for
+  # the two dashboards, matching the seedbox-traefik job. The entrypoint landed
+  # with the 2026-07-30 fleet convergence (nut-apps), bound to the LAN address
+  # like the exporters above.
+  staticConfigs:
+    - targets:
+        - ${NUT_SERVER_ADDR}:8082
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: nut-appliance

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -232,3 +232,41 @@ spec:
           for: 2h
           labels:
             severity: info
+    # ---- container lifecycle (docker_state_exporter, seedbox-docker job) ------
+    # Three rules, matching the appliance's lean set rather than the NAS's five:
+    # exporter-down needs no rule of its own here (the job carries
+    # instance=seedbox, so SeedboxDown / SeedboxScrapePathDegraded absorb it),
+    # and OOM-kill is sticky until recreate and re-pages every repeatInterval —
+    # a poor trade on the flappy tailnet scrape path. That flap is also why
+    # `for` is 10m, not the NAS's 5m: container_state_* series simply go absent
+    # when a scrape misses (absence never fires), and 10m rides out a missed
+    # scrape without delaying a real page much.
+    #
+    # Scoped to the doco-cd-managed fleet (cd_doco_metadata_manager) so a
+    # hand-run throwaway container never pages.
+    - name: seedbox-docker.rules
+      rules:
+        - alert: SeedboxContainerDown
+          annotations:
+            summary: "Seedbox container {{ $labels.name }} is not running (state: {{ $labels.status }})."
+          expr: |-
+            container_state_status{job="seedbox-docker", status=~"exited|dead", container_label_cd_doco_metadata_manager="doco-cd"} == 1
+          for: 10m
+          labels:
+            severity: critical
+        - alert: SeedboxContainerUnhealthy
+          annotations:
+            summary: "Seedbox container {{ $labels.name }} healthcheck is failing (unhealthy)."
+          expr: |-
+            container_state_health_status{job="seedbox-docker", health_status="unhealthy"} == 1
+          for: 10m
+          labels:
+            severity: critical
+        - alert: SeedboxContainerFlapping
+          annotations:
+            summary: "Seedbox container {{ $labels.name }} restart count changed {{ $value }} times in the last hour."
+          expr: |-
+            changes(container_restartcount{job="seedbox-docker"}[1h]) > 3
+          for: 10m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
@@ -121,3 +121,34 @@ spec:
     - action: replace
       targetLabel: instance
       replacement: seedbox
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name seedbox-docker
+spec:
+  # docker_state_exporter on the seedbox (:9419) — per-container state, health,
+  # restart count and OOM-kill, keyed by container NAME. Landed with the
+  # 2026-07-30 fleet convergence (seedbox-apps): the seedbox was the one box
+  # without it — netdata sees containers, but the estate's container-lifecycle
+  # alerting keys on container_state_* series only this exposes.
+  staticConfigs:
+    - targets:
+        - seedbox.observability.svc.cluster.local:9419
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  scrapeTimeout: 30s # tailnet-egress scrapes are slow; 30s stops false up=0 (see node job)
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: seedbox
+  metricRelabelings:
+    # Drop the noisy per-container label set but KEEP cd_doco_metadata_manager,
+    # so "container down" can be scoped to the GitOps-managed fleet and a
+    # hand-run throwaway never pages. Same shape as the truenas and appliance jobs.
+    - action: labelkeep
+      regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager

--- a/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
@@ -115,3 +115,56 @@ spec:
     - action: replace
       targetLabel: job
       replacement: *name
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name truenas-traefik
+spec:
+  # Traefik metrics entrypoint (:8082) — per-router/service request stats for
+  # the NAS dashboards and the Garage S3 routes, matching the seedbox-traefik
+  # job. Traefik always had --metrics.prometheus on this box, but until the
+  # 2026-07-30 fleet convergence (truenas-apps) there was no reachable metrics
+  # entrypoint to scrape.
+  staticConfigs:
+    - targets:
+        - ${SECRET_STORAGE_SERVER}:8082
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: truenas
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name truenas-doco-cd
+spec:
+  # doco-cd's own metrics (:9120) — GitOps poll and deploy status for the NAS,
+  # matching the seedbox-doco-cd and nut-appliance-doco-cd jobs.
+  #
+  # Strictly better than "the container is running", which the
+  # truenas-docker-exporter job already covers: doco_cd_polls_total is the
+  # signal that the repo is actually being polled. A doco-cd that is up but has
+  # stopped polling deploys nothing, and the box drifts from truenas-apps with
+  # no other symptom. Unlike the appliance, publishing the port IS
+  # GitOps-adjacent here — it lives in bootstrap/compose.yaml, applied by the
+  # NAS's hourly bootstrap cron rather than by doco-cd itself.
+  staticConfigs:
+    - targets:
+        - ${SECRET_STORAGE_SERVER}:9120
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: truenas


### PR DESCRIPTION
The 2026-07-30 fleet-consistency work on the three doco-cd repos exposed
metrics that had no scrape jobs yet. Close the loop:

- seedbox-docker: docker_state_exporter (:9419) — the seedbox was the one
  box without container-lifecycle series; plus a lean seedbox-docker.rules
  group (down/unhealthy/flapping, 10m holds for the flappy tailnet path;
  exporter-down is absorbed by the existing instance-wide health signals).
- nut-appliance-traefik: the appliance's new Traefik metrics entrypoint
  (:8082), matching seedbox-traefik.
- truenas-traefik + truenas-doco-cd: the NAS's new metrics entrypoint and
  the newly published doco-cd :9120, matching the other two boxes.
- Refresh the NutApplianceHostMetricsMissing comment — its job regex now
  covers five scrapes, not three.
