### PR TITLE
feat: apc-fleet GitOps wiring (private fleet repo sync)

### DIFF
--- a/kubernetes/apps/observability/apc-fleet/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/apc-fleet/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: apc-fleet-deploy
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: apc-fleet-deploy
+    template:
+      engineVersion: v2
+      data:
+        # Flux GitRepository SSH auth expects keys: identity, known_hosts.
+        identity: '{{ index . "private-key" }}'
+        known_hosts: '{{ index . "known-hosts" }}'
+  dataFrom:
+    - extract:
+        key: apc-fleet-deploy-key

--- a/kubernetes/apps/observability/apc-fleet/app/fleet-sync.yaml
+++ b/kubernetes/apps/observability/apc-fleet/app/fleet-sync.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apc-fleet-sync
+spec:
+  interval: 1h
+  path: ./kubernetes
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: apc-fleet
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/observability/apc-fleet/app/gitrepository.yaml
+++ b/kubernetes/apps/observability/apc-fleet/app/gitrepository.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: apc-fleet
+spec:
+  interval: 1h
+  ref:
+    branch: main
+  secretRef:
+    name: apc-fleet-deploy
+  url: ssh://git@github.com/LukeEvansTech/apc-fleet.git

--- a/kubernetes/apps/observability/apc-fleet/app/kustomization.yaml
+++ b/kubernetes/apps/observability/apc-fleet/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+resources:
+  - ./externalsecret.yaml
+  - ./fleet-sync.yaml
+  - ./gitrepository.yaml

--- a/kubernetes/apps/observability/apc-fleet/ks.yaml
+++ b/kubernetes/apps/observability/apc-fleet/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app apc-fleet
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/observability/apc-fleet/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./namespace.yaml
   - ./netpol.yaml
   - ./acinfinity-exporter/ks.yaml
+  - ./apc-fleet/ks.yaml
   - ./blackbox-exporter/ks.yaml
   - ./bmc-exporter/ks.yaml
   - ./exportarr/ks.yaml


### PR DESCRIPTION
GitRepository + deploy-key ExternalSecret + sync Kustomization for the apc-fleet private repo, following the established fleet-source pattern. Workload manifests live in the private repo.