### PR TITLE
feat(observability): Redfish BMC monitoring for the Supermicro fleet

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -115,6 +115,7 @@ ALLOWLIST: dict[str, str] = {
     "kubernetes/apps/network/envoy-gateway/app/envoy.yaml": "Envoy LB listener IPs",
     "kubernetes/apps/network/scanopy/app/daemon-helmrelease.yaml": "LAN scan ranges",
     "kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml": "blackbox LAN probe targets",
+    "kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml": "BMC Redfish hosts (as blackbox probe)",
     "kubernetes/apps/observability/nut-exporter/app/prometheusrule.yaml": "NUT UPS alert selectors",
     "kubernetes/apps/observability/nut-exporter/app/servicemonitor.yaml": "NUT scrape targets",
     "kubernetes/apps/observability/snmp-exporter/app/configmap-entity-sensor.yaml": "SNMP sensor module",

--- a/docs/docs/operations/device-monitoring.md
+++ b/docs/docs/operations/device-monitoring.md
@@ -19,6 +19,7 @@ cross-cutting "what lives where and how to update it" reference.
 | Firewall       | `AthennaMind/opnsense-exporter`   | `opnsense-exporter`                           | `host` field in item         | `opnsense-exporter`                    |
 | Core switch    | `prometheus/snmp_exporter`        | `snmp-exporter`                               | `${ONYX_ADDR}`               | — (SNMP community `<community>`)       |
 | UPS (NUT)      | `hon95/prometheus-nut-exporter`   | `nut-exporter`                                | `${NUT_SERVER_ADDR}`         | — (anonymous NUT protocol read)        |
+| Server BMCs    | `mrlhansen/idrac_exporter`        | `bmc-exporter`                                | ExternalSecret (`/discover`) | one item per BMC (shared with certwarden) |
 
 All of these run on **least-privilege, dedicated read-only accounts**, never an
 admin credential.
@@ -147,6 +148,38 @@ Add an entry under `serviceMonitor.params` in
 A custom SNMP module or auth goes in `configmap-entity-sensor.yaml`; it is merged
 with the image's bundled `snmp.yml` via the two `--config.file` `extraArgs`.
 
+### Add a BMC to Redfish monitoring
+
+`bmc-exporter` is a multi-target Redfish exporter for the Supermicro BMC fleet,
+added by PR #4022. Everything about a BMC — hostname, username, password — lives
+in `app/externalsecret.yaml`, which templates the exporter's whole `idrac.yml`
+and mounts it via the chart's `existingSecret`. There is no second target list:
+Prometheus discovers targets from the exporter's own `/discover` endpoint, so
+the ExternalSecret is the single source of truth.
+
+To add one:
+
+1. Create (or reuse) the per-BMC item in the `Talos` vault with `IPMI_USERNAME`
+   and `IPMI_PASSWORD`. The fleet already has one item per BMC because
+   certwarden uses the same items to deploy certificates to these boards.
+2. Add a `data:` pair pointing at that item, and a matching entry under `hosts:`
+   in the templated `idrac.yml`.
+3. Add the same host to the `lan-icmp` Probe in
+   `blackbox-exporter/lan/probes.yaml` if it is not already there — see below
+   for why both exist.
+
+Credentials are **not** uniform across the fleet: it shares one username but
+every board has its own password, so `hosts.default` cannot be used and each BMC
+needs its own entry.
+
+### Why ICMP probes and Redfish both cover the BMCs
+
+They answer different questions and the overlap is deliberate. A Redfish scrape
+needs reachability, TLS and a valid login all at once, so a failure is
+ambiguous. The ICMP result is what separates a dead BMC from a broken
+credential: down in both means network or BMC, up in ICMP but down in Redfish
+means credentials, TLS or firmware.
+
 ### Add a RouterOS switch to snmp-exporter
 
 The `mktxp` route is retired (see the warning above). Add RouterOS switches the
@@ -209,3 +242,25 @@ kubectl exec -n observability deploy/snmp-exporter -- \
 - **TrueNAS ZFS metrics** require the graphite Custom App to be installed on
   TrueNAS itself (see `truenas-monitoring.md`); until then
   `truenas-graphite-exporter` shows `up=0`.
+- **A Redfish scrape is slow, and the exporter's default timeout is too short
+  for these boards.** Measured on the live fleet: ~7.5s warm on the newer
+  boards, ~13s on the older one, ~23s cold after a BMC restart. The exporter
+  defaults to a 10s Redfish timeout, which aborts collection mid-flight and
+  yields a partial scrape rather than an obvious error, so `bmc-exporter` sets
+  `timeout: 45` against a 60s interval and 55s scrape timeout.
+- **A powered-off host drops every sensor series.** Only `idrac_system_power_on
+  0` remains — no temperatures, no fans, no PSU readings. Any alert on those
+  sensors therefore cannot fire for a machine that is off, which is why
+  `BmcFanStopped` is guarded on `idrac_system_power_on == 1` rather than relying
+  on the series being absent.
+- **Supermicro exposes no storage metrics over Redfish** on either board
+  generation here — the tree exists but is not populated. Drive health stays
+  with `smartctl-exporter`; do not expect `idrac_storage_*` to appear.
+- **Do not read `idrac_power_supply_output_watts` as consumption.** On these
+  boards it disagrees with the system-level reading by an order of magnitude (a
+  node drawing 95W at `idrac_power_control_consumed_watts` reports ~450W per
+  PSU). Dashboards use the system-level metric for draw; the PSU figure is shown
+  separately and labelled as reported.
+- **`idrac_*_health` metrics are an enum, not a boolean**: 0=OK, 1=Warning,
+  2=Critical. Alert on `> 0`, never `== 1`, or a jump straight to Critical is
+  missed.

--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -21,6 +21,10 @@ spec:
         - cr-node-06-ipmi.${SECRET_INTERNAL_DOMAIN}
         - cr-node-07-ipmi.${SECRET_INTERNAL_DOMAIN}
         - cr-node-08-ipmi.${SECRET_INTERNAL_DOMAIN}
+        # Storage BMC. The eight above are compute nodes; this one was simply
+        # never added, so the box holding the bulk data had no out-of-band
+        # liveness signal at all.
+        - cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}
   metricRelabelings:
     - action: replace
       replacement: blackbox-exporter-lan

