### PR TITLE
fix(security): move sentinel-syslog to the 9.5.2 image with a loadable Sentinel plugin

### DIFF
--- a/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
+++ b/kubernetes/apps/security/sentinel-syslog/app/helmrelease.yaml
@@ -30,8 +30,11 @@ spec:
           app:
             image:
               # Custom image: Logstash + microsoft-sentinel output plugin (LukeEvansTech/containers).
+              # 9.5.2 carries plugin 2.5.0 — the 2.1.0 pin installed but failed to LOAD under the
+              # JRuby 10 runtime Logstash 9.4+ ships, crashlooping every rebuilt digest since
+              # 2026-08-17 while the (mis-tagged) 9.1.10 builds moved their base to 9.4/9.5.
               repository: ghcr.io/lukeevanstech/logstash-sentinel
-              tag: 9.1.10@sha256:f4837b9c8a1878bc16c2f58b6a88f5cb7e7aa27a42646cb1894e388241e7a234
+              tag: 9.5.2@sha256:6042b0d12a7d011791d87f65537cb8985182f06d97b9805d12cf2d62e83d6300
             env:
               TZ: ${TIMEZONE}
               # Bound the JVM heap AND Netty/direct off-heap for the semi-hyperconverged


### PR DESCRIPTION
Closes the `FluxHelmReleaseNotReady` alert firing since 2026-08-20 22:48.

**What was happening:** three consecutive Renovate digest bumps (#4343, #4351, #4432) crashlooped on startup and were rolled back by Flux (3 retries → `RollbackSucceeded`, HR stalled), pinning the workload to a digest from three weeks ago. The rebuilt images had silently moved their Logstash base onto the JRuby 10 (Ruby 3.4) runtime — while still publishing under the old version tag — and the pinned Sentinel output plugin 2.1.0 **installs at build time but fails to load at pipeline creation** (`Couldn't find any output plugin named microsoft-sentinel-log-analytics-logstash-output-plugin`; Logstash exits, pod crashloops, Helm times out).

**Fix (image side, LukeEvansTech/containers#54):** plugin pin 2.1.0 → 2.5.0, publish under the true 9.5.2 tag, Renovate custom managers so the VERSION file tracks the base and the gem pin tracks rubygems.

**This PR:** points the HelmRelease at the fixed image. The published digest was verified in-cluster before this bump — plugin listed, plugin starts, pipeline starts. flate 13/13 and the super-linter mirror pass locally.

Renovate will follow the new `9.5.2` tag for future digest/version updates.