### PR TITLE
fix(gpu-operator): stop GpuHighMemoryUsage flapping on the LLM card

### DIFF
--- a/kubernetes/apps/gpu-operator/gpu-operator/app/prometheusrule.yaml
+++ b/kubernetes/apps/gpu-operator/gpu-operator/app/prometheusrule.yaml
@@ -20,8 +20,17 @@ spec:
           annotations:
             description: GPU {{ $labels.gpu }} on {{ $labels.Hostname }} memory usage is above 90%.
             summary: GPU memory usage is critically high.
+          # Exclude the card running an llmkube InferenceService: llama.cpp holds
+          # its weights + KV cache resident by design, idling at ~90% and peaking
+          # higher during prompt processing, so this alert flapped on every
+          # request (fire >90% for 5m, resolve when idle, repeat). DCGM
+          # attributes the series to the GPU's occupant via exported_container
+          # ("llama-server" for every llmkube runtime pod, whatever the model).
+          # That card's real failure mode — CUDA OOM killing the server — is
+          # covered by InferenceServiceDown and pod restart alerting instead.
           expr: |-
-            DCGM_FI_DEV_FB_USED / (DCGM_FI_DEV_FB_USED + DCGM_FI_DEV_FB_FREE) > 0.9
+            DCGM_FI_DEV_FB_USED{exported_container!="llama-server"}
+              / (DCGM_FI_DEV_FB_USED{exported_container!="llama-server"} + DCGM_FI_DEV_FB_FREE{exported_container!="llama-server"}) > 0.9
           for: 5m
           labels:
             severity: warning


### PR DESCRIPTION
Since the Qwen3.8 consolidation (#4424–#4428) the LLM-serving GPU idles at ~89.9% (by design — resident weights + KV) and every request pushes it over the 90% threshold: fire >5m, resolve at idle, repeat ~every 20 minutes.

Fix: exclude DCGM series attributed to an llmkube runtime container (`exported_container="llama-server"` — model-agnostic, follows the pod wherever it schedules). All other GPUs keep the 90% rule. The excluded card's real failure mode (CUDA OOM killing llama-server) is covered by `InferenceServiceDown` + restart alerting, which is exactly what caught the OOM fixed in #4428.

Validated against live Prometheus: the old expression matches the flapping series, the new one matches zero while other-GPU coverage is unchanged.