### PR TITLE
feat(hamcp): deploy the Home Assistant MCP server

### DIFF
--- a/kubernetes/apps/home/hamcp/app/externalsecret.yaml
+++ b/kubernetes/apps/home/hamcp/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hamcp-secret
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hamcp-secret
+    template:
+      engineVersion: v2
+      data:
+        # Long-lived access token minted in the Home Assistant user profile.
+        HOMEASSISTANT_TOKEN: "{{ .HOMEASSISTANT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: hamcp

--- a/kubernetes/apps/home/hamcp/app/helmrelease.yaml
+++ b/kubernetes/apps/home/hamcp/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hamcp
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: hamcp
+  values:
+    controllers:
+      hamcp:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/homeassistant-ai/ha-mcp
+              tag: 8.0.0@sha256:d65630f6a3fd14d8f536c27432d4d2cf3045e6f6a2d196cba754ee8566491ae4
+            command:
+              - "ha-mcp-web"
+            env:
+              FASTMCP_CHECK_FOR_UPDATES: "off"
+              HA_MCP_CONFIG_DIR: &configDir /config
+              HA_MCP_DISABLE_UPDATE_CHECK: true
+              HOMEASSISTANT_URL: http://homeassistant.home.svc.cluster.local:8123
+              MCP_HEALTHZ: true
+              MCP_HOST: 0.0.0.0
+              MCP_PORT: &port 80
+              TZ: ${TIMEZONE}
+            envFrom:
+              - secretRef:
+                  name: "{{ .Release.Name }}-secret"
+            probes:
+              liveness:
+                enabled: true
+                spec:
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: *configDir

--- a/kubernetes/apps/home/hamcp/app/kustomization.yaml
+++ b/kubernetes/apps/home/hamcp/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/home/hamcp/app/ocirepository.yaml
+++ b/kubernetes/apps/home/hamcp/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hamcp
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/home/hamcp/ks.yaml
+++ b/kubernetes/apps/home/hamcp/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hamcp
+  namespace: &namespace home
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: onepassword-connect
+      namespace: external-secrets
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/home/hamcp/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/home/kustomization.yaml
+++ b/kubernetes/apps/home/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ./netpol.yaml
   - ./esphome/ks.yaml
   - ./go2rtc/ks.yaml
+  - ./hamcp/ks.yaml
   - ./homeassistant/ks.yaml
   - ./homeassistanttimemachine/ks.yaml
   - ./homebridge/ks.yaml


### PR DESCRIPTION
Adopted from upstream home-ops (their `home-assistant-mcp`), named hyphen-free per the house rule so the route host stays clean: `hamcp.${SECRET_DOMAIN}`, internal listener only.

- `ghcr.io/homeassistant-ai/ha-mcp` 8.0.0 (digest-pinned), `ha-mcp-web` mode, health endpoint on `/healthz` with the full probe set.
- Talks to HA over the cluster network (`homeassistant.home.svc:8123`); the home namespace netpol already covers it the same way it covers node-red and timemachine.
- volsync component, 1Gi config PVC; standard non-root security context; app-template 5.0.1 like its neighbours.
- Rendered through the published app-template 5.0.1 chart locally: schema-valid.

**⛔ Do not merge until the secret exists** — mint a long-lived access token in the Home Assistant UI (user profile → Security → long-lived access tokens), then create the 1Password item in the `Talos` vault:

```text
op item create --vault Talos --category "API Credential" --title hamcp "HOMEASSISTANT_TOKEN[password]=<token>"
```

Without it the ExternalSecret never materialises and the deployment sits Pending on the secret.