### PR TITLE
feat(observability): alert when the backup source snapshot goes stale

### DIFF
--- a/kubernetes/apps/observability/docker-backup/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/docker-backup/app/prometheusrule.yaml
@@ -11,7 +11,7 @@ spec:
     # metrics through node-exporter's textfile collector; the cluster is NEVER in
     # the data path, only the alerting path.
     #
-    # THREE rules, deliberately. Every alert here PAGES — Alertmanager's root
+    # FIVE rules, deliberately. Every alert here PAGES — Alertmanager's root
     # route sends all severities to Pushover, so `warning` is not a quiet tier.
     # The justification for each is that it fires approximately never: unlike a
     # threshold alert on a continuous signal, these are booleans about a thing
@@ -89,6 +89,44 @@ spec:
               check `docker logs backrest` on that box.
           expr: |-
             restic_backup_exit_code != 0
+          for: 15m
+          labels:
+            severity: warning
+        # Source freshness. The NAS backs up a fixed-name zfs snapshot refreshed
+        # by a separate cron 30 min beforehand, not the live tree — so a failed
+        # refresh means restic re-reads the OLD snapshot and exits 0. That is
+        # how 2026-08-05 to 08-09 ran four nights against a frozen source with
+        # every rule above green.
+        #
+        # No absent() companion: both textfiles share a directory and a
+        # node-exporter, so DockerBackupMetricsMissing already covers it.
+        #
+        # 36h/30m mirrors DockerBackupStale. This is the backstop for the cron
+        # never running, which the ok-flag rule below cannot see — a script that
+        # never runs never writes a 0.
+        - alert: DockerBackupSourceStale
+          annotations:
+            summary: >-
+              The {{ $labels.dataset }} source snapshot on {{ $labels.box }} has not
+              refreshed in over 36h — backups are copying stale data and still
+              reporting success.
+          expr: |-
+            time() - restic_snapshot_source_last_success_timestamp_seconds > 129600
+          for: 30m
+          labels:
+            severity: critical
+        # The fast complement — the script traps EXIT and writes 0 on every
+        # failure path, so this fires in 15m rather than 36h. Stays firing until
+        # the next nightly refresh succeeds, which is honest: the source really
+        # is stale until then.
+        - alert: DockerBackupSourceRefreshFailing
+          annotations:
+            summary: >-
+              The {{ $labels.dataset }} source snapshot refresh on {{ $labels.box }}
+              failed — tonight's backup will exit 0 against a stale source. Check
+              `zfs list -t snapshot {{ $labels.dataset }}` and the cron log.
+          expr: |-
+            restic_snapshot_source_refresh_ok == 0
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
The NAS backs up a fixed-name zfs snapshot refreshed by a separate cron, not the live tree. A failed refresh leaves restic re-reading the old snapshot and exiting 0, so all three existing `docker-backup.rules` stay green while the offsite copy silently freezes — exactly what happened for four nights from 2026-08-05, found by hand rather than by an alert.

Adds two rules on the metrics the refresh script now publishes:

| Alert | Expr | For | Severity | Catches |
| --- | --- | --- | --- | --- |
| `DockerBackupSourceStale` | `time() - restic_snapshot_source_last_success_timestamp_seconds > 129600` | 30m | critical | the cron never running — no 0 is ever written, the timestamp just ages |
| `DockerBackupSourceRefreshFailing` | `restic_snapshot_source_refresh_ok == 0` | 15m | warning | a refresh that ran and failed (the script traps EXIT and writes 0 on every failure path) |

36h/30m mirrors `DockerBackupStale` — same daily cadence, so one missed refresh plus 12h slack self-heals without paging.

No `absent()` companion: both textfiles share a directory and a node-exporter, so `DockerBackupMetricsMissing` already covers that cause and a second rule would only double-page.

## Verification

Both expressions run against live Prometheus rather than eyeballed:

- `time() - ... > 129600` → 0 series (not firing)
- same expr with threshold `0` → 1 series, age 40358s — proves the metric exists and the rule can fire
- `restic_snapshot_source_refresh_ok == 0` → 0 series; `!= 0` → 1 series, value 1

`kustomize build` clean, and `kubectl apply --dry-run=server` validates against the PrometheusRule CRD schema.