--- a/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
@@ -1,0 +1,145 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# The exporter reads one config file that must carry a login for every BMC, so
+# the whole of idrac.yml is templated here and mounted from the rendered Secret
+# (helmrelease `existingSecret`) rather than living in a git-tracked ConfigMap.
+#
+# Credentials are NOT uniform: the fleet shares one username but every board has
+# its own password, so `hosts.default` cannot be used and each BMC needs its own
+# entry. The per-host 1Password items are the same ones certwarden already uses
+# to deploy certificates to these boards.
+#
+# The FQDNs are the same nine already carried by the allowlisted blackbox
+# `probes.yaml`, so this file is allowlisted in check_internal_identifiers.py on
+# the same basis. `${SECRET_INTERNAL_DOMAIN}` is substituted by Flux at
+# apply-time; `{{ . }}` is left alone by Flux and rendered by external-secrets.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bmc-exporter
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: bmc-exporter-config
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        idrac.yml: |
+          address: 0.0.0.0
+          port: 9348
+          # A cold scrape of the X12 board takes ~23s and a warm one ~13s, so the
+          # 10s default aborts mid-collection. Kept below the 55s scrape timeout
+          # in the ScrapeConfig.
+          timeout: 45
+          metrics:
+            all: true
+          # Supermicro SEL entries surface here as idrac_events_log_entry. Bounded
+          # deliberately: `message` is a label, so an unfiltered log would be a
+          # cardinality risk. warning-and-above over 7d is nothing in steady state.
+          events:
+            severity: warning
+            maxage: 7d
+          hosts:
+            cr-node-01-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node01_user }}"
+              password: "{{ .node01_pass }}"
+            cr-node-02-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node02_user }}"
+              password: "{{ .node02_pass }}"
+            cr-node-03-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node03_user }}"
+              password: "{{ .node03_pass }}"
+            cr-node-04-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node04_user }}"
+              password: "{{ .node04_pass }}"
+            cr-node-05-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node05_user }}"
+              password: "{{ .node05_pass }}"
+            cr-node-06-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node06_user }}"
+              password: "{{ .node06_pass }}"
+            cr-node-07-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node07_user }}"
+              password: "{{ .node07_pass }}"
+            cr-node-08-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .node08_user }}"
+              password: "{{ .node08_pass }}"
+            cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}:
+              username: "{{ .storage_user }}"
+              password: "{{ .storage_pass }}"
+  data:
+    - secretKey: node01_user
+      remoteRef:
+        key: cr-node-01-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node01_pass
+      remoteRef:
+        key: cr-node-01-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node02_user
+      remoteRef:
+        key: cr-node-02-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node02_pass
+      remoteRef:
+        key: cr-node-02-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node03_user
+      remoteRef:
+        key: cr-node-03-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node03_pass
+      remoteRef:
+        key: cr-node-03-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node04_user
+      remoteRef:
+        key: cr-node-04-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node04_pass
+      remoteRef:
+        key: cr-node-04-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node05_user
+      remoteRef:
+        key: cr-node-05-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node05_pass
+      remoteRef:
+        key: cr-node-05-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node06_user
+      remoteRef:
+        key: cr-node-06-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node06_pass
+      remoteRef:
+        key: cr-node-06-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node07_user
+      remoteRef:
+        key: cr-node-07-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node07_pass
+      remoteRef:
+        key: cr-node-07-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: node08_user
+      remoteRef:
+        key: cr-node-08-ipmi
+        property: IPMI_USERNAME
+    - secretKey: node08_pass
+      remoteRef:
+        key: cr-node-08-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: storage_user
+      remoteRef:
+        key: cr-storage-ipmi
+        property: IPMI_USERNAME
+    - secretKey: storage_pass
+      remoteRef:
+        key: cr-storage-ipmi
+        property: IPMI_PASSWORD

