### PR TITLE
fix(volsync): reconcile restore destinations, raise plex and the cache floor

### DIFF
--- a/docs/docs/operations/backups.md
+++ b/docs/docs/operations/backups.md
@@ -34,3 +34,22 @@ replacing, VolSync for those apps.
 
 See the [VolSync / Kopia migration](../migrations/volsync-kopia.md) for the move to the Kopia mover
 and the repository layout.
+
+## Restoring
+
+Each app has two `ReplicationDestination` objects — `<app>-nfs-dst` (Kopia, from the NAS) and
+`<app>-dst` (restic, from R2). Flux reconciles both, so **suspend the Kustomization before touching
+one** or the trigger you bump gets reverted on the next reconcile:
+
+```console
+$ flux suspend ks <app> -n flux-system
+$ kubectl patch replicationdestination <app>-nfs-dst -n <ns> --type=merge \
+    -p "{\"spec\":{\"trigger\":{\"manual\":\"restore-$(date +%s)\"}}}"
+```
+
+Watch for `status.latestImage`, then recreate the app's PVC from it and
+`flux resume ks <app> -n flux-system`.
+
+Destinations were frozen at their creation-time values until 2026-08-22 — see
+[KB-031](../troubleshooting/kb/031-volsync-restore-destinations-never-updated.md) for what that
+broke and the field-manager conflict to check for.

--- a/docs/docs/troubleshooting/index.md
+++ b/docs/docs/troubleshooting/index.md
@@ -24,6 +24,7 @@ Work down from what you observe to the most likely entry:
     - `CephMonDownQuorumAtRisk` (critical) fires minutes after cordoning a control-plane node → [KB-019](kb/019-cordon-control-plane-breaks-ceph-mon-quorum.md)
     - Snapshot CRDs vanish minutes after merging a chart migration; controller crash-loops on "failure to ensure CRDs exist"; HelmRelease rollback loop re-deletes them each retry → [KB-029](kb/029-chart-migration-deletes-keep-annotated-crds.md)
     - One app's `volsync-src-<app>-nfs-*` mover pods sit in `Error` while every other app backs up fine; the log ends `write /cache/CACHEDIR.TAG: no space left on device` then `found existing data in storage location` → [KB-030](kb/030-volsync-kopia-cache-pvc-too-small.md)
+    - A restore hangs on an unbindable cache PVC, is offered less capacity than the data, or hits ENOSPC on `/cache` — while every backup is green → [KB-031](kb/031-volsync-restore-destinations-never-updated.md)
 - **Workloads / pods**
     - A JVM/Logstash pod OOMKills on a cadence despite a bounded heap → [KB-012](kb/012-jvm-container-rss-oom-malloc-arena-max.md)
     - A pure-Go pod SIGSEGVs (`exit 139`) on a large fraction of starts, before any logs → [KB-013](kb/013-go-1264-binary-startup-sigsegv.md)
@@ -77,3 +78,4 @@ Work down from what you observe to the most likely entry:
 - [KB-028: Talos Upgrade Installs Successfully but the Node Boots the Old Version (NVRAM Wipe)](kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md)
 - [KB-029: Chart Migration Deletes Keep-Annotated CRDs (postRenderer Removal Races the Chart Swap)](kb/029-chart-migration-deletes-keep-annotated-crds.md)
 - [KB-030: VolSync Kopia Backups Fail with `no space left on device` on `/cache`](kb/030-volsync-kopia-cache-pvc-too-small.md)
+- [KB-031: VolSync Restore Destinations Silently Frozen at Creation-Time Values](kb/031-volsync-restore-destinations-never-updated.md)

