### PR TITLE
fix(runner): mount minted os:admin talosconfig (fixes image pre-pull)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/talos-cluster/helmrelease.yaml
@@ -52,7 +52,12 @@ spec:
                 mountPath: /home/runner/_work
               - name: talos-secrets
                 mountPath: /home/runner/.talos/config
-                subPath: talosconfig
+                # Minted talosconfig secrets carry the config under key `config`
+                # (matches the talos MCP mount). The old `talosconfig` key never
+                # existed, so this subPath came up as an empty *directory* and
+                # `talosctl … --talosconfig ~/.talos/config` failed with
+                # "is a directory" on every image-pull run.
+                subPath: config
                 readOnly: true
         volumes:
           - name: work
@@ -67,7 +72,11 @@ spec:
                       storage: 25Gi
           - name: talos-secrets
             secret:
-              secretName: talos-cluster-runner-secret
+              # The os:admin talosconfig minted by the talos.dev ServiceAccount
+              # in rbac.yaml (Secret `talos-cluster-runner`) — NOT the GitHub App
+              # creds (`talos-cluster-runner-secret`), which was wired here by
+              # mistake and carries no talosconfig.
+              secretName: talos-cluster-runner
     controllerServiceAccount:
       name: actions-runner-controller
       namespace: actions-runner-system


### PR DESCRIPTION
## Problem

The `Image Pull` workflow's **Pull Images** step has failed on every run (across unrelated merges) with:

```text
failed to open config file "/home/runner/.talos/config":
  yaml: … read /home/runner/.talos/config: is a directory
```

## Root cause

The runner's `talos-secrets` volume was wired to the **GitHub App creds** secret (`talos-cluster-runner-secret`) with `subPath: talosconfig` — a key that secret has never had (it only holds `github_app_*`). A `subPath` over a missing key materialises as an **empty directory**, so `talosctl … --talosconfig ~/.talos/config` sees a dir, not a file.

The `os:admin` `talos.dev` ServiceAccount in `rbac.yaml` already mints the real talosconfig into a **different** secret — `talos-cluster-runner` — under key **`config`** (same convention the talos MCP uses). The volume was just pointed at the wrong secret + wrong key. The near-identical names (`…-runner` vs `…-runner-secret`) are what caused the mixup.

## Fix

Point the volume at `talos-cluster-runner` with `subPath: config`. Mount path is unchanged (`~/.talos/config`), so the workflow needs no edit.

## Validation

Verified live that Secret `talos-cluster-runner` carries key `config`, and a throwaway pod mounting it exactly as the runner now does resolves `~/.talos/config` to a **file** and `talosctl --talosconfig … version` authenticates to the nodes. (Merging this PR itself won't exercise Pull Images — no image changes — so the next image bump is the end-to-end confirmation.)