### PR TITLE
feat: claude cloud SessionStart hook (inert outside cloud sessions)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c '[ \"$CLAUDE_CODE_REMOTE\" = true ] && [ -x /opt/claude-cloud-env/session-start.sh ] && bash /opt/claude-cloud-env/session-start.sh || true'",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ docs/superpowers/
 .private/
 .task/
 .venv/
-.claude/
+.claude/*
+!.claude/settings.json
 .playwright-mcp/
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Summary

- Un-ignore `.claude/settings.json` via the `.claude/*` + `!.claude/settings.json` carve-out (git cannot re-include a file inside an ignored directory, so the broader `.claude/` ignore is replaced with the two-line form).
- Add a `SessionStart` hook that only runs the cloud environment's session-start script when `CLAUDE_CODE_REMOTE=true` and the script exists at `/opt/claude-cloud-env/session-start.sh`; it is a no-op everywhere else (local sessions, other machines).

## Test plan

- [x] `git check-ignore .claude/settings.json` exits `1` (file is tracked, not ignored)
- [x] Guard command run locally with `CLAUDE_CODE_REMOTE` unset exits `0` with no output (confirms inertness outside a cloud session)
- [x] `git status --porcelain` shows only `.gitignore` and `.claude/settings.json` staged; no other local/ignored files touched
- [x] Local `lefthook` pre-commit + commit-msg hooks passed, including the internal-identifier guard