### PR TITLE
feat(lurcher): deploy v1.6.0 (ContractorUK source)

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.5.0@sha256:e5b5a0c9b60f895cd85b3369a8f059a63c06b366fcef3ecce08a123fce3d2d53
+              image: ghcr.io/lukeevanstech/lurcher:1.6.0@sha256:79364cb20e089a68884bc5df034ea57f08f750653512ec93d5dba2438c79a02a
               args:
                 - "run"
               env:


### PR DESCRIPTION
Bump the `lurcher` CronJob image to **v1.6.0**, which adds **ContractorUK** as a fourth contract source.

- Contract-native UK board (HTML-scraped), with **explicit per-listing IR35** and real day-rates — the signal the LinkedIn source lacked.
- Board pattern (pull-all, no alert gate); purely additive to the app (no schema/config migration beyond the source registration).
- Digest-pinned to the v1.6.0 release build (`ghcr.io/lukeevanstech/lurcher:1.6.0@sha256:79364cb2…`).

App code: LukeEvansTech/lurcher#17 (merged), released as v1.6.0.