### PR TITLE
feat(observability): add the VM host and workstation BMCs, plus a host dashboard

### DIFF
--- a/kubernetes/apps/observability/bmc-exporter/app/externalsecret-workstation.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/externalsecret-workstation.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Config for the workstation-only exporter instance. See the header of
+# helmrelease-workstation.yaml for why the workstation is scraped by its own
+# deployment rather than added to the main config.
+#
+# Keyed by an address from 1Password because the workstation BMC has no
+# internal DNS record; the value only ever exists in the rendered Secret.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bmc-exporter-workstation
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: bmc-exporter-workstation-config
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      data:
+        idrac.yml: |
+          address: 0.0.0.0
+          port: 9348
+          timeout: 45
+          metrics:
+            all: true
+          events:
+            severity: warning
+            maxage: 7d
+          hosts:
+            "{{ .ws_addr }}":
+              username: "{{ .ws_user }}"
+              password: "{{ .ws_pass }}"
+  data:
+    - secretKey: ws_addr
+      remoteRef:
+        key: workstation-ipmi
+        property: IPMI_ADDR
+    - secretKey: ws_user
+      remoteRef:
+        key: workstation-ipmi
+        property: IPMI_USERNAME
+    - secretKey: ws_pass
+      remoteRef:
+        key: workstation-ipmi
+        property: IPMI_PASSWORD

--- a/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
@@ -70,6 +70,15 @@ spec:
             cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}:
               username: "{{ .storage_user }}"
               password: "{{ .storage_pass }}"
+            # The VM host has no internal DNS record, so it is keyed by an
+            # address carried in its 1Password item rather than a name. That is
+            # the documented route for a device address in this public repo:
+            # the value only ever exists in the rendered Secret. If a DNS record
+            # is created for it later, switch this to the name and drop
+            # IPMI_ADDR — every other host here is keyed by name.
+            "{{ .vm00_addr }}":
+              username: "{{ .vm00_user }}"
+              password: "{{ .vm00_pass }}"
   data:
     - secretKey: node01_user
       remoteRef:
@@ -142,4 +151,16 @@ spec:
     - secretKey: storage_pass
       remoteRef:
         key: cr-storage-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: vm00_addr
+      remoteRef:
+        key: cr-vm-00-ipmi
+        property: IPMI_ADDR
+    - secretKey: vm00_user
+      remoteRef:
+        key: cr-vm-00-ipmi
+        property: IPMI_USERNAME
+    - secretKey: vm00_pass
+      remoteRef:
+        key: cr-vm-00-ipmi
         property: IPMI_PASSWORD

