### PR TITLE
fix(observability): stop scraping the NAS twice on both ports

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -5,14 +5,56 @@ kind: ScrapeConfig
 metadata:
   name: &name node-exporter
 spec:
+  # node-exporter on the NAS (:9100). The cluster's own three nodes come from a
+  # ServiceMonitor under this same job name; this ScrapeConfig adds only the NAS,
+  # which is why it can carry a metricRelabelings block without touching them.
+  #
+  # Keeping the NAS under the cluster's job name rather than a truenas-* one is
+  # deliberate — 22 default node alert rules select job="node-exporter"
+  # (filesystem fill, RAID degraded, bonding degraded, clock skew, systemd unit
+  # failed…) and this is the box everything else depends on. See
+  # truenas-exporter/app/scrapeconfig.yaml for the full reasoning and for what
+  # was removed there.
   staticConfigs:
     - targets:
         - ${SECRET_STORAGE_SERVER}:9100
   metricsPath: /metrics
+  # 60s: host metrics on a box that is not a cluster node do not need the
+  # cluster's default cadence.
+  scrapeInterval: 60s
   relabelings:
     - action: replace
       targetLabel: job
       replacement: *name
+  metricRelabelings:
+    # Load-bearing, not tidying. Several ceph-mixin alerts ship with NO job
+    # selector and so adopt every node-exporter target in the cluster.
+    # CephNodeDiskspaceWarning joins through node_uname_info, then runs a 5-day
+    # predict_linear over every filesystem it finds. This host exposes ~89 of
+    # them, so without this drop a single scrape hands the ceph rules ~89 ZFS
+    # datasets to forecast. The seedbox and the NUT appliance drop it for the
+    # same reason.
+    #
+    # This drop existed on the (now removed) duplicate truenas-node ScrapeConfig
+    # and was completely ineffective there, because THIS job was publishing
+    # node_uname_info for the same host all along. Measured before the fix: the
+    # ceph join returned 178 filesystem series for this host — 89 from each copy.
+    #
+    # Verified that no default node rule needs it: of the 22 alert rules
+    # selecting job="node-exporter", ZERO join through node_uname_info, so the
+    # drop costs this host nothing and starves only the unscoped ceph rules.
+    #
+    # The other two unscoped ceph node alerts were checked against this box
+    # rather than assumed:
+    #   CephNodeRootFilesystemFull — keys on mountpoint="/", which here is a
+    #     17.1 GB filesystem at 0.6% used. Real, unlike FCOS's composefs, but
+    #     nowhere near any threshold.
+    #   CephNodeInconsistentMTU — compares each device against the cluster-wide
+    #     median for that device name.
+    - action: drop
+      sourceLabels:
+        - __name__
+      regex: node_uname_info
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
 apiVersion: monitoring.coreos.com/v1alpha1
@@ -20,10 +62,23 @@ kind: ScrapeConfig
 metadata:
   name: &name smartctl-exporter
 spec:
+  # smartctl-exporter on the NAS (:9633) — per-drive SMART health. As above, the
+  # cluster's own nodes arrive under this job from a ServiceMonitor and this adds
+  # only the NAS.
+  #
+  # This job name is load-bearing: truenas-exporter's prometheusrule.yaml and
+  # truenas-zfs.json hardcode job="smartctl-exporter" in five places, so the
+  # drive-temperature alert and four dashboard panels depend on the NAS's drives
+  # arriving under it. A duplicate truenas-smartctl ScrapeConfig was removed on
+  # 2026-08-09; this is the copy that was always feeding them.
   staticConfigs:
     - targets:
         - ${SECRET_STORAGE_SERVER}:9633
   metricsPath: /metrics
+  # 300s, matching the seedbox and the NUT appliance: SMART attributes move on a
+  # timescale of days, so a 5x cheaper scrape loses nothing — and this host has
+  # far more drives than either of them.
+  scrapeInterval: 300s
   relabelings:
     - action: replace
       targetLabel: job

