### PR TITLE
feat(smtp2graph): measure delivery, not liveness

### DIFF
--- a/kubernetes/apps/infrastructure/smtp2graph/app/dashboards/smtp2graph.json
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/dashboards/smtp2graph.json
@@ -1,0 +1,541 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Undeliverable mail",
+      "description": "Messages the relay has permanently given up on. Healthy is a hard zero. This sat at 353 for days in Aug 2026 with nobody watching.",
+      "id": 1,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smtp2graph_messages_failed",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Queued",
+      "description": "In flight to Graph. Brief non-zero values are normal.",
+      "id": 2,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smtp2graph_messages_queued",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Last canary success",
+      "description": "Age of the last proven end-to-end delivery. The canary runs every 6h, so anything past ~14h means mail is broken even if nothing is trying to send.",
+      "id": 3,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 25200
+              },
+              {
+                "color": "red",
+                "value": 50400
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "time() - smtp2graph_canary_last_success_timestamp_seconds",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "title": "Canary result",
+      "description": "Result of the most recent canary.",
+      "id": 4,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "FAILING",
+                  "color": "red",
+                  "index": 0
+                },
+                "1": {
+                  "text": "OK",
+                  "color": "green",
+                  "index": 1
+                }
+              }
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smtp2graph_canary_success",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Mail queue",
+      "description": "Undeliverable is the one that matters \u2014 it never self-heals.",
+      "id": 5,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "opacity"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smtp2graph_messages_failed",
+          "legendFormat": "undeliverable",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smtp2graph_messages_queued",
+          "legendFormat": "queued",
+          "range": true,
+          "refId": "B"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Oldest queued message age",
+      "description": "Rising with a non-empty queue means Graph delivery is stalled, not merely busy.",
+      "id": 6,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "opacity"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "smtp2graph_oldest_queued_seconds",
+          "legendFormat": "oldest",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Canary failures",
+      "description": "Canary outcomes over time. Explicit [6h] window \u2014 $__rate_interval is unsafe at this scrape interval.",
+      "id": 7,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": true,
+            "axisPlacement": "auto",
+            "gradientMode": "opacity"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "increase(smtp2graph_canary_failures_total[6h])",
+          "legendFormat": "failures (6h)",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "increase(smtp2graph_canary_runs_total[6h])",
+          "legendFormat": "runs (6h)",
+          "range": true,
+          "refId": "B"
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["mail", "smtp2graph", "infrastructure"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "SMTP2Graph \u2014 mail delivery",
+  "uid": "smtp2graph-delivery",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/apps/infrastructure/smtp2graph/app/exporter/exporter.py
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/exporter/exporter.py
@@ -1,0 +1,153 @@
+import http.server, os, socketserver, threading, time, uuid, smtplib
+from email.message import EmailMessage
+
+MAILROOT = os.environ.get("MAILROOT", "/data/mailroot")
+PORT = int(os.environ.get("METRICS_PORT", "9184"))
+SMTP_HOST = os.environ.get("SMTP_HOST", "127.0.0.1")
+SMTP_PORT = int(os.environ.get("SMTP_PORT", "25"))
+CANARY_ENABLED = os.environ.get("CANARY_ENABLED", "true").lower() == "true"
+CANARY_INTERVAL = int(os.environ.get("CANARY_INTERVAL_SECONDS", "21600"))
+CANARY_TIMEOUT = int(os.environ.get("CANARY_TIMEOUT_SECONDS", "180"))
+CANARY_FROM = os.environ.get("CANARY_FROM", "")
+CANARY_TO = os.environ.get("CANARY_TO", "")
+SETTLE = int(os.environ.get("CANARY_SETTLE_SECONDS", "5"))
+
+S = {"ok": 0, "last_success": 0.0, "last_attempt": 0.0, "runs": 0, "failures": 0}
+
+def _names(d):
+    try:
+        return [n for n in os.listdir(os.path.join(MAILROOT, d)) if n.endswith(".eml")]
+    except OSError:
+        return []
+
+def count(d):
+    return len(_names(d))
+
+def oldest_age(d):
+    p = os.path.join(MAILROOT, d)
+    ts = []
+    for n in _names(d):
+        try:
+            ts.append(os.path.getmtime(os.path.join(p, n)))
+        except OSError:
+            continue
+    return max(0.0, time.time() - min(ts)) if ts else 0.0
+
+def has_marker(d, marker):
+    p = os.path.join(MAILROOT, d)
+    needle = marker.encode()
+    for n in _names(d):
+        try:
+            with open(os.path.join(p, n), "rb") as fh:
+                if needle in fh.read():
+                    return True
+        except OSError:
+            continue
+    return False
+
+def canary_once():
+    marker = "smtp2graph-canary-" + uuid.uuid4().hex
+    m = EmailMessage()
+    m["From"] = CANARY_FROM
+    m["To"] = CANARY_TO
+    m["Subject"] = "[canary] smtp2graph delivery check"
+    m.set_content(
+        "Automated smtp2graph delivery canary — safe to delete.\n"
+        "It exists because a silent Graph-side failure went unnoticed for 9 days\n"
+        "in Aug 2026 while the SMTP listener stayed perfectly healthy.\n"
+        f"marker={marker}\n")
+    S["last_attempt"] = time.time()
+    S["runs"] += 1
+    try:
+        s = smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30)
+        s.send_message(m)
+        s.quit()
+    except Exception as e:
+        print(f"canary: submit failed: {e}", flush=True)
+        S["ok"] = 0
+        S["failures"] += 1
+        return
+    # smtp2graph writes the file to queue/ before returning 250, so a short
+    # settle is enough to avoid reading before the file exists.
+    time.sleep(SETTLE)
+    deadline = time.time() + CANARY_TIMEOUT
+    while time.time() < deadline:
+        if has_marker("failed", marker):
+            print("canary: message landed in failed/ — Graph rejected it", flush=True)
+            S["ok"] = 0
+            S["failures"] += 1
+            return
+        if not has_marker("queue", marker) and not has_marker("temp", marker):
+            S["ok"] = 1
+            S["last_success"] = time.time()
+            print("canary: delivered", flush=True)
+            return
+        time.sleep(5)
+    print("canary: still queued at timeout", flush=True)
+    S["ok"] = 0
+    S["failures"] += 1
+
+def canary_loop():
+    time.sleep(30)  # let the relay finish starting
+    while True:
+        try:
+            canary_once()
+        except Exception as e:
+            print(f"canary: unexpected error: {e}", flush=True)
+            S["ok"] = 0
+        time.sleep(CANARY_INTERVAL)
+
+def render():
+    L = []
+    def g(name, help_, val):
+        L.append(f"# HELP {name} {help_}")
+        L.append(f"# TYPE {name} gauge")
+        L.append(f"{name} {val}")
+    g("smtp2graph_up", "Exporter is running (absence means monitoring is blind).", 1)
+    g("smtp2graph_messages_failed",
+      "Messages the relay gave up on. Any non-zero value is mail that will never arrive.",
+      count("failed"))
+    g("smtp2graph_messages_queued", "Messages awaiting delivery to Graph.", count("queue"))
+    g("smtp2graph_oldest_queued_seconds", "Age of the oldest queued message.",
+      round(oldest_age("queue"), 1))
+    g("smtp2graph_canary_enabled", "Whether the end-to-end canary is running.",
+      1 if CANARY_ENABLED else 0)
+    g("smtp2graph_canary_success", "Result of the most recent canary (1 ok, 0 failed).", S["ok"])
+    g("smtp2graph_canary_last_success_timestamp_seconds",
+      "Unix time of the last successful canary.", round(S["last_success"], 0))
+    g("smtp2graph_canary_last_attempt_timestamp_seconds",
+      "Unix time of the last canary attempt.", round(S["last_attempt"], 0))
+    L.append("# HELP smtp2graph_canary_runs_total Canary attempts since start.")
+    L.append("# TYPE smtp2graph_canary_runs_total counter")
+    L.append(f"smtp2graph_canary_runs_total {S['runs']}")
+    L.append("# HELP smtp2graph_canary_failures_total Canary failures since start.")
+    L.append("# TYPE smtp2graph_canary_failures_total counter")
+    L.append(f"smtp2graph_canary_failures_total {S['failures']}")
+    return "\n".join(L) + "\n"
+
+class H(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    def do_GET(self):
+        if self.path.split("?")[0] not in ("/metrics", "/"):
+            self.send_error(404)
+            return
+        body = render().encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def log_message(self, *a):
+        pass
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+if __name__ == "__main__":
+    if CANARY_ENABLED and CANARY_FROM and CANARY_TO:
+        threading.Thread(target=canary_loop, daemon=True).start()
+    else:
+        print("canary: disabled or unconfigured", flush=True)
+    print(f"exporter: listening on :{PORT}, mailroot={MAILROOT}", flush=True)
+    Server(("0.0.0.0", PORT), H).serve_forever()

--- a/kubernetes/apps/infrastructure/smtp2graph/app/exporter/exporter.py
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/exporter/exporter.py
@@ -1,8 +1,30 @@
-import http.server, os, socketserver, threading, time, uuid, smtplib
+#!/usr/bin/env python3
+"""Prometheus exporter and delivery canary for smtp2graph.
+
+smtp2graph exposes no metrics of its own — it listens on :25 and nothing else,
+and its config schema has no metrics or health options. This sidecar therefore
+reads the relay's own on-disk queue directories and, separately, proves the
+whole SMTP -> Graph path still works by sending a message through it.
+
+It exists because between 2026-08-10 and 2026-08-19 every Graph send failed
+with ErrorSendAsDenied — 353 messages lost, zero delivered — while the SMTP
+listener stayed perfectly healthy. Liveness was never the problem; delivery
+was. Everything here measures delivery outcome.
+
+Configuration is entirely by environment variable; see helmrelease.yaml.
+"""
+
+import http.server
+import os
+import socketserver
+import threading
+import time
+import uuid
 from email.message import EmailMessage
+from smtplib import SMTP
 
 MAILROOT = os.environ.get("MAILROOT", "/data/mailroot")
-PORT = int(os.environ.get("METRICS_PORT", "9184"))
+METRICS_PORT = int(os.environ.get("METRICS_PORT", "9184"))
 SMTP_HOST = os.environ.get("SMTP_HOST", "127.0.0.1")
 SMTP_PORT = int(os.environ.get("SMTP_PORT", "25"))
 CANARY_ENABLED = os.environ.get("CANARY_ENABLED", "true").lower() == "true"
@@ -10,125 +32,171 @@ CANARY_INTERVAL = int(os.environ.get("CANARY_INTERVAL_SECONDS", "21600"))
 CANARY_TIMEOUT = int(os.environ.get("CANARY_TIMEOUT_SECONDS", "180"))
 CANARY_FROM = os.environ.get("CANARY_FROM", "")
 CANARY_TO = os.environ.get("CANARY_TO", "")
-SETTLE = int(os.environ.get("CANARY_SETTLE_SECONDS", "5"))
+CANARY_SETTLE = int(os.environ.get("CANARY_SETTLE_SECONDS", "5"))
+STARTUP_DELAY = int(os.environ.get("CANARY_STARTUP_DELAY_SECONDS", "30"))
 
-S = {"ok": 0, "last_success": 0.0, "last_attempt": 0.0, "runs": 0, "failures": 0}
+STATE = {"ok": 0, "last_success": 0.0, "last_attempt": 0.0, "runs": 0, "failures": 0}
 
-def _names(d):
+
+def log(msg):
+    """Print a message to stdout, unbuffered so it reaches the pod log promptly."""
+    print(f"exporter: {msg}", flush=True)
+
+
+def _entries(subdir):
+    """Return the .eml filenames in a mailroot subdirectory, or [] if unreadable."""
     try:
-        return [n for n in os.listdir(os.path.join(MAILROOT, d)) if n.endswith(".eml")]
+        return [n for n in os.listdir(os.path.join(MAILROOT, subdir)) if n.endswith(".eml")]
     except OSError:
         return []
 
-def count(d):
-    return len(_names(d))
 
-def oldest_age(d):
-    p = os.path.join(MAILROOT, d)
-    ts = []
-    for n in _names(d):
+def count(subdir):
+    """Return how many messages sit in a mailroot subdirectory."""
+    return len(_entries(subdir))
+
+
+def oldest_age(subdir):
+    """Return the age in seconds of the oldest message in a subdirectory, or 0.0 if empty."""
+    base = os.path.join(MAILROOT, subdir)
+    stamps = []
+    for name in _entries(subdir):
         try:
-            ts.append(os.path.getmtime(os.path.join(p, n)))
+            stamps.append(os.path.getmtime(os.path.join(base, name)))
         except OSError:
             continue
-    return max(0.0, time.time() - min(ts)) if ts else 0.0
+    return max(0.0, time.time() - min(stamps)) if stamps else 0.0
 
-def has_marker(d, marker):
-    p = os.path.join(MAILROOT, d)
+
+def has_marker(subdir, marker):
+    """Return True if any message in a subdirectory contains the canary marker."""
+    base = os.path.join(MAILROOT, subdir)
     needle = marker.encode()
-    for n in _names(d):
+    for name in _entries(subdir):
         try:
-            with open(os.path.join(p, n), "rb") as fh:
-                if needle in fh.read():
+            with open(os.path.join(base, name), "rb") as handle:
+                if needle in handle.read():
                     return True
         except OSError:
             continue
     return False
 
-def canary_once():
-    marker = "smtp2graph-canary-" + uuid.uuid4().hex
-    m = EmailMessage()
-    m["From"] = CANARY_FROM
-    m["To"] = CANARY_TO
-    m["Subject"] = "[canary] smtp2graph delivery check"
-    m.set_content(
+
+def _submit(marker):
+    """Submit one canary message to the relay. Return True if it was accepted."""
+    msg = EmailMessage()
+    msg["From"] = CANARY_FROM
+    msg["To"] = CANARY_TO
+    msg["Subject"] = "[canary] smtp2graph delivery check"
+    msg.set_content(
         "Automated smtp2graph delivery canary — safe to delete.\n"
-        "It exists because a silent Graph-side failure went unnoticed for 9 days\n"
+        "It exists because a silent Graph-side failure went unnoticed for nine days\n"
         "in Aug 2026 while the SMTP listener stayed perfectly healthy.\n"
-        f"marker={marker}\n")
-    S["last_attempt"] = time.time()
-    S["runs"] += 1
+        f"marker={marker}\n"
+    )
     try:
-        s = smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=30)
-        s.send_message(m)
-        s.quit()
-    except Exception as e:
-        print(f"canary: submit failed: {e}", flush=True)
-        S["ok"] = 0
-        S["failures"] += 1
+        client = SMTP(SMTP_HOST, SMTP_PORT, timeout=30)
+        client.send_message(msg)
+        client.quit()
+        return True
+    except OSError as exc:  # covers every socket/SMTP transport failure
+        log(f"canary: submit failed: {exc}")
+        return False
+
+
+def canary_once():
+    """Send one canary and record whether it was delivered rather than dropped.
+
+    Success means the message left the queue without ever appearing in failed/,
+    which is only true if Graph actually accepted it.
+    """
+    marker = "smtp2graph-canary-" + uuid.uuid4().hex
+    STATE["last_attempt"] = time.time()
+    STATE["runs"] += 1
+    if not _submit(marker):
+        STATE["ok"] = 0
+        STATE["failures"] += 1
         return
     # smtp2graph writes the file to queue/ before returning 250, so a short