--- a/kubernetes/apps/observability/bmc-exporter/app/grafanadashboard-host.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/grafanadashboard-host.yaml
@@ -1,0 +1,219 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: bmc-host-detail
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  # Single-host companion to the BMC Fleet dashboard: pick one machine and see
+  # everything Redfish reports about it. The fleet view answers "is anything
+  # wrong across the estate"; this one answers "what is wrong with this box".
+  #
+  # Grafana template variables are bare ($host) — Flux postBuild only consumes
+  # the braced ${VAR} form.
+  #
+  # job=~"bmc-exporter.*" so the workstation, which is scraped by its own
+  # deployment under a separate job label, appears here alongside the servers.
+  json: |-
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "refresh": "1m",
+      "schemaVersion": 39,
+      "tags": ["bmc", "redfish", "hardware"],
+      "time": {"from": "now-12h", "to": "now"},
+      "timezone": "browser",
+      "title": "BMC Host Detail (Redfish)",
+      "uid": "bmc-host-detail",
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "datasource": {"type": "prometheus", "uid": "prometheus"},
+            "definition": "label_values(idrac_system_power_on{job=~\"bmc-exporter.*\"}, instance)",
+            "includeAll": false,
+            "multi": false,
+            "name": "host",
+            "label": "Host",
+            "query": "label_values(idrac_system_power_on{job=~\"bmc-exporter.*\"}, instance)",
+            "refresh": 2,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "panels": [
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}, "id": 100, "panels": [], "title": "Identity and state", "type": "row"},
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Power",
+          "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_system_power_on{job=~\"bmc-exporter.*\", instance=\"$host\"}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OFF", "color": "red", "index": 0}, "1": {"text": "ON", "color": "green", "index": 1}}}]}, "overrides": []}
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Health",
+          "gridPos": {"h": 4, "w": 4, "x": 4, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_system_health{job=~\"bmc-exporter.*\", instance=\"$host\"}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARNING", "color": "orange", "index": 1}, "2": {"text": "CRITICAL", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Draw",
+          "gridPos": {"h": 4, "w": 4, "x": 8, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "sum(idrac_power_control_consumed_watts{job=~\"bmc-exporter.*\", instance=\"$host\"})", "refId": "A"}],
+          "options": {"colorMode": "value", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"unit": "watt", "color": {"mode": "fixed", "fixedColor": "blue"}}, "overrides": []}
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Installed memory",
+          "gridPos": {"h": 4, "w": 4, "x": 12, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_system_memory_size_bytes{job=~\"bmc-exporter.*\", instance=\"$host\"}", "refId": "A"}],
+          "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"unit": "bytes", "color": {"mode": "fixed", "fixedColor": "text"}}, "overrides": []}
+        },
+        {
+          "id": 5,
+          "type": "stat",
+          "title": "CPU cores / threads",
+          "gridPos": {"h": 4, "w": 4, "x": 16, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "sum(idrac_cpu_total_cores{job=~\"bmc-exporter.*\", instance=\"$host\"})", "legendFormat": "cores", "refId": "A"},
+            {"expr": "sum(idrac_cpu_total_threads{job=~\"bmc-exporter.*\", instance=\"$host\"})", "legendFormat": "threads", "refId": "B"}
+          ],
+          "options": {"colorMode": "value", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"unit": "short", "color": {"mode": "fixed", "fixedColor": "text"}}, "overrides": []}
+        },
+        {
+          "id": 6,
+          "type": "stat",
+          "title": "BMC health",
+          "gridPos": {"h": 4, "w": 4, "x": 20, "y": 1},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_manager_health{job=~\"bmc-exporter.*\", instance=\"$host\"}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARNING", "color": "orange", "index": 1}, "2": {"text": "CRITICAL", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {
+          "id": 7,
+          "type": "table",
+          "title": "Hardware inventory",
+          "gridPos": {"h": 6, "w": 24, "x": 0, "y": 5},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "idrac_system_machine_info{job=~\"bmc-exporter.*\", instance=\"$host\"}", "format": "table", "instant": true, "refId": "A"},
+            {"expr": "idrac_system_bios_info{job=~\"bmc-exporter.*\", instance=\"$host\"}", "format": "table", "instant": true, "refId": "B"},
+            {"expr": "idrac_cpu_info{job=~\"bmc-exporter.*\", instance=\"$host\"}", "format": "table", "instant": true, "refId": "C"},
+            {"expr": "idrac_manager_info{job=~\"bmc-exporter.*\", instance=\"$host\"}", "format": "table", "instant": true, "refId": "D"}
+          ],
+          "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true, "Value": true, "__name__": true, "job": true, "instance": true}}}],
+          "options": {"showHeader": true}
+        },
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 11}, "id": 101, "panels": [], "title": "Thermal and fans", "type": "row"},
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "Temperatures",
+          "gridPos": {"h": 9, "w": 12, "x": 0, "y": 12},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_sensors_temperature{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "{{name}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "fieldConfig": {"defaults": {"unit": "celsius", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 80}, {"color": "red", "value": 90}]}}, "overrides": []}
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "Fan speed",
+          "gridPos": {"h": 9, "w": 12, "x": 12, "y": 12},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_sensors_fan_speed{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "{{name}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "min", "max"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
+          "fieldConfig": {"defaults": {"unit": "rotrpm", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}}, "overrides": []}
+        },
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21}, "id": 102, "panels": [], "title": "Power", "type": "row"},
+        {
+          "id": 10,
+          "type": "timeseries",
+          "title": "System draw",
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 22},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_power_control_consumed_watts{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "{{name}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"]}, "tooltip": {"mode": "multi"}},
+          "fieldConfig": {"defaults": {"unit": "watt", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never"}}, "overrides": []}
+        },
+        {
+          "id": 11,
+          "type": "timeseries",
+          "title": "PSU input voltage (0 V = feed lost)",
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 22},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_power_supply_input_voltage{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "PSU {{id}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "min"]}, "tooltip": {"mode": "multi"}},
+          "fieldConfig": {"defaults": {"unit": "volt", "min": 0, "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}}, "overrides": []}
+        },
+        {
+          "id": 12,
+          "type": "stat",
+          "title": "PSU health and rating",
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 22},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [
+            {"expr": "idrac_power_supply_health{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "PSU {{id}} health", "refId": "A"},
+            {"expr": "idrac_power_supply_capacity_watts{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "PSU {{id}} rated W", "refId": "B"}
+          ],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 30}, "id": 103, "panels": [], "title": "Components and events", "type": "row"},
+        {
+          "id": 13,
+          "type": "stat",
+          "title": "Memory modules (ECC)",
+          "gridPos": {"h": 7, "w": 8, "x": 0, "y": 31},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_memory_module_health{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "DIMM {{id}}", "refId": "A"}],
+          "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
+          "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
+        },
+        {
+          "id": 14,
+          "type": "timeseries",
+          "title": "CPU clock",
+          "gridPos": {"h": 7, "w": 8, "x": 8, "y": 31},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_cpu_current_speed_mhz{job=~\"bmc-exporter.*\", instance=\"$host\"}", "legendFormat": "CPU {{id}}", "refId": "A"}],
+          "options": {"legend": {"displayMode": "list", "placement": "bottom", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi"}},
+          "fieldConfig": {"defaults": {"unit": "rothz", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}}, "overrides": []}
+        },
+        {
+          "id": 15,
+          "type": "table",
+          "title": "Hardware event log (warning and above, last 7d)",
+          "gridPos": {"h": 7, "w": 8, "x": 16, "y": 31},
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "targets": [{"expr": "idrac_events_log_entry{job=~\"bmc-exporter.*\", instance=\"$host\"}", "format": "table", "instant": true, "refId": "A"}],
+          "transformations": [{"id": "organize", "options": {"excludeByName": {"Time": true, "__name__": true, "job": true, "instance": true, "id": true}}}],
+          "options": {"showHeader": true}
+        }
+      ]
+    }

