### PR TITLE
fix(observability): drop the retired traefik-nas cert probe target

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -73,7 +73,12 @@ spec:
         # acme.json, so in principle one target would do — they are listed
         # individually because a per-host issuance failure is exactly the kind
         # of partial breakage a single sampled target would hide.
-        - traefik-nas.${SECRET_DOMAIN}:443
+        #
+        # This list is hand-maintained and WILL drift: traefik-nas was removed
+        # on 2026-07-30 after truenas-apps#34 retired that hostname, which left
+        # this probe paging LanProbeFailed against a name external-dns had
+        # already deleted. If a NAS hostname is added or retired there, change
+        # it here too.
         - dozzle.${SECRET_DOMAIN}:443
         - garage-nas.${SECRET_DOMAIN}:443
         - s3-nas.${SECRET_DOMAIN}:443


### PR DESCRIPTION
## What broke

`truenas-apps#34` retired the `traefik-nas` hostname. external-dns then removed its record, so the name no longer resolves at all.

The cert-expiry probe added earlier the same day (#3954) hardcoded that hostname from a point-in-time grep of the NAS's `Host()` rules — taken *before* #34 landed. Since then it has been failing its TLS handshake and **firing `LanProbeFailed` at critical severity** against a name that does not exist.

Confirmed rather than inferred:

- `probe_success{instance="traefik-nas...:443"} = 0`, all six other targets = 1
- `ALERTS{alertname="LanProbeFailed"}` → **firing**, severity critical, that instance
- `dig traefik-nas.codelooks.com` → no answer, internal or external
- No `Host()` rule for it anywhere on `truenas-apps` `main`

## Fix

Remove the target. The NAS now serves five hostnames, not six.

Also adds a note in the file that this list is **hand-maintained and will drift** with `truenas-apps` — since that is precisely what went wrong, and the next person adding or retiring a NAS hostname needs to know to change it here too.

## Verification

- `lan-tls-cert` now declares 6 targets, matching the 5 live NAS `Host()` rules plus `peanut`.
- super-linter v8 (pinned CI version), `VALIDATE_YAML` → clean.