### PR TITLE
fix(certwarden): repair APC cert lane and make deploy failures observable

### DIFF
--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/externalsecret.yaml
@@ -2,23 +2,17 @@
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
 # ExternalSecret for APC NMC host credentials
 #
-# This pulls credentials from 1Password for your APC NMC device.
+# The 1Password item is the apc-fleet per-device item, whose field names
+# (IP_Address, username, password, ...) do not match the APC_* keys the
+# deploy Job reads. The template below maps them explicitly - a bare
+# dataFrom extract produced a secret with none of the keys the Job needs,
+# which made every certificate deployment fail at "APC_HOSTNAME is empty".
 #
-# Required fields in 1Password:
-#   APC_HOSTNAME         - Hostname or IP address of the APC NMC
-#   APC_USERNAME         - Admin username for the APC NMC
-#   APC_PASSWORD         - Password for the APC NMC
-#   APC_FINGERPRINT      - SSH host key fingerprint for the APC NMC
-#   APC_INSECURE_CIPHER  - Set to "true" for older APC devices (optional, defaults to "false")
-#
-# Example 1Password item structure:
-#   Item name: apc-ups-main
-#   Fields:
-#     - APC_HOSTNAME: 10.32.8.58
-#     - APC_USERNAME: apc
-#     - APC_PASSWORD: your-secure-password
-#     - APC_FINGERPRINT: 4sd7MpvwhQrOEhAIjlL5Cr2s6ml0c22KX0rxYClwbN8
-#     - APC_INSECURE_CIPHER: true
+# Fields consumed from the 1Password item:
+#   IP_Address           - address of the APC NMC (deploy target)
+#   username / password  - NMC admin credentials
+#   APC_FINGERPRINT      - SSH host key fingerprint for the NMC
+#   APC_INSECURE_CIPHER  - "true" for legacy cryptlib SSH devices
 #
 # To get the SSH fingerprint for APC devices, run:
 #   ssh -o KexAlgorithms=+diffie-hellman-group1-sha1,diffie-hellman-group14-sha1 \
@@ -36,6 +30,13 @@ spec:
     name: onepassword-connect
   target:
     name: apc-cr-ups-main
+    template:
+      data:
+        APC_HOSTNAME: "{{ .IP_Address }}"
+        APC_USERNAME: "{{ .username }}"
+        APC_PASSWORD: "{{ .password }}"
+        APC_FINGERPRINT: "{{ .APC_FINGERPRINT }}"
+        APC_INSECURE_CIPHER: "{{ .APC_INSECURE_CIPHER }}"
   dataFrom:
     - extract:
         key: cr-ups-main

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/scripts-configmap.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/apc/scripts-configmap.yaml
@@ -254,8 +254,11 @@ data:
         --from-literal=cert.pem="${CERTIFICATE_PEM}" \
         --from-literal=key.pem="${PRIVATE_KEY_PEM}"
 
-    # Note: Secret cleanup is handled by the Job's ownerReferences
-    # The secret will be garbage collected when the Job is deleted via ttlSecondsAfterFinished
+    # The Secret is adopted by the Job further down, once the Job exists and has
+    # a UID to point at. It cannot be created with an ownerReference here
+    # because the owner does not exist yet. (Same fix as the supermicro script:
+    # the old comment claimed ownerReferences handled cleanup but nothing ever
+    # set one, so every renewal leaked a Secret holding the private key.)
 
     # Create the deployment Job
     echo "Creating deployment Job: ${JOB_NAME}" >&2
@@ -345,24 +348,61 @@ data:
                 secretName: ${CERT_SECRET_NAME}
     EOF
 
-    # Wait for the job to complete
-    echo "Waiting for Job to complete..." >&2
-    kubectl wait --for=condition=complete --timeout=5m "job/${JOB_NAME}" -n "${NAMESPACE}"
-
-    # Get the job logs
-    echo "=== Job Logs ===" >&2
-    kubectl logs "job/${JOB_NAME}" -n "${NAMESPACE}"
-
-    # Check if the job succeeded
-    JOB_STATUS=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}')
-    if [[ "${JOB_STATUS}" == "True" ]]; then
-        echo "✅ Certificate deployed successfully to ${APC_HOST}" >&2
-        exit 0
+    # Make the Job the owner of the cert Secret so the two are deleted together.
+    # blockOwnerDeletion is false so the Secret can never hold up deletion of
+    # the Job, and a failure here is not fatal: the deployment itself has
+    # already been submitted, and a Secret that outlives its Job is the old
+    # (bad) behaviour rather than a new one.
+    echo "Binding Secret ${CERT_SECRET_NAME} to Job ${JOB_NAME} for cleanup" >&2
+    JOB_UID=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.metadata.uid}' 2>/dev/null || true)
+    if [[ -n "${JOB_UID}" ]]; then
+        kubectl patch secret "${CERT_SECRET_NAME}" -n "${NAMESPACE}" --type merge -p \
+            "{\"metadata\":{\"ownerReferences\":[{\"apiVersion\":\"batch/v1\",\"kind\":\"Job\",\"name\":\"${JOB_NAME}\",\"uid\":\"${JOB_UID}\",\"controller\":false,\"blockOwnerDeletion\":false}]}}" \
+            || echo "WARNING: could not set ownerReference on ${CERT_SECRET_NAME}; it will need manual cleanup" >&2
     else
-        echo "❌ Failed to deploy certificate to ${APC_HOST}" >&2
-        kubectl logs "job/${JOB_NAME}" -n "${NAMESPACE}" >&2
-        exit 1
+        echo "WARNING: could not read Job UID; ${CERT_SECRET_NAME} will need manual cleanup" >&2
     fi
