### PR TITLE
fix(observability): band BMC temperature alerts by sensor class

### DIFF
--- a/docs/docs/operations/device-monitoring.md
+++ b/docs/docs/operations/device-monitoring.md
@@ -256,11 +256,20 @@ kubectl exec -n observability deploy/snmp-exporter -- \
 - **Supermicro exposes no storage metrics over Redfish** on either board
   generation here — the tree exists but is not populated. Drive health stays
   with `smartctl-exporter`; do not expect `idrac_storage_*` to appear.
-- **Do not read `idrac_power_supply_output_watts` as consumption.** On these
-  boards it disagrees with the system-level reading by an order of magnitude (a
-  node drawing 95W at `idrac_power_control_consumed_watts` reports ~450W per
-  PSU). Dashboards use the system-level metric for draw; the PSU figure is shown
-  separately and labelled as reported.
+- **Do not read `idrac_power_supply_output_watts` as consumption.** Measured
+  across the fleet, the PSU figure sums to ~7000W against ~1100W of
+  `idrac_power_control_consumed_watts` — roughly 6x. It is not capacity being
+  mislabelled either, since `idrac_power_supply_capacity_watts` is a separate
+  series reporting the real ~2kW rating. Dashboards use the system-level metric
+  for draw; the PSU figure is shown separately and labelled as reported.
+- **Temperature thresholds must be split by sensor class.** CPU packages run far
+  hotter than anything else here — `max by (name)` over the running fleet gives
+  CPU Temp 77C against 68C for the hottest NIC and =<53C for every other rail.
+  One blanket threshold either sits a few degrees off a perfectly normal CPU or
+  lets a NIC cook unnoticed, so the rules band CPUs at 90/95C and everything
+  else at 80/90C. Do not set these from a single sampled host: the first pass at
+  this used one node reading 59C and picked 80C, which would have left 3C of
+  headroom on the busiest CPUs.
 - **`idrac_*_health` metrics are an enum, not a boolean**: 0=OK, 1=Warning,
   2=Critical. Alert on `> 0`, never `== 1`, or a jump straight to Critical is
   missed.

--- a/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
@@ -5,9 +5,11 @@
 # 2=Critical. Hence `> 0` throughout rather than `== 1`, so a jump straight to
 # Critical is never missed.
 #
-# Thresholds below were set against readings taken from the live fleet under
-# normal load: CPU 59C, System 43C, VRM 42C, DIMM 40C, NVMe 38C, NIC 57C. The
-# 80C warning therefore sits ~20C above the hottest sensor in routine service.
+# Temperature thresholds are split by sensor class, from `max by (name)` across
+# the whole running fleet rather than one sampled host: CPU Temp 77C, AOC_NIC1
+# 68C, MLP_NIC 66C, GPU0 63C, M2_SSD 53C, and every remaining rail at or below
+# 49C. A single fleet-wide threshold cannot fit that spread — 80C would sit 3C
+# off a normal CPU while letting a NIC reach 79C unnoticed.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -86,12 +88,39 @@ spec:
           for: 10m
           labels:
             severity: critical
+        # CPU packages get their own band. Measured across the running fleet,
+        # CPU Temp peaks at 77C while the next hottest sensor of any kind is a
+        # NIC at 68C and everything else sits at or below 53C — so one blanket
+        # threshold cannot serve both. The matcher is `CPU[0-9]* Temp` rather
+        # than a `CPU` prefix so it covers a second socket ("CPU1 Temp") without
+        # catching the much cooler "CPU_VRM0 Temp" / "SOC_VRM Temp" rails.
+        - alert: BmcCpuTemperatureHigh
+          annotations:
+            summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C."
+          expr: |-
+            idrac_sensors_temperature{job="bmc-exporter", name=~"CPU[0-9]* Temp"} > 90
+            and idrac_sensors_temperature{job="bmc-exporter", name=~"CPU[0-9]* Temp"} <= 95
+          for: 15m
+          labels:
+            severity: warning
+        - alert: BmcCpuTemperatureCritical
+          annotations:
+            summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C — thermal shutdown territory."
+          expr: |-
+            idrac_sensors_temperature{job="bmc-exporter", name=~"CPU[0-9]* Temp"} > 95
+          for: 5m
+          labels:
+            severity: critical
+        # Everything that is not a CPU package: NICs, GPUs, VRMs, DIMMs, SSDs,
+        # inlet and board sensors. The hottest of these runs at 68C, so 80C is
+        # ~12C of headroom rather than the ~3C a single fleet-wide threshold
+        # would have left on the CPUs.
         - alert: BmcTemperatureHigh
           annotations:
             summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C."
           expr: |-
-            idrac_sensors_temperature{job="bmc-exporter"} > 80
-            and idrac_sensors_temperature{job="bmc-exporter"} <= 90
+            idrac_sensors_temperature{job="bmc-exporter", name!~"CPU[0-9]* Temp"} > 80
+            and idrac_sensors_temperature{job="bmc-exporter", name!~"CPU[0-9]* Temp"} <= 90
           for: 15m
           labels:
             severity: warning
@@ -102,7 +131,7 @@ spec:
           annotations:
             summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C — thermal shutdown territory."
           expr: |-
-            idrac_sensors_temperature{job="bmc-exporter"} > 90
+            idrac_sensors_temperature{job="bmc-exporter", name!~"CPU[0-9]* Temp"} > 90
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
Follow-up to #4022.

## The problem

I set the temperature thresholds in #4022 from a single sampled host, which read 59C on its CPU. 80C/90C looked like ~20C of headroom. It was not representative.

`max by (name)` across the whole running fleet:

| Sensor | Max |
|---|---|
| CPU Temp | **77C** |
| AOC_NIC1 Temp | 68C |
| MLP_NIC Temp | 66C |
| GPU0 Temp | 63C |
| M2_SSD1/2 Temp | 53C |
| everything else | =<49C |

A single blanket threshold cannot serve that spread. At 80C it sat **3C above a perfectly normal CPU under load** — near-certain noise — while simultaneously letting a NIC reach 79C without a word.

## The fix

Two bands:

- **CPU packages** — `name=~"CPU[0-9]* Temp"` — warning 90C, critical 95C
- **Everything else** — `name!~"CPU[0-9]* Temp"` — warning 80C, critical 90C

The matcher is `CPU[0-9]* Temp` rather than a `CPU` prefix so a second socket (`CPU1 Temp`) would be covered while the much cooler `CPU_VRM0 Temp` / `SOC_VRM Temp` rails stay in the general band.

## Verification

Against live series:

```
cpu_count    = 7      cpu_max   = 77
other_count  = 53     other_max = 68
total_count  = 60                       (7 + 53 = 60, clean partition)
VRM rails landing in the CPU bucket = 0
```

Both bands now carry 12-13C of headroom. `promtool check rules` passes on all 15 rules.

## Also

Corrects the PSU wattage note in the docs. The discrepancy is ~6x at fleet scale (7000W of reported PSU output against 1100W of actual system draw), not the order of magnitude I estimated from one host — and it is not capacity being mislabelled, since `idrac_power_supply_capacity_watts` is a separate series reporting the real ~2kW rating.