### PR TITLE
feat(kopia): export index blob counts and alert on runaway growth

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -54,6 +54,87 @@ spec:
                 memory: 1Gi
               limits:
                 memory: 2Gi
+
+          # Counts kopia's index blobs and serves them for Prometheus. It lives
+          # here as a sidecar rather than as its own app purely because this pod
+          # already mounts the repository; it does not talk to the kopia server
+          # process at all, it only walks the filesystem.
+          #
+          # Kopia warns "too many index blobs" and degrades once these pile up,
+          # but exposes no metrics endpoint of its own, so the number existed
+          # only in the maintenance job's log output and nothing could alert on
+          # it. Layout, confirmed against the live repository:
+          #   xn* uncompacted epoch indexes  <- the ones that pile up
+          #   xs* single-epoch compacted
+          #   xr* range-compacted
+          # Split by kind rather than summed because a rising total is only
+          # worth paging on when it is the uncompacted set doing the rising —
+          # that is the signal that compaction is losing to snapshot creation.
+          #
+          # Counted on a slow loop and cached, NOT per scrape: this is a walk
+          # over an NFS export shared with every backup in the estate.
+          index-exporter:
+            image:
+              repository: docker.io/library/busybox
+              tag: 1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+            command:
+              - /bin/sh
+              - -c
+              - |
+                set -eu
+                # Every shell variable reference in this script is doubled in
+                # the source manifest so Flux postBuild emits a single one.
+                # Left undoubled, envsubst either blanks the expansion or fails
+                # the build on a name it cannot parse. Blanking is the dangerous
+                # case: it would emit an empty kind label and a count of zero
+                # forever, giving a monitor that looks healthy and can never
+                # fire. Check the rendered output, not just the source, after
+                # editing this block.
+                M=kopia_repo_index_blobs
+                # arg 1 = blob prefix under /repository, arg 2 = metric label
+                emit() {
+                  n=$$(find /repository/x$$1[0-9] -type f 2>/dev/null | wc -l)
+                  echo "$$M{kind=\"$$2\"} $$n"
+                }
+                # Write atomically so a scrape never reads a half-built file.
+                collect() {
+                  {
+                    echo "# HELP $$M Index blobs in the kopia repository."
+                    echo "# TYPE $$M gauge"
+                    emit n uncompacted
+                    emit s single_epoch
+                    emit r range
+                  } > /metrics/.index.prom
+                  mv /metrics/.index.prom /metrics/index.prom
+                }
+                collect
+                while true; do sleep 900; collect; done &
+                exec httpd -f -v -p 9101 -h /metrics
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /index.prom
+                    port: 9101
+                  initialDelaySeconds: 15
+                  periodSeconds: 60
+                  failureThreshold: 3
+              readiness:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -67,6 +148,8 @@ spec:
         ports:
           http:
             port: *port
+          metrics:
+            port: &metricsPort 9101
     route:
       app:
         parentRefs:
@@ -105,8 +188,22 @@ spec:
         type: nfs
         server: ${SECRET_STORAGE_SERVER:-localhost}
         path: ${SECRET_STORAGE_SERVER_VOLSYNC_NFS:-/tmp}
-        globalMounts:
-          - path: /repository
+        # advancedMounts rather than globalMounts so the exporter gets the
+        # repository read-only. It only ever counts files, and nothing that
+        # merely observes the backup repository should be able to write to it.
+        advancedMounts:
+          kopia:
+            app:
+              - path: /repository
+            index-exporter:
+              - path: /repository
+                readOnly: true
+      metrics:
+        type: emptyDir
+        advancedMounts:
+          kopia:
+            index-exporter:
+              - path: /metrics
       tmpfs:
         type: emptyDir
         advancedMounts:

--- a/kubernetes/apps/volsync-system/kopia/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - ./gatus.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./prometheusrule.yaml
+  - ./servicemonitor.yaml

