### PR TITLE
feat(toolhive): add the Home Assistant MCP server to the fleet

### DIFF
--- a/kubernetes/apps/ai/litellm/app/configmap.yaml
+++ b/kubernetes/apps/ai/litellm/app/configmap.yaml
@@ -119,7 +119,7 @@ data:
       drop_params: true
       num_retries: 2
       request_timeout: 600
-      # Surfaces only the top-k relevant MCP tools per request (8 servers) using
+      # Surfaces only the top-k relevant MCP tools per request (9 servers) using
       # the all-minilm embedding model above.
       mcp_semantic_tool_filter:
         enabled: true
@@ -128,7 +128,7 @@ data:
         similarity_threshold: 0.3
 
     # MCP tools proxied to any LiteLLM client (ToolHive-managed endpoints, ai ns).
-    # 8 servers — the semantic filter above trims each request to the top-k
+    # 9 servers — the semantic filter above trims each request to the top-k
     # relevant tools.
     mcp_servers:
       kubectl:
@@ -151,6 +151,10 @@ data:
       # container (no proxy hop), so the Service is mcp-seerr:8085 directly.
       seerr:
         url: http://mcp-seerr.ai.svc.cluster.local:8085/mcp
+      # Home Assistant tools (ha-mcp in ha-mcp-web mode). Native streamable-http
+      # container like seerr, so the Service is mcp-hamcp:8080 directly.
+      hamcp:
+        url: http://mcp-hamcp.ai.svc.cluster.local:8080/mcp
 
     general_settings:
       health_check_endpoint: /v1/health

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+# Reuses the EXISTING `homeassistanttimemachine` 1Password item, extracting only
+# its LONG_LIVED_ACCESS_TOKEN property into a dedicated ai-namespace Secret.
+# No new 1Password items are created (same convention as toolhive-seerr).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name toolhive-hamcp
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: *name
+    template:
+      data:
+        HOMEASSISTANT_TOKEN: "{{ .LONG_LIVED_ACCESS_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: homeassistanttimemachine

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/kustomization.yaml
@@ -3,12 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./kubectl
-  - ./flux
-  - ./talos
-  - ./searxng
-  - ./github
-  - ./grafana
-  - ./arr-mcp
-  - ./seerr-mcp
-  - ./hamcp
+  - ./externalsecret.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/mcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/mcpserver.yaml
@@ -1,0 +1,55 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/toolhive.stacklok.dev/mcpserver_v1alpha1.json
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: hamcp
+spec:
+  # ha-mcp (github.com/homeassistant-ai/ha-mcp) run in its `ha-mcp-web` mode —
+  # native FastMCP streamable-http (endpoint /mcp), so LiteLLM talks to the
+  # mcp-hamcp Service directly like seerr, no proxy hop. The image's default
+  # entrypoint is the stdio variant, hence the command override below.
+  image: ghcr.io/homeassistant-ai/ha-mcp:8.0.0@sha256:d65630f6a3fd14d8f536c27432d4d2cf3045e6f6a2d196cba754ee8566491ae4
+  transport: streamable-http
+  mcpPort: 8080
+  env:
+    - name: FASTMCP_CHECK_FOR_UPDATES
+      value: "off"
+    - name: HA_MCP_CONFIG_DIR
+      value: /config
+    - name: HA_MCP_DISABLE_UPDATE_CHECK
+      value: "true"
+    - name: HOMEASSISTANT_URL
+      value: http://homeassistant.home.svc.cluster.local:8123
+    - name: MCP_HEALTHZ
+      value: "true"
+    - name: MCP_HOST
+      value: 0.0.0.0
+    - name: MCP_PORT
+      value: "8080"
+  secrets:
+    - name: toolhive-hamcp
+      key: HOMEASSISTANT_TOKEN
+      targetEnvName: HOMEASSISTANT_TOKEN
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  telemetryConfigRef:
+    name: prometheus
+  groupRef:
+    name: mcp-tools
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          command:
+            - "ha-mcp-web"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: config
+          emptyDir: {}

--- a/kubernetes/apps/home/netpol.yaml
+++ b/kubernetes/apps/home/netpol.yaml
@@ -13,3 +13,22 @@ spec:
             io.kubernetes.pod.namespace: network
     - fromEntities:
         - world
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cilium.io/ciliumnetworkpolicy_v2.json
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-hamcp-from-ai
+spec:
+  # The `hamcp` ToolHive MCP server (ai namespace) drives Home Assistant over
+  # its API. Additive to the namespace-wide policy above (Cilium unions
+  # allows), scoped to the HA endpoint and to the hamcp MCP pod as the source.
+  description: "Allow the hamcp MCP server (ai) to reach Home Assistant"
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: homeassistant
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            io.kubernetes.pod.namespace: ai
+            toolhive-name: hamcp


### PR DESCRIPTION
Replaces #4212 with the house pattern: `hamcp` as an MCPServer CR under `toolhive/mcp-servers/`, not a standalone app-template deployment.

- **MCPServer** `hamcp`: `ghcr.io/homeassistant-ai/ha-mcp` 8.0.0 (digest-pinned) in `ha-mcp-web` mode — native FastMCP streamable-http like seerr, so no proxy hop; `mcp-tools` group + prometheus telemetry like the rest of the fleet; emptyDir `/config` (the config dir is a cache, nothing worth a PVC).
- **Secret**: reuses the existing `homeassistanttimemachine` 1Password item's `LONG_LIVED_ACCESS_TOKEN` property (same no-new-items convention as `toolhive-seerr`) — no credential provisioning needed.
- **netpol**: additive `allow-hamcp-from-ai` in the home namespace, scoped to the HA endpoint and the `toolhive-name: hamcp` source pod — mirrors media's `allow-seerr-mcp-from-ai`. Without it the home namespace only admits ingress from `network` + world.
- **LiteLLM**: registered under `mcp_servers` (`mcp-hamcp:8080/mcp`), server-count comments bumped to 9.