### PR TITLE
fix(blackbox): device certificate probes need a non-verifying TLS module

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
@@ -56,6 +56,21 @@ spec:
           tcp:
             tls: true
             preferred_ip_protocol: ip4
+        # Device management endpoints (BMCs, the UPS NMC) serve a chainless
+        # leaf — the Certwarden device deploy paths install only the server
+        # certificate, so Go's verifier has no intermediate to chain with and
+        # a verifying probe scores every device probe_success=0. These probes
+        # exist to harvest expiry, not to validate trust; skip verification
+        # for the device module only, keeping the stricter tls_connect for
+        # the Traefik targets (where a broken chain IS worth failing on).
+        tls_connect_noverify:
+          prober: tcp
+          timeout: 5s
+          tcp:
+            tls: true
+            preferred_ip_protocol: ip4
+            tls_config:
+              insecure_skip_verify: true
     serviceMonitor:
       enabled: true
       selfMonitor:

--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -88,14 +88,40 @@ spec:
         - s3-nas.${SECRET_DOMAIN}:443
         - scrutiny-nas.${SECRET_DOMAIN}:443
         - syncthing.${SECRET_DOMAIN}:443
-        # Supermicro BMCs. Certwarden renews these certificates and pushes
-        # them to each BMC via a deploy Job — a chain with two failure modes
-        # seen in production: the Job fails outright (CertDeployJobFailed
-        # covers that, but only for ~5 minutes per failure), and the upload
-        # "succeeds" while the BMC keeps serving the old certificate until
-        # reboot. Probing what the socket actually serves catches both, weeks
-        # before expiry. One BMC served an expired certificate for 3.5 months
-        # with nothing anywhere to say so — these targets close that gap.
+  metricRelabelings:
+    - action: replace
+      replacement: blackbox-exporter-lan
+      targetLabel: service
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: lan-tls-cert-device
+spec:
+  # Certificate expiry for device management endpoints whose certificates
+  # Certwarden renews and pushes via deploy Jobs — a chain with two failure
+  # modes seen in production: the Job fails outright (CertDeployJobFailed
+  # covers that, but only for ~5 minutes per failure), and the upload
+  # "succeeds" while the device keeps serving the old certificate until
+  # reboot. Probing what the socket actually serves catches both, weeks
+  # before expiry. One BMC served an expired certificate for 3.5 months
+  # with nothing anywhere to say so — these targets close that gap.
+  #
+  # Separate Probe from lan-tls-cert because these devices serve a chainless
+  # leaf (the deploy paths install only the server certificate), which fails
+  # the verifying tls_connect module — see tls_connect_noverify in the
+  # HelmRelease. Same jobName, so dashboards and the expiry alerts treat
+  # both probes as one fleet.
+  jobName: tls_cert
+  interval: 5m
+  module: tls_connect_noverify
+  prober:
+    url: blackbox-exporter-lan.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        # Supermicro BMCs.
         - cr-node-01-ipmi.${SECRET_INTERNAL_DOMAIN}:443
         - cr-node-02-ipmi.${SECRET_INTERNAL_DOMAIN}:443
         - cr-node-03-ipmi.${SECRET_INTERNAL_DOMAIN}:443


### PR DESCRIPTION
The BMC/UPS targets added for certificate-expiry monitoring all scored
probe_success=0: the Certwarden device deploy paths install only the
server certificate, so the devices serve a chainless leaf and the
verifying tls_connect module fails with "certificate signed by unknown
authority" before any expiry metric is emitted.

Split the device fleet into its own Probe using tls_connect_noverify
(insecure_skip_verify) - these probes exist to harvest expiry from what
the socket serves, not to validate trust. The Traefik targets keep the
verifying module, where a broken chain is itself a signal worth failing
on. Same jobName, so the expiry alerts cover both probes as one fleet.
