### PR TITLE
fix(blackbox): 15s timeout for device TLS probes - RSA-4096 BMC handshakes exceed 5s

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
@@ -63,9 +63,13 @@ spec:
         # exist to harvest expiry, not to validate trust; skip verification
         # for the device module only, keeping the stricter tls_connect for
         # the Traefik targets (where a broken chain IS worth failing on).
+        # 15s, not 5s: the H12-generation storage BMC holds an RSA-4096 key
+        # (the H13s carry ECDSA) and its BMC processor takes several seconds
+        # for the private-key operation, so its handshake blows a 5s budget.
+        # Probes run every 5m; a generous timeout costs nothing.
         tls_connect_noverify:
           prober: tcp
-          timeout: 5s
+          timeout: 15s
           tcp:
             tls: true
             preferred_ip_protocol: ip4


### PR DESCRIPTION
The storage BMC holds an RSA-4096 key and its processor needs several
seconds for the private-key operation, so its handshake alone blows the
5s module budget and the probe reported it down while the certificate
was fine. Probes run every 5m; a generous timeout costs nothing.
