### PR TITLE
fix(observability): retention headroom and log-noise cuts

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -88,7 +88,9 @@ spec:
         scrapeConfigSelectorNilUsesHelmValues: false
         serviceMonitorSelectorNilUsesHelmValues: false
         retention: 14d
-        retentionSize: 50GB
+        # ~80% of the 50Gi PVC — leaves headroom for the WAL and compaction
+        # churn, which retentionSize does not account for.
+        retentionSize: 40GiB
         resources:
           requests:
             cpu: 500m

--- a/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/prometheus-adapter/app/helmrelease.yaml
@@ -11,6 +11,7 @@ spec:
     name: prometheus-adapter
   values:
     fullnameOverride: *app
+    logLevel: 1
     prometheus:
       url: http://prometheus-operated.observability.svc.cluster.local
       port: 9090

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -47,6 +47,8 @@ spec:
           osd_class_update_on_start: "false" # quote
           device_failure_prediction_mode: local # requires mgr module
           mon_data_avail_warn: "15" # quote - mons live on OS disk, not OSD disk
+        mon:
+          mon_cluster_log_level: info # default debug floods the cluster log
       cleanupPolicy:
         wipeDevicesFromOtherClusters: true
       crashCollector:


### PR DESCRIPTION
Adopted from upstream home-ops observability hygiene.

- **kube-prometheus-stack**: `retentionSize: 50GB` (≈46.6GiB) on the 50Gi PVC left ~3.4Gi of headroom for the WAL and compaction churn, which retentionSize does not account for — the classic way Prometheus fills its volume. Now `40GiB` (~80% of the PVC). Time retention stays 14d.
- **prometheus-adapter**: `logLevel: 1` cuts per-request INFO chatter.
- **rook-ceph**: `cephConfig.mon.mon_cluster_log_level: info` — the default debug level floods the cluster log, all of which victoria-logs ingests.