--- a/kubernetes/apps/observability/bmc-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/grafanadashboard.yaml
@@ -1,0 +1,192 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: bmc-redfish
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  # Grafana template variables are written bare ($instance, not $${instance}):
+  # Flux postBuild only consumes the braced ${VAR} form, verified against the
+  # live onyx-core-switch dashboard which has carried bare $instance unharmed.
+  #
+  # Fleet draw is taken from idrac_power_control_consumed_watts (the system-level
+  # reading) rather than by summing idrac_power_supply_output_watts. On these
+  # H13 boards the two disagree by an order of magnitude — a node drawing 95W at
+  # the system level reports ~450W per PSU — so the PSU figure is shown on its
+  # own panel, labelled as reported, and is not to be read as consumption.
+  json: |-
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "refresh": "1m",
+      "schemaVersion": 39,
+      "tags": ["bmc", "redfish", "hardware"],
+      "time": {"from": "now-6h", "to": "now"},
+      "timezone": "browser",
+      "title": "BMC Fleet (Redfish)",
+      "uid": "bmc-redfish",
+      "templating": {
+        "list": [
+          {
+            "allValue": ".*",
+            "current": {"selected": true, "text": "All", "value": "$__all"},
+            "datasource": {"type": "prometheus", "uid": "prometheus"},
+            "definition": "label_values(idrac_system_power_on{job=\"bmc-exporter\"}, instance)",
+            "includeAll": true,
+            "multi": true,
+            "name": "instance",
+            "label": "BMC",
+            "query": "label_values(idrac_system_power_on{job=\"bmc-exporter\"}, instance)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "panels": [
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}, "id": 100, "panels": [], "title": "Fleet", "type": "row"},
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Hosts powered on",
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "sum(idrac_system_power_on{job=\"bmc-exporter\"})", "refId": "A"}],
+          "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "green"}, "unit": "short"}, "overrides": []}
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Hosts powered off",
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "count(idrac_system_power_on{job=\"bmc-exporter\"} == 0) or vector(0)", "refId": "A"}],
+          "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"unit": "short", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}}, "overrides": []}
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Fleet power draw",
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "sum(idrac_power_control_consumed_watts{job=\"bmc-exporter\"})", "refId": "A"}],
+          "options": {"colorMode": "value", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "blue"}, "unit": "watt"}, "overrides": []}
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Unhealthy components",
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "count(idrac_system_health{job=\"bmc-exporter\"} > 0) + count(idrac_power_supply_health{job=\"bmc-exporter\"} > 0) + count(idrac_sensors_fan_health{job=\"bmc-exporter\"} > 0) + count(idrac_memory_module_health{job=\"bmc-exporter\"} > 0) + count(idrac_cpu_health{job=\"bmc-exporter\"} > 0) or vector(0)", "refId": "A"}],
+          "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"unit": "short", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []}
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "Power state by host",
+          "gridPos": {"h": 6, "w": 12, "x": 0, "y": 5},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_system_power_on{job=\"bmc-exporter\"}", "legendFormat": "{{instance}}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OFF", "color": "red", "index": 0}, "1": {"text": "ON", "color": "green", "index": 1}}}]}, "overrides": []}
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "System health by host",
+          "gridPos": {"h": 6, "w": 12, "x": 12, "y": 5},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_system_health{job=\"bmc-exporter\"}", "legendFormat": "{{instance}}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARNING", "color": "orange", "index": 1}, "2": {"text": "CRITICAL", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 11}, "id": 101, "panels": [], "title": "Thermal and fans", "type": "row"},
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "Temperatures",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_sensors_temperature{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / {{name}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "fieldConfig": {"defaults": {"unit": "celsius", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 80}, {"color": "red", "value": 90}]}}, "overrides": []}
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Fan speed",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_sensors_fan_speed{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / {{name}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "min"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "fieldConfig": {"defaults": {"unit": "rotrpm", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}}, "overrides": []}
+        },
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 20}, "id": 102, "panels": [], "title": "Power", "type": "row"},
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "System power draw",
+          "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_power_control_consumed_watts{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "mean", "max"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "fieldConfig": {"defaults": {"unit": "watt", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never"}}, "overrides": []}
+        },
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "PSU input voltage (0 V = feed lost)",
+          "gridPos": {"h": 8, "w": 12, "x": 12, "y": 21},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_power_supply_input_voltage{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / PSU {{id}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "min"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "fieldConfig": {"defaults": {"unit": "volt", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}, "min": 0}, "overrides": []}
+        },
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 29}, "id": 103, "panels": [], "title": "Component health", "type": "row"},
+        {
+          "id": 11,
+          "type": "stat",
+          "title": "Memory modules (ECC)",
+          "gridPos": {"h": 7, "w": 8, "x": 0, "y": 30},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_memory_module_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / DIMM {{id}}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {
+          "id": 12,
+          "type": "stat",
+          "title": "Power supplies",
+          "gridPos": {"h": 7, "w": 8, "x": 8, "y": 30},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_power_supply_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / PSU {{id}}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {
+          "id": 13,
+          "type": "stat",
+          "title": "Processors and BMC",
+          "gridPos": {"h": 7, "w": 8, "x": 16, "y": 30},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "idrac_cpu_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / CPU {{id}}", "refId": "A"},
+            {"expr": "idrac_manager_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / BMC", "refId": "B"}
+          ],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/bmc-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/helmrelease.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+#
+# Redfish monitoring for the Supermicro BMC fleet.
+#
+# Named bmc-exporter for what it does here, while the chart, image and metric
+# prefix stay upstream's `idrac`: the exporter is vendor-neutral Redfish and is
+# explicitly tested against Supermicro, and keeping the default `idrac_` prefix
+# means upstream's dashboards and docs apply to this deployment unchanged. The
+# prefix is settable, but changing it later orphans every stored series, so it
+# is left alone deliberately rather than by omission.
+#
+# What the boards actually return here, measured against the live fleet rather
+# than assumed from the schema:
+#   - temperatures, fan RPM/health, voltages, PSU health/watts/input voltage,
+#     per-DIMM health, per-CPU health, BMC manager health, system power state
+#   - NO storage metrics on either board generation — Supermicro does not
+#     populate that Redfish tree, so drive health stays with smartctl-exporter
+#   - a powered-off host drops all of its sensor series and reports only
+#     idrac_system_power_on 0, which is what the alert rules key off
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bmc-exporter
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: idrac-exporter
+      version: 2.6.1
+      sourceRef:
+        kind: HelmRepository
+        name: idrac-exporter
+  values:
+    fullnameOverride: *app
+    image:
+      repository: ghcr.io/mrlhansen/idrac_exporter
+      tag: 2.6.1@sha256:2679bafcc31f87bce9f4dcd4d29df20b76aebd037b4df5f826a0ccc4027b0d59
+    # The whole of idrac.yml, credentials included, is rendered by the
+    # ExternalSecret and mounted at /etc/prometheus. Setting this suppresses the
+    # chart's own config Secret, so no BMC login is ever built from git values.
+    existingSecret: bmc-exporter-config
+    # The exporter only reads its config at startup, and the chart exposes a
+    # deployment annotation directly, so no postRenderer is needed here.
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    # Nothing here talks to the Kubernetes API — it reads a mounted config and
+    # makes outbound HTTPS calls to the BMCs.
+    serviceAccount:
+      automount: false
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+    prometheus:
+      # Deliberately off. The chart's ServiceMonitor scrapes /metrics with no
+      # target parameter, which is not a valid call for a multi-target exporter.
+      # Every per-target scrape below already carries idrac_exporter_build_info
+      # and idrac_exporter_scrape_errors_total, and `up` per target covers
+      # liveness, so this would add a permanently-failing target and nothing else.
+      monitor:
+        enabled: false
+      # Alerts are a standalone PrometheusRule in this directory rather than the
+      # chart's additionalRules, so they read as ordinary rule YAML.
+      rules:
+        enabled: false
+      # Targets come from the exporter's own /discover endpoint, which lists
+      # exactly the hosts in the mounted config. One source of truth: adding a
+      # BMC to the ExternalSecret adds a scrape target, with no second list to
+      # drift out of step.
+      #
+      # 60s/55s, not the usual 30s: a warm scrape measured ~7.5s on the H13
+      # boards and ~13s on the X12, and a cold one after a BMC restart ~23s.
+      scrapeConfig:
+        enabled: true
+        interval: 60s
+        scrapeTimeout: 55s
+        # The chart's own relabelings map the discovered host into ?target= and
+        # into `instance`; these are appended after them. Without an explicit
+        # job the operator names it scrapeConfig/<ns>/<name>, so it is set here
+        # the same way the nut-appliance ScrapeConfigs do it.
+        relabelings:
+          - action: replace
+            replacement: *app
+            targetLabel: job

--- a/kubernetes/apps/observability/bmc-exporter/app/helmrepository.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/helmrepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/helmrepository_v1.json
+# HelmRepository rather than the house-preferred OCIRepository: this chart is
+# only published as tarballs on GitHub Pages, with no OCI artifact anywhere.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: idrac-exporter
+spec:
+  interval: 1h
+  url: https://mrlhansen.github.io/idrac_exporter

--- a/kubernetes/apps/observability/bmc-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./grafanadashboard.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
@@ -1,0 +1,147 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+#
+# All idrac_*_health metrics are an enum, not a boolean: 0=OK, 1=Warning,
+# 2=Critical. Hence `> 0` throughout rather than `== 1`, so a jump straight to
+# Critical is never missed.
+#
+# Thresholds below were set against readings taken from the live fleet under
+# normal load: CPU 59C, System 43C, VRM 42C, DIMM 40C, NVMe 38C, NIC 57C. The
+# 80C warning therefore sits ~20C above the hottest sensor in routine service.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: bmc-exporter.rules
+spec:
+  groups:
+    - name: bmc-exporter.rules
+      rules:
+        # Covers both the exporter process dying and a single BMC becoming
+        # unreachable or rejecting the login. It cannot distinguish those, which
+        # is exactly why the ICMP probes in blackbox-exporter were kept: a BMC
+        # that is down there too is a network/BMC fault, one that is up there but
+        # down here is credentials, TLS or firmware.
+        - alert: BmcTargetDown
+          annotations:
+            summary: "Redfish scrape of {{ $labels.instance }} is failing — check the ICMP probe for the same host to tell a dead BMC from a broken login."
+          expr: |-
+            up{job="bmc-exporter"} == 0
+          for: 15m
+          labels:
+            severity: critical
+        # The gap this whole exporter exists to close: a BMC answers ICMP
+        # identically whether its host is running or powered off.
+        - alert: BmcHostPoweredOff
+          annotations:
+            summary: "Host behind {{ $labels.instance }} is powered off."
+          expr: |-
+            idrac_system_power_on{job="bmc-exporter"} == 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: BmcSystemUnhealthy
+          annotations:
+            summary: "{{ $labels.instance }} reports system health {{ $labels.status }} — check the BMC event log."
+          expr: |-
+            idrac_system_health{job="bmc-exporter"} > 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: BmcPowerSupplyUnhealthy
+          annotations:
+            summary: "PSU {{ $labels.id }} on {{ $labels.instance }} reports {{ $labels.status }}."
+          expr: |-
+            idrac_power_supply_health{job="bmc-exporter"} > 0
+          for: 15m
+          labels:
+            severity: warning
+        # Redundancy lost rather than the PSU itself faulting: the module is
+        # healthy but its feed is gone, which is what a tripped breaker or a
+        # pulled cable looks like. Both PSUs read ~237V in normal service.
+        - alert: BmcPowerSupplyInputLost
+          annotations:
+            summary: "PSU {{ $labels.id }} on {{ $labels.instance }} has lost input voltage — the host is running unprotected on its remaining supply."
+          expr: |-
+            idrac_power_supply_input_voltage{job="bmc-exporter"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        - alert: BmcFanUnhealthy
+          annotations:
+            summary: "Fan {{ $labels.name }} on {{ $labels.instance }} reports {{ $labels.status }}."
+          expr: |-
+            idrac_sensors_fan_health{job="bmc-exporter"} > 0
+          for: 10m
+          labels:
+            severity: warning
+        # Guarded on power state so a deliberate shutdown does not read as a
+        # stopped fan. A powered-off host drops its sensor series entirely, but
+        # the guard also covers the window while it is spinning down.
+        - alert: BmcFanStopped
+          annotations:
+            summary: "Fan {{ $labels.name }} on {{ $labels.instance }} has stopped while the host is running."
+          expr: |-
+            idrac_sensors_fan_speed{job="bmc-exporter"} == 0
+            and on (instance) idrac_system_power_on{job="bmc-exporter"} == 1
+          for: 10m
+          labels:
+            severity: critical
+        - alert: BmcTemperatureHigh
+          annotations:
+            summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C."
+          expr: |-
+            idrac_sensors_temperature{job="bmc-exporter"} > 80
+            and idrac_sensors_temperature{job="bmc-exporter"} <= 90
+          for: 15m
+          labels:
+            severity: warning
+        # Bounded away from the warning above because this Alertmanager has no
+        # inhibit_rules — an unbounded warning would page a second time for the
+        # same sensor alongside the critical.
+        - alert: BmcTemperatureCritical
+          annotations:
+            summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C — thermal shutdown territory."
+          expr: |-
+            idrac_sensors_temperature{job="bmc-exporter"} > 90
+          for: 5m
+          labels:
+            severity: critical
+        # Correctable ECC errors degrade a DIMM's health long before it fails
+        # outright, and nothing else in the estate can see this.
+        - alert: BmcMemoryModuleUnhealthy
+          annotations:
+            summary: "DIMM {{ $labels.id }} on {{ $labels.instance }} reports {{ $labels.status }} — likely ECC errors."
+          expr: |-
+            idrac_memory_module_health{job="bmc-exporter"} > 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: BmcCpuUnhealthy
+          annotations:
+            summary: "CPU {{ $labels.id }} on {{ $labels.instance }} reports {{ $labels.status }}."
+          expr: |-
+            idrac_cpu_health{job="bmc-exporter"} > 0
+          for: 15m
+          labels:
+            severity: warning
+        # The BMC reporting on itself. Long `for` because a firmware update or a
+        # BMC reset trips this briefly and resolves on its own.
+        - alert: BmcManagerUnhealthy
+          annotations:
+            summary: "BMC {{ $labels.instance }} reports its own health as {{ $labels.status }}."
+          expr: |-
+            idrac_manager_health{job="bmc-exporter"} > 0
+          for: 30m
+          labels:
+            severity: warning
+        # SEL entries at warning or above, within the 7d window set in the
+        # exporter config. The metric's value is the entry's creation timestamp,
+        # so presence alone is the signal.
+        - alert: BmcEventLogWarning
+          annotations:
+            summary: "{{ $labels.instance }} logged a {{ $labels.severity }} hardware event: {{ $labels.message }}"
+          expr: |-
+            idrac_events_log_entry{job="bmc-exporter"} > 0
+          for: 5m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/bmc-exporter/ks.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app bmc-exporter
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/observability/bmc-exporter/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./netpol.yaml
   - ./acinfinity-exporter/ks.yaml
   - ./blackbox-exporter/ks.yaml
+  - ./bmc-exporter/ks.yaml
   - ./exportarr/ks.yaml
   - ./gatus/ks.yaml
   - ./grafana/ks.yaml


### PR DESCRIPTION
Closes #4018.

## What this replaces

The BMC fleet was covered by a single ICMP target in the `lan-icmp` Probe. That proves a BMC answers ping and nothing more — a host that is powered off, overheating, or running on one surviving PSU looked identical to a healthy one.

That gap is live right now: **two hosts are powered off and every ICMP probe for the fleet is green.**

## Exporter choice

The issue proposed `jenningsloy318/redfish_exporter`. Rejected — last release 2020, last commit 2023. Using `mrlhansen/idrac_exporter` instead: vendor-neutral Redfish despite the name, explicitly supports Supermicro, released last month, and ships an official chart with ServiceMonitor / ScrapeConfig / PrometheusRule templates.

## Verified against the live boards

Everything below was measured with a throwaway exporter pod, not taken from the schema:

- **Credentials are not uniform.** One shared username, a distinct password per board, so `hosts.default` is unusable and each BMC needs its own entry.
- **Scrape cost** is ~7.5s warm on the newer boards, ~13s on the older one, ~23s cold. The exporter's 10s default timeout aborts mid-collection — raised to 45s, with a 60s interval and 55s scrape timeout.
- **No storage metrics** on either board generation; Supermicro does not populate that Redfish tree. Drive health stays with smartctl-exporter.
- **A powered-off host** drops all sensor series and reports only `idrac_system_power_on 0`, which is what the power alert keys off.
- Sample from a healthy host: CPU 59C, System 43C, VRM 42C, DIMM 40C, NVMe 38C, NIC 57C, fan 13300 rpm, both PSUs OK at 237V, 4x DIMM health OK.

## Design notes

- **Whole config templated in the ExternalSecret**, mounted via the chart's `existingSecret`. No BMC login is ever built from git values.
- **Targets come from the exporter's `/discover` endpoint**, not a second list in git — adding a BMC to the ExternalSecret is the only change needed, and the two lists cannot drift.
- **Metric prefix stays upstream's `idrac_`.** Changing it orphans every stored series later, and keeping it means upstream docs and dashboards apply unchanged.
- **ICMP probes deliberately kept.** A Redfish scrape needs reachability, TLS and a valid login simultaneously, so its failure is ambiguous; the ICMP result is what separates a dead BMC from a broken credential.
- The ExternalSecret is added to the `check_internal_identifiers.py` allowlist on the same basis as the blackbox `probes.yaml` — it carries the same host set that file already carries.

## Alerts

Target down, host powered off, system/PSU/fan/DIMM/CPU/BMC health, PSU input voltage lost, fan stopped while running, temperature above 80C and 90C, and SEL entries at warning or above. Health metrics are an enum (0=OK, 1=Warning, 2=Critical) so all use `> 0`.

Temperature thresholds sit ~20C above the hottest sensor seen in routine service.

## Validation

- `flate test all --namespace observability` — 70 passed
- `kustomize build` — clean
- scoped super-linter (`slim-v8`, same flags as `just lint`) — all linters clean
- `check_internal_identifiers.py` — clean across all 1683 tracked files

## Note on merge

`BmcHostPoweredOff` will fire for the two currently-off hosts once this reconciles. That is a true positive by design — if those are meant to be off, either power them on or silence the alert.