### PR TITLE
feat(homeassistant): add health probes, drop inert proxy env vars

### DIFF
--- a/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
@@ -25,9 +25,28 @@ spec:
               # Custom components (Rako, MG/SAIC, etc.) are added via the HACS UI
               # - the standard home-ops pattern for this image.
               HOME_ASSISTANT__HACS_INSTALL: "true"
-              # Trust proxy from pod network and management network
-              HASS_HTTP_TRUSTED_PROXY_1: 10.42.0.0/16
-              HASS_HTTP_TRUSTED_PROXY_2: 10.32.8.0/24
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8123
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false
@@ -66,7 +85,7 @@ spec:
         ports:
           http:
             appProtocol: kubernetes.io/ws
-            port: 8123
+            port: *port
 
     route:
       app:


### PR DESCRIPTION
Adopted from upstream home-ops.

- **Probes**: liveness (default TCP), readiness via `httpGet /healthz:8123`, and a startup probe (30×10s budget). The `/healthz` endpoint is proven on the exact image digest we run — upstream added the same probe while on the identical `2026.7.4@sha256:17a97c…` image.
- **Dropped `HASS_HTTP_TRUSTED_PROXY_1/2`**: the home-operations image never consumed these (checked the entrypoint at current main and at a May-2025 ref — no proxy handling ever existed, and the image dir has no other scripts). HA behind envoy works today with them ignored, so removal is a runtime no-op.
- Port anchored (`&port 8123`, unquoted int per house rule).