### PR TITLE
fix(homeassistant): probe /manifest.json — /healthz is not a stock endpoint

### DIFF
--- a/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homeassistant/app/helmrelease.yaml
@@ -40,7 +40,10 @@ spec:
                 custom: true
                 spec:
                   httpGet:
-                    path: /healthz
+                    # Unauthenticated 200 on stock HA — /healthz 404s on this
+                    # instance (it is not a core endpoint) and wedged every
+                    # upgrade in a readiness-timeout rollback loop.
+                    path: /manifest.json
                     port: &port 8123
                   periodSeconds: 10
                   timeoutSeconds: 5


### PR DESCRIPTION
Closes the loop on #4168/#4214. The `/healthz` readiness path 404s on this instance — verified in-pod (`/healthz` → 404, `/manifest.json` → 200, `/api/` → 401). It is not a Home Assistant core route; upstream's working probe evidently relies on something in their HA config, not the shared image. With readiness unable to pass, every upgrade timed out into RemediateOnFailure rollback (v76→v84 overnight) no matter the helm window.

`/manifest.json` is the community-standard unauthenticated probe path for HA. Liveness (TCP) and startup probes unchanged. Merging this lands the probed spec via one Recreate restart.