--- a/kubernetes/apps/volsync-system/kopia/app/prometheusrule.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/prometheusrule.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: &app kopia
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  groups:
+    - name: kopia.repository
+      rules:
+        # One alert, on an absolute ceiling, because every severity here pages.
+        #
+        # Kopia warns "too many index blobs" and degrades every repository
+        # operation once these accumulate, and maintenance compacts only a
+        # bounded number of epochs per run. About 100 ReplicationSources share
+        # this repository, so creation can outpace compaction — which is exactly
+        # what happened on 2026-07-30 (2803 -> 4048 over 16h at a 4h cadence,
+        # fixed by moving maintenance to hourly).
+        #
+        # 10000 is roughly 2.5x the level that trend reached, so it fires only
+        # if hourly maintenance is clearly losing rather than merely lagging.
+        # Deliberately NOT a growth-rate alert: the per-run deltas are lumpy
+        # (+6 one run, +618 the next), so a rate threshold would page on noise.
+        #
+        # `for: 2h` means at least two maintenance runs have failed to bring it
+        # back under, so a single slow run does not page.
+        - alert: KopiaIndexBlobsHigh
+          expr: sum(kopia_repo_index_blobs) > 10000
+          for: 2h
+          labels:
+            severity: warning
+          annotations:
+            summary: Kopia index blobs above 10000 for 2h
+            description: >-
+              The kopia repository holds {{ $value | humanize }} index blobs.
+              Maintenance runs hourly and compacts a bounded number of epochs
+              per run, so this means compaction is losing to snapshot creation.
+              Break it down by kind with
+              kopia_repo_index_blobs — a high "uncompacted" share confirms it.
+              Next lever is backup retention (hourly: 168 in
+              components/volsync/nfs), not maintenance frequency.

--- a/kubernetes/apps/volsync-system/kopia/app/servicemonitor.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/servicemonitor.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: &app kopia
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: *app
+  endpoints:
+    # The sidecar recounts on a 15m loop and serves the cached result, so the
+    # scrape itself is a static file read — the interval here costs nothing and
+    # does not drive NFS load. Path is the file busybox httpd serves, not
+    # /metrics.
+    - port: metrics
+      scheme: http
+      path: /index.prom
+      interval: 5m
+      relabelings:
+        - action: replace
+          targetLabel: instance
+          replacement: *app


### PR DESCRIPTION
Follow-up to #3981. That PR moved maintenance to hourly to stop index blobs accumulating, but nothing watches whether it worked — the number lives only in the maintenance job's log output, and I found the growth by reading logs by hand.

## What this adds

A sidecar on the **existing** kopia pod (it already mounts the repository), plus a ServiceMonitor and one PrometheusRule.

The sidecar never talks to the kopia server process — it only walks the filesystem — and takes the repository mount **read-only**, since nothing that merely observes the backup repository should be able to write to it. That required switching the NFS volume from `globalMounts` to `advancedMounts`.

```
kopia_repo_index_blobs{kind="uncompacted"}    xn*  <- the ones that pile up
kopia_repo_index_blobs{kind="single_epoch"}   xs*
kopia_repo_index_blobs{kind="range"}          xr*
```

Split by kind rather than summed, because a rising total only matters when it is the **uncompacted** set rising — that is the signal compaction is losing to snapshot creation. Layout confirmed against the live repository.

Counted on a **15m loop and cached**, not per scrape: this is a directory walk over an NFS export shared with every backup in the estate.

## The alert

One alert, absolute ceiling `sum(kopia_repo_index_blobs) > 10000`, `for: 2h`, `severity: warning` — because every severity here pages, so it has to fire approximately never. 10000 is ~2.5x the level the pre-fix trend reached (2803 → 4048 over 16h), so it fires only if hourly maintenance is clearly losing rather than merely lagging.

Deliberately **not** a growth-rate alert: the per-run deltas are lumpy (+6 one run, +618 the next), so a rate threshold would page on noise.

## A trap worth recording

My first two attempts were silently broken by Flux `postBuild`:

- `${p%%:*}` / `${p##*:}` were **blanked** — envsubst replaces unknown `${name}` with the empty string. The exporter rendered `kind=""` with a count of `0`, permanently. A monitor that looks healthy and can never fire.
- Rewriting with `$1`/`$2` then failed the build outright: `postBuild: unable to parse variable name`.

Every shell variable is now doubled in the source so Flux emits a single one, and there is a comment on the block saying to check the **rendered** output rather than the source after editing it.

## Verified

- Ran the **rendered** script (not the source) against the live repository: `3120 / 229 / 28`, matching a manual count exactly
- `kubectl apply --server-side --dry-run=server` on both new CRs — accepted
- `flate test all --namespace volsync-system` — 9 passed
- Rendered Deployment confirms `/repository` is `readOnly: true` on the sidecar and read-write on kopia
- Rendered Service carries `app.kubernetes.io/instance: kopia`, matching the ServiceMonitor selector; Prometheus `ruleSelector` and `serviceMonitorSelector` are both `{}`, so no extra labels are needed
- Scoped super-linter (`VALIDATE_YAML`) clean

Post-merge I will confirm the rule actually **loads** in Prometheus and the series appears — a CR existing is not the same as a rule being live.