### PR TITLE
feat(miroir): enable volume group snapshots

### DIFF
--- a/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
+++ b/kubernetes/apps/miroir-system/miroir/app/helmrelease.yaml
@@ -24,6 +24,8 @@ spec:
       resources:
         limits:
           memory: 512Mi
+    groupSnapshots:
+      enabled: true
     monitoring:
       podMonitor:
         enabled: true

--- a/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./miroirnodegroup.yaml
   - ./storageclass.yaml
+  - ./volumegroupsnapshotclass.yaml
   - ./volumesnapshotclass.yaml

--- a/kubernetes/apps/miroir-system/miroir/config/volumegroupsnapshotclass.yaml
+++ b/kubernetes/apps/miroir-system/miroir/config/volumegroupsnapshotclass.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/groupsnapshot.storage.k8s.io/volumegroupsnapshotclass_v1.json
+apiVersion: groupsnapshot.storage.k8s.io/v1
+kind: VolumeGroupSnapshotClass
+metadata:
+  name: miroir
+driver: miroir.home-operations.com
+deletionPolicy: Delete


### PR DESCRIPTION
Adopted from upstream home-ops (we already run miroir 0.11.21, which supports this).

- `groupSnapshots.enabled: true` in the miroir HelmRelease — rendered the published 0.11.21 chart with this value locally: schema-valid, adds the `groupsnapshot.storage.k8s.io` RBAC to the controller.
- New `VolumeGroupSnapshotClass` (`miroir` / `miroir.home-operations.com`) beside the existing VolumeSnapshotClass.

**Merge order:** after #4187 and its post-merge CRD apply — the `VolumeGroupSnapshotClass` needs the `groupsnapshot.storage.k8s.io/v1` CRD at apply time (already present live from the piraeus install, refreshed to the v8.6.0 vintage by #4187's manual step).

**VolSync impact: none.** Every ReplicationSource pins `volumeSnapshotClassName: csi-ceph-blockpool` explicitly and group snapshots are a separate API surface; this only rolls the miroir controller (DRBD data plane keeps serving volumes through the rollout).