### PR TITLE
chore(actions-runner): scale the talos-cluster runner to zero when idle

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
     githubConfigUrl: https://github.com/LukeEvansTech/talos-cluster
     githubConfigSecret: talos-cluster-runner-secret
     maxRunners: 3
-    minRunners: 1
+    minRunners: 0
     containerMode:
       type: dind
     template:


### PR DESCRIPTION
Adopted from upstream home-ops. `minRunners: 1 → 0` — the terraform-vsphere and packer runner sets already idle at zero; this frees the standing dind pod and its 25Gi ephemeral miroir-local work volume between jobs, at the cost of a ~30–60s cold start when a job lands.