--- a/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/truenas-exporter/app/scrapeconfig.yaml
@@ -41,80 +41,36 @@ spec:
   metricRelabelings:
     - action: labelkeep
       regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
-apiVersion: monitoring.coreos.com/v1alpha1
-kind: ScrapeConfig
-metadata:
-  name: &name truenas-node
-spec:
-  # node-exporter on the NAS (:9100) — CPU/memory/disk/network for the host
-  # itself. It has been RUNNING since the monitoring stack landed
-  # (truenas-apps apps/monitoring) but was never scraped, so the NAS was the
-  # only Docker box in the estate with no host metrics at all: the seedbox has
-  # seedbox-node and the NUT appliance has nut-appliance-node, and this one had
-  # nothing. The graphite bridge on :9108 carries TrueNAS's own ZFS/pool
-  # reporting, which is a different dataset and not a substitute.
-  staticConfigs:
-    - targets:
-        - ${SECRET_STORAGE_SERVER}:9100
-  metricsPath: /metrics
-  scrapeInterval: 60s
-  relabelings:
-    - action: replace
-      targetLabel: job
-      replacement: *name
-  metricRelabelings:
-    # Load-bearing, not tidying — and it matters MORE here than anywhere else.
-    # Several ceph-mixin alerts ship with NO job selector and so adopt every
-    # node-exporter target in the cluster. CephNodeDiskspaceWarning joins
-    # through node_uname_info, then runs a 5-day predict_linear over every
-    # filesystem it finds. This host exposes 85 of them, so without this drop a
-    # single scrape would hand the ceph rules 85 new ZFS datasets to forecast.
-    # The seedbox and the NUT appliance drop it for the same reason.
-    #
-    # The other two unscoped ceph node alerts were checked against this box
-    # rather than assumed:
-    #   CephNodeRootFilesystemFull — keys on mountpoint="/", which here is a
-    #     17.1 GB filesystem at 0.6% used. Real, unlike FCOS's composefs, but
-    #     nowhere near any threshold.
-    #   CephNodeInconsistentMTU — compares each device against the cluster-wide
-    #     median for that device name.
-    - action: drop
-      sourceLabels:
-        - __name__
-      regex: node_uname_info
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
-apiVersion: monitoring.coreos.com/v1alpha1
-kind: ScrapeConfig
-metadata:
-  name: &name truenas-smartctl
-spec:
-  # smartctl-exporter on the NAS (:9633) — per-drive SMART health. Also already
-  # running and never scraped, which is the more serious of the two gaps: this
-  # is the box whose entire job is spinning disks, and it was the only one in
-  # the estate with no drive-health series in Prometheus.
-  #
-  # scrutiny (truenas-apps apps/scrutiny) has its own view of SMART, but it is a
-  # separate UI with its own store and does not feed Prometheus, so it cannot
-  # drive alerts or sit alongside the other boxes on a shared dashboard.
-  #
-  # Needs no rules of its own: the shared smartctl-exporter.rules carry no job
-  # selector, so this inherits smart_status / critical_warning / media_errors /
-  # available_spare / temperature for free — the same way the NUT appliance does.
-  staticConfigs:
-    - targets:
-        - ${SECRET_STORAGE_SERVER}:9633
-  metricsPath: /metrics
-  # 300s, matching the seedbox and the NUT appliance: SMART attributes move on a
-  # timescale of days, so a 5x cheaper scrape loses nothing — and this host has
-  # far more drives than either of them.
-  scrapeInterval: 300s
-  relabelings:
-    - action: replace
-      targetLabel: job
-      replacement: *name
+# The NAS's node-exporter (:9100) and smartctl-exporter (:9633) are NOT scraped
+# from here. `truenas-node` and `truenas-smartctl` used to live at this point in
+# the file and were removed 2026-08-09: kube-prometheus-stack's own
+# scrapeconfig.yaml had been scraping both of those ports since long before,
+# under the `node-exporter` and `smartctl-exporter` job names, so every series
+# from this host arrived TWICE and every alert on it fired twice.
+#
+# The premise they were added on — "the NAS is the only Docker box in the estate
+# with no host metrics at all" — was simply wrong. It had them; they were just
+# under the cluster's job names rather than a truenas-* one.
+#
+# The duplication was not merely cosmetic. Only the truenas-node copy dropped
+# node_uname_info, so the unfiltered `node-exporter` copy kept publishing it and
+# the unscoped ceph-mixin rules went on adopting this host anyway — the drop
+# protected nothing while both existed. That drop now lives on the surviving
+# `node-exporter` ScrapeConfig, where it actually bites.
+#
+# Kept the cluster job names rather than the estate's `<box>-*` convention,
+# which is the one place this host deliberately differs from the seedbox and the
+# NUT appliance. Two reasons, both checked rather than assumed:
+#   - 22 default node alert rules select job="node-exporter" (filesystem fill,
+#     RAID degraded, bonding degraded, clock skew, systemd unit failed…). This
+#     is the box the whole estate depends on and it has a bond0; dropping all 22
+#     to gain a naming convention is a bad trade. None of them are firing on
+#     this host today, so they are not noisy either.
+#   - This app's OWN prometheusrule.yaml and truenas-zfs.json hardcode
+#     job="smartctl-exporter" in five places. Renaming would have silently
+#     blanked the drive-temperature alert and four dashboard panels.
+# Checked before deleting: nothing anywhere referenced truenas-node or
+# truenas-smartctl.
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
 apiVersion: monitoring.coreos.com/v1alpha1


