### PR TITLE
feat(lurcher): deploy v1.5.0 (LinkedIn source)

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.4.0@sha256:d2dd529cf09345f81b63bcac253e9aa25e767a107a96e831bd4e900d27c9e410
+              image: ghcr.io/lukeevanstech/lurcher:1.5.0@sha256:e5b5a0c9b60f895cd85b3369a8f059a63c06b366fcef3ecce08a123fce3d2d53
               args:
                 - "run"
               env:


### PR DESCRIPTION
Bump the `lurcher` CronJob image to **v1.5.0**, which adds **LinkedIn** as a third contract source.

- Guest-endpoint scraping via rotating residential proxy (query-driven from the search config).
- Store-all with a contract-signal alert gate (permanent-role leakage is stored silently, not alerted).
- Digest-pinned to the v1.5.0 release build (`ghcr.io/lukeevanstech/lurcher:1.5.0@sha256:e5b5a0c9…`).

App code: LukeEvansTech/lurcher#14 (merged), released as v1.5.0.