### PR TITLE
feat(snapshot-controller): migrate to the home-operations chart

### DIFF
--- a/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/helmrelease.yaml
@@ -9,21 +9,13 @@ spec:
   chartRef:
     kind: OCIRepository
     name: snapshot-controller
+  # This chart ships CRDs in crds/ (Helm never upgrades or deletes them), so
+  # the old piraeus-era keep-policy postRenderer is gone. The flip side: after
+  # an appVersion bump, apply the matching CRDs by hand:
+  #   helm show crds oci://ghcr.io/home-operations/charts/snapshot-controller \
+  #     | kubectl apply --server-side -f -
   values:
-    controller:
-      replicaCount: 2
+    replicaCount: 2
+    monitoring:
       serviceMonitor:
-        create: true
-  # The chart templates its CRDs (templates/crds.yaml) rather than shipping them
-  # in crds/, so they are inside the Helm release's delete scope — dropping this
-  # HelmRelease would cascade-delete every VolumeSnapshot in the cluster. The
-  # chart exposes no annotation knob, so stamp the keep policy post-render.
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: CustomResourceDefinition
-            patch: |-
-              - op: add
-                path: /metadata/annotations/helm.sh~1resource-policy
-                value: keep
+        enabled: true

--- a/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/snapshot-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 5.2.0
-  url: oci://ghcr.io/piraeusdatastore/helm-charts/snapshot-controller
+    tag: 0.1.0
+  url: oci://ghcr.io/home-operations/charts/snapshot-controller


### PR DESCRIPTION
Replaces the piraeus chart (5.2.0) with `ghcr.io/home-operations/charts/snapshot-controller` 0.1.0 — the chart home-operations built specifically because the piraeus chart's CRD handling is hazardous (templated CRDs sit inside the release delete scope; see piraeusdatastore/helm-charts#98).

**What this removes:** our postRenderer that stamped `helm.sh/resource-policy: keep` onto the templated CRDs. The new chart ships CRDs in `crds/`, which Helm installs once and never upgrades or deletes — the workaround's reason is gone.

**VolSync safety (verified live before this PR):**
- Live controller is already `registry.k8s.io/sig-storage/snapshot-controller:v8.6.0` — identical to the new chart's appVersion. Packaging changes, the binary does not.
- All 196 ReplicationSources healthy; every one pins `volumeSnapshotClassName: csi-ceph-blockpool` explicitly (rook-owned class, untouched by this chart).
- The live CRDs carry the keep annotation from the old postRenderer, so the upgrade (whose new manifest contains no CRDs) orphans them in place rather than deleting them.
- Live `groupsnapshot.storage.k8s.io` CRDs already exist with `conversion.strategy: None` — matching the upstream shape the new chart vendors byte-for-byte.

**Post-merge step (Helm upgrades ignore `crds/`):** refresh CRDs to the v8.6.0 vintage by hand —
`helm show crds oci://ghcr.io/home-operations/charts/snapshot-controller | kubectl apply --server-side -f -`

Rendered the published chart with these exact values locally: schema-valid, replicas 2, ServiceMonitor enabled. Prerequisite for enabling miroir volume group snapshots (follow-up PR).