--- a/kubernetes/apps/observability/bmc-exporter/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/grafanadashboard.yaml
@@ -38,12 +38,12 @@ spec:
             "allValue": ".*",
             "current": {"selected": true, "text": "All", "value": "$__all"},
             "datasource": {"type": "prometheus", "uid": "prometheus"},
-            "definition": "label_values(idrac_system_power_on{job=\"bmc-exporter\"}, instance)",
+            "definition": "label_values(idrac_system_power_on{job=~\"bmc-exporter.*\"}, instance)",
             "includeAll": true,
             "multi": true,
             "name": "instance",
             "label": "BMC",
-            "query": "label_values(idrac_system_power_on{job=\"bmc-exporter\"}, instance)",
+            "query": "label_values(idrac_system_power_on{job=~\"bmc-exporter.*\"}, instance)",
             "refresh": 2,
             "sort": 1,
             "type": "query"
@@ -58,7 +58,7 @@ spec:
           "title": "Hosts powered on",
           "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "sum(idrac_system_power_on{job=\"bmc-exporter\"})", "refId": "A"}],
+          "targets": [{"expr": "sum(idrac_system_power_on{job=~\"bmc-exporter.*\"})", "refId": "A"}],
           "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "green"}, "unit": "short"}, "overrides": []}
         },
