### PR TITLE
feat(observability): probe the storage BMC

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -21,6 +21,10 @@ spec:
         - cr-node-06-ipmi.${SECRET_INTERNAL_DOMAIN}
         - cr-node-07-ipmi.${SECRET_INTERNAL_DOMAIN}
         - cr-node-08-ipmi.${SECRET_INTERNAL_DOMAIN}
+        # Storage BMC. The eight above are compute nodes; this one was simply
+        # never added, so the box holding the bulk data had no out-of-band
+        # liveness signal at all.
+        - cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}
   metricRelabelings:
     - action: replace
       replacement: blackbox-exporter-lan


### PR DESCRIPTION
The `lan-icmp` probe covered the eight compute-node BMCs but not the storage one, so the box holding the bulk data had no out-of-band liveness signal at all.

Same established pattern, one additional target. DNS for the name already resolves, so nothing else is needed.