### PR TITLE
feat(arc): org-scoped runner scale set for codelooks-com [blocked on GitHub App permission]

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: codelooks-org-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: codelooks-org-runner-secret
+    template:
+      engineVersion: v2
+      data:
+        github_app_id: "{{ .ACTIONS_RUNNER_APP_ID }}"
+        github_app_installation_id: "{{ .ACTIONS_RUNNER_INSTALLATION_ID }}"
+        github_app_private_key: "{{ .ACTIONS_RUNNER_PRIVATE_KEY }}"
+  dataFrom:
+    # Same codelooks-com GitHub App the terraform-vsphere runner uses. Note an
+    # org-scoped scale set needs the app to hold the ORGANISATION permission
+    # "Self-hosted runners: Read and write" — repo-scoped registration (which is
+    # all this app has had to do until now) only needs the repository one. If
+    # that permission is missing the listener fails to register the scale set;
+    # the error surfaces in the listener pod, not here.
+    - extract:
+        key: github-codelooks

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/helmrelease.yaml
@@ -1,0 +1,76 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name codelooks-org-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set-codelooks-org
+  interval: 1h
+  values:
+    fullnameOverride: *name
+    # ORG-scoped, not repo-scoped: one scale set serves every repo in
+    # codelooks-com via the Default runner group, instead of the one-scale-set-
+    # per-repo pattern the other runners here use. Personal-account repos can't
+    # do this — GitHub has no user-level runner scope (`users/<u>/actions/runners`
+    # and `user/actions/runners` both 404), only repository and organisation —
+    # which is why LukeEvansTech repos still need one scale set each.
+    githubConfigUrl: https://github.com/codelooks-com
+    githubConfigSecret: codelooks-org-runner-secret
+    runnerGroup: Default
+    runnerScaleSetName: codelooks-org
+    # 12 private repos share this pool and Renovate lands PRs in batches, so
+    # some parallelism matters; 6 concurrent runners is well inside the cluster
+    # (3 x 24 cores) while bounding the blast radius of a runaway workflow.
+    maxRunners: 6
+    minRunners: 0
+    containerMode:
+      # dind, NOT kubernetes mode. super-linter and checkov-action are Docker
+      # CONTAINER actions (`using: docker`, `image: docker://...`), which need a
+      # Docker daemon. kubernetes mode would have to translate them via the
+      # container hooks, and the two other runners here that use kubernetes mode
+      # only ever run plain `run:` steps. dind is the mode already proven for
+      # container workloads by talos-cluster-runner.
+      type: dind
+    template:
+      spec:
+        # miroir-local provisions a real ext4 block device whose root comes up
+        # root:root 0755, and this image runs as uid/gid 1001. Without fsGroup
+        # the runner cannot create _work/_tool and every job dies in ~2s with
+        # UnauthorizedAccessException before a single step executes. miroir's
+        # CSIDriver is fsGroupPolicy: ReadWriteOnceWithFSType and this claim is
+        # RWO + ext4, so kubelet honours fsGroup and chowns the volume.
+        securityContext:
+          fsGroup: 1001
+        containers:
+          - name: runner
+            # Same digest as talos-cluster-runner / terraform-vsphere-runner.
+            # Renovate manages this.
+            image: ghcr.io/home-operations/actions-runner:2.336.0@sha256:281a9a090522fafbf4967f158b8c97d03552b1978b688893c5f7cb1944bc5fe5
+            command:
+              - "/home/runner/run.sh"
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
+        volumes:
+          - name: work
+            ephemeral:
+              volumeClaimTemplate:
+                spec:
+                  accessModes:
+                    - "ReadWriteOnce"
+                  storageClassName: miroir-local
+                  resources:
+                    requests:
+                      # Roomier than talos-cluster-runner's 25Gi: the super-linter
+                      # image alone is several GB and checkov/trivy add more. Note
+                      # dind's own image store is the sidecar's writable layer
+                      # (node ephemeral storage), not this claim — and Spegel does
+                      # not mirror dind pulls, only containerd ones, so every run
+                      # pulls super-linter from ghcr.io afresh.
+                      storage: 40Gi
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/kustomization.yaml
@@ -3,7 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./talos-cluster
-  - ./packer
-  - ./terraform-vsphere
-  - ./codelooks-org
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/codelooks-org/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gha-runner-scale-set-codelooks-org
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.2
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set


### PR DESCRIPTION
> [!WARNING]
> **Draft — do not merge yet.** Needs a GitHub App permission change first, detailed below. Merging before that lands would leave the listener unable to register the scale set.

## What

Adds `codelooks-org`, an **org-scoped** `AutoscalingRunnerSet` serving every repo in `codelooks-com` via the Default runner group — rather than the one-scale-set-per-repo pattern the existing three runners use.

## Why

Measured over the 30 days to 2026-08-19 (job-level timings, GitHub's per-job round-up model), `codelooks-com` burns **~4,100 billable Actions minutes/month against a 3,000-minute Team allowance**. Almost all of it is `Lint` (super-linter) plus `security-scans` across 12 private repos — workloads with no reason to sit on paid runners.

`LukeEvansTech/shared-workflows#36` added the `runner` input those callers need to redirect here.

## Two design decisions worth stating

**Org-scoped here, but per-repo for the personal account.** GitHub has no user-level runner scope — `users/<user>/actions/runners` and `user/actions/runners` both return 404, leaving only repository and organisation scope. So `LukeEvansTech` repos will still need one scale set each; only the org can collapse to one.

**`dind`, not `kubernetes` mode.** `super-linter` and `checkov-action` are Docker **container** actions (`using: docker`, `image: docker://…`) and need a real Docker daemon. The two kubernetes-mode runners here only ever run plain `run:` steps. `dind` is the mode already proven for container workloads by `talos-cluster-runner`.

## Blocked on

`codelooks-arc-runner` (owned by `codelooks-com`) currently holds only the **repository** permission `administration: write` plus `metadata: read`, and its installation is `repository_selection: selected`.

An org-scoped scale set requires the **organisation** permission `organization_self_hosted_runners` = *Self-hosted runners: Read and write*, which the app does not have.

Required before merge:

1. App permissions → **Organization permissions → Self-hosted runners: Read and write**
2. Installation → switch **Selected repositories** → **All repositories**, so one scale set covers all 12
3. Approve the pending permission request on the installation

## Validation so far

- `kubectl kustomize` builds the full runners tree cleanly (16 resources); `codelooks-org` resolves with the intended `githubConfigUrl`, `runnerScaleSetName`, and `type: dind`
- All four new manifests parse; lefthook pre-commit (yamllint, prettier, codespell, editorconfig) passed
- Reuses the same `github-codelooks` 1Password key and three-field secret template as the working `terraform-vsphere-runner`

Once merged and the listener is confirmed Running, the 12 caller repos get `runner: codelooks-org` — **not before**, since a job requesting a label no runner advertises queues indefinitely rather than failing.