### PR TITLE
feat(talos): cap parallel image pulls and crashloop backoff

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -4,6 +4,9 @@ machine:
     extraConfig:
       maxPods: 250
       serializeImagePulls: false
+      maxParallelImagePulls: 3
+      crashLoopBackOff:
+        maxContainerRestartPeriod: 60s
       imageGCHighThresholdPercent: 55
       imageGCLowThresholdPercent: 50
       imageMaximumGCAge: 72h


### PR DESCRIPTION
Adopted from upstream home-ops kubelet tuning.

- `maxParallelImagePulls: 3` — `serializeImagePulls: false` previously left pull concurrency unbounded, so a node coming up after an upgrade races every image fetch at once.
- `crashLoopBackOff.maxContainerRestartPeriod: 60s` — the default backoff climbs to 5m; this caps it so transiently-failing pods recover sooner. The kubelet gate behind this field (KubeletCrashLoopBackOffMax) is on by default on Kubernetes v1.36.

**Not applied by Flux** — takes effect on the next `just talos gen-config` + `just talos apply-node <ip>` (kubelet restarts in place, no reboot). Suggest applying to one node first and checking `kubectl get node` + kubelet health before the rest.