### PR TITLE
feat(observability): scrape qui metrics from the seedbox (seedbox-qui job)

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
@@ -79,6 +79,28 @@ spec:
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
+  name: &name seedbox-qui
+spec:
+  # qui (qBittorrent WebUI) metrics — host port 9476 (in-container default 9074 is
+  # taken on the host by autobrr, same project family, same default).
+  staticConfigs:
+    - targets:
+        - seedbox.observability.svc.cluster.local:9476
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  scrapeTimeout: 30s # tailnet-egress scrapes are slow; 30s stops false up=0 (see node job)
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: seedbox
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
   name: &name seedbox-doco-cd
 spec:
   # doco-cd native metrics (:9120) — GitOps deploy/poll status on the seedbox.


### PR DESCRIPTION
Adds a `seedbox-qui` ScrapeConfig mirroring the existing seedbox jobs (60s interval, 30s timeout for the tailnet-egress path, instance=seedbox). Companion change on the seedbox side: LukeEvansTech/seedbox-apps#81 enables `QUI__METRICS_ENABLED` and publishes the metrics on host port 9476 (autobrr already owns the family-default 9074).

Note for the SeedboxScrapePathDegraded alert: this raises the seedbox job count to 8 — the alert uses `avg(up)` so no threshold change is needed.