### PR TITLE
chore(lurcher): bump image to 1.8.0

### DIFF
--- a/kubernetes/apps/default/lurcher/app/cronjob.yaml
+++ b/kubernetes/apps/default/lurcher/app/cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               type: RuntimeDefault
           containers:
             - name: lurcher
-              image: ghcr.io/lukeevanstech/lurcher:1.7.0@sha256:0fa8699b7f8efa91794aacd918e01e164fd7455a259c219329142af5658765f1
+              image: ghcr.io/lukeevanstech/lurcher:1.8.0@sha256:cee06bdf08c6745f905b5339fd359e5c17f075b1682dca1469ca151a913715a0
               args:
                 - "run"
               env:


### PR DESCRIPTION
Deploys lurcher **1.8.0** — per-connector filter overrides (`sourceOverrides`). A search can now override rateMin/rateMax/ir35/locations per connector from a single definition. Enables a ContractorUK £400 floor (set via SEARCHES_YAML) while other sources stay £500. No manifest change beyond the image ref; Flux reconciles the `lurcher` ks in ns `default`.

Image: `ghcr.io/lukeevanstech/lurcher:1.8.0@sha256:cee06bdf08c6745f905b5339fd359e5c17f075b1682dca1469ca151a913715a0`