### PR TITLE
fix(lurcher): scrape at 10:00 London, after the source's ~07:00 UTC publish batch

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -6,7 +6,10 @@ metadata:
   name: lurcher
   namespace: default
 spec:
-  schedule: "0 7 * * *" # daily 07:00
+  # Source publishes its daily batch ~06:00-08:00 UTC (peak 07:00 UTC), weekdays.
+  # Run at 10:00 London (09:00 UTC in summer / 10:00 UTC in winter) so the scrape
+  # lands AFTER the batch and catches new roles same-morning, not a day late.
+  schedule: "0 10 * * *" # daily 10:00 London
   timeZone: "Europe/London"
   concurrencyPolicy: Forbid
   startingDeadlineSeconds: 300


### PR DESCRIPTION
## Why
Analysis of `date_posted` across the 905 stored listings shows outsidespy publishes its daily batch **06:00–08:00 UTC (peak 07:00 UTC), weekdays only** (~93% of postings land in that window; zero at weekends).

The old schedule `0 7 * * *` Europe/London = **06:00 UTC** (in BST) fired *as that window opened*, before the day's batch existed — so new roles were only picked up by the *next* day's run. Evidence: none of the 905 listings were first-seen by a scheduled run.

## Change
`0 7 * * *` → `0 10 * * *` (Europe/London). That's **09:00 UTC in summer / 10:00 UTC in winter** — comfortably after the ~07:00 UTC batch in both DST states, so the scrape catches new roles same-morning instead of a day late.

No other changes; concurrency/deadline/history limits untouched.