### PR TITLE
chore(renovate): opt into home-operations app presets for the 7.0.0 restructure

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -6,7 +6,18 @@
   // :timezone(Europe/London), Copilot reviewers, suppressNotifications,
   // dependencies/security labels, and vulnerabilityAlerts — single source of
   // truth, so they are no longer duplicated here.
-  extends: ["github>LukeEvansTech/renovate-config"],
+  // Since renovate-presets 6.0.0 the app-specific presets are opt-in under
+  // apps/ (the base keeps only general-purpose rules), so the ones this
+  // cluster runs are extended here directly. phanpy is the only apps/ preset
+  // not deployed here.
+  extends: [
+    "github>LukeEvansTech/renovate-config",
+    "github>home-operations/renovate-presets//apps/cnpg.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/grafanaDashboards.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/llamacpp.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/searxng.json5#7.0.0",
+    "github>home-operations/renovate-presets//apps/talosFactory.json5#7.0.0",
+  ],
   // Assign manual PRs to me so they reach my GitHub "Participating" notifications.
   // assignAutomerge:false (the Renovate default, pinned here for clarity) means
   // auto-merge PRs are NOT assigned — so with the repo Watch set to
@@ -47,9 +58,12 @@
   },
 
   // --- Custom managers (from customManagers.json5 + grafanaDashboards.json5) ---
-  // OCI, CloudNative-PG imageName, and standard "# renovate:" annotated managers
-  // come from home-operations/renovate-presets. Only the managers the preset does
-  // not cover live here (Minecraft, homebridge date tags, GrafanaDashboard CRD).
+  // OCI and "# renovate:" annotated managers come from the renovate-presets
+  // base; CNPG imageName, Grafana download-URL, and Talos factory managers
+  // from the apps/ presets above. Only what no preset covers lives here:
+  // Minecraft, homebridge date tags, and this repo's GrafanaDashboard CRD
+  // layout (the preset's grafanaCom manager needs `id:` directly under
+  // `grafanaCom:`, but our files put the renovate comment between them).
   customManagers: [
     {
       customType: "regex",
@@ -440,12 +454,6 @@
       matchDatasources: ["docker"],
       matchManagers: ["helmfile"],
       overrideDepName: "{{packageName}}",
-    },
-    {
-      description: "Override Talos Installer Package Name",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/factory\\.talos\\.dev/"],
-      overridePackageName: "ghcr.io/siderolabs/installer",
     },
     {
       description: "Disable helm-values manager for homebridge (handled by custom regex manager with quotes)",


### PR DESCRIPTION
Incorporates the [renovate-presets 7.0.0 restructure](https://github.com/home-operations/renovate-presets/compare/2.2.0...7.0.0) (the change onedr0p/home-ops picked up in [4acb6a5](https://github.com/onedr0p/home-ops/commit/4acb6a5cf1e7b89282d39b6ae2b7a46635586879)).

Presets 6.0.0 moved the app-specific presets out of the default bundle into opt-in `apps/` presets, and 7.0.0 consolidated the remaining general-purpose presets into `default.json`. The shared `LukeEvansTech/renovate-config` base is being bumped `2.2.0 → 7.0.0` in a companion PR; without these opt-ins that bump would silently drop:

- **apps/cnpg.json5** — the CNPG `imageName` custom manager (the Postgres image pin)
- **apps/grafanaDashboards.json5** — the `custom.grafana-dashboards` datasource (which the local GrafanaDashboard CRD manager references) plus the download-URL manager tracking four dashboards
- **apps/llamacpp.json5** — variant-stream versioning for the llama.cpp images
- **apps/searxng.json5** — versioning for searxng's `semver-sha` tags
- **apps/talosFactory.json5** — the `talosVersion:` tracker that contributes the `siderolabs/talos` member of the Talos group

phanpy is the only `apps/` preset not deployed here. Pinning at `#7.0.0` alongside the still-2.2.0 base is safe in the interim: the opt-in content is identical (or a compatible superset) of what the old bundle shipped, so deps merge rather than duplicate.

Also removes the `Override Talos Installer Package Name` rule: the talosFactory preset both owns `factory.talos.dev` refs via its custom datasource and disables them for generic docker managers, and this repository's factory URLs are tagless anyway, so the docker-datasource package that rule rewrote can no longer exist.

Verified with `renovate-config-validator --strict` (passes).