### PR TITLE
fix(toolhive): give hamcp its own HA token item

### DIFF
--- a/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/mcp-servers/hamcp/externalsecret.yaml
@@ -1,8 +1,8 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
-# Reuses the EXISTING `homeassistanttimemachine` 1Password item, extracting only
-# its LONG_LIVED_ACCESS_TOKEN property into a dedicated ai-namespace Secret.
-# No new 1Password items are created (same convention as toolhive-seerr).
+# Dedicated `hamcp` 1Password item holding this server's own HA long-lived
+# token (client_name "hamcp"), so it can be revoked in HA independently of the
+# timemachine token it briefly borrowed at first deploy.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -15,7 +15,7 @@ spec:
     name: *name
     template:
       data:
-        HOMEASSISTANT_TOKEN: "{{ .LONG_LIVED_ACCESS_TOKEN }}"
+        HOMEASSISTANT_TOKEN: "{{ .HOMEASSISTANT_TOKEN }}"
   dataFrom:
     - extract:
-        key: homeassistanttimemachine
+        key: hamcp


### PR DESCRIPTION
Swaps the borrowed `homeassistanttimemachine` token for a dedicated one: a new long-lived token (client_name `hamcp`, 3650-day lifespan) was minted via HA's websocket API and stored in a new `hamcp` item in the Talos vault. The ExternalSecret now extracts that item's `HOMEASSISTANT_TOKEN` property. Revoking either token in HA no longer affects the other consumer.