### PR TITLE
feat(observability): monitor the firewall BMC; smarter power + WAN alerts

### DIFF
--- a/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
@@ -79,6 +79,12 @@ spec:
             "{{ .vm00_addr }}":
               username: "{{ .vm00_user }}"
               password: "{{ .vm00_pass }}"
+            # The firewall's BMC (AS-1015A-MT, added 2026-08-02 after the WAN
+            # outage found it unmonitored). Same no-DNS-record route as the VM
+            # host above: keyed by the address carried in its 1Password item.
+            "{{ .fwbmc_addr }}":
+              username: "{{ .fwbmc_user }}"
+              password: "{{ .fwbmc_pass }}"
   data:
     - secretKey: node01_user
       remoteRef:
@@ -163,4 +169,16 @@ spec:
     - secretKey: vm00_pass
       remoteRef:
         key: cr-vm-00-ipmi
+        property: IPMI_PASSWORD
+    - secretKey: fwbmc_addr
+      remoteRef:
+        key: cr-fw-ipmi
+        property: IPMI_ADDR
+    - secretKey: fwbmc_user
+      remoteRef:
+        key: cr-fw-ipmi
+        property: IPMI_USERNAME
+    - secretKey: fwbmc_pass
+      remoteRef:
+        key: cr-fw-ipmi
         property: IPMI_PASSWORD

--- a/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
@@ -44,11 +44,19 @@ spec:
         # solely so this exact-match excludes it: a desk machine is off most of
         # the time and would otherwise page on every shutdown. It stays covered
         # by every other rule here. See helmrelease-workstation.yaml.
+        # Gated on the host having been ON within the last 24h: an unexpected
+        # power-off pages within 15m and keeps paging for a day, then the host
+        # is treated as deliberately parked and the alert self-silences. This is
+        # what stops the retired-firewall sled and the cold spare — off for good
+        # since the 2026-07-30 migration — from paging forever, without keeping
+        # a hostname list here (this repo is public) that would drift anyway.
         - alert: BmcHostPoweredOff
           annotations:
-            summary: "Host behind {{ $labels.instance }} is powered off."
+            summary: "Host behind {{ $labels.instance }} is powered off (was on within 24h)."
           expr: |-
             idrac_system_power_on{job="bmc-exporter"} == 0
+            and
+            max_over_time(idrac_system_power_on{job="bmc-exporter"}[24h]) == 1
           for: 15m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/opnsense-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/opnsense-exporter/app/prometheusrule.yaml
@@ -16,16 +16,39 @@ spec:
           for: 5m
           labels:
             severity: critical
-        # Gateway RTT monitoring is disabled on this OPNsense, so the loss/RTT
-        # value on opnsense_gateways_monitor_info isn't populated. The reliable
-        # down signal is the no_route label (set from the routing table when a
-        # gateway loses its default route), which is independent of monitoring.
-        # Enable gateway monitoring on the firewall to unlock loss/RTT alerting.
+        # The no_route signal is set from the routing table when a gateway loses
+        # its default route — independent of dpinger, so it stays as the
+        # belt-and-braces down signal alongside the loss alert below.
         - alert: OPNsenseGatewayDown
           annotations:
             summary: "OPNsense gateway {{ $labels.name }} has no route (down)."
           expr: |-
             opnsense_gateways_monitor_info{job="opnsense-exporter", no_route="true"}
+          for: 5m
+          labels:
+            severity: critical
+        # dpinger was enabled on the v4 WAN gateway 2026-08-02 (monitor 1.1.1.1),
+        # which populated the loss/RTT series for the first time. Sustained loss
+        # is upstream/ISP degradation the routing table can't see.
+        - alert: OPNsenseWanGatewayLossHigh
+          annotations:
+            summary: "WAN gateway packet loss at {{ $value }}% for 10m."
+          expr: |-
+            opnsense_gateways_loss_percentage{job="opnsense-exporter", name="WAN_DHCP"} > 20
+          for: 10m
+          labels:
+            severity: critical
+        # The 2026-08-02 outage signature: both WAN counters froze to exactly
+        # zero for 15 minutes while the link stayed up and no watchdog logged —
+        # dpinger's monitor traffic rides this interface, so a healthy WAN can
+        # never legitimately read zero-in-both-directions for 5 minutes.
+        - alert: OPNsenseWanTrafficFrozen
+          annotations:
+            summary: "WAN has passed zero bytes in BOTH directions for 5m — NIC/modem wedge, likely needs a link bounce."
+          expr: |-
+            rate(opnsense_interfaces_received_bytes_total{job="opnsense-exporter", interface="WAN"}[5m]) == 0
+            and
+            rate(opnsense_interfaces_transmitted_bytes_total{job="opnsense-exporter", interface="WAN"}[5m]) == 0
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
Follow-ons from the 2026-08-02 WAN outage: (1) the firewall's BMC joins bmc-exporter via the address-carried-in-1P route (item already created and verified against the live Redfish endpoint); (2) BmcHostPoweredOff becomes data-driven — only pages for hosts that were on within 24h, so parked sleds self-silence without a public hostname list; (3) two new WAN alerts: sustained gateway loss (dpinger enabled today) and the zero-bytes-both-directions freeze that was this outage's signature.