### PR TITLE
feat(snmp-exporter): APC rack PDU power telemetry

### DIFF
--- a/kubernetes/apps/observability/snmp-exporter/app/configmap-apc-pdu.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/configmap-apc-pdu.yaml
@@ -1,0 +1,124 @@
+---
+# Custom snmp_exporter modules for the APC rack PDU fleet (PowerNet-MIB).
+# Two module generations, verified against the live devices 2026-08-01:
+#   apc_rpdu2 — Rack PDU 2G (AP8659EU3, NMC2 AOS 7.2.x): rPDU2 device +
+#     phase status tables. Power is reported in hundredths of kilowatts
+#     (multiply by 10 for watts), current in tenths of amps, energy in
+#     tenths of kWh. The pdu_name label is looked up from the device's own
+#     rPDU2DeviceStatusName, so no internal hostname lives in this repo.
+#   apc_rpdu — legacy Rack PDU (AP7921B): rPDUIdentDevicePowerWatts is a
+#     plain watts scalar; rPDULoadStatusLoad is tenths of amps.
+# Config drift/compliance for these devices is the apc-fleet exporter's job —
+# these modules carry power telemetry only. Auths (community) live in the
+# snmp-exporter-auth Secret (external-secrets), never here (public repo).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: snmp-exporter-apc-pdu
+  namespace: observability
+data:
+  snmp.yml: |-
+    modules:
+      apc_rpdu2:
+        walk:
+          - 1.3.6.1.2.1.1.3                # sysUpTime
+          - 1.3.6.1.4.1.318.1.1.26.4.3.1   # rPDU2DeviceStatusTable
+          - 1.3.6.1.4.1.318.1.1.26.6.3.1   # rPDU2PhaseStatusTable
+        metrics:
+          - name: sysUpTime
+            oid: 1.3.6.1.2.1.1.3
+            type: gauge
+            help: Time since the SNMP agent was last re-initialized (hundredths of a second)
+          - name: rPDU2DeviceStatusLoadState
+            oid: 1.3.6.1.4.1.318.1.1.26.4.3.1.4
+            type: gauge
+            help: PDU load state (1=lowLoad 2=normal 3=nearOverload 4=overload)
+            indexes:
+              - labelname: rPDU2DeviceStatusIndex
+                type: gauge
+            lookups:
+              - labels: [rPDU2DeviceStatusIndex]
+                labelname: pdu_name
+                oid: 1.3.6.1.4.1.318.1.1.26.4.3.1.3
+                type: DisplayString
+          - name: rPDU2DeviceStatusPower
+            oid: 1.3.6.1.4.1.318.1.1.26.4.3.1.5
+            type: gauge
+            help: PDU load power in hundredths of kilowatts (x10 = watts)
+            indexes:
+              - labelname: rPDU2DeviceStatusIndex
+                type: gauge
+            lookups:
+              - labels: [rPDU2DeviceStatusIndex]
+                labelname: pdu_name
+                oid: 1.3.6.1.4.1.318.1.1.26.4.3.1.3
+                type: DisplayString
+          - name: rPDU2DeviceStatusEnergy
+            oid: 1.3.6.1.4.1.318.1.1.26.4.3.1.9
+            type: gauge
+            help: Lifetime energy through the PDU in tenths of kWh
+            indexes:
+              - labelname: rPDU2DeviceStatusIndex
+                type: gauge
+            lookups:
+              - labels: [rPDU2DeviceStatusIndex]
+                labelname: pdu_name
+                oid: 1.3.6.1.4.1.318.1.1.26.4.3.1.3
+                type: DisplayString
+          - name: rPDU2PhaseStatusLoadState
+            oid: 1.3.6.1.4.1.318.1.1.26.6.3.1.4
+            type: gauge
+            help: Phase load state (1=lowLoad 2=normal 3=nearOverload 4=overload)
+            indexes:
+              - labelname: rPDU2PhaseStatusIndex
+                type: gauge
+          - name: rPDU2PhaseStatusCurrent
+            oid: 1.3.6.1.4.1.318.1.1.26.6.3.1.5
+            type: gauge
+            help: Phase current in tenths of amps
+            indexes:
+              - labelname: rPDU2PhaseStatusIndex
+                type: gauge
+          - name: rPDU2PhaseStatusVoltage
+            oid: 1.3.6.1.4.1.318.1.1.26.6.3.1.6
+            type: gauge
+            help: Phase voltage in volts
+            indexes:
+              - labelname: rPDU2PhaseStatusIndex
+                type: gauge
+          - name: rPDU2PhaseStatusPower
+            oid: 1.3.6.1.4.1.318.1.1.26.6.3.1.7
+            type: gauge
+            help: Phase power in hundredths of kilowatts (x10 = watts)
+            indexes:
+              - labelname: rPDU2PhaseStatusIndex
+                type: gauge
+      apc_rpdu:
+        get:
+          - 1.3.6.1.4.1.318.1.1.12.1.16.0  # rPDUIdentDevicePowerWatts
+        walk:
+          - 1.3.6.1.2.1.1.3                # sysUpTime
+          - 1.3.6.1.4.1.318.1.1.12.2.3.1   # rPDULoadStatusTable
+        metrics:
+          - name: sysUpTime
+            oid: 1.3.6.1.2.1.1.3
+            type: gauge
+            help: Time since the SNMP agent was last re-initialized (hundredths of a second)
+          - name: rPDUIdentDevicePowerWatts
+            oid: 1.3.6.1.4.1.318.1.1.12.1.16
+            type: gauge
+            help: PDU load power in watts
+          - name: rPDULoadStatusLoad
+            oid: 1.3.6.1.4.1.318.1.1.12.2.3.1.1.2
+            type: gauge
+            help: Phase/bank load current in tenths of amps
+            indexes:
+              - labelname: rPDULoadStatusIndex
+                type: gauge
+          - name: rPDULoadState
+            oid: 1.3.6.1.4.1.318.1.1.12.2.3.1.1.3
+            type: gauge
+            help: Phase/bank load state (1=lowLoad 2=normal 3=nearOverload 4=overload)
+            indexes:
+              - labelname: rPDULoadStatusIndex
+                type: gauge

