### PR TITLE
feat(shelly): operator 0.5.0 + alert on devices pending a restart

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.4.0@sha256:378356b126a9d1b2941c98fe40ddbc4e123f1ecc955f7e83ada58a1c173a53c3
+      tag: 0.5.0@sha256:cde95ddde351affecb4a5e80bf74763811c2437a9494f9474738fb05d22971ae
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.4.0
+    tag: 0.5.0
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator

--- a/kubernetes/apps/home/shelly-operator/app/prometheusrule.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/prometheusrule.yaml
@@ -50,3 +50,23 @@ spec:
           for: 24h
           labels:
             severity: info
+        - alert: ShellyDeviceRestartRequired
+          annotations:
+            summary: Shelly device needs a restart for a setting to take effect.
+            description: >-
+              {{ $labels.name }}{{ with $labels.room }} in {{ . }}{{ end }}
+              ({{ $labels.mac }}) has reported restart_required for over 6h. A
+              setting has been written but is NOT live until the device is
+              rebooted. Note this does not show up as drift: InSync compares the
+              config the device REPORTS, and the value is already written, so
+              such a device reads as fully in sync. Clear it by rebooting the
+              device, or set rebootWhenRequired on its profile if that load
+              tolerates an interruption.
+            # 6h, not 24h: unlike a pending firmware update there is no daily
+            # window that clears this on its own -- it waits for a human
+            # indefinitely. Four devices sat pending before this alert existed,
+            # the oldest for four and a half days.
+          expr: shelly_device_restart_required == 1
+          for: 6h
+          labels:
+            severity: info


### PR DESCRIPTION
Bumps shelly-operator **0.4.0 -> 0.5.0** and adds `ShellyDeviceRestartRequired`.

**The gap.** A device that has had a setting written which needs a reboot reports
`restart_required`. Until 0.5.0 that was invisible — the operator raised a *Normal*
Event which expired within the hour, and nothing else recorded it. A manual sweep found
**four devices pending, the oldest for 4½ days**, with zero surviving Events.

**It isn't drift, which is why it needs its own alert.** `InSync` compares the config
the device *reports*, and a value needing a restart is already reported as written:

```
Air Console: InSync=True | configuration matches profile infra-managed
HDHomeRun:   InSync=True | configuration matches profile always-on-managed
```

Both were pending a restart. `InSync: True` means *written*, not *active*.

**Why `for: 6h`** and not the 24h used for pending firmware: nothing clears this on its
own. A firmware update has the device's daily 00:00 window to retry into; this waits for
a human indefinitely.

**`rebootWhenRequired` is deliberately left unset everywhere.** It is opt-in per profile
and a reboot is a physical act on whatever the plug feeds. The four known-pending devices
stay pending on purpose, so the alert can be watched firing — and then resolving — against
real hardware before anything is automated.

Upstream: LukeEvansTech/shelly-operator#56, released v0.5.0. Image digest pinned; no
literal LAN addresses in the diff.