### PR TITLE
fix(certwarden): supermicro-ipmi-cert 0.2.0 - verify the served certificate

### DIFF
--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/supermicro/scripts-configmap.yaml
@@ -52,7 +52,7 @@ data:
     echo "Certificate: ${CERTIFICATE_NAME:-unknown}"
     echo "Target Supermicro: ${SUPERMICRO_HOST}"
     echo "Namespace: ${NAMESPACE}"
-    echo "Container: ghcr.io/lukeevanstech/supermicro-ipmi-cert@sha256:fec1afbf9f59423a4b9f8149c30c106c1383d69ce4d074579a471e2c45475053"
+    echo "Container: ghcr.io/lukeevanstech/supermicro-ipmi-cert:0.2.0@sha256:a4de3125d1bd995fa7c479a0e6681c3ad2ed58a60f8c193a92dbd1f0efea33d5"
 
     # Create a unique job name with timestamp
     JOB_NAME="supermicro-cert-deploy-${SUPERMICRO_HOST}-$(date +%s)"
@@ -92,7 +92,7 @@ data:
           restartPolicy: Never
           containers:
             - name: supermicro-deploy
-              image: ghcr.io/lukeevanstech/supermicro-ipmi-cert@sha256:f248b92d9245ec1b35fb22d75b26721a6379c21d3df33fcf98d986bec997a45e
+              image: ghcr.io/lukeevanstech/supermicro-ipmi-cert:0.2.0@sha256:a4de3125d1bd995fa7c479a0e6681c3ad2ed58a60f8c193a92dbd1f0efea33d5
               command:
                 - sh
                 - -c


### PR DESCRIPTION
The deployer could report success while the BMC kept serving the old
certificate: an empty-body Manager.Reset returns 200 on some firmware
without restarting, a failed reboot was only a warning, and nothing
compared what the BMC actually serves. 0.2.0 sends a proper ResetType,
treats reboot failure as deploy failure, polls the TLS port until the
served leaf matches the uploaded certificate, and raises the upload
timeout for BMC generations that process SmcSSLCert.Upload slowly.

Also aligns the informational echo digest with the Job image digest -
the two references had drifted apart.
