### PR TITLE
fix(homeassistant): give helm a 10m window for the probed boot

### DIFF
--- a/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
@@ -6,6 +6,9 @@ metadata:
   name: homeassistant
 spec:
   interval: 1h
+  # HA cold-boots in 4-6 minutes and the readiness probe now gates the helm
+  # wait, so the default 5m timeout rolls the upgrade back mid-boot.
+  timeout: 10m
   chartRef:
     kind: OCIRepository
     name: homeassistant


### PR DESCRIPTION
Follow-up to #4168. The readiness probe makes the helm upgrade wait until HA actually serves `/healthz`, and a cold boot takes 4–6 minutes (HACS install at startup) — the node-reboot window tonight pushed it past helm's default 5m and RemediateOnFailure rolled the release back to the probe-less spec. `spec.timeout: 10m` (rook already runs 15m for the same reason) makes the probed spec land reliably.