### PR TITLE
fix(blackbox): the device probe timeout was clamped away by the scrape timeout

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/helmrelease.yaml
@@ -63,13 +63,20 @@ spec:
         # exist to harvest expiry, not to validate trust; skip verification
         # for the device module only, keeping the stricter tls_connect for
         # the Traefik targets (where a broken chain IS worth failing on).
-        # 15s, not 5s: the H12-generation storage BMC holds an RSA-4096 key
+        # 30s, not 5s: the H12-generation storage BMC holds an RSA-4096 key
         # (the H13s carry ECDSA) and its BMC processor takes several seconds
         # for the private-key operation, so its handshake blows a 5s budget.
         # Probes run every 5m; a generous timeout costs nothing.
+        #
+        # This value is only half the setting — blackbox clamps it to the
+        # scrape timeout Prometheus sends in X-Prometheus-Scrape-Timeout-
+        # Seconds, minus a 0.5s offset. Against the 10s default that is 9.5s,
+        # so the 15s set here on 2026-08-02 never applied and the probe kept
+        # the 9.5s budget it was written to escape. The matching scrapeTimeout
+        # lives on the lan-tls-cert-device Probe; raise both or neither.
         tls_connect_noverify:
           prober: tcp
-          timeout: 15s
+          timeout: 30s
           tcp:
             tls: true
             preferred_ip_protocol: ip4

--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -128,6 +128,13 @@ spec:
   # both probes as one fleet.
   jobName: tls_cert
   interval: 5m
+  # Without this the scrape timeout defaults to 10s, and blackbox clamps its
+  # own module timeout to that minus 0.5s — so the module's 30s became 9.5s
+  # and the storage BMC failed ~83% of scrapes for a week while serving its
+  # certificate perfectly. Measured handshakes on that BMC: 1-3s warm, but
+  # 6.6s, 15s and 20s on the first connection after an idle gap, which is
+  # every scrape at a 5m interval. Keep this above the module timeout.
+  scrapeTimeout: 35s
   module: tls_connect_noverify
   prober:
     url: blackbox-exporter-lan.observability.svc.cluster.local:9115


### PR DESCRIPTION
The storage BMC's TLS probe has been failing about **83% of scrapes** (hourly success rate 0-42%, ~17% over 24h), firing `LanProbeFailed` critical — while the device served its certificate on every single attempt I made. ICMP to the same host never dropped, and the eight node BMCs on the same probe were unaffected.

## Why it fails

Blackbox clamps a module timeout to the scrape timeout Prometheus sends in `X-Prometheus-Scrape-Timeout-Seconds`, minus a 0.5s offset. Against the 10s default that is **9.5s**, and every failing scrape ended at exactly 9.5s with no TLS metrics recorded — a timeout, not a rejected handshake.

So the `timeout: 15s` added to `tls_connect_noverify` on 2026-08-02 never applied. The probe kept the very budget its own comment says it was raised to escape.

## Why the budget matters

This BMC is slow on the **first connection after an idle gap** — which, at a 5m probe interval, is every scrape. Measured from inside the exporter's own network namespace:

```text
elapsed=15s   <- first connection
elapsed=2s
elapsed=1s
elapsed=2s
elapsed=2s
```

Same shape elsewhere: 6.6s then 1.9s and 1.6s, plus one 20s outlier in a run of twenty. Warm bursts always pass — 35+ ad-hoc probes succeeded at 1-3s — which is exactly why this could not be reproduced by hand and looked like a flaky device.

## Change

- `tls_connect_noverify` module timeout 15s → **30s**
- `lan-tls-cert-device` Probe gains **`scrapeTimeout: 35s`**, above the module value so the module timeout is the one that binds

The alert keeps its `for: 15m` window — it was reporting a real timeout, not crying wolf, and it is why this surfaced at all.

## Ruled out

DNS (single stable A record, no AAAA), duplicate scrape targets (exactly one, healthy), a dead BMC (certificate served every time), an odd network path (standard Cilium, same as the test pods), and phase-locking against `bmc-exporter`'s 60s Redfish poll (26 back-to-back probes, no periodic busy window).

## Verification

Treat this as a hypothesis to confirm, not a certainty — the failure would not reproduce on demand. Watch `probe_success` for the storage BMC over an hour after it lands rather than assuming it is solved. Note the clamp only bites modules whose timeout exceeds ~9.5s, so `tls_connect` at 5s is unaffected.