### PR TITLE
ci(renovate-review): raise --max-turns 35 -> 60

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -308,18 +308,19 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }} # zizmor: ignore[secrets-outside-env]
           allowed_bots: "renovate[bot]"
           show_full_output: true
-          # --max-turns is 35, not 25: full-depth reviews land right on the old
-          # ceiling (21/25/26 turns across three consecutive Opus reviews on
-          # 2026-07-31). Overrunning it AFTER the verdict is posted still fails the
-          # action, so a successful review red-flags its own run — the status step
-          # reads the posted review and resolves correctly, but a routinely-red run
-          # trains you to ignore red runs. A ceiling, not a target: it costs nothing
-          # when a review finishes early, and the prompt still aims at 12-18 turns.
+          # --max-turns is 60, not 35: full-depth reviews keep outgrowing the
+          # ceiling (21/25/26 turns on 2026-07-31 broke 25; a 50-turn Opus review
+          # on 2026-08-10 broke 35). Overrunning it AFTER the verdict is posted
+          # still fails the action, so a successful review red-flags its own run —
+          # the status step reads the posted review and resolves correctly, but a
+          # routinely-red run trains you to ignore red runs. A ceiling, not a
+          # target: it costs nothing when a review finishes early, and the prompt
+          # still aims at 12-18 turns.
           # (Comments cannot live inside claude_args — it is a literal block whose
           # lines are passed to the CLI as arguments.)
           claude_args: |
             --model ${{ steps.model_tier.outputs.model }}
-            --max-turns 35
+            --max-turns 60
             --setting-sources user
             --allowedTools "Read,Glob,Grep,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh issue view:*),Bash(gh api:*),Bash(gh release view:*),Bash(gh release list:*),Bash(gh repo view:*),Bash(git log:*),Bash(git show:*),Bash(git tag:*),Bash(curl:*),WebFetch,WebSearch"
           prompt: |

--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -31,7 +31,7 @@ spec:
           app:
             image:
               repository: ghcr.io/dispatcharr/dispatcharr
-              tag: 0.28.2@sha256:ba0565a7c62019847dbdca1f7037074c25dfaa6d1cbaa7b8661ebd7617b6b6e0
+              tag: 0.29.0@sha256:3ce081119e5a4da3cf2f398719f35d0987bcf4067440454a34e3d36cd0ab3bbb
             env:
               TZ: ${TIMEZONE}
               DISPATCHARR_ENV: aio

--- a/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/dispatcharr/app/helmrelease.yaml
@@ -37,6 +37,11 @@ spec:
               DISPATCHARR_ENV: aio
               DISPATCHARR_LOG_LEVEL: info
               DISPATCHARR_PORT: &port 9191
+              # 0.29.0's get_client_ip trusts the RFC1918 ranges by default, so
+              # behind envoy every client resolved to the proxy pod IP (shared
+              # login-throttle bucket). Trust only the pod CIDR so the XFF walk
+              # stops at the real LAN client.
+              DISPATCHARR_TRUSTED_PROXIES: ${CLUSTER_PODS_CIDR}
               REDIS_HOST: dragonfly.database.svc.cluster.local
             envFrom:
               - secretRef:
@@ -82,6 +87,18 @@ spec:
         parentRefs:
           - name: envoy-internal
             namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+            # 0.29.0 prefers a client-supplied X-Real-IP over the XFF walk for
+            # throttling/ACLs/audit, and nothing on the uwsgi path strips it —
+            # drop it at the gateway so clients cannot spoof their identity.
+            filters:
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  remove:
+                    - "X-Real-IP"
     persistence:
       config:
         existingClaim: *app


### PR DESCRIPTION
A 50-turn full-depth review on #4224 overran the 35-turn ceiling after posting its verdict, failing the run and red-flagging a successful review — the same pattern that broke the 25-turn cap on 2026-07-31. The cap does not bound execution or cost (the review ran to 50 turns regardless); it only falsifies the job result. Raised to 60 and the comment updated with the new data point.