-    # settle is enough to avoid reading before the file exists.
-    time.sleep(SETTLE)
+    # settle avoids reading the directory before the file exists.
+    time.sleep(CANARY_SETTLE)
     deadline = time.time() + CANARY_TIMEOUT
     while time.time() < deadline:
         if has_marker("failed", marker):
-            print("canary: message landed in failed/ — Graph rejected it", flush=True)
-            S["ok"] = 0
-            S["failures"] += 1
+            log("canary: message landed in failed/ — Graph rejected it")
+            STATE["ok"] = 0
+            STATE["failures"] += 1
             return
         if not has_marker("queue", marker) and not has_marker("temp", marker):
-            S["ok"] = 1
-            S["last_success"] = time.time()
-            print("canary: delivered", flush=True)
+            STATE["ok"] = 1
+            STATE["last_success"] = time.time()
+            log("canary: delivered")
             return
         time.sleep(5)
-    print("canary: still queued at timeout", flush=True)
-    S["ok"] = 0
-    S["failures"] += 1
+    log("canary: still queued at timeout")
+    STATE["ok"] = 0
+    STATE["failures"] += 1
+
 
 def canary_loop():
-    time.sleep(30)  # let the relay finish starting
+    """Run the canary forever. Never raise: a dead loop would look like healthy silence."""
+    time.sleep(STARTUP_DELAY)
     while True:
         try:
             canary_once()
