### PR TITLE
feat(observability): scrape the firewall's node_exporter

### DIFF
--- a/kubernetes/apps/observability/opnsense-exporter/app/kustomization.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml
+  - ./scrapeconfig.yaml
   - ./servicemonitor.yaml
 configMapGenerator:
   - name: opnsense-exporter-dashboard

--- a/kubernetes/apps/observability/opnsense-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/scrapeconfig.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name opnsense-node
+spec:
+  # node-exporter (os-node_exporter plugin, :9100) on the firewall — kernel-level
+  # CPU/memory/ZFS/disk/netdev that the API-based opnsense-exporter above cannot
+  # see. Added 2026-08-02: the WAN-wedge outage that day had to be reconstructed
+  # from cluster-side probes because the box exposed no OS-level metrics.
+  #
+  # Plain LAN scrape, no egress Service — the nut-appliance shape, not the
+  # seedbox one (nothing here crosses the tailnet).
+  staticConfigs:
+    - targets:
+        - ${OPNSENSE_ADDR}:9100
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      # Matches OPNSENSE_EXPORTER_INSTANCE_LABEL on the API exporter so both
+      # jobs' series join on the same instance.
+      replacement: opnsense
+  metricRelabelings:
+    # Same load-bearing drop as nut-appliance and the seedbox: ceph-mixin ships
+    # alerts with no job selector that join through node_uname_info
+    # (`* on(cluster, instance) group_left(nodename) node_uname_info`) and would
+    # otherwise adopt this target; dropping the metric breaks that join.
+    - action: drop
+      sourceLabels:
+        - __name__
+      regex: node_uname_info

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -58,6 +58,11 @@ stringData:
   # unroutable, so a failed ExternalSecret fails the scrape loudly instead of
   # silently pointing UPS monitoring at some other host.
   NUT_SERVER_ADDR: "192.0.2.2"
+  # The firewall's LAN address, scraped by the opnsense-node ScrapeConfig
+  # (os-node_exporter :9100 — OS-level metrics the API exporter cannot see).
+  # TEST-NET-1 again: unroutable, so a failed ExternalSecret fails the scrape
+  # loudly instead of silently pointing firewall monitoring at another host.
+  OPNSENSE_ADDR: "192.0.2.3"
   # Brother printer fleet on PRINT VLAN 72, polled by snmp-exporter over SNMPv3.
   # Real addresses (the .10/.15/.20/.25 DHCP reservations) live in the cluster-secrets
   # 1Password item; TEST-NET-1 placeholders again fail loudly if the


### PR DESCRIPTION
os-node_exporter is now enabled on the firewall (installed 2026-08-02 after the WAN-wedge outage left nothing OS-level to diagnose from). This adds a ScrapeConfig in the opnsense-exporter app (nut-appliance shape: static target from ${OPNSENSE_ADDR}, job/instance relabels, ceph-mixin node_uname_info guard) plus the TEST-NET-1 placeholder var. Real value already added to the cluster-secrets 1Password item.