### PR TITLE
fix(observability): scrape truenas traefik/doco-cd on the ingress alias

### DIFF
--- a/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
@@ -129,7 +129,10 @@ spec:
   # entrypoint to scrape.
   staticConfigs:
     - targets:
-        - ${SECRET_STORAGE_SERVER}:8082
+        # SECRET_STORAGE_INGRESS, not SECRET_STORAGE_SERVER: Traefik and doco-cd
+        # publish on the NAS's dedicated ingress alias address (the bind is the
+        # guard), not the primary address the host-network exporters answer on.
+        - ${SECRET_STORAGE_INGRESS}:8082
   metricsPath: /metrics
   scrapeInterval: 60s
   relabelings:
@@ -158,7 +161,10 @@ spec:
   # NAS's hourly bootstrap cron rather than by doco-cd itself.
   staticConfigs:
     - targets:
-        - ${SECRET_STORAGE_SERVER}:9120
+        # SECRET_STORAGE_INGRESS, not SECRET_STORAGE_SERVER: Traefik and doco-cd
+        # publish on the NAS's dedicated ingress alias address (the bind is the
+        # guard), not the primary address the host-network exporters answer on.
+        - ${SECRET_STORAGE_INGRESS}:9120
   metricsPath: /metrics
   scrapeInterval: 60s
   relabelings:


### PR DESCRIPTION
The two jobs added in #3983 targeted SECRET_STORAGE_SERVER, but Traefik's
metrics entrypoint and doco-cd's :9120 publish on the NAS's dedicated
ingress alias address (bind-is-the-guard discipline), not the primary
address the host-network exporters answer on — so both scraped up=0. New
substitution var SECRET_STORAGE_INGRESS added to the cluster-secrets item
and verified present in the cluster Secret before this lands.
