### PR TITLE
feat(default): deploy lurcher (contract extractor + Pushover alerts)

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -6,7 +6,8 @@
 #                enabled_plugins list); upstream's spelling, must stay verbatim
 # intoto — SLSA in-toto provenance paths in mise.lock (provenance.intoto.jsonl)
 # showin — Grafana annotation schema key `showIn` (vendored dashboard JSON)
-ignore-words-list = NotIn,adn,flate,informations,intoto,showin
+# matchIn — lurcher search-config field (title|description|both) in its ConfigMap
+ignore-words-list = NotIn,adn,flate,informations,intoto,matchIn,showin
 # mise.lock is a generated lockfile (checksums/URLs); not prose. NB: super-linter
 # passes files explicitly with its own --skip, so the config `skip` below is
 # ignored in CI — `intoto` above is the load-bearing fix. Kept for local runs.

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -42,6 +42,7 @@ resources:
   - ./it-tools/ks.yaml
   - ./jobops/ks.yaml
   - ./keeper/ks.yaml
+  - ./lurcher/ks.yaml
   - ./mail-archiver/ks.yaml
   - ./mailrise/ks.yaml
   - ./manyfold/ks.yaml

--- a/kubernetes/apps/default/lurcher/app/configmap.yaml
+++ b/kubernetes/apps/default/lurcher/app/configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lurcher-searches
+data:
+  searches.yaml: |-
+    # Keywords are OR; exclude rejects; rate/location/IR35 filters AND together.
+    # rateMin/rateMax are whole £/day. Edit to taste, then commit — the CronJob
+    # picks up the change on its next run.
+    - name: "Cloud / Platform (Outside IR35)"
+      keywords: [azure, aws, kubernetes, terraform, platform engineer, devops, sre]
+      exclude: [helpdesk, "1st line", "service desk"]
+      ir35: outside
+      locations: [remote, london]
+      matchIn: both

--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.0.0
+              image: ghcr.io/lukeevanstech/lurcher:1.0.0@sha256:ec8373e8d10b8599e37621ff722b5fc9f4901c37c9a3e0c9225d283daea1df82
               args:
                 - "run"
               env:

--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/batch/cronjob_v1.json
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: lurcher
+  namespace: default
+spec:
+  schedule: "0 7 * * *" # daily 07:00
+  timeZone: "Europe/London"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      activeDeadlineSeconds: 3600
+      ttlSecondsAfterFinished: 86400
+      template:
+        metadata:
+          labels:
+            app: lurcher
+        spec:
+          restartPolicy: OnFailure
+          automountServiceAccountToken: false
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65532
+            runAsGroup: 65532
+            fsGroup: 65532
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: lurcher
+              image: ghcr.io/lukeevanstech/lurcher:1.0.0
+              args:
+                - "run"
+              env:
+                - name: LURCHER_DB
+                  value: /data/lurcher.db
+                - name: HOME # apprise/node need a writable home under readOnlyRootFilesystem
+                  value: /tmp
+              envFrom:
+                - secretRef:
+                    name: lurcher-secret
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: searches
+                  mountPath: /app/searches.yaml
+                  subPath: searches.yaml
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop:
+                    - "ALL"
+              resources:
+                requests:
+                  cpu: 25m
+                  memory: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: lurcher
+            - name: searches
+              configMap:
+                name: lurcher-searches
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/apps/default/lurcher/app/externalsecret.yaml
+++ b/kubernetes/apps/default/lurcher/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: lurcher
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: lurcher-secret
+    template:
+      engineVersion: v2
+      data:
+        # Residential proxy (IPRoyal) — the code appends _country-gb at runtime.
+        PROXY_PROVIDER: "{{ .PROXY_PROVIDER }}"
+        PROXY_USERNAME: "{{ .PROXY_USERNAME }}"
+        PROXY_PASSWORD: "{{ .PROXY_PASSWORD }}"
+        # Notifications via Apprise → Pushover (lurcher's own app token).
+        APPRISE_URLS: "pover://{{ .PUSHOVER_USER_KEY }}@{{ .LURCHER_PUSHOVER_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: lurcher
+    - extract:
+        key: pushover

--- a/kubernetes/apps/default/lurcher/app/kustomization.yaml
+++ b/kubernetes/apps/default/lurcher/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./configmap.yaml
+  - ./pvc.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/default/lurcher/app/pvc.yaml
+++ b/kubernetes/apps/default/lurcher/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: lurcher
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/default/lurcher/ks.yaml
+++ b/kubernetes/apps/default/lurcher/ks.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app lurcher
+  namespace: &namespace default
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph-cluster
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/default/lurcher/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false


### PR DESCRIPTION
Deploys **lurcher** v1.0.0 as a daily CronJob in `default`.

- **Scrape:** OutsideSpy via IPRoyal residential proxies (`PROXY_*` from `Talos/lurcher`).
- **Alert:** matched contracts → Pushover (`APPRISE_URLS=pover://...` from `Talos/pushover`; tested).
- **State:** SQLite on a 1Gi `ceph-block` PVC (regenerable; no volsync).
- **Config:** `searches.yaml` in a ConfigMap (starter cloud/platform criteria — editable).
- Non-root (65532), readOnlyRootFilesystem, cpu+mem limits; passes kubeconform.

Supersedes the `contracthound` app (still registered — separate cleanup).