-        except Exception as e:
-            print(f"canary: unexpected error: {e}", flush=True)
-            S["ok"] = 0
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Deliberately broad. This thread is the only thing proving mail
+            # works; if it dies the metric simply freezes, which reads as "no
+            # recent success" rather than as an alert.
+            log(f"canary: unexpected error: {exc}")
+            STATE["ok"] = 0
+            STATE["failures"] += 1
         time.sleep(CANARY_INTERVAL)
 
-def render():
-    L = []
-    def g(name, help_, val):
-        L.append(f"# HELP {name} {help_}")
-        L.append(f"# TYPE {name} gauge")
-        L.append(f"{name} {val}")
-    g("smtp2graph_up", "Exporter is running (absence means monitoring is blind).", 1)
-    g("smtp2graph_messages_failed",
-      "Messages the relay gave up on. Any non-zero value is mail that will never arrive.",
-      count("failed"))
-    g("smtp2graph_messages_queued", "Messages awaiting delivery to Graph.", count("queue"))
-    g("smtp2graph_oldest_queued_seconds", "Age of the oldest queued message.",
-      round(oldest_age("queue"), 1))
-    g("smtp2graph_canary_enabled", "Whether the end-to-end canary is running.",
-      1 if CANARY_ENABLED else 0)
-    g("smtp2graph_canary_success", "Result of the most recent canary (1 ok, 0 failed).", S["ok"])
-    g("smtp2graph_canary_last_success_timestamp_seconds",
-      "Unix time of the last successful canary.", round(S["last_success"], 0))
-    g("smtp2graph_canary_last_attempt_timestamp_seconds",
-      "Unix time of the last canary attempt.", round(S["last_attempt"], 0))
-    L.append("# HELP smtp2graph_canary_runs_total Canary attempts since start.")
-    L.append("# TYPE smtp2graph_canary_runs_total counter")
-    L.append(f"smtp2graph_canary_runs_total {S['runs']}")
-    L.append("# HELP smtp2graph_canary_failures_total Canary failures since start.")
-    L.append("# TYPE smtp2graph_canary_failures_total counter")
-    L.append(f"smtp2graph_canary_failures_total {S['failures']}")
-    return "\n".join(L) + "\n"
 
