### PR TITLE
feat(observability): alert on the Veeam B&R server being down or its backups going stale

### DIFF
--- a/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/observability/blackbox-exporter/lan/probes.yaml
@@ -155,3 +155,28 @@ spec:
     - action: replace
       replacement: blackbox-exporter-lan
       targetLabel: service
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/probe_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: lan-tcp-veeam
+spec:
+  # Veeam B&R REST API (:9419) on the backup server. Complements
+  # VeeamServerGuestDown (vmware-exporter): that one sees a dead guest OS, this
+  # one sees "OS up but the Veeam services are not" — the service stopping or
+  # failing to start after a reboot. Alerted by the generic LanProbeFailed rule
+  # (probe_success == 0 for 15m, critical).
+  jobName: veeam_probe
+  interval: 1m
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter-lan.observability.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - ${SECRET_VEEAM_HOST}:9419
+  metricRelabelings:
+    - action: replace
+      replacement: blackbox-exporter-lan
+      targetLabel: service

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -38,5 +38,6 @@ resources:
   - ./snmp-exporter/ks.yaml
   - ./tautulli-exporter/ks.yaml
   - ./truenas-exporter/ks.yaml
+  - ./veeam-backup/ks.yaml
   - ./victoria-logs/ks.yaml
   - ./vmware-exporter/ks.yaml

--- a/kubernetes/apps/observability/veeam-backup/app/kustomization.yaml
+++ b/kubernetes/apps/observability/veeam-backup/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./scrapeconfig.yaml
+  - ./prometheusrule.yaml

--- a/kubernetes/apps/observability/veeam-backup/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/veeam-backup/app/prometheusrule.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: veeam-backup.rules
+spec:
+  groups:
+    # Backup-job health for the Veeam B&R server, modelled on docker-backup.rules.
+    # Same principle: alert on the ABSENCE OF SUCCESS, not the presence of
+    # errors. In Aug 2026 the server BSOD'd mid-job and stayed down for 12 days;
+    # no error event was ever produced, the schedule simply stopped advancing.
+    # These rules turn "the last success is getting old" into a page.
+    #
+    # Series come from a scheduled task on the box (veeam-config,
+    # powershell/Write-VeeamBackupMetrics.ps1) that parses event 190
+    # ("Backup job 'X' finished with Success|Warning|Failed") from the
+    # "Veeam Backup" event log into node-exporter-style textfiles:
+    #   veeam_backup_last_success_timestamp_seconds{veeam_job}  last Success/Warning
+    #   veeam_backup_last_run_timestamp_seconds{veeam_job}      last finish, any result
+    #   veeam_backup_last_result_code{veeam_job}                0 Success 1 Warning 2 Failed
+    #
+    # Every alert here pages (Alertmanager routes everything to Pushover), so
+    # each one is a boolean that fires approximately never, not a threshold.
+    - name: veeam-backup.rules
+      rules:
+        # THE load-bearing alert. Jobs run nightly; 36h = one missed run plus
+        # 12h of slack, so a single transient failure self-heals without paging.
+        # Keeps working when the box is dead: the textfile stops advancing and
+        # Prometheus keeps the last scraped value for the staleness window, and
+        # once that expires VeeamBackupMetricsMissing below takes over.
+        - alert: VeeamBackupStale
+          annotations:
+            summary: >-
+              No successful run of Veeam job "{{ $labels.veeam_job }}" in over 36h —
+              backups are stale.
+          expr: |-
+            time() - veeam_backup_last_success_timestamp_seconds{job="veeam-windows-exporter"} > 129600
+          for: 30m
+          labels:
+            severity: critical
+        # A run finished Failed. Veeam's own email covers the detail; this exists
+        # so a failure still pages when mail is broken. Warning (1) is not
+        # alerted here on purpose — it still wrote a restore point, and it
+        # already goes out by email.
+        - alert: VeeamBackupFailed
+          annotations:
+            summary: >-
+              Last run of Veeam job "{{ $labels.veeam_job }}" finished Failed.
+          expr: |-
+            veeam_backup_last_result_code{job="veeam-windows-exporter"} == 2
+          for: 15m
+          labels:
+            severity: critical
+        # The complement: the series vanishing, which the rules above cannot see
+        # because they have nothing left to evaluate. Exporter removed, textfile
+        # deleted, scheduled task disabled — box otherwise fine. Bare absent()
+        # is right here: one box, one exporter. 2h fuse and warning severity
+        # because a genuine box outage already pages via VeeamServerGuestDown
+        # and LanProbeFailed; this is for the box-up-but-metric-gone case.
+        - alert: VeeamBackupMetricsMissing
+          annotations:
+            summary: >-
+              Veeam backup metrics absent for 2h — cannot tell whether backups are running.
+          expr: |-
+            absent(veeam_backup_last_success_timestamp_seconds{job="veeam-windows-exporter"})
+          for: 2h
+          labels:
+            severity: warning
+        # windows_exporter itself unreachable while the guest and Veeam are up
+        # (VeeamServerGuestDown / LanProbeFailed silent). Usually the exporter
+        # service stopped or the firewall rule went. 30m so a reboot never pages.
+        - alert: VeeamWindowsExporterDown
+          annotations:
+            summary: >-
+              windows_exporter on the Veeam server is not being scraped.
+          expr: |-
+            up{job="veeam-windows-exporter"} == 0
+          for: 30m
+          labels:
+            severity: warning

