### PR TITLE
feat(lurcher): bump to v1.2.0 (repost dedup + agency extraction)

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.1.1@sha256:e667117d3d17dbbd0a268b40f9577e3691a4ee2c7dabfbb9140248043db61dfd
+              image: ghcr.io/lukeevanstech/lurcher:1.2.0@sha256:67b709861e783f0d98b4412e2b11995aea810fd6551d9ffa3e1249a3169c7c51
               args:
                 - "run"
               env:


### PR DESCRIPTION
Bumps the lurcher CronJob image `1.1.1 → 1.2.0` (LukeEvansTech/lurcher#10).

- Collapses recruiter reposts to a single alert (fingerprint-based notify dedup) — a role was pinging 2–9×.
- Extracts the real agency from the title into `company` (was always "Outside Spy").
- drizzle migration 0003 adds nullable `fingerprint` columns; applied automatically on the next run (ALTER TABLE ADD COLUMN).

Digest `sha256:67b70986…`, built from tag v1.2.0.