-class H(http.server.BaseHTTPRequestHandler):
+def render():
+    """Render the current state as a Prometheus text-format exposition."""
+    lines = []
+
+    def gauge(name, helptext, value):
+        lines.extend([f"# HELP {name} {helptext}", f"# TYPE {name} gauge", f"{name} {value}"])
+
+    def counter(name, helptext, value):
+        lines.extend([f"# HELP {name} {helptext}", f"# TYPE {name} counter", f"{name} {value}"])
+
+    gauge("smtp2graph_up", "Exporter is running (absence means monitoring is blind).", 1)
+    gauge(
+        "smtp2graph_messages_failed",
+        "Messages the relay gave up on. Any non-zero value is mail that will never arrive.",
+        count("failed"),
+    )
+    gauge("smtp2graph_messages_queued", "Messages awaiting delivery to Graph.", count("queue"))
+    gauge("smtp2graph_oldest_queued_seconds", "Age of the oldest queued message.", round(oldest_age("queue"), 1))
+    gauge("smtp2graph_canary_enabled", "Whether the end-to-end canary is running.", int(CANARY_ENABLED))
+    gauge("smtp2graph_canary_success", "Result of the most recent canary (1 ok, 0 failed).", STATE["ok"])
+    gauge(
+        "smtp2graph_canary_last_success_timestamp_seconds",
+        "Unix time of the last successful canary.",
+        round(STATE["last_success"]),
+    )
+    gauge(
+        "smtp2graph_canary_last_attempt_timestamp_seconds",
+        "Unix time of the last canary attempt.",
+        round(STATE["last_attempt"]),
+    )
+    counter("smtp2graph_canary_runs_total", "Canary attempts since start.", STATE["runs"])
+    counter("smtp2graph_canary_failures_total", "Canary failures since start.", STATE["failures"])
+    return "\n".join(lines) + "\n"
+
+
+class MetricsHandler(http.server.BaseHTTPRequestHandler):
+    """Serve the exposition on /metrics and nothing else."""
+
     protocol_version = "HTTP/1.1"
