### PR TITLE
fix(kopia): serve the index metrics as .txt so Prometheus will scrape it

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -96,6 +96,14 @@ spec:
                   n=$$(find /repository/x$$1[0-9] -type f 2>/dev/null | wc -l)
                   echo "$$M{kind=\"$$2\"} $$n"
                 }
+                # Served as .txt, not .prom, and that extension is load-bearing:
+                # busybox httpd sets Content-Type from a built-in table that
+                # knows .txt (text/plain) but not .prom, and Prometheus 3
+                # refuses a target "sending blank Content-Type" unless a
+                # fallback_scrape_protocol is set — which this operator's
+                # ServiceMonitor CRD does not expose. Renaming to .prom marks
+                # the target down.
+                #
                 # Write atomically so a scrape never reads a half-built file.
                 collect() {
                   {
@@ -104,8 +112,8 @@ spec:
                     emit n uncompacted
                     emit s single_epoch
                     emit r range
-                  } > /metrics/.index.prom
-                  mv /metrics/.index.prom /metrics/index.prom
+                  } > /metrics/.metrics.txt
+                  mv /metrics/.metrics.txt /metrics/metrics.txt
                 }
                 collect
                 while true; do sleep 900; collect; done &
@@ -116,7 +124,7 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /index.prom
+                    path: /metrics.txt
                     port: 9101
                   initialDelaySeconds: 15
                   periodSeconds: 60

--- a/kubernetes/apps/volsync-system/kopia/app/servicemonitor.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/servicemonitor.yaml
@@ -13,11 +13,16 @@ spec:
   endpoints:
     # The sidecar recounts on a 15m loop and serves the cached result, so the
     # scrape itself is a static file read — the interval here costs nothing and
-    # does not drive NFS load. Path is the file busybox httpd serves, not
-    # /metrics.
+    # does not drive NFS load.
+    #
+    # Path is a static file, and the .txt is load-bearing: busybox httpd sets
+    # Content-Type from a built-in table that knows .txt but not .prom, and
+    # Prometheus 3 marks a target down for "sending blank Content-Type" unless
+    # a fallback_scrape_protocol is set, which this operator's ServiceMonitor
+    # CRD does not expose. Keep the extension if this file is ever renamed.
     - port: metrics
       scheme: http
-      path: /index.prom
+      path: /metrics.txt
       interval: 5m
       relabelings:
         - action: replace


### PR DESCRIPTION
Fixes the exporter added in #4009. It came up healthy and served correct numbers, but Prometheus marked the target **down**:

```
non-compliant scrape target sending blank Content-Type and no
fallback_scrape_protocol specified for target
```

## Cause

busybox `httpd` sets `Content-Type` from a built-in table that knows `.txt` but has no entry for `.prom`, so it sent none. Prometheus 3 rejects that unless `fallback_scrape_protocol` is configured.

Verified empirically in the running container rather than assumed:

```
index.prom   -> (no Content-Type header)
t.txt        -> Content-type: text/plain
```

## Why not fallback_scrape_protocol

That would be the semantically correct fix, but this operator's ServiceMonitor CRD does not expose it — I checked the installed schema and there is no fallback/protocol property on the endpoint object. Renaming the served file makes the target genuinely compliant instead of working around it.

## Change

`/metrics/index.prom` → `/metrics/metrics.txt`, with the ServiceMonitor path and the sidecar liveness probe updated to match. The extension is now load-bearing, so both the script and the ServiceMonitor carry a comment saying so — this is exactly the kind of thing that gets "tidied" back to `.prom` later.

## Verified

- Rendered script writes and serves `metrics.txt`; probe path is `/metrics.txt`
- `flate test all --namespace volsync-system` — 9 passed
- Scoped super-linter (`VALIDATE_YAML`) clean

Post-merge I will confirm the target goes `health=up` and the series actually appears — the previous PR passed every static check and still produced a dead target, so nothing counts until the scrape lands.