### PR TITLE
fix(tautulli): disable GA analytics

### DIFF
--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -22,6 +22,9 @@ spec:
             env:
               TZ: ${TIMEZONE}
               TAUTULLI_HTTP_PORT: &port 80
+              # Opt out of the silent GA4 telemetry (Tautulli/Tautulli#2781).
+              # Must be "0": any other value fails int() and falls back to on.
+              TAUTULLI_SYSTEM_ANALYTICS: "0"
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"


### PR DESCRIPTION
## What

Adds `TAUTULLI_SYSTEM_ANALYTICS: "0"` to the Tautulli container env.

## Why

Tautulli defaults to `system_analytics = 1` and sends GA4 events on `install`, `update`, and every `start` — with no setup-wizard prompt, no Settings toggle, and no log line unless the send *fails* ([Tautulli/Tautulli#2781](https://github.com/Tautulli/Tautulli/issues/2781), surfaced on [r/Tautulli](https://old.reddit.com/r/Tautulli/comments/1vmiz7r/analytics_is_on_by_default/)). Payload is system-mix data (version, branch, install method, platform/distro, Python, timezone, language, country) plus a stable `client_id` that since v2.12.0 is the raw `PMS_UUID` — the same identifier sent to plex.tv.

The maintainer has committed to a wizard checkbox + Settings toggle in the next release, but the default will remain on, so the env override is the declarative way to keep it off across restarts and upgrades.

Verified against the v2.17.2 source (the tag we run):

- `plexpy/config.py:205` — `'SYSTEM_ANALYTICS': (int, 'Advanced', 1)`
- `plexpy/config.py:492-518` — `get_setting()` reads `TAUTULLI_<KEY>` from the environment before `config.ini`
- `plexpy/__init__.py:556` — `if CONFIG.SYSTEM_ANALYTICS:` gates all three events

## Gotchas

- **Value must be `"0"`.** `false`/`no`/`off` fail `int()` in `_cast_setting` and silently fall back to the default `1`.
- **`config.ini` will still show `system_analytics = 1`.** Expected — the env is read first, and `set_setting` refuses to persist a key owned by the environment. Don't "fix" the ini.

## Validation

- `kustomize build kubernetes/apps/media/tautulli/app` ✅
- `just kube flate-build-hr media tautulli` → Deployment renders `TAUTULLI_SYSTEM_ANALYTICS="0"` ✅
- lefthook pre-commit + commit-msg ✅