--- a/kubernetes/apps/observability/veeam-backup/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/veeam-backup/app/scrapeconfig.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/scrapeconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: &name veeam-windows-exporter
+spec:
+  # windows_exporter on the Veeam B&R server (:9182), installed and configured
+  # by LukeEvansTech/veeam-config (ansible/monitoring.yml). Besides the usual
+  # OS metrics it serves the textfile collector, which is where the job-result
+  # series (veeam_backup_*) come from — written by a scheduled task on the box
+  # that reads the "Veeam Backup" Windows event log every 10 minutes.
+  staticConfigs:
+    - targets:
+        - ${SECRET_VEEAM_HOST}:9182
+  metricsPath: /metrics
+  scrapeInterval: 60s
+  scrapeTimeout: 30s
+  relabelings:
+    - action: replace
+      targetLabel: job
+      replacement: *name
+    - action: replace
+      targetLabel: instance
+      replacement: veeam-server

--- a/kubernetes/apps/observability/veeam-backup/ks.yaml
+++ b/kubernetes/apps/observability/veeam-backup/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app veeam-backup
+  namespace: &namespace observability
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 1h
+  path: ./kubernetes/apps/observability/veeam-backup/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  # CR-only app, same shape as docker-backup: the Veeam B&R server runs
+  # windows_exporter itself (LukeEvansTech/veeam-config, ansible/monitoring.yml)
+  # and publishes job-result metrics through its textfile collector, so the
+  # cluster is only in the alerting path. Nothing in-cluster to health-check.
+  wait: false

--- a/kubernetes/apps/observability/vmware-exporter/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/vmware-exporter/app/prometheusrule.yaml
@@ -38,6 +38,26 @@ spec:
           for: 5m
           labels:
             severity: critical
+        # The Veeam B&R server sat at a BSOD for 12 days in Aug 2026 with nothing
+        # to say so. This series was 1 with tools_status="toolsNotRunning" for the
+        # entire outage and flipped back to toolsOk on the reset, so it is the
+        # earliest, cheapest signal for "guest OS is dead" — BSOD, hung boot,
+        # or an unexpected power-off (a powered-off VM also reports
+        # toolsNotRunning, verified live). 15m rides out a normal reboot.
+        # Deliberately no absent() clause: the exporter being down is already
+        # VMwareExporterDown, and absent() would echo tools_status="toolsOk"
+        # into the annotation. The VM name comes from cluster-secrets so the
+        # vCenter inventory name never lands in this public repo.
+        - alert: VeeamServerGuestDown
+          annotations:
+            summary: >-
+              Veeam B&R server guest is not running (VMware Tools {{ $labels.tools_status }})
+              — check the VM console; backups are not happening.
+          expr: |-
+            vmware_vm_guest_tools_running_status{job="vmware-exporter", vm_name="${SECRET_VEEAM_VM_NAME}", tools_status!="toolsOk"} == 1
+          for: 15m
+          labels:
+            severity: critical
         - alert: VMwareSnapshotAgeHigh
           annotations:
             summary: "VM {{ $labels.vm_name }} has a snapshot older than 7 days."

