### PR TITLE
feat(lurcher): v1.1.1 — delta-fetch self-heal fix

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -33,7 +33,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.1.0@sha256:3c605afbe9cc70489cde2c146e51c410f563396590fcd607af2c02f843e757e1
+              image: ghcr.io/lukeevanstech/lurcher:1.1.1@sha256:e667117d3d17dbbd0a268b40f9577e3691a4ee2c7dabfbb9140248043db61dfd
               args:
                 - "run"
               env:


### PR DESCRIPTION
Bumps lurcher to v1.1.1. Fixes `dump()` so a missing/stale `listing_hash` on an unchanged row is backfilled — without it, delta-aware fetching never engaged for rows created by the v1.0.0 prime and every run re-fetched all detail pages (~33 MB observed). The live DB was already hand-backfilled; this makes the source self-correcting.