### PR TITLE
feat(blackbox): UPS NMC joins the certificate-expiry probe

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -96,8 +96,6 @@ spec:
         # reboot. Probing what the socket actually serves catches both, weeks
         # before expiry. One BMC served an expired certificate for 3.5 months
         # with nothing anywhere to say so — these targets close that gap.
-        # (The UPS NMC belongs here too once its stale DNS record is fixed
-        # and its first certificate deployment lands.)
         - cr-node-01-ipmi.${SECRET_INTERNAL_DOMAIN}:443
         - cr-node-02-ipmi.${SECRET_INTERNAL_DOMAIN}:443
         - cr-node-03-ipmi.${SECRET_INTERNAL_DOMAIN}:443
@@ -107,6 +105,12 @@ spec:
         - cr-node-07-ipmi.${SECRET_INTERNAL_DOMAIN}:443
         - cr-node-08-ipmi.${SECRET_INTERNAL_DOMAIN}:443
         - cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}:443
+        # Main UPS NMC3 — same Certwarden deploy chain as the BMCs (via
+        # apc-p15-tool over SSH rather than Redfish). First successful
+        # deployment 2026-08-02; the name resolves via an Unbound host
+        # override (network-ops) shadowing a stale public record. Apex zone,
+        # matching the name the certificate is issued for.
+        - cr-ups-main.${SECRET_DOMAIN}:443
   metricRelabelings:
     - action: replace
       replacement: blackbox-exporter-lan


### PR DESCRIPTION
Its first certificate deployment landed and its name now resolves via an
Unbound host override, so the UPS gets the same served-certificate watch
as the BMCs: the existing CertificateExpiringSoon/Critical rules cover
the whole Certwarden device fleet from here.