--- a/docs/docs/troubleshooting/kb/031-volsync-restore-destinations-never-updated.md
+++ b/docs/docs/troubleshooting/kb/031-volsync-restore-destinations-never-updated.md
@@ -1,0 +1,122 @@
+# KB-031: VolSync Restore Destinations Silently Frozen at Creation-Time Values
+
+**Status:** Resolved. The `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` label was removed from both
+`ReplicationDestination` templates in `kubernetes/components/volsync/`, so Flux now reconciles all
+198 of them instead of only creating them. Backups were never affected — this only ever broke
+restores.
+
+## Symptom
+
+Nothing. That is the whole problem.
+
+Every `ReplicationSource` is healthy, `lastSyncTime` is current, the Kopia and restic repositories
+are fine, and no alert fires. The breakage only appears the day someone actually needs a restore,
+which is the worst possible day to discover it.
+
+Read the live values against what Git renders:
+
+```console
+$ kubectl get replicationdestination -A -o json \
+  | jq -r '.items[] | [.metadata.name,
+      (.spec.kopia // .spec.restic).capacity,
+      (.spec.kopia // .spec.restic).cacheCapacity,
+      (.spec.kopia // .spec.restic).cacheStorageClassName] | @tsv'
+plex-nfs-dst     200Gi   100Gi   ceph-block
+wizarr-nfs-dst   5Gi     2Gi     ceph-block
+hermes-dst       5Gi     10Gi    openebs-hostpath
+```
+
+Three separate failures were live at once:
+
+| Drift | Count | What a restore does |
+| --- | --- | --- |
+| `cacheStorageClassName: openebs-hostpath` | 42 | Hangs forever — that StorageClass was deleted with OpenEBS |
+| `capacity` smaller than the data | 7 | Fails to provision; `plex` offered 200Gi for 290G of data |
+| `cacheCapacity` below the 8Gi floor | 163 | ENOSPC on `/cache` — the KB-030 failure, during the restore |
+
+## Cause
+
+Both destination templates carried an SSA opt-out:
+
+```yaml
+metadata:
+  name: "${APP}-nfs-dst"
+  labels:
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+```
+
+`IfNotPresent` tells kustomize-controller to **create the object if it is absent and never update it
+again**. Each destination therefore froze at whatever `VOLSYNC_CAPACITY` /
+`VOLSYNC_CACHE_CAPACITY` happened to be on the day the app was first deployed. Every later change —
+the Kopia migration's move to `miroir-local`, the OpenEBS decommission, the KB-030 8Gi floor, every
+`VOLSYNC_CAPACITY` bump — landed on the `ReplicationSource` and was silently dropped on the
+destination.
+
+The label exists upstream so that a hand-bumped `spec.trigger.manual` is not reverted mid-restore.
+That is a real concern, but it was buying one convenience at the cost of every restore path in the
+cluster quietly rotting.
+
+## Fix
+
+Remove the label from both templates and let Flux own the objects:
+
+- `kubernetes/components/volsync/nfs/replicationdestination.yaml`
+- `kubernetes/components/volsync/remote/replicationdestination.yaml`
+
+**Restores now need the Kustomization suspended first**, or Flux will revert the trigger you just
+bumped:
+
+```console
+$ flux suspend ks <app> -n flux-system
+$ kubectl patch replicationdestination <app>-nfs-dst -n <ns> --type=merge \
+    -p '{"spec":{"trigger":{"manual":"restore-'"$(date +%s)"'"}}}'
+# ... restore, then:
+$ flux resume ks <app> -n flux-system
+```
+
+Note the quoting. One destination in this cluster was found holding the **literal** string
+`restore-$(date +%s)`, because the shell never expanded it inside single quotes.
+
+## Two traps when rolling this out
+
+**Field-manager conflicts do not force themselves.** That hand-patched destination had
+`spec.trigger` owned by the `kubectl-patch` field manager, so Flux's server-side apply returns:
+
+```text
+Error from server (Conflict): Apply failed with 1 conflict:
+  conflict with "kubectl-patch" using volsync.backube/v1alpha1: .spec.trigger.manual
+```
+
+The Flux `Kustomization` does not set `spec.force`, so that one app wedges while the other 197
+apply cleanly. Find them before merging — `kubectl get` hides this unless you ask:
+
+```console
+$ kubectl get replicationdestination -A -o json --show-managed-fields \
+  | jq -r '.items[] | select(.metadata.managedFields[]?.manager
+      | startswith("kubectl")) | .metadata.namespace + "/" + .metadata.name'
+default/forgejo-dst
+```
+
+Clear it with a one-off `--server-side --field-manager=kustomize-controller --force-conflicts`
+apply, which hands ownership back.
+
+**Reconciling changes `spec.trigger.manual`, which fires one sync.** Any destination whose
+`status.lastManualSync` does not match the rendered `restore-once` runs a restore as soon as Flux
+owns it. This is safe: the templates set `copyMethod: Snapshot` and no `destinationPVC`, so the
+mover restores into a temporary volume and snapshots it — the app's live PVC is never touched. It
+costs a mover run and refreshes a stale `latestImage`.
+
+## Verification
+
+```console
+$ kubectl get replicationdestination -A -o json \
+  | jq -r '[.items[] | (.spec.kopia // .spec.restic).cacheStorageClassName] | unique'
+["miroir-local"]
+```
+
+No destination should report `openebs-hostpath`, and no `cacheCapacity` below `8Gi`.
+
+## Related
+
+- [KB-030](030-volsync-kopia-cache-pvc-too-small.md) — the same ENOSPC, on the backup side
+- [Backups](../../operations/backups.md) — the `8Gi` cache floor and the restore procedure

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -96,6 +96,7 @@ nav = [
       { "028: Talos upgrade boots old version" = "troubleshooting/kb/028-talos-upgrade-boots-old-version-loaderentrydefault.md" },
       { "029: Chart migration deletes keep-annotated CRDs" = "troubleshooting/kb/029-chart-migration-deletes-keep-annotated-crds.md" },
       { "030: VolSync Kopia cache PVC too small" = "troubleshooting/kb/030-volsync-kopia-cache-pvc-too-small.md" },
+      { "031: VolSync restore destinations never updated" = "troubleshooting/kb/031-volsync-restore-destinations-never-updated.md" },
     ] },
   ] },
   { "FAQ" = "faq.md" },

