### PR TITLE
fix(resources): drop CPU limits from Flux controllers and CronJobs

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/r2-backup-cronjob.yaml
@@ -74,7 +74,6 @@ spec:
                   cpu: 100m
                   memory: 128Mi
                 limits:
-                  cpu: 500m
                   memory: 512Mi
 
               volumeMounts:

--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -67,7 +67,6 @@ spec:
                   cpu: 25m
                   memory: 128Mi
                 limits:
-                  cpu: "1"
                   memory: 512Mi
           volumes:
             - name: data

--- a/kubernetes/apps/downloads/sabnzbd/app/cleanup-cronjob.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/cleanup-cronjob.yaml
@@ -64,7 +64,6 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 100m
                   memory: 64Mi
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/downloads/sabnzbd/app/complete-cleanup-cronjob.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/complete-cleanup-cronjob.yaml
@@ -76,7 +76,6 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 100m
                   memory: 128Mi
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -39,7 +39,12 @@ spec:
             target:
               kind: Deployment
               name: (kustomize-controller|helm-controller|source-controller)
-          - # Set resources for kustomize-controller
+          - # Set resources for kustomize-controller.
+            # `cpu: null` strips the upstream `limits.cpu: 1000m` (a strategic
+            # merge only overrides keys it names, so memory-only limits left the
+            # CPU cap live) — kustomize-controller was CFS-throttled in 83% of
+            # periods during merge bursts with `--concurrent=20`. Same on the
+            # other three controllers below.
             patch: |-
               apiVersion: apps/v1
               kind: Deployment
@@ -55,6 +60,7 @@ spec:
                             cpu: 500m
                             memory: 512Mi
                           limits:
+                            cpu: null
                             memory: 512Mi
             target:
               kind: Deployment
@@ -75,6 +81,7 @@ spec:
                             cpu: 250m
                             memory: 512Mi
                           limits:
+                            cpu: null
                             memory: 512Mi
             target:
               kind: Deployment
@@ -99,6 +106,7 @@ spec:
                             cpu: 10m
                             memory: 1Gi
                           limits:
+                            cpu: null
                             memory: 1Gi
             target:
               kind: Deployment
@@ -119,6 +127,7 @@ spec:
                             cpu: 10m
                             memory: 128Mi
                           limits:
+                            cpu: null
                             memory: 128Mi
             target:
               kind: Deployment

--- a/kubernetes/apps/infrastructure/nextdns/app/cronjob.yaml
+++ b/kubernetes/apps/infrastructure/nextdns/app/cronjob.yaml
@@ -39,7 +39,6 @@ spec:
                   cpu: 10m
                   memory: 16Mi
                 limits:
-                  cpu: 100m
                   memory: 32Mi
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/media/exclusion-sync/app/cronjob.yaml
+++ b/kubernetes/apps/media/exclusion-sync/app/cronjob.yaml
@@ -45,7 +45,6 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 100m
                   memory: 64Mi
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/network/opnsense-dns/app/restart-cronjob.yaml
+++ b/kubernetes/apps/network/opnsense-dns/app/restart-cronjob.yaml
@@ -81,7 +81,6 @@ spec:
                   cpu: 10m
                   memory: 32Mi
                 limits:
-                  cpu: 100m
                   memory: 64Mi
               securityContext:
                 allowPrivilegeEscalation: false

--- a/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
+++ b/kubernetes/apps/storage/garage/app/sync-cronjob.yaml
@@ -80,7 +80,6 @@ spec:
                   cpu: 100m
                   memory: 128Mi
                 limits:
-                  cpu: 500m
                   memory: 512Mi
               volumeMounts:
                 - name: secrets


### PR DESCRIPTION
## Why

CPU limits are a hard CFS quota — they throttle even when the node is idle and protect nothing that requests do not already guarantee (requests are the `cpu.shares` weight, so a pod's request is always honoured under contention). This repo already follows the no-CPU-limit / memory-request-equals-limit convention; this PR closes the two gaps found by measuring `container_cpu_cfs_throttled_periods_total / container_cpu_cfs_periods_total` on the live cluster.

## Flux controllers (`flux-instance` HelmRelease)

The four resource patches set memory-only limits, but a strategic-merge patch only overrides the keys it names — the upstream Flux manifests' `limits.cpu: 1000m` stayed live on every controller. `kustomize-controller` (which we run with `--concurrent=20`) was **CFS-throttled in 83% of periods** in its worst 5-minute window over the last 7 days while its p95 usage read 0.08 cores: the reconcile loop was being slowed by a limit nobody set on purpose.

Fix: `cpu: null` under `limits` in each patch. Verified locally with `kustomize build` (v5.6, same kyaml as flux-operator's `fluxcd/pkg/kustomize`) that SMP `null` deletes the key; it is a no-op if upstream ever drops the default, so it is safer than a JSON-patch `remove`.

## CronJobs

Stripped the eight remaining `limits.cpu` entries: cloudnative-pg r2-backup, opnsense-dns restart, lurcher, garage NAS sync, nextdns, both sabnzbd cleanups, exclusion-sync. The garage rclone job was throttled in 65–88% of periods against a 500m cap for a ~15 s hourly run. Memory limits are unchanged.

## Not touched (deliberately)

- Prometheus's Git-authored `cpu: 2000m` — 7-day max usage 0.21 cores, never binds.
- The other upstream-default CPU limits live in the cluster (coredns, descheduler, volsync, gpu-operator, ceph-csi, llmkube, toolhive, dragonfly-operator, silence-operator, flux-operator) — all ≤ 2% throttled; not worth per-chart overrides.

## Validation

- `kustomize build` OK on all eight touched app directories.
- After merge: `kubectl -n flux-system get deploy kustomize-controller -o jsonpath='{.spec.template.spec.containers[0].resources.limits}'` should show memory only.
