### PR TITLE
feat(observability): firewall BMC by name, plus its ICMP liveness probe

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -25,6 +25,9 @@ spec:
         # never added, so the box holding the bulk data had no out-of-band
         # liveness signal at all.
         - cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}
+        # Firewall BMC (named 2026-08-02 after the WAN outage; the device that
+        # matters most in a recovery previously had no OOB liveness signal).
+        - cr-fw-ipmi.${SECRET_INTERNAL_DOMAIN}
   metricRelabelings:
     - action: replace
       replacement: blackbox-exporter-lan

--- a/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/externalsecret.yaml
@@ -70,19 +70,16 @@ spec:
             cr-storage-ipmi.${SECRET_INTERNAL_DOMAIN}:
               username: "{{ .storage_user }}"
               password: "{{ .storage_pass }}"
-            # The firewall's BMC (AS-1015A-MT). No internal DNS record, so it is
-            # keyed by the address carried in its 1Password item rather than a
-            # name — the documented route for a device address in this public
-            # repo: the value only ever exists in the rendered Secret. If a DNS
-            # record is created later, switch this to the name.
+            # The firewall's BMC (AS-1015A-MT), keyed by name since the
+            # cr-fw-ipmi Unbound overrides landed (network-ops, 2026-08-02).
             #
             # The former "VM host" entry was REMOVED here (2026-08-02): its
-            # item's stored address had been recorded against the wrong board —
-            # it resolved to this same firewall BMC, which both crashed the
-            # exporter (duplicate mapping key) and meant the entry never watched
-            # a VM host at all. The standalone VM host is a MicroCloud sled
-            # whose BMC is already covered by its own numbered entry above.
-            "{{ .fwbmc_addr }}":
+            # item's stored address was a legacy record of this same chassis's
+            # previous life as the VM host — it resolved to this firewall BMC,
+            # crashing the exporter on a duplicate mapping key, and had never
+            # watched an actual VM host. The standalone VM host is a MicroCloud
+            # sled whose BMC is already covered by its own numbered entry above.
+            cr-fw-ipmi.${SECRET_INTERNAL_DOMAIN}:
               username: "{{ .fwbmc_user }}"
               password: "{{ .fwbmc_pass }}"
   data:
@@ -158,10 +155,6 @@ spec:
       remoteRef:
         key: cr-storage-ipmi
         property: IPMI_PASSWORD
-    - secretKey: fwbmc_addr
-      remoteRef:
-        key: cr-fw-ipmi
-        property: IPMI_ADDR
     - secretKey: fwbmc_user
       remoteRef:
         key: cr-fw-ipmi


### PR DESCRIPTION
The Unbound overrides for the firewall BMC landed in network-ops, so
the bmc-exporter entry switches from address-keyed to name-keyed like
the rest of the fleet, and the BMC joins the lan-icmp probe set — the
device that matters most in a recovery previously had no out-of-band
liveness signal.