--- a/kubernetes/apps/default/homebox/ks.yaml
+++ b/kubernetes/apps/default/homebox/ks.yaml
@@ -17,7 +17,9 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 15Gi
-      VOLSYNC_CACHE_CAPACITY: 5Gi
+      # 8Gi cluster floor — the Kopia cache tracks the shared repository, not
+      # VOLSYNC_CAPACITY (KB-030).
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/default/jobops/ks.yaml
+++ b/kubernetes/apps/default/jobops/ks.yaml
@@ -22,7 +22,10 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_CACHE_CAPACITY: 5Gi
+      # Kopia's /cache holds the SHARED repository index + metadata, not this app's
+      # data, so it does not scale with VOLSYNC_CAPACITY. 8Gi is the cluster floor
+      # (KB-030); this app was at 80% of 5Gi.
+      VOLSYNC_CACHE_CAPACITY: 8Gi
   prune: true
   retryInterval: 2m
   sourceRef:

--- a/kubernetes/apps/media/plex/ks.yaml
+++ b/kubernetes/apps/media/plex/ks.yaml
@@ -23,7 +23,9 @@ spec:
   postBuild:
     substitute:
       APP: *app
-      VOLSYNC_CAPACITY: 300Gi
+      # 290G of 294G used and growing ~7.5G/week, almost all of it generated
+      # trickplay thumbnails under Media/. 500Gi buys ~6 months.
+      VOLSYNC_CAPACITY: 500Gi
       VOLSYNC_CACHE_CAPACITY: 100Gi
       HOMEPAGE_NAME: Plex
       HOMEPAGE_GROUP: Media