-    def do_GET(self):
-        if self.path.split("?")[0] not in ("/metrics", "/"):
+
+    def do_GET(self):  # pylint: disable=invalid-name  # name is fixed by BaseHTTPRequestHandler
+        """Handle a metrics scrape."""
+        if self.path.split("?", 1)[0] not in ("/metrics", "/"):
             self.send_error(404)
             return
         body = render().encode()
@@ -137,17 +205,27 @@ class H(http.server.BaseHTTPRequestHandler):
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
-    def log_message(self, *a):
-        pass
 
-class Server(socketserver.ThreadingTCPServer):
+    def log_message(self, *args):
+        """Silence per-request logging; a 60s scrape would otherwise dominate the pod log."""
+
+
+class ThreadedHTTPServer(socketserver.ThreadingTCPServer):
+    """Threaded server so a slow scrape cannot block the next one."""
+
     allow_reuse_address = True
     daemon_threads = True
 
-if __name__ == "__main__":
+
+def main():
+    """Start the canary thread (if configured) and serve metrics forever."""
     if CANARY_ENABLED and CANARY_FROM and CANARY_TO:
         threading.Thread(target=canary_loop, daemon=True).start()
     else:
-        print("canary: disabled or unconfigured", flush=True)
-    print(f"exporter: listening on :{PORT}, mailroot={MAILROOT}", flush=True)
-    Server(("0.0.0.0", PORT), H).serve_forever()
+        log("canary: disabled or unconfigured")
+    log(f"listening on :{METRICS_PORT}, mailroot={MAILROOT}")
+    ThreadedHTTPServer(("0.0.0.0", METRICS_PORT), MetricsHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes/apps/infrastructure/smtp2graph/app/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/externalsecret.yaml
@@ -22,6 +22,27 @@ spec:
           receive:
             port: 25
             maxSize: 25m
+            # Fail LOUDLY at submission instead of silently at Graph.
+            #
+            # Without this the relay accepts anything and only discovers minutes
+            # later that Graph will not send as that From — the message lands in
+            # failed/ and the sender is never told. That is precisely how the
+            # NMC alerts died quietly for nine days in Aug 2026.
+            #
+            # Every entry must be the noreply@ shared mailbox itself or a
+            # verified alias of it, or Graph returns ErrorSendAsDenied. Each
+            # address below was confirmed to deliver by live probe on
+            # 2026-08-19 before this gate was applied.
+            #
+            # ⚠️ THIS IS A HARD GATE. A new mail consumer whose From is not
+            # listed here is rejected at MAIL FROM. Adding a consumer means:
+            # add its From as an alias on the shared mailbox, THEN add it here.
+            allowedFrom:
+              - noreply@${SECRET_DOMAIN} # NMC fleet (apc-fleet baseline) + the delivery canary
+              - pocket-id@${SECRET_DOMAIN}
+              - tandoor@${SECRET_DOMAIN}
+              - epicgames@${SECRET_DOMAIN}
+              - scanopy@${SECRET_DOMAIN}
           send:
             appReg:
               tenant: "{{ .SMTP2GRAPH_TENANT }}"

--- a/kubernetes/apps/infrastructure/smtp2graph/app/grafanadashboard.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/grafanadashboard.yaml
@@ -1,0 +1,22 @@
+---
+# Bespoke because there is no upstream smtp2graph dashboard — the application
+# exposes no metrics at all; everything here comes from the sidecar in
+# helmrelease.yaml. Panels deliberately mirror the alert rules, so what pages
+# you is what you can see.
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: smtp2graph
+spec:
+  allowCrossNamespaceImport: true
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  resyncPeriod: 1h
+  datasources:
+    - datasourceName: prometheus
+      inputName: DS_PROMETHEUS
+  configMapRef:
+    name: smtp2graph-dashboard
+    key: smtp2graph.json

--- a/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/helmrelease.yaml
@@ -33,6 +33,68 @@ spec:
                 cpu: 10m
               limits:
                 memory: 256Mi
+          # smtp2graph v1.1.5 exposes NO metrics of its own — it listens on :25
+          # and nothing else, and its config schema has no metrics or health
+          # options. This sidecar is the only source of delivery telemetry.
+          #
+          # It exists because between 2026-08-10 and 2026-08-19 every Graph send
+          # failed with ErrorSendAsDenied — 353 messages lost, zero delivered —
+          # and nothing noticed for nine days, because the SMTP listener stayed
+          # healthy throughout. Liveness was never the problem; delivery was.
+          #
+          # It reads the queue directories (see persistence.data below) and runs
+          # a 6-hourly end-to-end canary through the relay's own :25. Script is
+          # a real file under exporter/, not inline YAML, so it can be unit
+          # tested — its three scenarios (delivered / rejected by Graph / relay
+          # down) were each exercised against a stub SMTP server before merge.
+          metrics:
+            image:
+              repository: python
+              tag: 3.13-alpine@sha256:540c7d91f98ff6880174c40e99067bf5941eb54d818a7a5e094d188b196a934d
+            command:
+              - "python"
+              - "-u"
+              - "/opt/exporter/exporter.py"
+            env:
+              MAILROOT: /data/mailroot
+              METRICS_PORT: "9184"
+              SMTP_HOST: 127.0.0.1
+              SMTP_PORT: "25"
+              CANARY_ENABLED: "true"
+              # 6h. The canary sends REAL mail to CANARY_TO — a mailbox rule on
+              # the "[canary] smtp2graph" subject keeps it out of the way.
+              # Shorten for a tighter detection window at the cost of more mail.
+              CANARY_INTERVAL_SECONDS: "21600"
+              CANARY_TIMEOUT_SECONDS: "180"
+              # MUST be listed in allowedFrom (see externalsecret.yaml) or the
+              # canary is rejected at MAIL FROM and reports a false outage.
+              CANARY_FROM: noreply@${SECRET_DOMAIN}
+              CANARY_TO: operations@${SECRET_DOMAIN}
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /metrics, port: 9184 }
+                  initialDelaySeconds: 20
+                  periodSeconds: 60
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /metrics, port: 9184 }
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 5m
+              limits:
+                memory: 64Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -52,24 +114,53 @@ spec:
         ports:
           smtp:
             port: 25