+
+    # Wait for the Job to reach a terminal condition (Complete or Failed).
+    # kubectl wait --for=condition=complete ignores Failed, so on a fast pod
+    # failure it would block the full --timeout instead of surfacing the real
+    # error. Poll both conditions explicitly so failures are caught quickly.
+    echo "Waiting for Job to complete..." >&2
+    JOB_TIMEOUT=300
+    DEADLINE=$(( $(date +%s) + JOB_TIMEOUT ))
+    JOB_RESULT=""
+    while [[ $(date +%s) -lt ${DEADLINE} ]]; do
+        COMPLETE=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Complete")].status}' 2>/dev/null || true)
+        FAILED=$(kubectl get job "${JOB_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.conditions[?(@.type=="Failed")].status}' 2>/dev/null || true)
+        if [[ "${COMPLETE}" == "True" ]]; then
+            JOB_RESULT="complete"
+            break
+        fi
+        if [[ "${FAILED}" == "True" ]]; then
+            JOB_RESULT="failed"
+            break
+        fi
+        sleep 5
+    done
+
+    # Always dump pod logs so Certwarden captures them on success and failure
+    echo "=== Job Logs ===" >&2
+    kubectl logs "job/${JOB_NAME}" -n "${NAMESPACE}" --all-containers --tail=-1 >&2 || true
+
+    case "${JOB_RESULT}" in
+        complete)
+            echo "✅ Certificate deployed successfully to ${APC_HOST}" >&2
+            exit 0
+            ;;
+        failed)
+            echo "❌ Failed to deploy certificate to ${APC_HOST}" >&2
+            exit 1
+            ;;
+        *)
+            echo "❌ Job did not reach a terminal state within ${JOB_TIMEOUT}s on ${APC_HOST}" >&2
+            exit 1
+            ;;
+    esac
 kind: ConfigMap
 metadata:
   annotations:

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/kustomization.yaml
@@ -6,6 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: infrastructure
 resources:
+  - ./prometheusrule.yaml
   - ./supermicro
   - ./apc
   - ./brother

--- a/kubernetes/apps/infrastructure/certwarden/cert-deployment/prometheusrule.yaml
+++ b/kubernetes/apps/infrastructure/certwarden/cert-deployment/prometheusrule.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: certwarden-cert-deploy
+spec:
+  groups:
+    - name: certwarden-cert-deploy
+      rules:
+        # Certwarden post-processing failures were previously invisible: a
+        # deploy Job that failed every retry only left a line in Certwarden's
+        # own log, and one device served an expired certificate for months
+        # before anyone noticed. The Jobs have ttlSecondsAfterFinished: 300,
+        # so kube-state-metrics only exposes a failed Job for ~5 minutes -
+        # "for: 1m" fires within that window while still absorbing a single
+        # odd scrape. The certificate-expiry probes in blackbox-exporter-lan
+        # are the slow-burn backstop; this is the real-time signal.
+        - alert: CertDeployJobFailed
+          expr: |-
+            kube_job_failed{namespace="infrastructure", condition="true", job_name=~"(supermicro|apc)-cert-deploy-.*"} == 1
+          for: 1m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              Certificate deploy Job {{ $labels.job_name }} failed - the device
+              is still serving its previous certificate. Check Certwarden's
+              post-processing log, fix the cause, then retry post processing
+              from the Certwarden UI (the deploy is safe to re-run).

--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -88,6 +88,25 @@ spec:
         - s3-nas.${SECRET_DOMAIN}:443
         - scrutiny-nas.${SECRET_DOMAIN}:443
         - syncthing.${SECRET_DOMAIN}:443
+        # Supermicro BMCs. Certwarden renews these certificates and pushes
+        # them to each BMC via a deploy Job — a chain with two failure modes
+        # seen in production: the Job fails outright (CertDeployJobFailed
+        # covers that, but only for ~5 minutes per failure), and the upload
+        # "succeeds" while the BMC keeps serving the old certificate until
+        # reboot. Probing what the socket actually serves catches both, weeks
+        # before expiry. One BMC served an expired certificate for 3.5 months
+        # with nothing anywhere to say so — these targets close that gap.
+        # (The UPS NMC belongs here too once its stale DNS record is fixed
+        # and its first certificate deployment lands.)
+        - cr-node-01-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-02-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-03-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-04-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-05-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-06-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-07-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-node-08-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        - cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}:443
   metricRelabelings:
     - action: replace
       replacement: blackbox-exporter-lan


### PR DESCRIPTION
The APC certificate deployment has failed every renewal cycle since it
was set up. Root cause: the ExternalSecret does a bare dataFrom extract
of the fleet 1Password item, whose field names (IP_Address, username,
password) do not match the APC_* keys the deploy Job reads - so the Job
always saw an empty hostname. Map the fields explicitly via a template.

Port two proven fixes from the supermicro wrapper to the APC wrapper:
bind the temporary cert Secret to its Job via ownerReference (every
renewal previously leaked a Secret holding the private key), and poll
both Complete and Failed conditions instead of kubectl wait, which
ignores Failed and blocked the full timeout on fast failures.

Deploy failures were also invisible outside Certwarden's own log - one
device served an expired certificate for 3.5 months with no signal
anywhere. Two layers fix that:

- CertDeployJobFailed fires on kube_job_failed for any cert-deploy Job
  (the Jobs are TTL'd after 300s, hence the short "for")
- the BMC fleet joins the lan-tls-cert blackbox probe, so the existing
  CertificateExpiringSoon/Critical rules now watch what each BMC
  actually serves, catching uploads that never took effect
