### PR TITLE
fix(security): sentinel-syslog LB must use externalTrafficPolicy Cluster

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -112,7 +112,15 @@ spec:
           # components/global-vars/cluster-secrets.yaml — kept out of this PUBLIC repo per the
           # internal-identifier scan, same pattern as the other SVC_*_ADDR LB services.
           lbipam.cilium.io/ips: ${SVC_SYSLOG_ADDR}
-        externalTrafficPolicy: Local
+        # Cluster, not Local: Cilium's L2 announcement elects a lease-holder node
+        # without regard to backend locality, so with Local the LB IP is ARP'd by a
+        # node that then refuses the traffic whenever the pod lands elsewhere —
+        # external senders got TCP RST / silent UDP loss while in-cluster socket-LB
+        # kept working (found 2026-08-02: the firewall had been refused on every
+        # syslog write for days). Client source IP is SNAT'd under Cluster, which
+        # is acceptable here: the pipeline keys on [program] and the in-message
+        # hostname (logsource), not the peer address.
+        externalTrafficPolicy: Cluster
         ports:
           syslog-udp:
             port: 514


### PR DESCRIPTION
External (LAN) senders to the syslog LB were getting TCP RST / silent UDP loss whenever the pod scheduled onto a different node than the Cilium L2 lease holder — eTP Local + L2 announcement don't compose (lease election ignores backend locality). In-cluster socket-LB kept working, which masked it. Found while investigating why the firewall logs a refused syslog write every minute. Pipeline keys on program/logsource, not peer IP, so Cluster's SNAT is harmless.