### PR TITLE
fix(flux): stop re-applying placeholder cluster-secrets over live values

### DIFF
--- a/docs/docs/troubleshooting/kb/020-httproute-drifts-to-placeholder-hostnames.md
+++ b/docs/docs/troubleshooting/kb/020-httproute-drifts-to-placeholder-hostnames.md
@@ -1,7 +1,8 @@
 # KB-020: App Returns 404 Through the Gateway (HTTPRoute Drifted to Placeholder Hostnames)
 
-**Status:** Rare and self-correcting; fixed per-app with a one-liner. Structural fix
-**deliberately declined** (see end). If it recurs, just remediate. Don't re-investigate.
+**Status:** Structurally fixed 2026-08-03: the placeholder Secret now carries
+`kustomize.toolkit.fluxcd.io/ssa: IfNotPresent`, so the race below can no longer recur.
+Objects that drifted *before* the fix stay drifted until remediated per-app (see Fix).
 
 ## Symptom
 
@@ -74,14 +75,31 @@ kubectl get httproute -A -o json | jq -r '.items[]
 
   and confirm the body is **not** `Error 404: Not Found`.
 
-## Why no structural fix
+## Structural fix (shipped 2026-08-03)
 
-Decided not to fix structurally: the race is rare (a handful of apps in the cluster's lifetime,
-only at first render before ESO syncs), well understood, and self-corrects in the HelmRelease
-values. Only already-rendered live objects stay drifted, and the delete+recreate one-liner
-clears those. Options considered and declined: global `driftDetection.mode: enabled` (would
-fight the zeroscaler HPAs), a self-healing CronJob guard, splitting `cluster-secrets` into its own
-`dependsOn`-gated Kustomization (the only complete fix, too invasive), and hardcoding the domain
+The race was originally left in place as "rare, first render only". That aged badly: the
+placeholder was not applied once at first render, it was re-applied on **every**
+kustomize-controller reconcile (managedFields showed kustomize-controller writing the
+placeholder and ESO overwriting it one second later, hourly). Each reconcile reopened the
+window, and on 2026-07-30 the giteamirror route rendered `example.com` mid-reconcile (the
+helm upgrade that wrote it died with "context canceled") and stayed drifted for four days.
+
+The fix is one annotation on the placeholder Secret in
+`kubernetes/components/global-vars/cluster-secrets.yaml`:
+
+```yaml
+kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+```
+
+kustomize-controller now creates the Secret only when it does not exist (bootstrap), and
+never again overwrites the ESO-managed real values. CI rendering (flate/Konflate) is
+unaffected: both read the git file, not the live object. Trade-off: a key added to the
+placeholder file after bootstrap reaches only CI rendering; the live value must land in
+the `cluster-secrets` 1Password item, which was already the required workflow.
+
+Options considered earlier and declined: global `driftDetection.mode: enabled` (would
+fight the zeroscaler HPAs), a self-healing CronJob guard, splitting `cluster-secrets` into
+its own `dependsOn`-gated Kustomization (complete but invasive), and hardcoding the domain
 literally (only patches the domain symptom, not the general race).
 
 ## References

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -9,6 +9,17 @@ metadata:
   annotations:
     # Namespace is provided by Kustomize component usage
     checkov.io/skip1: CKV_K8S_21=Namespace provided by kustomization overlay
+    # Create-once. Without this, every kustomize-controller reconcile re-applies
+    # these placeholder values over the ExternalSecret-managed real ones, and any
+    # app Kustomization whose postBuild substitution reads the Secret inside that
+    # ~1s window renders placeholders into live manifests (an HTTPRoute shipped
+    # with the example.com domain this way on 2026-07-30 and stayed broken until
+    # noticed, because Helm's three-way merge never saw a reason to re-patch it).
+    # Trade-off: keys added to this file after bootstrap reach only CI rendering;
+    # the live Secret gets new keys solely via the 1Password item, so update the
+    # item first. The fail-loud dead-address placeholders below still apply on a
+    # fresh bootstrap, which is when they matter.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 stringData:
   CLUSTER_PODS_CIDR: "10.244.0.0/16"
   CLUSTER_SVCS_CIDR: "10.245.0.0/16"


### PR DESCRIPTION
## Problem

The `global-vars` component ships a placeholder `cluster-secrets` Secret so offline renders (flate, Konflate) can substitute `${VAR}`s. kustomize-controller was also re-applying it on **every reconcile**, briefly reverting the ExternalSecret-managed real values (managedFields show kustomize-controller writing at HH:MM:58 and external-secrets restoring at HH:MM:59, hourly). Any app Kustomization whose postBuild substitution read the Secret inside that window baked placeholder values into live manifests.

That is the KB-020 race, previously believed to be a first-render-only event. It bit again on 2026-07-30: a route rendered with the `example.com` placeholder domain mid-reconcile (the Helm upgrade writing it died with "context canceled") and stayed drifted for four days, because consecutive Helm revisions rendered identically so no later upgrade ever re-patched the live object. Gatus flagged the endpoint down; the live object has been remediated.

## Fix

`kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` on the placeholder Secret: kustomize-controller creates it only when absent (bootstrap) and never again overwrites the ExternalSecret-managed values. CI rendering is unaffected (flate/Konflate read the git file, not the live object). Trade-off, documented in the file: placeholder keys added after bootstrap reach only CI rendering; live values must land in the 1Password item first, which was already the required workflow.

KB-020 updated to record the structural fix and the evidence that superseded the earlier remediate-only decision.

## Validation

- Scoped super-linter run on the changed component: pass
- `flate test all --namespace default`: 177 passed