### PR TITLE
feat(coredns): short-circuit AAAA lookups and harden the cache

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helm/values.yaml
@@ -4,6 +4,7 @@ image:
   repository: mirror.gcr.io/coredns/coredns
 replicaCount: 2
 k8sAppLabelOverride: kube-dns
+priorityClassName: system-cluster-critical
 podDisruptionBudget:
   enabled: true
   minAvailable: 1
@@ -19,6 +20,12 @@ servers:
         use_tcp: true
     port: 53
     plugins:
+      # The cluster is IPv4-only, so answer every AAAA query with an instant
+      # empty NOERROR instead of forwarding it upstream.
+      - name: template
+        parameters: ANY AAAA
+        configBlock: |-
+          authority "{{ .Zone }} 60 IN SOA ns.dns.cluster.local. hostmaster.cluster.local. (1 60 60 60 60)"
       - name: errors
       - name: health
         configBlock: |-
@@ -37,6 +44,7 @@ servers:
         configBlock: |-
           prefetch 20
           serve_stale
+          servfail 0
       - name: loop
       - name: reload
       - name: loadbalance


### PR DESCRIPTION
Adopted from upstream home-ops CoreDNS tuning for an IPv4-only cluster.

- `template ANY AAAA` answers every AAAA query with an instant empty NOERROR (with SOA authority) instead of forwarding upstream — halves lookup traffic for dual-query clients.
- `servfail 0` stops caching SERVFAIL responses.
- `priorityClassName: system-cluster-critical` so DNS survives node pressure evictions.

Verified locally by rendering chart 1.47.0 with these values: the Corefile carries the `{{ .Zone }}` template literally for CoreDNS to evaluate at runtime (Helm does not interpolate it).