### PR TITLE
fix(ai): give llama-nvidia real VRAM headroom after CUDA OOM crash

### DIFF
--- a/kubernetes/apps/ai/llmkube/models/qwen3.8-27b.yaml
+++ b/kubernetes/apps/ai/llmkube/models/qwen3.8-27b.yaml
@@ -58,9 +58,14 @@ spec:
   runtimeClassName: nvidia
   priorityClassName: gpu-preemptible
   # VRAM budget on a 24GB L4 (~22.4Gi usable): 14.9Gi weights (Q4_K_S + MTP
-  # head) + 0.6Gi mmproj + 4Gi KV (128k @ q8_0, only 16/64 layers are full
-  # attention) + compute buffers. Measured without MTP: 20.2Gi used, 2.3Gi
-  # free; the MTP head + draft state costs ~0.5–1Gi of that headroom.
+  # head) + 0.6Gi mmproj + 3Gi KV (128k, K q8_0 + V q4_0; only 16/64 layers
+  # are full attention) + compute buffers. With MTP on and q8/q8 KV the card
+  # sat at 22.0/22.5Gi and the FIRST real prompt crashed llama-server with
+  # "CUDA error: out of memory" in ggml_cuda_pool_vmm::alloc — the mul_mat
+  # compute pool grows at decode time, so ~0.5Gi idle headroom is NOT enough;
+  # keep ≥1.5Gi free. V-cache q4_0 buys 1Gi (K stays q8_0 — K quantization is
+  # the recall-sensitive half) and uBatchSize 512 shrinks the CUDA compute
+  # buffers for the rest, at a modest prompt-processing cost.
   # 2 slots × 64k gives every request — opencode's ~41k agent baseline
   # included — the window the old YaRN-extended uncensored model needed
   # hacks for, with no YaRN and no --override-kv.
@@ -69,11 +74,11 @@ spec:
   flashAttention: true
   jinja: true
   cacheTypeK: q8_0
-  cacheTypeV: q8_0
+  cacheTypeV: q4_0
   reasoningBudget: 16384
   reasoningBudgetMessage: "Stop reasoning and produce the final answer or tool call."
   batchSize: 4096
-  uBatchSize: 1024
+  uBatchSize: 512
   resources:
     gpu: 1
     cpu: "500m"


### PR DESCRIPTION
Follow-up to #4426. First real prompt after MTP enablement crashed llama-server: `CUDA error: out of memory` in `ggml_cuda_pool_vmm::alloc` (exit 139, restart observed). The CUDA mul_mat pool grows at decode time, so the ~500MiB idle headroom was not survivable.

Fix keeps the 2 × 64k window and MTP:
- V-cache q8_0 → **q4_0** (−1Gi; K stays q8_0 — K quantization is the recall-sensitive half)
- `uBatchSize` 1024 → **512** (smaller CUDA compute buffers, modest PP cost)

Post-merge: re-measure idle VRAM (target ≥1.5Gi free), re-run the crashing workload, re-bench decode.