### PR TITLE
fix(observability): stop the declarative restore inits paging forever

### DIFF
--- a/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/nut-appliance/app/prometheusrule.yaml
@@ -86,6 +86,17 @@ spec:
         # not redundant: "container nut-upsd exited" is directly actionable where
         # "UPS monitoring is blind" is a symptom. Different alertnames, so the
         # critical->warning inhibit rule does not couple them.
+        # The declarative restore inits (apps/*/compose.yaml, service
+        # restore-<app>) are one-shots: they run, exit 0 and STAY exited. That
+        # is their steady state, so they are excluded from NutApplianceContainerDown
+        # above — without the exclusion every one of them pages forever, which
+        # is exactly what happened when they first landed (13 across the fleet).
+        #
+        # A restore init that FAILS is still caught, just not here. It exits
+        # non-zero, so compose never starts the app it gates, and the app is
+        # left in `created` rather than `exited` — which is why `created` was
+        # added to the status list above. Nothing sits in `created` for
+        # 5m in normal operation; a deploy moves through it in seconds.
         - alert: NutApplianceContainerDown
           annotations:
             description: >-
@@ -94,7 +105,7 @@ spec:
               nut-apps with no other symptom.
             summary: NUT appliance container {{ $labels.name }} is not running.
           expr: |-
-            container_state_status{job="nut-appliance-docker", status=~"exited|dead", container_label_cd_doco_metadata_manager="doco-cd"} == 1
+            container_state_status{job="nut-appliance-docker", status=~"exited|dead|created", container_label_cd_doco_metadata_manager="doco-cd", name!~".*-restore-.*-[0-9]+"} == 1
           for: 5m
           labels:
             severity: warning

--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -246,11 +246,22 @@ spec:
     # hand-run throwaway container never pages.
     - name: seedbox-docker.rules
       rules:
+        # The declarative restore inits (apps/*/compose.yaml, service
+        # restore-<app>) are one-shots: they run, exit 0 and STAY exited. That
+        # is their steady state, so they are excluded from SeedboxContainerDown
+        # above — without the exclusion every one of them pages forever, which
+        # is exactly what happened when they first landed (13 across the fleet).
+        #
+        # A restore init that FAILS is still caught, just not here. It exits
+        # non-zero, so compose never starts the app it gates, and the app is
+        # left in `created` rather than `exited` — which is why `created` was
+        # added to the status list above. Nothing sits in `created` for
+        # 10m in normal operation; a deploy moves through it in seconds.
         - alert: SeedboxContainerDown
           annotations:
             summary: "Seedbox container {{ $labels.name }} is not running (state: {{ $labels.status }})."
           expr: |-
-            container_state_status{job="seedbox-docker", status=~"exited|dead", container_label_cd_doco_metadata_manager="doco-cd"} == 1
+            container_state_status{job="seedbox-docker", status=~"exited|dead|created", container_label_cd_doco_metadata_manager="doco-cd", name!~".*-restore-.*-[0-9]+"} == 1
           for: 10m
           labels:
             severity: critical

--- a/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/prometheusrule.yaml
@@ -85,11 +85,22 @@ spec:
             severity: critical
         # "exited|dead" scoped to the doco-cd-managed fleet so containers outside
         # that fleet (or intentionally stopped) never page.
+        # The declarative restore inits (apps/*/compose.yaml, service
+        # restore-<app>) are one-shots: they run, exit 0 and STAY exited. That
+        # is their steady state, so they are excluded from TrueNASContainerDown
+        # above — without the exclusion every one of them pages forever, which
+        # is exactly what happened when they first landed (13 across the fleet).
+        #
+        # A restore init that FAILS is still caught, just not here. It exits
+        # non-zero, so compose never starts the app it gates, and the app is
+        # left in `created` rather than `exited` — which is why `created` was
+        # added to the status list above. Nothing sits in `created` for
+        # 5m in normal operation; a deploy moves through it in seconds.
         - alert: TrueNASContainerDown
           annotations:
             summary: "TrueNAS container {{ $labels.name }} is not running (state: {{ $labels.status }})."
           expr: |-
-            container_state_status{job="truenas-docker-exporter", status=~"exited|dead", container_label_cd_doco_metadata_manager="doco-cd"} == 1
+            container_state_status{job="truenas-docker-exporter", status=~"exited|dead|created", container_label_cd_doco_metadata_manager="doco-cd", name!~".*-restore-.*-[0-9]+"} == 1
           for: 5m
           labels:
             severity: critical


### PR DESCRIPTION
The doco-cd fleet's new declarative restore inits are **one-shots**: they run at deploy, exit 0, and stay exited. That is their steady state — but all three `*ContainerDown` rules treat any doco-cd-managed container in `exited|dead` as a **critical** page.

Thirteen fired at once the moment the feature landed: seedbox 7, NUT appliance 2, TrueNAS 4. All false — and thirteen permanent criticals are exactly the kind of noise that buries a real one.

## The fix

Excluded by name pattern (`name!~".*-restore-.*-[0-9]+"`, matching Compose's `<project>-<service>-<index>` naming). `name` and the doco-cd manager label are the only labels these exporters expose, so a name pattern is the available discriminator.

Verified against live Prometheus before and after:

| job | old expr | new expr |
|---|---|---|
| `seedbox-docker` | 7 | **0** |
| `nut-appliance-docker` | 2 | **0** |
| `truenas-docker-exporter` | 4 | **0** |

The thirteen excluded names are **exactly** the restore inits — checked explicitly, nothing real is masked.

## And a gap the same feature opened

A restore init that **fails** exits non-zero, so Compose never starts the app it gates — leaving that app in `created`, not `exited`. None of these rules matched `created`, so **a failed restore would have been silent**: app down, nothing paging.

`created` is now in the status list. Nothing sits there for the alert hold-down (5m/10m) in normal operation — a deploy moves through it in seconds. So the failure mode that matters is covered while the steady state that does not is quiet.

## Verification

- Both expressions run against live Prometheus; counts above.
- super-linter v8.6.0 in a scoped sandbox with this repo's linter config and `MARKDOWN_CONFIG_FILE` staged the way the shared workflow does. **Coverage proven** by planting a YAML error and confirming the run failed with all three rule files in the examined set.