### PR TITLE
fix(imgur-proxy): disable gluetun probes that drove a restart loop

### DIFF
--- a/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/imgur-proxy/app/helmrelease.yaml
@@ -123,9 +123,23 @@ spec:
             envFrom:
               - secretRef:
                   name: imgur-proxy-secret
+            # Both probes are disabled, matching the gluetun sidecars in
+            # qbittorrent / sabnzbd / prowlarr. A kubelet probe on the health
+            # server restarts the *container*, but gluetun keeps the pod's
+            # network namespace across container restarts and re-appends its
+            # firewall rules on every start. One transient tunnel failure
+            # therefore becomes self-sustaining: probe 500 -> restart ->
+            # more accumulated netns state -> slower/failed start -> probe
+            # 500. This container sat in exactly that loop for 4+ days and
+            # 1352 restarts, ending in OOMKills against the limit below, and
+            # only a pod recreation could break it. gluetun's own internal
+            # healthcheck loop already restarts the *tunnel* in-process on
+            # failure, which recovers the same faults without touching the
+            # netns, so the kubelet probe adds a failure mode without adding
+            # a recovery path.
             probes:
               liveness:
-                enabled: true
+                enabled: false
                 custom: true
                 spec:
                   httpGet:
@@ -135,7 +149,7 @@ spec:
                   periodSeconds: 30
                   failureThreshold: 5
               startup:
-                enabled: true
+                enabled: false
                 custom: true
                 spec:
                   httpGet:


### PR DESCRIPTION
## Problem

The `gluetun` sidecar in `imgur-proxy` had been restarting continuously for over four days (1352 restarts). The pod never reached `Ready`, so the LoadBalancer service had zero ready endpoints and the proxy was down for the entire period.

## Root cause

`imgur-proxy` was the only one of the four gluetun sidecars in the `downloads` namespace with the kubelet probes on the health server enabled — `qbittorrent`, `sabnzbd` and `prowlarr` all set both to `enabled: false`.

That probe restarts the *container*, but gluetun keeps the pod's network namespace across container restarts and re-appends its firewall rules on every start. A single transient tunnel failure therefore became self-sustaining:

```
health 500 -> container restart -> more accumulated netns state -> failed start -> health 500
```

It ended in repeated OOMKills against the memory limit, and only a pod recreation could break the cycle.

## Why the memory limit was not the cause

The exit reason was `OOMKilled` and this is the only gluetun sidecar with a memory limit, which made the limit the obvious suspect. It was ruled out: a fresh pod at the same **512Mi** starts cleanly and settles at **24Mi**, matching the other three sidecars (23-24Mi). The limit is left unchanged.

## Fix

Disable both gluetun probes, matching the three sibling apps. gluetun's own internal healthcheck loop already restarts the *tunnel* in-process on failure, which recovers the same faults without touching the netns — the kubelet probe added a failure mode without adding a recovery path.

## Verification

- Fresh pod running `2/2`, `0` restarts, gluetun at 24Mi
- Health server returns `200`, tunnel up and reporting its egress location
- Service endpoint back to `ready=True`
- `yamlfmt`, `prettier`, `kustomize build` all clean; live cluster spec matches Git with no drift