@@ -68,7 +68,7 @@ spec:
           "title": "Hosts powered off",
           "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "count(idrac_system_power_on{job=\"bmc-exporter\"} == 0) or vector(0)", "refId": "A"}],
+          "targets": [{"expr": "count(idrac_system_power_on{job=~\"bmc-exporter.*\"} == 0) or vector(0)", "refId": "A"}],
           "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"unit": "short", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 1}]}}, "overrides": []}
         },
@@ -78,7 +78,7 @@ spec:
           "title": "Fleet power draw",
           "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "sum(idrac_power_control_consumed_watts{job=\"bmc-exporter\"})", "refId": "A"}],
+          "targets": [{"expr": "sum(idrac_power_control_consumed_watts{job=~\"bmc-exporter.*\"})", "refId": "A"}],
           "options": {"colorMode": "value", "graphMode": "area", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"color": {"mode": "fixed", "fixedColor": "blue"}, "unit": "watt"}, "overrides": []}
         },
@@ -88,7 +88,7 @@ spec:
           "title": "Unhealthy components",
           "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "count(idrac_system_health{job=\"bmc-exporter\"} > 0) + count(idrac_power_supply_health{job=\"bmc-exporter\"} > 0) + count(idrac_sensors_fan_health{job=\"bmc-exporter\"} > 0) + count(idrac_memory_module_health{job=\"bmc-exporter\"} > 0) + count(idrac_cpu_health{job=\"bmc-exporter\"} > 0) or vector(0)", "refId": "A"}],
+          "targets": [{"expr": "count(idrac_system_health{job=~\"bmc-exporter.*\"} > 0) + count(idrac_power_supply_health{job=~\"bmc-exporter.*\"} > 0) + count(idrac_sensors_fan_health{job=~\"bmc-exporter.*\"} > 0) + count(idrac_memory_module_health{job=~\"bmc-exporter.*\"} > 0) + count(idrac_cpu_health{job=~\"bmc-exporter.*\"} > 0) or vector(0)", "refId": "A"}],
           "options": {"colorMode": "value", "graphMode": "none", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"unit": "short", "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "red", "value": 1}]}}, "overrides": []}
         },
@@ -98,7 +98,7 @@ spec:
           "title": "Power state by host",
           "gridPos": {"h": 6, "w": 12, "x": 0, "y": 5},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_system_power_on{job=\"bmc-exporter\"}", "legendFormat": "{{instance}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_system_power_on{job=~\"bmc-exporter.*\"}", "legendFormat": "{{instance}}", "refId": "A"}],
           "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OFF", "color": "red", "index": 0}, "1": {"text": "ON", "color": "green", "index": 1}}}]}, "overrides": []}
         },
@@ -108,7 +108,7 @@ spec:
           "title": "System health by host",
           "gridPos": {"h": 6, "w": 12, "x": 12, "y": 5},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_system_health{job=\"bmc-exporter\"}", "legendFormat": "{{instance}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_system_health{job=~\"bmc-exporter.*\"}", "legendFormat": "{{instance}}", "refId": "A"}],
           "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARNING", "color": "orange", "index": 1}, "2": {"text": "CRITICAL", "color": "red", "index": 2}}}]}, "overrides": []}
         },
