### PR TITLE
fix(ci): catch single-segment device hostnames in the identifier guard

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -60,7 +60,13 @@ PATTERNS: dict[str, re.Pattern] = {
     "node name": re.compile(r"cr-talos-\d+"),
     # site-prefixed device hostnames, kept as two single-line patterns so black and
     # ruff agree; both exclude cr-talos-* and "ghcr-auth"-style substrings.
-    "device hostname (cr)": re.compile(r"(?<![a-z0-9])cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)+"),
+    #
+    # The trailing group is `*`, not `+`: requiring a second hyphenated segment
+    # meant a single-segment device name (cr-<word>) matched nothing, so the
+    # guard passed on both the tracked-file and the prose path and one such name
+    # reached main in a non-allowlisted file. The leading lookbehind still
+    # excludes "ghcr-auth"-style substrings.
+    "device hostname (cr)": re.compile(r"(?<![a-z0-9])cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)*"),
     "device hostname (sw)": re.compile(r"(?<![a-z0-9])sw-(?:main|comms)-[a-z0-9]+"),
     "MAC address": re.compile(r"(?<![0-9a-fA-F:])(?:[0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}(?![0-9a-fA-F:])"),
     "internal hostname": re.compile(r"\b[a-z0-9_-]+\.(?:lan|internal)\b"),

--- a/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
@@ -76,9 +76,9 @@ spec:
         # Added 2026-07-29 after an incident that was invisible for weeks. Two
         # hand-made Cloudflare DNS-01 tokens carried an IP allowlist that no
         # longer matched the home WAN address, so ACME renewal was dead on both
-        # the cr-nut and TrueNAS Traefik instances. It only came to light
-        # because a cr-nut rebuild destroyed its acme.json and forced an
-        # immediate re-issue; TrueNAS still held a cached certificate valid for
+        # non-cluster Traefik instances. It only came to light because a rebuild
+        # of one of them destroyed its acme.json and forced an immediate
+        # re-issue; TrueNAS still held a cached certificate valid for
         # another six weeks and would have failed silently at its renewal, with
         # nothing in the estate to say so until a browser threw a warning.
         #

--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -41,7 +41,26 @@ spec:
               ANALYTICS_DISABLED: "true"
               APP_URL: "https://id.${SECRET_DOMAIN}"
               DB_PROVIDER: postgres
-              EMAILS_VERIFIED: "true"
+              # Verify email addresses for real rather than asserting them.
+              #
+              # EMAILS_VERIFIED (previously "true") is what a changed or newly
+              # signed-up address is set to, so with it on, a user editing their
+              # own account had any address they typed emitted as
+              # email_verified: true in OIDC claims without ever proving control
+              # of it. AllowOwnAccountEdit defaults to true and we do not
+              # override it, so that path was open to every account.
+              #
+              # EMAIL_VERIFICATION_ENABLED is a SEPARATE setting that also
+              # defaults to false, and it gates the "verify your email" prompt.
+              # Dropping EMAILS_VERIFIED without it would leave new and changed
+              # addresses permanently unverified with no way to verify them.
+              # Both are required; neither is sufficient alone.
+              #
+              # Not a lockout risk: EmailVerified feeds only the OIDC
+              # email_verified claim and is never used to gate login. Existing
+              # rows are untouched — the flag is written only at signup or on an
+              # email change.
+              EMAIL_VERIFICATION_ENABLED: "true"
               KEYS_STORAGE: database
               UI_CONFIG_DISABLED: "true"
               # TODO: Enable LDAP when Active Directory is configured

--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -143,7 +143,7 @@ spec:
             }
 
             filter {
-              # OPNsense (cr-fw) keeps its clock in UTC and sends RFC3164 timestamps with no zone.
+              # OPNsense keeps its clock in UTC and sends RFC3164 timestamps with no zone.
               # The syslog input otherwise reads them in the container's local zone (Europe/London
               # => BST in summer), shifting TimeGenerated ~1h behind ingestion. Re-parse as UTC so
               # TimeGenerated (= the plugin's ls_timestamp = @timestamp) is correct.


### PR DESCRIPTION
## The hole

The `device hostname (cr)` pattern in `check_internal_identifiers.py` was:

```python
cr-(?!talos(?:-|\b))[a-z][a-z0-9]*(?:-[a-z0-9]+)+
```

That trailing `+` requires a **second** hyphenated segment, so a single-segment device name matched nothing at all. `scan_text()` and `scan_files()` share the same pattern dict, so the tracked-file path and the prose path (commit messages, PR bodies) were both blind to it.

Consequence: one such name is already on `main` in a file that is not allowlisted, and every PR carrying it passed `Internal Identifier Scan` green.

## The fix

`+` → `*` on the trailing group. Verified the exclusions still hold:

| Input | Before | After |
|---|---|---|
| single-segment device name | ✗ missed | ✓ caught |
| two-segment device name | ✓ caught | ✓ caught |
| `ghcr-auth` (substring) | ✓ ignored | ✓ ignored |
| a Talos node name | ✓ ignored (node-name pattern owns it) | ✓ ignored |
| `docker-backup` (app name) | ✓ ignored | ✓ ignored |

Both paths tested — tracked-file scan and `--text-file`.

## Cleanup

The tightened pattern finds three pre-existing occurrences, all in explanatory comments where the name was incidental rather than functional, so all three are reworded rather than allowlisted (the allowlist is for values that operate the cluster). Full tracked scan is clean afterwards: `OK -- no new internal infrastructure identifiers (all 1674 tracked files)`.

## How it surfaced

A Codex code-review trial on the open PRs flagged the name in a pending PR — one this guard had just passed green. The finding's stated rationale was wrong (it called the name "previously untracked"; it is already on `main`), but chasing it found the regex defect.

## Validation

- `python3 .github/scripts/check_internal_identifiers.py` — clean
- Prose path spot-checked against the four cases above
- super-linter v8.6.0 locally, scoped to the changed files, with the shared workflow's `VALIDATE_*=false` flags copied verbatim so the polarity matches CI — exit 0