--- a/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/externalsecret.yaml
@@ -24,6 +24,13 @@ spec:
               community: "{{ .ONYX_COMMUNITY }}"
               security_level: noAuthNoPriv
               version: 2
+            # APC NMC2 cards speak SNMPv1 and v3 only — no v2c. Read-only
+            # community, NMS access open estate-wide (write community is
+            # IP-restricted on the devices; the exporter never writes anyway).
+            apc_ro:
+              community: "{{ .APC_COMMUNITY }}"
+              security_level: noAuthNoPriv
+              version: 1
             # Brother printer fleet — SNMPv3 authPriv, one shared read-only user
             # with per-device auth+priv passphrases. Brother offers no v3
             # read-only mode (v3 is always read-write), so containment is: authPriv

--- a/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/helmrelease.yaml
@@ -21,6 +21,7 @@ spec:
       - --config.file=/etc/snmp_exporter/snmp.yml
       - --config.file=/run/snmp-extra/snmp.yml
       - --config.file=/run/snmp-printer/snmp.yml
+      - --config.file=/run/snmp-apc/snmp.yml
       - --config.file=/run/snmp-auth/snmp.yml
     extraConfigmapMounts:
       - name: entity-sensor
@@ -30,6 +31,10 @@ spec:
       - name: brother-printer
         configMap: snmp-exporter-brother-printer
         mountPath: /run/snmp-printer
+        readOnly: true
+      - name: apc-pdu
+        configMap: snmp-exporter-apc-pdu
+        mountPath: /run/snmp-apc
         readOnly: true
     # Credentials only (auths:) — templated by the snmp-exporter ExternalSecret
     # so no community string lives in git (public repo).
@@ -129,6 +134,53 @@ spec:
               targetLabel: instance
             - targetLabel: device_class
               replacement: printer
+        # APC rack PDU fleet — power telemetry only (config drift/compliance is
+        # the apc-fleet exporter's job). NMC2 cards speak SNMPv1/v3 only; apc_ro
+        # is the v1 read-only community from the ExternalSecret. The two 2G PDUs
+        # use the rPDU2 MIB, the legacy comms PDU the classic rPDU MIB. The
+        # pdu_name label comes from the device itself at scrape time.
+        - name: apc-pdu-main-1
+          target: ${APC_PDU_MAIN1_ADDR}
+          module:
+            - apc_rpdu2
+          auth:
+            - apc_ro
+          interval: 60s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: pdu
+        - name: apc-pdu-main-2
+          target: ${APC_PDU_MAIN2_ADDR}
+          module:
+            - apc_rpdu2
+          auth:
+            - apc_ro
+          interval: 60s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: pdu
+        - name: apc-pdu-comms
+          target: ${APC_PDU_COMMS_ADDR}
+          module:
+            - apc_rpdu
+          auth:
+            - apc_ro
+          interval: 60s
+          scrapeTimeout: 30s
+          relabelings:
+            - sourceLabels:
+                - __param_target
+              targetLabel: instance
+            - targetLabel: device_class
+              replacement: pdu
     resources:
       requests:
         cpu: 10m

--- a/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/snmp-exporter/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./externalsecret.yaml
   - ./configmap-entity-sensor.yaml
   - ./configmap-brother-printer.yaml
+  - ./configmap-apc-pdu.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./grafanadashboard.yaml


### PR DESCRIPTION
Adds `apc_rpdu2` + `apc_rpdu` snmp_exporter modules and three PDU scrape targets (addresses via cluster-secrets substitution, v1 RO community via the ExternalSecret). Both modules live-verified through the pinned image before this PR: 2G PDU returns device power/phase current/voltage/energy with `pdu_name` looked up from the device; legacy PDU returns the watts scalar. `device_class=pdu` brings the targets under the existing `SnmpTargetDown` alert. Power panels land on the APC Fleet dashboard (private apc-fleet repo, issue 7).