@@ -119,7 +119,7 @@ spec:
           "title": "Temperatures",
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 12},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_sensors_temperature{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / {{name}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_sensors_temperature{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / {{name}}", "refId": "A"}],
           "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
           "fieldConfig": {"defaults": {"unit": "celsius", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 5, "showPoints": "never"}, "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}, {"color": "orange", "value": 80}, {"color": "red", "value": 90}]}}, "overrides": []}
         },
@@ -129,7 +129,7 @@ spec:
           "title": "Fan speed",
           "gridPos": {"h": 8, "w": 12, "x": 12, "y": 12},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_sensors_fan_speed{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / {{name}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_sensors_fan_speed{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / {{name}}", "refId": "A"}],
           "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "min"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
           "fieldConfig": {"defaults": {"unit": "rotrpm", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}}, "overrides": []}
         },
@@ -140,7 +140,7 @@ spec:
           "title": "System power draw",
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 21},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_power_control_consumed_watts{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_power_control_consumed_watts{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}}", "refId": "A"}],
           "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "mean", "max"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
           "fieldConfig": {"defaults": {"unit": "watt", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 10, "showPoints": "never"}}, "overrides": []}
         },
@@ -150,7 +150,7 @@ spec:
           "title": "PSU input voltage (0 V = feed lost)",
           "gridPos": {"h": 8, "w": 12, "x": 12, "y": 21},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_power_supply_input_voltage{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / PSU {{id}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_power_supply_input_voltage{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / PSU {{id}}", "refId": "A"}],
           "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "min"]}, "tooltip": {"mode": "multi", "sort": "desc"}},
           "fieldConfig": {"defaults": {"unit": "volt", "custom": {"drawStyle": "line", "lineWidth": 1, "fillOpacity": 0, "showPoints": "never"}, "min": 0}, "overrides": []}
         },
@@ -161,7 +161,7 @@ spec:
           "title": "Memory modules (ECC)",
           "gridPos": {"h": 7, "w": 8, "x": 0, "y": 30},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_memory_module_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / DIMM {{id}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_memory_module_health{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / DIMM {{id}}", "refId": "A"}],
           "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
         },
@@ -171,7 +171,7 @@ spec:
           "title": "Power supplies",
           "gridPos": {"h": 7, "w": 8, "x": 8, "y": 30},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
-          "targets": [{"expr": "idrac_power_supply_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / PSU {{id}}", "refId": "A"}],
+          "targets": [{"expr": "idrac_power_supply_health{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / PSU {{id}}", "refId": "A"}],
           "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}
         },
@@ -182,8 +182,8 @@ spec:
           "gridPos": {"h": 7, "w": 8, "x": 16, "y": 30},
           "datasource": {"type": "prometheus", "uid": "prometheus"},
           "targets": [
-            {"expr": "idrac_cpu_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / CPU {{id}}", "refId": "A"},
-            {"expr": "idrac_manager_health{job=\"bmc-exporter\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / BMC", "refId": "B"}
+            {"expr": "idrac_cpu_health{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / CPU {{id}}", "refId": "A"},
+            {"expr": "idrac_manager_health{job=~\"bmc-exporter.*\", instance=~\"$instance\"}", "legendFormat": "{{instance}} / BMC", "refId": "B"}
           ],
           "options": {"colorMode": "background", "graphMode": "none", "textMode": "value_and_name", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}},
           "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "OK", "color": "green", "index": 0}, "1": {"text": "WARN", "color": "orange", "index": 1}, "2": {"text": "CRIT", "color": "red", "index": 2}}}]}, "overrides": []}

--- a/kubernetes/apps/observability/bmc-exporter/app/helmrelease-workstation.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/helmrelease-workstation.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+#
+# A second, single-target exporter instance for the workstation BMC.
+#
+# Why a separate deployment rather than one more host in the main config: the
+# workstation is a desk machine and is powered off most of the time, so it must
+# be exempt from BmcHostPoweredOff while still being covered by every other
+# rule. Excluding one host from one alert needs something in the PromQL to
+# match on, and none of the available options work here:
+#
+#   - `instance` is the target address, and this BMC has no DNS record, so
+#     matching on it would put a LAN address in this public repository
+#   - the `model` label does not discriminate: this board and the storage node
+#     both report the generic "Super Server"
+#   - the ScrapeConfig relabelings could synthesise a label, but only by
+#     matching the address, which is the same leak
+#
+# Giving it its own deployment gives it its own `job` label instead, which is a
+# plain string that discloses nothing. The rules then use job=~"bmc-exporter.*"
+# for hardware health and job="bmc-exporter" for power state. The cost is one
+# more 64Mi pod.
+#
+# If an internal DNS record is ever created for this BMC, the tidier form is to
+# fold it back into the main config and select on the hostname instead.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app bmc-exporter-workstation
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: idrac-exporter
+      version: 2.6.1
+      sourceRef:
+        kind: HelmRepository
+        name: idrac-exporter
+  values:
+    fullnameOverride: *app
+    image:
+      repository: ghcr.io/mrlhansen/idrac_exporter
+      tag: 2.6.1@sha256:2679bafcc31f87bce9f4dcd4d29df20b76aebd037b4df5f826a0ccc4027b0d59
+    existingSecret: bmc-exporter-workstation-config
+    deploymentAnnotations:
+      reloader.stakater.com/auto: "true"
+    serviceAccount:
+      automount: false
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+      runAsGroup: 65534
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        memory: 64Mi
+    prometheus:
+      monitor:
+        enabled: false
+      rules:
+        enabled: false
+      scrapeConfig:
+        enabled: true
+        interval: 60s
+        scrapeTimeout: 55s
+        relabelings:
+          - action: replace
+            replacement: *app
+            targetLabel: job

--- a/kubernetes/apps/observability/bmc-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/kustomization.yaml
@@ -4,7 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-workstation.yaml
   - ./helmrepository.yaml
   - ./helmrelease.yaml
+  - ./helmrelease-workstation.yaml
   - ./grafanadashboard.yaml
+  - ./grafanadashboard-host.yaml
   - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
@@ -10,6 +10,10 @@
 # 68C, MLP_NIC 66C, GPU0 63C, M2_SSD 53C, and every remaining rail at or below
 # 49C. A single fleet-wide threshold cannot fit that spread — 80C would sit 3C
 # off a normal CPU while letting a NIC reach 79C unnoticed.
+#
+# Job matchers: `job=~"bmc-exporter.*"` covers both exporter deployments and is
+# the default here. Only BmcHostPoweredOff pins job="bmc-exporter" exactly, to
+# exclude the workstation — see the comment on that rule.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -27,12 +31,19 @@ spec:
           annotations:
             summary: "Redfish scrape of {{ $labels.instance }} is failing — check the ICMP probe for the same host to tell a dead BMC from a broken login."
           expr: |-
-            up{job="bmc-exporter"} == 0
+            up{job=~"bmc-exporter.*"} == 0
           for: 15m
           labels:
             severity: critical
         # The gap this whole exporter exists to close: a BMC answers ICMP
         # identically whether its host is running or powered off.
+        #
+        # This is the one rule pinned to job="bmc-exporter" exactly rather than
+        # the job=~"bmc-exporter.*" used everywhere else. The workstation is
+        # scraped by its own deployment under job="bmc-exporter-workstation"
+        # solely so this exact-match excludes it: a desk machine is off most of
+        # the time and would otherwise page on every shutdown. It stays covered
+        # by every other rule here. See helmrelease-workstation.yaml.
         - alert: BmcHostPoweredOff
           annotations:
             summary: "Host behind {{ $labels.instance }} is powered off."
@@ -45,7 +56,7 @@ spec:
           annotations:
             summary: "{{ $labels.instance }} reports system health {{ $labels.status }} — check the BMC event log."
           expr: |-
-            idrac_system_health{job="bmc-exporter"} > 0
+            idrac_system_health{job=~"bmc-exporter.*"} > 0
           for: 15m
           labels:
             severity: warning
@@ -53,7 +64,7 @@ spec:
           annotations:
             summary: "PSU {{ $labels.id }} on {{ $labels.instance }} reports {{ $labels.status }}."
           expr: |-
-            idrac_power_supply_health{job="bmc-exporter"} > 0
+            idrac_power_supply_health{job=~"bmc-exporter.*"} > 0
           for: 15m
           labels:
             severity: warning
@@ -64,7 +75,7 @@ spec:
           annotations:
             summary: "PSU {{ $labels.id }} on {{ $labels.instance }} has lost input voltage — the host is running unprotected on its remaining supply."
           expr: |-
-            idrac_power_supply_input_voltage{job="bmc-exporter"} == 0
+            idrac_power_supply_input_voltage{job=~"bmc-exporter.*"} == 0
           for: 5m
           labels:
             severity: critical
@@ -72,7 +83,7 @@ spec:
           annotations:
             summary: "Fan {{ $labels.name }} on {{ $labels.instance }} reports {{ $labels.status }}."
           expr: |-
-            idrac_sensors_fan_health{job="bmc-exporter"} > 0
+            idrac_sensors_fan_health{job=~"bmc-exporter.*"} > 0
           for: 10m
           labels:
             severity: warning
@@ -83,8 +94,8 @@ spec:
           annotations:
             summary: "Fan {{ $labels.name }} on {{ $labels.instance }} has stopped while the host is running."
           expr: |-
-            idrac_sensors_fan_speed{job="bmc-exporter"} == 0
-            and on (instance) idrac_system_power_on{job="bmc-exporter"} == 1
+            idrac_sensors_fan_speed{job=~"bmc-exporter.*"} == 0
+            and on (instance) idrac_system_power_on{job=~"bmc-exporter.*"} == 1
           for: 10m
           labels:
             severity: critical
@@ -98,8 +109,8 @@ spec:
           annotations:
             summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C."
           expr: |-
-            idrac_sensors_temperature{job="bmc-exporter", name=~"CPU[0-9]* Temp"} > 90
-            and idrac_sensors_temperature{job="bmc-exporter", name=~"CPU[0-9]* Temp"} <= 95
+            idrac_sensors_temperature{job=~"bmc-exporter.*", name=~"CPU[0-9]* Temp"} > 90
+            and idrac_sensors_temperature{job=~"bmc-exporter.*", name=~"CPU[0-9]* Temp"} <= 95
           for: 15m
           labels:
             severity: warning
@@ -107,7 +118,7 @@ spec:
           annotations:
             summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C — thermal shutdown territory."
           expr: |-
-            idrac_sensors_temperature{job="bmc-exporter", name=~"CPU[0-9]* Temp"} > 95
+            idrac_sensors_temperature{job=~"bmc-exporter.*", name=~"CPU[0-9]* Temp"} > 95
           for: 5m
           labels:
             severity: critical
@@ -119,8 +130,8 @@ spec:
           annotations:
             summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C."
           expr: |-
-            idrac_sensors_temperature{job="bmc-exporter", name!~"CPU[0-9]* Temp"} > 80
-            and idrac_sensors_temperature{job="bmc-exporter", name!~"CPU[0-9]* Temp"} <= 90
+            idrac_sensors_temperature{job=~"bmc-exporter.*", name!~"CPU[0-9]* Temp"} > 80
+            and idrac_sensors_temperature{job=~"bmc-exporter.*", name!~"CPU[0-9]* Temp"} <= 90
           for: 15m
           labels:
             severity: warning
@@ -131,7 +142,7 @@ spec:
           annotations:
             summary: "{{ $labels.name }} on {{ $labels.instance }} is at {{ $value }}C — thermal shutdown territory."
           expr: |-
-            idrac_sensors_temperature{job="bmc-exporter", name!~"CPU[0-9]* Temp"} > 90
+            idrac_sensors_temperature{job=~"bmc-exporter.*", name!~"CPU[0-9]* Temp"} > 90
           for: 5m
           labels:
             severity: critical
@@ -141,7 +152,7 @@ spec:
           annotations:
             summary: "DIMM {{ $labels.id }} on {{ $labels.instance }} reports {{ $labels.status }} — likely ECC errors."
           expr: |-
-            idrac_memory_module_health{job="bmc-exporter"} > 0
+            idrac_memory_module_health{job=~"bmc-exporter.*"} > 0
           for: 15m
           labels:
             severity: warning
@@ -149,7 +160,7 @@ spec:
           annotations:
             summary: "CPU {{ $labels.id }} on {{ $labels.instance }} reports {{ $labels.status }}."
           expr: |-
-            idrac_cpu_health{job="bmc-exporter"} > 0
+            idrac_cpu_health{job=~"bmc-exporter.*"} > 0
           for: 15m
           labels:
             severity: warning
@@ -159,7 +170,7 @@ spec:
           annotations:
             summary: "BMC {{ $labels.instance }} reports its own health as {{ $labels.status }}."
           expr: |-
-            idrac_manager_health{job="bmc-exporter"} > 0
+            idrac_manager_health{job=~"bmc-exporter.*"} > 0
           for: 30m
           labels:
             severity: warning
@@ -170,7 +181,7 @@ spec:
           annotations:
             summary: "{{ $labels.instance }} logged a {{ $labels.severity }} hardware event: {{ $labels.message }}"
           expr: |-
-            idrac_events_log_entry{job="bmc-exporter"} > 0
+            idrac_events_log_entry{job=~"bmc-exporter.*"} > 0
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
Follows #4022 / #4023.

## Discovery

Swept the management VLAN for the IPMI port. Twelve BMCs answer:

- **9 already monitored** (8 compute + storage)
- **1 with no Redfish** — the NUT appliance, not a candidate
- **2 unmonitored** — the VM host and the workstation

The workstation's recorded address in 1Password was stale; its BMC actually answers on a different address, confirmed by authenticating with its own non-default credential.

## Addressing

Neither new host has an internal DNS record, so both are keyed by an address held in their 1Password item and templated into the rendered Secret — the route this repo prescribes for device addresses. **Neither address appears anywhere in git**, verified by grep and by the internal-identifier guard across all 1686 tracked files.

Every other host here is keyed by name. If DNS records are created later, switch these over and drop the address field.

## Why the workstation gets its own exporter deployment

It's a desk machine, off most of the time, so it must be exempt from `BmcHostPoweredOff` while staying covered by every other rule. Excluding one host from one rule needs something in the PromQL to match on, and none of the alternatives work:

| Option | Why not |
|---|---|
| match on `instance` | that's the address — leaks into a public repo |
| match on `model` | doesn't discriminate: this board and the storage node both report `Super Server` |
| synthesise a label via relabeling | the relabeling would have to match the address — same leak |

A separate deployment gives it a distinct `job` label, which is a plain string that discloses nothing. Rules now use `job=~"bmc-exporter.*"` throughout, with `BmcHostPoweredOff` alone pinned to `job="bmc-exporter"` so the workstation falls out. Cost is one extra 64Mi pod.

## Dashboards

New **BMC Host Detail** dashboard as a companion to the fleet view — pick one machine and see identity/inventory, every temperature and fan, draw and PSU state, per-DIMM health, CPU clock, and the recent hardware event log. The fleet dashboard's 16 queries are widened to the same job matcher so both exporters appear.

## Needs your attention separately

**The VM host reports health `Critical`, and it is not a stale latch.** Its chassis intrusion sensor reads asserted *right now* — either the case is open or the switch has failed. CPU and memory both report OK, so nothing else is wrong. This can't be cleared remotely; the board exposes no intrusion-reset action. Once it's dealt with physically, `BmcSystemUnhealthy` for that host becomes meaningful. Until then it will fire.

## Validation

- `flate test all --namespace observability` — 71 passed
- `promtool check rules` — 15 rules
- both dashboard JSON blobs parse; 17 and 19 panels
- scoped super-linter — clean
- internal-identifier guard — clean