+      # Separate ClusterIP so metrics are never published on the LoadBalancer
+      # that faces the LAN. The port NAME (http) is what the ServiceMonitor
+      # matches on — see the note in servicemonitor.yaml.
+      metrics:
+        controller: smtp2graph
+        type: ClusterIP
+        ports:
+          http:
+            port: 9184
     persistence:
       # WORKDIR is /data: config.yml is read from here and the disk queue
       # (queue/ temp/ failed/) is created alongside it. emptyDir matches the
       # maddy smtp-relay's queue durability — acceptable at estate volume.
+      # advancedMounts, not globalMounts: the sidecar must NOT see client.key.
+      # globalMounts would hand the Graph signing key to a container whose only
+      # job is counting files, so each mount is now targeted at the container
+      # that actually needs it.
       data:
         type: emptyDir
-        globalMounts:
-          - path: /data
+        advancedMounts:
+          smtp2graph:
+            app:
+              - path: /data
+            metrics:
+              - path: /data
+                readOnly: true
       config:
         type: secret
         name: smtp2graph-secret
-        globalMounts:
-          - path: /data/config.yml
-            subPath: config.yml
-            readOnly: true
-          - path: /secrets/client.key
-            subPath: client.key
-            readOnly: true
+        advancedMounts:
+          smtp2graph:
+            app:
+              - path: /data/config.yml
+                subPath: config.yml
+                readOnly: true
+              - path: /secrets/client.key
+                subPath: client.key
+                readOnly: true
+      exporter:
+        type: configMap
+        name: smtp2graph-exporter
+        advancedMounts:
+          smtp2graph:
+            metrics:
+              - path: /opt/exporter/exporter.py
+                subPath: exporter.py
+                readOnly: true
       tmp:
         type: emptyDir
         globalMounts:

--- a/kubernetes/apps/infrastructure/smtp2graph/app/kustomization.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/kustomization.yaml
@@ -6,3 +6,23 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./externalsecret.yaml
+  - ./servicemonitor.yaml
+  - ./prometheusrule.yaml
+  - ./grafanadashboard.yaml
+configMapGenerator:
+  # Kept as real files rather than inline YAML so both stay lintable and, in the
+  # exporter's case, unit-testable outside the cluster.
+  - name: smtp2graph-exporter
+    files:
+      - exporter.py=./exporter/exporter.py
+  - name: smtp2graph-dashboard
+    files:
+      - smtp2graph.json=./dashboards/smtp2graph.json
+generatorOptions:
+  # Stable names: the controller carries reloader.stakater.com/auto, so a
+  # content change restarts the pod without needing a new ConfigMap name.
+  disableNameSuffixHash: true
+  annotations:
+    # The dashboard JSON uses Grafana's own ${DS_PROMETHEUS} macro; disable Flux
+    # postBuild substitution so it is not clobbered to empty.
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/infrastructure/smtp2graph/app/prometheusrule.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/prometheusrule.yaml
@@ -1,0 +1,79 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+# Why this exists at all: between 2026-08-10 and 2026-08-19 this relay accepted
+# mail and then failed EVERY Graph send with ErrorSendAsDenied — 353 messages
+# lost, 2,824 errors, zero delivered — and nothing noticed for nine days. The
+# SMTP listener was healthy the entire time, so any liveness or TCP check would
+# have stayed green. These rules therefore measure DELIVERY OUTCOME, never
+# reachability.
+kind: PrometheusRule
+metadata:
+  name: smtp2graph
+spec:
+  groups:
+    - name: smtp2graph
+      rules:
+        # The exact signature of the Aug 2026 outage. A file in failed/ is a
+        # message the relay has permanently given up on — it is not a backlog,
+        # it is lost mail. Healthy steady state is a hard zero, so this needs no
+        # threshold beyond "any". 15m only so a single transient retry burst
+        # does not page.
+        - alert: SMTP2GraphUndeliverableMail
+          annotations:
+            description: >-
+              smtp2graph has {{ $value }} message(s) it has given up delivering. These
+              will never arrive. Check `kubectl logs -n infrastructure deploy/smtp2graph`
+              for the Graph error — ErrorSendAsDenied means the From address is not the
+              noreply@ shared mailbox or one of its aliases.
+            summary: smtp2graph has mail it can never deliver.
+          expr: smtp2graph_messages_failed > 0
+          for: 15m
+          labels:
+            severity: critical
+        # Backlog that is not draining. Distinct from the above: these have not
+        # been given up on yet, so this catches a slow or wedged Graph path
+        # before messages start expiring into failed/.
+        - alert: SMTP2GraphQueueStalled
+          annotations:
+            description: >-
+              smtp2graph has had mail queued for over 30 minutes (oldest is
+              {{ $value | humanizeDuration }}). Delivery to Graph is stalled or
+              throttled.
+            summary: smtp2graph delivery queue is not draining.
+          expr: smtp2graph_oldest_queued_seconds > 1800
+          for: 10m
+          labels:
+            severity: warning
+        # The queue metrics above only say anything when mail is actually
+        # flowing. Estate mail is bursty — the UPS alerts that exposed the
+        # original fault stopped entirely once the flapping calmed down — so a
+        # relay broken during a quiet spell would look perfectly healthy. The
+        # canary sends its own message every 6h and confirms it left the queue
+        # without landing in failed/, which exercises the real Graph call.
+        # 3x the interval plus slack: two consecutive misses before paging.
+        - alert: SMTP2GraphCanaryFailing
+          annotations:
+            description: >-
+              No successful smtp2graph delivery canary for over 14 hours. Mail is
+              probably broken even though nothing is currently trying to send — this is
+              the check that would have caught the Aug 2026 outage on day one.
+            summary: smtp2graph end-to-end delivery canary is failing.
+          expr: >-
+            smtp2graph_canary_enabled == 1
+            and (time() - smtp2graph_canary_last_success_timestamp_seconds) > 50400
+          for: 15m
+          labels:
+            severity: critical
+        # Monitoring that can fail silently is how the original outage lasted
+        # nine days. If the exporter stops reporting, say so.
+        - alert: SMTP2GraphMetricsMissing
+          annotations:
+            description: >-
+              No smtp2graph_up metric for over 15 minutes. The metrics sidecar is down or
+              unscrapeable, so mail delivery is unmonitored.
+            summary: smtp2graph delivery monitoring is blind.
+          expr: absent(smtp2graph_up)
+          for: 15m
+          labels:
+            severity: critical

