### PR TITLE
feat(lurcher): broaden search — azure, sharepoint, teams, purview

### DIFF
--- a/kubernetes/apps/default/lurcher/app/configmap.yaml
+++ b/kubernetes/apps/default/lurcher/app/configmap.yaml
@@ -24,7 +24,7 @@ data:
         - "active directory"
         - "conditional access"
         - "microsoft sentinel"
-        - "microsoft purview"
+        - "purview"
         - "microsoft defender"
         - "defender for"
         - "zero trust"
@@ -35,6 +35,9 @@ data:
         - "microsoft 365"
         - "office 365"
         - "copilot"
+        - "azure"
+        - "sharepoint"
+        - "microsoft teams"
       exclude:
         - "1st line"
         - "2nd line"


### PR DESCRIPTION
Adds `azure`, `sharepoint`, `microsoft teams` to the lurcher search keywords and broadens `microsoft purview` → `purview`. (`m365` was already present.) Rate/location/IR35 filters and the AWS/GCP/data-eng excludes are unchanged.