### PR DESCRIPTION
Every series from the storage host arrived **twice** and every alert on it **fired twice** — two ScrapeConfigs targeted the same two ports:

| Port | Jobs |
|---|---|
| `:9100` | `node-exporter` **+** `truenas-node` |
| `:9633` | `smartctl-exporter` **+** `truenas-smartctl` |

## The premise the duplicates were added on was wrong

Their comments say the NAS *"was never scraped, so it was the only Docker box in the estate with no host metrics at all"*. It had them all along — under the cluster's job names, from `kube-prometheus-stack`'s scrapeconfig.

## Not just cosmetic noise

Only the `truenas-node` copy dropped `node_uname_info`. The unfiltered `node-exporter` copy kept publishing it, so the unscoped ceph-mixin rules went on adopting this host regardless. That drop is documented in its own comment as *"load-bearing"* — and it protected nothing while both jobs existed. Measured before the fix:

```
9 series   <- node_filesystem_size_bytes{job="node-exporter"}
9 series   <- node_filesystem_size_bytes{job="truenas-node"}
178 series <- the ceph join (89 filesystems x both copies)
```

## Change

Remove `truenas-node` and `truenas-smartctl`; move the `node_uname_info` drop and the 60s/300s intervals onto the surviving pair.

## Why the cluster job names, not the estate's `<box>-*` convention

This is the one place the NAS deliberately differs from the seedbox and the NUT appliance. Both reasons were checked rather than assumed:

- **22 default node alert rules select `job="node-exporter"`** — filesystem fill, RAID degraded, bonding degraded, clock skew, systemd unit failed. This is the box the whole estate depends on, and it has a `bond0`. Dropping all 22 to gain a naming convention is a bad trade. None of them are firing on it today, so they aren't noisy either.
- **`truenas-exporter`'s own `prometheusrule.yaml` and `truenas-zfs.json` hardcode `job="smartctl-exporter"` in five places.** Renaming would have silently blanked the drive-temperature alert and four dashboard panels.

That second point is why the obvious cleanup — delete the `kube-prometheus-stack` file, keep the nicely-commented `truenas-*` one — is the wrong way round.

## Verified before deleting

- Of the 22 rules selecting `job="node-exporter"`, **zero** join through `node_uname_info`, so the drop costs this host no alerting and starves only the unscoped ceph rules.
- **Nothing anywhere** referenced `truenas-node` or `truenas-smartctl`.
- Each port now appears exactly once across all ScrapeConfigs; `kustomize build` passes for both apps.