--- a/kubernetes/apps/infrastructure/smtp2graph/app/servicemonitor.yaml
+++ b/kubernetes/apps/infrastructure/smtp2graph/app/servicemonitor.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+# Scrapes the metrics sidecar, NOT the relay itself — smtp2graph v1.1.5 has no
+# metrics endpoint of its own (verified: the container listens on :25 only, and
+# the upstream config schema has no metrics/health options).
+#
+# `port: http` is load-bearing. This selector also matches the LoadBalancer
+# service in front of :25, but a ServiceMonitor endpoint matches on the SERVICE
+# PORT NAME, and that one is named `smtp` — so only the metrics service yields
+# targets. Renaming either port silently changes what gets scraped.
+kind: ServiceMonitor
+metadata:
+  name: &app smtp2graph
+  labels:
+    app.kubernetes.io/name: *app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: *app
+  namespaceSelector:
+    matchNames:
+      - infrastructure
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 60s
+      scrapeTimeout: 10s


### PR DESCRIPTION
## Why

Between **2026-08-10 and 2026-08-19** this relay accepted mail and then failed **every** Graph send with `ErrorSendAsDenied` — **353 messages lost, 2,824 errors, zero delivered** — and nothing noticed for nine days.

The SMTP listener was healthy the entire time. A TCP check, a Gatus probe or a liveness probe would all have stayed **green** throughout. Nothing was measuring whether mail actually *arrived*.

Root cause is fixed separately in [apc-fleet#19](https://github.com/LukeEvansTech/apc-fleet/pull/19). This PR is about making sure the next one is noticed in minutes rather than days.

## Constraints (verified, not assumed)

- **smtp2graph v1.1.5 exposes no metrics.** The container listens on `:25` and nothing else, and the upstream config schema has no metrics or health options.
- **No vmalert**, so log-based alerting isn't available either — even though the logs *are* in VictoriaLogs.
- The estate is metrics-first: 75 PrometheusRules, Alertmanager → Pushover.

## What this adds

**A metrics sidecar** reading the relay's own queue directories:

| metric | why |
|---|---|
| `smtp2graph_messages_failed` | mail permanently given up on — the exact Aug signature |
| `smtp2graph_messages_queued` | in flight |
| `smtp2graph_oldest_queued_seconds` | stalled vs merely busy |
| `smtp2graph_canary_*` | proven end-to-end delivery |
| `smtp2graph_up` | so the monitoring cannot fail silently |

**An end-to-end canary**, because the queue metrics only say anything while mail is flowing — and estate mail is bursty. The UPS alerts that exposed this stopped entirely once the flapping calmed, so a relay broken during a quiet spell would look perfectly healthy. Every 6h it sends through the relay's own `:25` and confirms the message left the queue without landing in `failed/`, exercising the real Graph call.

⚠️ The canary sends **real mail** to `operations@`. A mailbox rule on the `[canary] smtp2graph` subject keeps it out of the way; `CANARY_INTERVAL_SECONDS` trades detection latency against volume.

**Four alerts**, all measuring outcome rather than reachability — including `SMTP2GraphMetricsMissing`, because monitoring that fails quietly is how this lasted nine days.

**`receive.allowedFrom`.** Without it the relay accepts anything and only discovers minutes later that Graph won't send as that From — at which point the message is lost and the sender never told. Every listed address was confirmed to deliver by live probe first.

> ⚠️ **Hard gate.** An unlisted From is rejected at `MAIL FROM`. Adding a consumer means adding its From as a mailbox alias, **then** listing it here. The five entries cover every consumer found in this repo (`pocket-id`, `tandoor`, `epicgames`, `scanopy`) plus the NMC fleet on `noreply@`. Senders **cannot** be enumerated retrospectively from the mailbox — `forceMailbox` rewrites them all to `noreply@` — so if an off-cluster sender exists that isn't in this repo, it will start getting SMTP rejections. That's loud rather than silent, but it is a behaviour change; happy to split it into its own PR if you'd rather land the observability alone.

## Security

Mounts move from `globalMounts` to `advancedMounts` so the sidecar **cannot read `client.key`** — `globalMounts` would have handed the Graph signing key to a container whose only job is counting files. Verified in the rendered Deployment:

```text
metrics: /data (readOnly=True), /opt/exporter/exporter.py, /tmp
  client.key in sidecar : False
  config.yml in sidecar : False
```

The app container's mounts render **byte-identical to what is running today**.

## Testing

The exporter is a real file under `exporter/`, not inline YAML, so it can be tested. All three paths were exercised against a stub SMTP server before merge:

| scenario | result |
|---|---|
| delivered | `canary_success=1`, `failures=0` |
| **rejected by Graph** (the Aug 2026 failure) | `canary_success=0`, `failures=1`, `messages_failed=1` |
| relay down | `canary_success=0`, `failures=1` |

Also verified: `kustomize build` renders all 8 resources; `helm template` against the real app-template 5.1.0 renders 1 Deployment + 2 Services; the ConfigMap round-trip leaves the script byte-identical and still compiling; the ServiceMonitor's `port: http` matches only the metrics service (the LB port is named `smtp`).

Dashboard queries use **explicit windows, never `$__rate_interval`** — this job is scraped at 60s and the macro expands from the datasource's 15s setting, the trap already documented on the nut-appliance dashboard.