### PR TITLE
fix(observability): drop the mislabeled VM-host BMC entry

### DIFF
--- a/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
@@ -70,18 +70,18 @@ spec:
             cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}:
               username: "{{ .storage_user }}"
               password: "{{ .storage_pass }}"
-            # The VM host has no internal DNS record, so it is keyed by an
-            # address carried in its 1Password item rather than a name. That is
-            # the documented route for a device address in this public repo:
-            # the value only ever exists in the rendered Secret. If a DNS record
-            # is created for it later, switch this to the name and drop
-            # IPMI_ADDR — every other host here is keyed by name.
-            "{{ .vm00_addr }}":
-              username: "{{ .vm00_user }}"
-              password: "{{ .vm00_pass }}"
-            # The firewall's BMC (AS-1015A-MT, added 2026-08-02 after the WAN
-            # outage found it unmonitored). Same no-DNS-record route as the VM
-            # host above: keyed by the address carried in its 1Password item.
+            # The firewall's BMC (AS-1015A-MT). No internal DNS record, so it is
+            # keyed by the address carried in its 1Password item rather than a
+            # name — the documented route for a device address in this public
+            # repo: the value only ever exists in the rendered Secret. If a DNS
+            # record is created later, switch this to the name.
+            #
+            # The former "VM host" entry was REMOVED here (2026-08-02): its
+            # item's stored address had been recorded against the wrong board —
+            # it resolved to this same firewall BMC, which both crashed the
+            # exporter (duplicate mapping key) and meant the entry never watched
+            # a VM host at all. The standalone VM host is a MicroCloud sled
+            # whose BMC is already covered by its own numbered entry above.
             "{{ .fwbmc_addr }}":
               username: "{{ .fwbmc_user }}"
               password: "{{ .fwbmc_pass }}"
@@ -157,18 +157,6 @@ spec:
     - secretKey: storage_pass
       remoteRef:
         key: cr-storage-ipmi
-        property: IPMI_PASSWORD
-    - secretKey: vm00_addr
-      remoteRef:
-        key: cr-vm-00-ipmi
-        property: IPMI_ADDR
-    - secretKey: vm00_user
-      remoteRef:
-        key: cr-vm-00-ipmi
-        property: IPMI_USERNAME
-    - secretKey: vm00_pass
-      remoteRef:
-        key: cr-vm-00-ipmi
         property: IPMI_PASSWORD
     - secretKey: fwbmc_addr
       remoteRef:


### PR DESCRIPTION
Rolling out #4071 crashed bmc-exporter on a duplicate config key: the old VM-host entry's 1P-carried address was recorded against the wrong board (it resolves to the firewall BMC added in #4071), so that entry never monitored a VM host. Removed — the actual standalone VM host's BMC is already covered by its numbered sled entry. Old replica kept serving throughout; no monitoring gap.