### PR TITLE
chore(lurcher): bump image to 1.7.0

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.6.0@sha256:79364cb20e089a68884bc5df034ea57f08f750653512ec93d5dba2438c79a02a
+              image: ghcr.io/lukeevanstech/lurcher:1.7.0@sha256:0fa8699b7f8efa91794aacd918e01e164fd7455a259c219329142af5658765f1
               args:
                 - "run"
               env:


### PR DESCRIPTION
Deploys lurcher **1.7.0** — description-aware remote detection across all four sources (contractoruk, outsidespy, outsideir35, linkedin). isRemote now reads title + description, not just the structured location field; ContractorUK remote flagging measured 0 → 26 on a 300-role sample. No manifest change beyond the image ref; Flux reconciles the `lurcher` ks in ns `default`.

Image: `ghcr.io/lukeevanstech/lurcher:1.7.0@sha256:0fa8699b7f8efa91794aacd918e01e164fd7455a259c219329142af5658765f1`