### PR TITLE
fix(github-action): repair the Image Pull filter for action-changed-files v0.6.0

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -26,8 +26,12 @@ jobs:
   filter:
     name: Filter
     runs-on: ubuntu-latest
+    # v0.6.0 renamed the input files→patterns and dropped the any_changed
+    # output for a changed_files JSON array ('[]' when empty). The old names
+    # were ignored silently, so extract never fired and the whole workflow
+    # was a no-op.
     outputs:
-      any_changed: ${{ steps.changed-files.outputs.any_changed }}
+      any_changed: ${{ steps.changed-files.outputs.changed_files != '[]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,7 +42,7 @@ jobs:
         id: changed-files
         uses: bjw-s-labs/action-changed-files@a9a36fb08ce06db9b02fbd8026cc2c0945eb9841 # v0.6.0
         with:
-          files: kubernetes/**
+          patterns: kubernetes/**/*
 
   extract:
     name: Extract Images


### PR DESCRIPTION
The v0.6.0 action bump renamed the input `files` → `patterns` and replaced the `any_changed` output with a `changed_files` JSON array (`[]` when empty). Both old names were ignored silently, so the filter always reported no changes and the extract/diff/pull chain has never run since the bump — the workflow was a complete no-op, which is also why the broken v-prefixed flate download URL (#4233) went unnoticed for so long. Action bumps are ungated pass-through in the review gate, so this class of rename slips straight to main.

Verified against the run log of the n8n merge (the action printed the changed file but the workflow read a nonexistent output) and against the action's current `action.yaml` + onedr0p's caller of the same pinned SHA.