### PR TITLE
chore(lurcher): bump to v1.4.0 (cross-source dedup)

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.3.0@sha256:36d8ed06fcc0fdd164ea90f9442ab74af4c80cfa420ff78167ca234181ba727b
+              image: ghcr.io/lukeevanstech/lurcher:1.4.0@sha256:d2dd529cf09345f81b63bcac253e9aa25e767a107a96e831bd4e900d27c9e410
               args:
                 - "run"
               env:


### PR DESCRIPTION
Bumps the `lurcher` CronJob image `1.3.0` → `1.4.0` (digest-pinned).

**What's new in v1.4.0:** a source-agnostic *global* fingerprint so a role syndicated to both contract boards alerts once instead of twice. Two nullable columns are added by an app-side DB migration on first run; no retroactive suppression of already-sent alerts.

The `Image Pull` workflow will pre-pull the new image to the Talos nodes on merge.