--- a/kubernetes/components/volsync/nfs/replicationdestination.yaml
+++ b/kubernetes/components/volsync/nfs/replicationdestination.yaml
@@ -4,8 +4,6 @@ apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
   name: "${APP}-nfs-dst"
-  labels:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   trigger:
     manual: restore-once

--- a/kubernetes/components/volsync/remote/replicationdestination.yaml
+++ b/kubernetes/components/volsync/remote/replicationdestination.yaml
@@ -4,8 +4,6 @@ apiVersion: volsync.backube/v1alpha1
 kind: ReplicationDestination
 metadata:
   name: "${APP}-dst"
-  labels:
-    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   trigger:
     manual: restore-once


### PR DESCRIPTION
## Problem

Backups are healthy. Restores were not, and nothing alerts on it.

Both `ReplicationDestination` templates carried `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent`,
which tells kustomize-controller to create the object if absent and **never update it again**.
Every destination froze at whatever `VOLSYNC_CAPACITY` / `VOLSYNC_CACHE_CAPACITY` happened to be
on the day its app was first deployed. The Kopia migration's move to `miroir-local`, the OpenEBS
decommission, the KB-030 8Gi floor and every capacity bump since all landed on the
`ReplicationSource` and were dropped on the destination.

Three failures were live at once across 198 destinations:

| Drift | Count | What a restore does |
| --- | --- | --- |
| `cacheStorageClassName: openebs-hostpath` | 42 | Hangs forever — that StorageClass no longer exists |
| `capacity` smaller than the data | 7 | Cannot provision; `plex` offered 200Gi for 290G |
| `cacheCapacity` below the 8Gi floor | 163 | ENOSPC on `/cache`, the KB-030 failure during a restore |

## Changes

- **`components/volsync/{nfs,remote}/replicationdestination.yaml`** — drop the `ssa: IfNotPresent`
  label so Flux reconciles all 198 destinations instead of only creating them.
- **`apps/media/plex/ks.yaml`** — `VOLSYNC_CAPACITY` 300Gi → 500Gi. The config volume sits at 290G
  of 294G and grows ~7.5G/week, so it had under four days of headroom. 247G of that is generated
  trickplay thumbnails under `Media/`.
- **`apps/default/{jobops,homebox}/ks.yaml`** — `VOLSYNC_CACHE_CAPACITY` 5Gi → 8Gi. The last two
  apps under the KB-030 floor; `jobops` was at 80% of 5Gi, roughly where `wizarr` was before it
  tipped.
- **KB-031** plus a restore procedure on the backups page, wired into the nav and symptom ladder.

## Pre-flight against the live cluster

Server-side dry-run as `kustomize-controller` applies cleanly to 243 of 244 destinations.

**One conflict, and it is handled separately:** `default/forgejo-dst` has `spec.trigger` owned by
the `kubectl-patch` field manager from an old hand-patch that stored the *literal* string
`restore-$(date +%s)`. The Flux `Kustomization` does not set `spec.force`, so that one app would
wedge on `conflict with "kubectl-patch" ... .spec.trigger.manual`. Ownership is being handed back
with a one-off force-conflicts apply before this merges.

Reconciling also rewrites `spec.trigger.manual`, so any destination whose `status.lastManualSync`
differs runs one restore. That is safe: the templates use `copyMethod: Snapshot` with no
`destinationPVC`, so the mover restores into a temporary volume and snapshots it — the app's live
PVC is never touched.

## Trade-off

Flux now owns `spec.trigger.manual`, so a restore needs `flux suspend ks <app>` first or the bumped
trigger is reverted on the next reconcile. That is the cost of the destinations tracking Git at all;
the procedure is documented in KB-031 and on the backups page.

## Validation

- `kustomize build kubernetes/components/volsync` renders all 7 resources, no `ssa` label remaining
- `kubectl apply --server-side --field-manager=kustomize-controller --dry-run=server` clean
- markdownlint clean on the new and edited docs