### PR TITLE
feat(shelly): operator 0.6.0, daily reboot window

### DIFF
--- a/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
   values:
     image:
       repository: ghcr.io/lukeevanstech/shelly-operator
-      tag: 0.5.0@sha256:cde95ddde351affecb4a5e80bf74763811c2437a9494f9474738fb05d22971ae
+      tag: 0.6.0@sha256:1299d458712cd8b110056deb2be64d3cec67929799a63f505601a8b622914300
     discovery:
       # Substituted from cluster-secrets (public repo: no literal LAN CIDRs).
       # IOT_TRUSTED_NETWORK_CIDR is the IoT VLAN the whole fleet lives on

--- a/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/home/shelly-operator/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.5.0
+    tag: 0.6.0
   url: oci://ghcr.io/lukeevanstech/charts/shelly-operator


### PR DESCRIPTION
0.6.0 adds `spec.rebootWindow`, so `rebootWhenRequired` can be confined to a chosen
time instead of firing on whichever reconcile first notices a device asking.

Deploying the operator **ahead of** the shelly-fleet change that uses it — the CRD has
to know the field before a profile references it, or the API server prunes it.

Upstream: LukeEvansTech/shelly-operator#57, released v0.6.0. Digest pinned.