--- a/kubernetes/components/global-vars/cluster-secrets.yaml
+++ b/kubernetes/components/global-vars/cluster-secrets.yaml
@@ -39,6 +39,10 @@ stringData:
   SECRET_STORAGE_SERVER_TV_NFS: "/mnt/tv"
   SECRET_STORAGE_SERVER_VOLSYNC_NFS: "/mnt/volsync"
   SECRET_VSPHERE_ENDPOINT: "vcenter.example.com"
+  # vCenter display name of the Veeam B&R server VM (vmware-exporter vm_name label).
+  SECRET_VEEAM_VM_NAME: "veeam-vm"
+  # FQDN of the Veeam B&R server (windows_exporter scrape target, REST probe).
+  SECRET_VEEAM_HOST: "veeam.example.com"
   IOT_NETWORK_CIDR: "10.0.0.0/24"
   IOT_TRUSTED_NETWORK_CIDR: "10.0.2.0/23"
   SVC_MOSQUITTO_ADDR: "10.0.0.10"


### PR DESCRIPTION
## Why
Aug 2026: the Veeam B&R server BSOD'd mid-job (`CRITICAL_PROCESS_DIED` during a HotAdd) and sat at the crash screen for **12 days**. Nothing paged; both domain controllers ran on Veeam temp snapshots the whole time. Every signal needed was already in Prometheus — this PR turns them into alerts. Delivery is the existing Alertmanager → Pushover route; nothing new there.

## Layer A — server down
- **`VeeamServerGuestDown`** (`vmware-exporter` rules): `vmware_vm_guest_tools_running_status{vm_name="${SECRET_VEEAM_VM_NAME}", tools_status!="toolsOk"} == 1` for 15m, critical.
  - **Replayed against the incident:** fires continuously 2026-08-04 22:00Z → 2026-08-16 23:00Z (crash → reset), silent before and after. Powered-off VMs also report `toolsNotRunning` (verified live), so power-off is covered too.
- **Blackbox TCP probe** on the Veeam REST port (`${SECRET_VEEAM_HOST}:9419`). Alerted by the generic `LanProbeFailed`. Catches "OS up but Veeam services dead", which the tools rule can't.

## Layer C — backups stale (the `docker-backup.rules` pattern)
New CR-only app `observability/veeam-backup`:
- `ScrapeConfig` → windows_exporter on the box (`${SECRET_VEEAM_HOST}:9182`), job `veeam-windows-exporter`.
- `veeam-backup.rules`: **`VeeamBackupStale`** (no success in 36h, critical), **`VeeamBackupFailed`** (last result Failed, critical), `VeeamBackupMetricsMissing` (absent 2h, warning), `VeeamWindowsExporterDown` (up==0 30m, warning).
- The metrics are produced on the box by `LukeEvansTech/veeam-config` (windows_exporter textfile collector + a scheduled task parsing event 190 from the "Veeam Backup" event log) — companion PR there. Already live: the exporter is serving `veeam_backup_last_success_timestamp_seconds` for the one job.

## Secrets
Both the VM's vCenter display name (`SECRET_VEEAM_VM_NAME`) and the server FQDN (`SECRET_VEEAM_HOST`) come from `cluster-secrets` — already added to the 1Password item; the placeholders in `components/global-vars` are for the CI render. Neither identifier appears in this repo.

## Validation
- `flate build ks` for `veeam-backup`, `vmware-exporter`, `blackbox-exporter-lan` renders with placeholders substituted; `kustomize build` clean; yamlfmt clean; `check_internal_identifiers.py --diff-base` clean.
- Rule expressions checked against live Prometheus for syntax; the Layer C ones return empty until the ScrapeConfig lands (expected).
