### PR TITLE
feat(lurcher): v1.1.0 delta-aware fetching + tuned remote search

### DIFF
--- a/kubernetes/apps/default/lurcher/app/configmap.yaml
+++ b/kubernetes/apps/default/lurcher/app/configmap.yaml
@@ -5,28 +5,55 @@ metadata:
   name: lurcher-searches
 data:
   searches.yaml: |-
-    # Luke Evans — Microsoft security/identity solutions architect (4x MVP).
+    # Luke Evans — Microsoft security/identity/devops architect (4x MVP), remote-only.
     # Keywords are OR (any match); exclude rejects; rate/location/IR35 AND together.
     # rateMin/rateMax are whole £/day. Edit + commit — the CronJob picks it up next run.
-    - name: "Security / Identity Architect (Microsoft)"
+    - name: "MS Security / Identity / DevOps (remote, Outside IR35)"
       keywords:
         - "security architect"
         - "identity architect"
         - "solutions architect"
-        - "cyber security architect"
-        - "cybersecurity architect"
+        - "security consultant"
+        - "technical design authority"
+        - "devops engineer"
+        - "azure devops"
+        - "bicep"
+        - "platform engineer"
         - "entra"
+        - "azure ad"
+        - "active directory"
         - "conditional access"
         - "microsoft sentinel"
         - "microsoft purview"
+        - "microsoft defender"
         - "defender for"
         - "zero trust"
         - "identity and access"
+        - "iam"
         - "intune"
+        - "m365"
         - "microsoft 365"
+        - "office 365"
         - "copilot"
-      exclude: ["1st line", "2nd line", "service desk", "helpdesk", "developer", "software engineer", "graduate"]
+      exclude:
+        - "1st line"
+        - "2nd line"
+        - "service desk"
+        - "helpdesk"
+        - "graduate"
+        - "data engineer"
+        - "data engineering"
+        - "databricks"
+        - "data platform"
+        - "software developer"
+        - "front end"
+        - "frontend"
+        - "rust"
+        - "golang"
+        - "aws"
+        - "gcp"
+        - "kafka"
       ir35: outside
-      rateMin: 550
+      rateMin: 500
       locations: [remote]
       matchIn: both

--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.0.0@sha256:ec8373e8d10b8599e37621ff722b5fc9f4901c37c9a3e0c9225d283daea1df82
+              image: ghcr.io/lukeevanstech/lurcher:1.1.0@sha256:3c605afbe9cc70489cde2c146e51c410f563396590fcd607af2c02f843e757e1
               args:
                 - "run"
               env:


### PR DESCRIPTION
Bumps lurcher to **v1.1.0** (delta-aware fetching — daily runs fetch listing pages + details only for new/changed contracts, cutting proxy requests from ~850/run to a handful) and sets the tuned remote-only MS security/identity/devops search (rate ≥ £500, data-eng + AWS/GCP excluded).

- cronjob image → `ghcr.io/lukeevanstech/lurcher:1.1.0@sha256:3c605af…`
- configmap search → `MS Security / Identity / DevOps (remote, Outside IR35)`