### PR TITLE
fix(renovate): group the talosctl CLI with the Talos node pins

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -53,6 +53,22 @@
   customManagers: [
     {
       customType: "regex",
+      // etcd-defrag fetches talosctl with a plain wget inside an inline shell
+      // script, which no built-in manager sees, so the pin silently drifted:
+      // it sat on v1.11.5 while every other Talos pin in the repo had moved to
+      // v1.13.7. Tracking it here keeps the client in step with the nodes it
+      // talks to, and because the package name is siderolabs/talos it joins the
+      // Talos group rather than arriving as its own PR.
+      description: "Track the talosctl binary fetched by etcd-defrag",
+      managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"],
+      matchStrings: [
+        "https://github\\.com/siderolabs/talos/releases/download/(?<currentValue>v[^/]+)/talosctl-",
+      ],
+      datasourceTemplate: "github-releases",
+      depNameTemplate: "siderolabs/talos",
+    },
+    {
+      customType: "regex",
       description: "Track Minecraft release versions",
       managerFilePatterns: ["/(^|/)kubernetes/.+\\.ya?ml$/"],
       matchStrings: [
@@ -289,14 +305,32 @@
       minimumGroupSize: 2,
     },
     {
+      // The Talos version is pinned in four places across three datasources:
+      // talconfig.yaml, talenv.yaml and the tuppr TalosUpgrade all carry a
+      // `datasource=docker depName=ghcr.io/siderolabs/installer` annotation, and
+      // .mise.toml pins the matching talosctl CLI as `aqua:siderolabs/talos`.
+      //
+      // This rule used to set matchDatasources: ["docker"], which grouped the
+      // first three but left the CLI to arrive as its own PR — so every Talos
+      // bump landed as two PRs that had to be reconciled by hand (1.13.6 ➔
+      // 1.13.7 came as #3753 for the CLI and #3754 for the image, the latter
+      // closed as superseded by #3842). Dropping the datasource restriction
+      // lets the regex below catch the aqua package too, since its package name
+      // is `aqua:siderolabs/talos`. Adopted from cluster-template 2026.8.0
+      // (onedr0p/cluster-template#2302), which groups the same three pins.
+      //
+      // Nothing else in the estate matches `siderolabs/`, and kubelet — which
+      // tracks the Kubernetes version, not the Talos one — is excluded below.
       description: "Talos Group",
       groupName: "Talos",
-      matchDatasources: ["docker"],
       // Negated match replaces the deprecated excludePackageNames: ["/kubelet/"]
       matchPackageNames: ["/siderolabs\\//", "!/kubelet/"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
+      // Kept at 2 rather than upstream's 3: the CLI occasionally releases
+      // without a matching node image, and a 3 would hold the whole group back
+      // until every pin moved.
       minimumGroupSize: 2,
     },
     {

--- a/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/etcd-defrag/app/helmrelease.yaml
@@ -27,8 +27,12 @@ spec:
               - /bin/sh
               - -c
               - |
-                # Install talosctl using wget (Alpine built-in)
-                wget -qO /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/v1.11.5/talosctl-linux-amd64
+                # Install talosctl using wget (Alpine built-in).
+                # This URL is tracked by the "Track the talosctl binary fetched
+                # by etcd-defrag" customManager in .renovaterc.json5, so it moves
+                # with the rest of the Talos pins instead of drifting. It had
+                # been left on v1.11.5 while the fleet ran v1.13.7.
+                wget -qO /usr/local/bin/talosctl https://github.com/siderolabs/talos/releases/download/v1.13.7/talosctl-linux-amd64
                 chmod +x /usr/local/bin/talosctl
                 # Run defrag script
                 sh /scripts/defrag.sh


### PR DESCRIPTION
From reviewing [cluster-template 2026.8.0](https://github.com/onedr0p/cluster-template/releases/tag/2026.8.0).

## What's worth taking from that release

Most of it is Renovate bumps or template-render machinery that doesn't apply here. One upstream change does:

| Upstream PR | Verdict |
|---|---|
| #2302 group Talos updates | **adopt** — same gap exists here, see below |
| #2299 refactor(sops) | N/A — SOPS was fully evicted from this repo |
| #2311 / #2312 / #2314 template render fixes | N/A — no `template/` tree; this repo is long past bootstrap |
| #2300 / #2316 e2e CI | N/A — upstream's own template test harness |
| #2313 docs | N/A |

Dependency-wise we're level or ahead on everything the release bumped: envoy-gateway 1.8.3 ✓, cloudflared 2026.7.3 ✓, Talos 1.13.7 ✓, coredns 1.47.0 (ahead of their 1.46.2).

## The gap

The Talos version is pinned in **four** places across two datasources:

| Pin | Datasource |
|---|---|
| `talos/talconfig.yaml` | docker (`ghcr.io/siderolabs/installer`) |
| `talos/talenv.yaml` | docker |
| tuppr `TalosUpgrade` | docker |
| `.mise.toml` talosctl CLI | `aqua:siderolabs/talos` |

The group set `matchDatasources: ["docker"]`, so the first three grouped and the CLI always came separately. Observed:

- 1.13.6 ➔ 1.13.7 — #3753 (CLI, merged) + #3754 (image, closed *"superseded by #3842"*)
- 1.13.5 ➔ 1.13.6 — #3466 (CLI, merged) + #3467 (image, autoclosed)

Dropping the datasource restriction lets the existing `/siderolabs\//` regex catch the aqua package, whose name is `aqua:siderolabs/talos`. `minimumGroupSize` stays at **2**, not upstream's 3 — the CLI sometimes releases without a matching node image and a 3 would stall the group.

I enumerated every tracked `siderolabs` reference to confirm nothing unintended is swept in. `kubelet` stays excluded (it tracks the Kubernetes version, not Talos).

## Stale pin found in the same audit

`etcd-defrag` fetches talosctl with a plain `wget` in an inline shell script, which no built-in manager sees:

```
https://github.com/siderolabs/talos/releases/download/v1.11.5/talosctl-linux-amd64
```

**v1.11.5 while the fleet runs v1.13.7** — two minors of client/server skew on a job that hits the etcd API on every run. Bumped to match and brought under a `customManager`, so it tracks from here and joins the Talos group rather than drifting again.

## Not adopted: oxfmt

Upstream has replaced yamlfmt + prettier with a single `oxfmt` across JSON, Markdown and YAML. **Not adopted here, deliberately** — our CI runs super-linter, which checks with *prettier*. If local hooks formatted with oxfmt and CI checked with prettier they'd fight on every commit, and this repo already has a documented three-way markdown formatting conflict. Switching would mean changing lint policy, which is a decision to take explicitly rather than as a side effect.

## Validation

- `renovate-config-validator` — passes
- regex verified against the real file: captures `v1.13.7`
- `flate test all --namespace kube-system` — 38 passed; rendered HelmRelease carries the new URL
- scoped super-linter (incl. its RENOVATE linter) — clean