### PR TITLE
fix(observability): stop informational First AC Power on entries paging

### DIFF
--- a/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/bmc-exporter/app/prometheusrule.yaml
@@ -185,11 +185,17 @@ spec:
         # SEL entries at warning or above, within the 7d window set in the
         # exporter config. The metric's value is the entry's creation timestamp,
         # so presence alone is the signal.
+        #
+        # PWR-0020 excluded: the BMC logs "First AC Power on" at Warning, but it
+        # is informational — every rack power-up emits one per node, which then
+        # pages for the whole 7d window. Four fired across the 2026-08-03
+        # maintenance and were still paging six days later. Scoped to the exact
+        # code rather than the PWR- prefix, which also carries real PSU faults.
         - alert: BmcEventLogWarning
           annotations:
             summary: "{{ $labels.instance }} logged a {{ $labels.severity }} hardware event: {{ $labels.message }}"
           expr: |-
-            idrac_events_log_entry{job=~"bmc-exporter.*"} > 0
+            idrac_events_log_entry{job=~"bmc-exporter.*", message!~".*PWR-0020.*"} > 0
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
`BmcEventLogWarning` alerts on any SEL entry at Warning or above within the exporter's 7d window. `[PWR-0020] First AC Power on` is logged at Warning severity but is **informational** — every rack power-up emits one per node, so each planned maintenance produces a handful of alerts that then page for a full week.

Four fired across the 2026-08-03 maintenance and were still paging six days later.

```diff
- idrac_events_log_entry{job=~"bmc-exporter.*"} > 0
+ idrac_events_log_entry{job=~"bmc-exporter.*", message!~".*PWR-0020.*"} > 0
```

Scoped to the exact code rather than the `PWR-` prefix, which also carries real PSU faults.

## Why scope the rule instead of clearing the SELs

Clearing was the other option and is the wrong trade twice over:

- The four entries are correctly timestamped Aug 2–3 and **self-resolve within ~36h** as they fall out of the 7d window, so a clear buys about a day.
- It destroys genuine hardware history on four production nodes, and does nothing to stop the next power-up doing the same thing.

A negative matcher is also the safe direction here: it matches series with no `message` label, so nothing is silently dropped if the label is ever absent.

## Verification

Run against live Prometheus:

| Expression | Series |
| --- | --- |
| current rule | 4 |
| scoped (excludes PWR-0020) | **0** |
| control — excludes a code that doesn't exist | 4 |

The control is the one that matters: it proves the matcher drops only the intended entries rather than silently emptying the result.

`kustomize build` clean; `kubectl apply --dry-run=server` validates against the PrometheusRule CRD schema.