### PR TITLE
feat(observability): redfish-fleet GitOps wiring (private fleet repo sync)

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -28,6 +28,7 @@ resources:
   - ./plex-exporter/ks.yaml
   - ./prometheus-adapter/ks.yaml
   - ./qbittorrent-exporter/ks.yaml
+  - ./redfish-fleet/ks.yaml
   - ./sabnzbd-dashboard/ks.yaml
   - ./scrutiny/ks.yaml
   - ./scrutiny-collector/ks.yaml

--- a/kubernetes/apps/observability/redfish-fleet/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/redfish-fleet/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: redfish-fleet-deploy
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: redfish-fleet-deploy
+    template:
+      engineVersion: v2
+      data:
+        # Flux GitRepository SSH auth expects keys: identity, known_hosts.
+        identity: '{{ index . "private-key" }}'
+        known_hosts: '{{ index . "known-hosts" }}'
+  dataFrom:
+    - extract:
+        key: redfish-fleet-deploy-key

--- a/kubernetes/apps/observability/redfish-fleet/app/gitrepository.yaml
+++ b/kubernetes/apps/observability/redfish-fleet/app/gitrepository.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: redfish-fleet
+spec:
+  interval: 1h
+  ref:
+    branch: main
+  secretRef:
+    name: redfish-fleet-deploy
+  url: ssh://git@github.com/LukeEvansTech/redfish-fleet.git

--- a/kubernetes/apps/observability/redfish-fleet/app/kustomization.yaml
+++ b/kubernetes/apps/observability/redfish-fleet/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: observability
+resources:
+  - ./externalsecret.yaml
+  - ./gitrepository.yaml
+  - ./sync.yaml

--- a/kubernetes/apps/observability/redfish-fleet/app/sync.yaml
+++ b/kubernetes/apps/observability/redfish-fleet/app/sync.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+# Syncs the private redfish-fleet repo (drift exporter Deployment/Service,
+# ServiceMonitor, PrometheusRule, and BMC metrics-credentials ExternalSecret).
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: redfish-fleet-sync
+spec:
+  interval: 1h
+  path: ./kubernetes
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: redfish-fleet
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/observability/redfish-fleet/ks.yaml
+++ b/kubernetes/apps/observability/redfish-fleet/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app redfish-fleet
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/observability/redfish-fleet/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
## Summary

Same pattern as the apc-fleet and shelly-fleet sources: GitRepository + deploy-key ExternalSecret + sync Kustomization for the redfish-fleet private repo, following the established fleet-source pattern. Workload manifests (drift exporter Deployment/Service, ServiceMonitor, PrometheusRule, and BMC metrics-credentials ExternalSecret) live in the private repo; this repo carries only the source wiring.

## Test plan

- [x] `kubectl kustomize kubernetes/apps/observability/redfish-fleet/app/` renders cleanly
- [x] `flate test all --namespace observability --path kubernetes/flux/cluster --allow-missing-secrets` — new Kustomization passes; the redfish-fleet GitRepository/sync Kustomization skip identically to the existing apc-fleet/shelly-fleet private-repo sources (missing secret in the local sandbox, expected until the deploy-key ExternalSecret resolves against the live cluster)
- [x] `lefthook run pre-commit` clean on staged files (yamlfmt, yamllint, prettier, codespell, editorconfig)
- [x] `lefthook run commit-msg` — `check-internal-identifiers` passes
- [x] Scoped super-linter run (`FILTER_REGEX_INCLUDE` on changed files, matching the repo's `lint.yml` flags) — all linted successfully

**Not merging yet** — the redfish-fleet image on GHCR is still private pending a separate follow-up action; merging now would deploy an ImagePullBackOff pod and trip the cluster's stock alerts.