### PR TITLE
fix(ci): compact jq output in Image Pull diff (multiline broke GITHUB_OUTPUT)

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -125,7 +125,11 @@ jobs:
           # Find new images (in pull but not in default).
           # Read job outputs from env, not template interpolation, to avoid
           # zizmor template-injection (untrusted output → shell).
-          NEW_IMAGES=$(jq -n \
+          # -c keeps the array on ONE line: a multi-line value breaks the
+          # `key=value` GITHUB_OUTPUT syntax ("Invalid format" on every line
+          # after the first) whenever the diff is non-empty, i.e. any push that
+          # adds a new image.
+          NEW_IMAGES=$(jq -c -n \
             --argjson default "${DEFAULT_IMAGES_JSON}" \
             --argjson pull "${PULL_IMAGES_JSON}" \
             '$pull - $default')


### PR DESCRIPTION
## Problem
The **Image Pull** workflow fails on any push to `main` that **adds a new image** — most recently the lurcher `v1.3.0` bump (#4319):
```text
##[error]Invalid format '  "ghcr.io/lukeevanstech/lurcher:1.3.0@sha256:36d8ed06…"'
```
The `diff` job computes `NEW_IMAGES=$(jq -n '$pull - $default')` **without `-c`**, so a non-empty diff is a pretty-printed multi-line JSON array. Writing a multi-line value to `$GITHUB_OUTPUT` with `key=value` makes Actions reject every line after the first (that 2-space-indented array element is exactly what shows in the error). Empty diffs (`[]`, single line) pass — which is why it looked intermittent.

## Fix
Add `-c` so the array stays on one line (matches the `extract` job, which already uses `jq -c`). Compact output is also required for `fromJson(needs.diff.outputs.new_images)` in the `pull` matrix.

Verified locally: `jq -n '…'` → 3 lines; `jq -c -n '…'` → `["ghcr.io/…/lurcher:1.3.0@sha256:36d8ed06"]` (one line).

Not a deploy blocker — the CronJob is already on v1.3.0; this job only pre-pulls new images onto the nodes.