### PR TITLE
fix(certwarden): bind temporary cert Secrets to their Job so they are collected

### DIFF
--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/rbac.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/rbac.yaml
@@ -33,7 +33,9 @@ rules:
     verbs:
       - "get"
       - "list"
-  # Allow managing secrets (for IPMI credentials and temporary cert secrets)
+  # Allow managing secrets (for IPMI credentials and temporary cert secrets).
+  # "patch" is needed to set the ownerReference that binds a temporary cert
+  # Secret to its Job, so the two are garbage-collected together.
   - apiGroups:
       - ""
     resources:
@@ -42,6 +44,7 @@ rules:
       - "create"
       - "get"
       - "list"
+      - "patch"
       - "delete"
 ---
 # RoleBinding to grant Certwarden the ability to create Jobs

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
@@ -66,8 +66,10 @@ data:
         --from-literal=cert.pem="${CERTIFICATE_PEM}" \
         --from-literal=key.pem="${PRIVATE_KEY_PEM}"
 
-    # Note: Secret cleanup is handled by the Job's ownerReferences
-    # The secret will be garbage collected when the Job is deleted via ttlSecondsAfterFinished
+    # The Secret is adopted by the Job further down, once the Job exists and has
+    # a UID to point at. It cannot be created with an ownerReference here
+    # because the owner does not exist yet, and a stale/incorrect ownerReference
+    # would have the Secret garbage-collected immediately.
 
     # Create the deployment Job
     echo "Creating deployment Job: ${JOB_NAME}"
@@ -125,6 +127,29 @@ data:
               secret:
                 secretName: ${CERT_SECRET_NAME}
     EOF
+
+    # Make the Job the owner of the cert Secret so the two are deleted together.
+    #
+    # This is the step that was missing. The comment above the secret creation
+    # used to claim ownerReferences handled cleanup, but nothing ever set one:
+    # ttlSecondsAfterFinished removed the Job while the Secret — which holds the
+    # certificate's PRIVATE KEY — stayed in the namespace forever. Every renewal
+    # since the first deployment left one behind; 40 had accumulated by
+    # 2026-07-31 and were cleared out alongside this fix.
+    #
+    # blockOwnerDeletion is false so the Secret can never hold up deletion of
+    # the Job, and a failure here is not fatal: the deployment itself has
+    # already been submitted, and a Secret that outlives its Job is the old
+    # (bad) behaviour rather than a new one.
+    echo "Binding Secret ${CERT_SECRET_NAME} to Job ${JOB_NAME} for cleanup"
+    JOB_UID=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+    if [[ -n "${JOB_UID}" ]]; then
+        kubectl patch secret "${CERT_SECRET_NAME}" -n "${NAMESPACE}" --type merge -p \
+            "{\"metadata\":{\"ownerReferences\":[{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"name\":\"${JOB_NAME}\",\"uid\":\"${JOB_UID}\",\"controller\":false,\"blockOwnerDeletion\":false}]}}" \
+            || echo "WARNING: could not set ownerReference on ${CERT_SECRET_NAME}; it will need manual cleanup"
+    else
+        echo "WARNING: could not read Job UID; ${CERT_SECRET_NAME} will need manual cleanup"
+    fi
 
     # Wait for the Job to reach a terminal condition (Complete or Failed).
     # kubectl wait --for=condition=complete ignores Failed, so on a fast pod


### PR DESCRIPTION
Found while working on #4022 — unrelated to that change, but in the same namespace.

## The bug

`certwarden-supermicro-deploy.sh` creates a temporary Secret holding the certificate and its **private key**, then creates a Job to consume it. A comment claimed:

```
# Note: Secret cleanup is handled by the Job's ownerReferences
# The secret will be garbage collected when the Job is deleted via ttlSecondsAfterFinished
```

Nothing ever set an ownerReference. `ttlSecondsAfterFinished: 300` removed the Job; the Secret stayed forever.

## Impact

**40 orphaned Secrets** in `infrastructure`, oldest `2025-11-21`, each holding a `key.pem` for a BMC certificate that has since been rotated several times. Audited: all 40 have no ownerReference and no surviving Job.

## The fix

The Secret can't carry the reference at creation time — its owner doesn't exist yet, and a dangling ownerReference would have it garbage-collected immediately. So it's adopted right after the Job is applied, once there's a UID to point at.

- `blockOwnerDeletion: false` so the Secret can never delay deletion of the Job
- the patch is non-fatal — by then the deployment is already submitted, and a Secret outliving its Job is the old behaviour, not a new failure
- adds the `patch` verb on secrets to the Role, which the adoption needs and which wasn't granted

The existing 40 are being cleared out separately; they predate this fix and nothing in Git owns them.

## Validation

- `bash -n` and `shellcheck -S warning` on the extracted script — clean
- `kustomize build` — clean
- scoped super-linter (incl. SHELL_SHFMT) — clean
- internal-identifier guard — clean