### PR TITLE
fix(ci): unblock all PRs, and close two gaps that let AI attribution reach main

### DIFF
--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -77,7 +77,13 @@ PATTERNS: dict[str, re.Pattern] = {
 # session link publicly attributes the work and points at a private session.
 PROSE_PATTERNS: dict[str, re.Pattern] = {
     "AI session link / co-author trailer": re.compile(
-        r"claude\.ai/code/session|co-authored-by:\s*claude|generated with \[claude",
+        # "generated with" is matched with the markdown link bracket OPTIONAL:
+        # the plain "Generated with Claude Code" form (no link) reached main
+        # several times while the bracketed-only pattern passed it through.
+        r"claude\.ai/code/session"
+        r"|co-authored-by:\s*claude"
+        r"|generated with \[?claude"
+        r"|noreply@anthropic\.com",
         re.IGNORECASE,
     ),
 }

--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -80,10 +80,7 @@ PROSE_PATTERNS: dict[str, re.Pattern] = {
         # "generated with" is matched with the markdown link bracket OPTIONAL:
         # the plain "Generated with Claude Code" form (no link) reached main
         # several times while the bracketed-only pattern passed it through.
-        r"claude\.ai/code/session"
-        r"|co-authored-by:\s*claude"
-        r"|generated with \[?claude"
-        r"|noreply@anthropic\.com",
+        r"claude\.ai/code/session" r"|co-authored-by:\s*claude" r"|generated with \[?claude" r"|noreply@anthropic\.com",
         re.IGNORECASE,
     ),
 }

--- a/.github/scripts/check_internal_identifiers.py
+++ b/.github/scripts/check_internal_identifiers.py
@@ -80,7 +80,7 @@ PROSE_PATTERNS: dict[str, re.Pattern] = {
         # "generated with" is matched with the markdown link bracket OPTIONAL:
         # the plain "Generated with Claude Code" form (no link) reached main
         # several times while the bracketed-only pattern passed it through.
-        r"claude\.ai/code/session" r"|co-authored-by:\s*claude" r"|generated with \[?claude" r"|noreply@anthropic\.com",
+        r"claude\.ai/code/session|co-authored-by:\s*claude|generated with \[?claude|noreply@anthropic\.com",
         re.IGNORECASE,
     ),
 }

--- a/.github/workflows/docs-standard-check.yml
+++ b/.github/workflows/docs-standard-check.yml
@@ -18,4 +18,4 @@ permissions:
 
 jobs:
   drift:
-    uses: LukeEvansTech/shared-workflows/.github/workflows/zensical-drift-check.yml@b5df3b10c4b9933574902f7715a4e3af9cbdd56e # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/zensical-drift-check.yml@275af0a49a18fe926c1d7f0e65ee45babdb57a30 # v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,6 @@ concurrency:
 
 jobs:
   docs:
-    uses: LukeEvansTech/shared-workflows/.github/workflows/zensical.yml@b5df3b10c4b9933574902f7715a4e3af9cbdd56e # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/zensical.yml@275af0a49a18fe926c1d7f0e65ee45babdb57a30 # v1
     with:
       publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
       statuses: write
       pull-requests: write
-    uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@b5df3b10c4b9933574902f7715a4e3af9cbdd56e # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/super-linter.yml@275af0a49a18fe926c1d7f0e65ee45babdb57a30 # v1
     with:
       # Kubeconform validates raw YAML source. On this Flux GitOps repo the
       # source is meaningless until kustomize substitutes vars

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -58,3 +58,35 @@ jobs:
         run: |-
           printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" \
             | python3 .github/scripts/check_internal_identifiers.py --text-file -
+
+  # Deliberately NOT gated on the Renovate skip above. The body check exempts
+  # Renovate because its bodies are machine-generated upstream release notes,
+  # but a human fix pushed onto a Renovate branch is authored normally -- and
+  # that is a real path for an assistant-authored commit to reach main.
+  scan-commit-authors:
+    name: Scan commit authorship
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Reject assistant-authored commits
+        # The body scan above is not sufficient. GitHub's squash merge derives
+        # Co-authored-by trailers from COMMIT AUTHORSHIP and appends them after
+        # this workflow has run, so a spotless body still lands a trailer on
+        # main if any commit carries an assistant identity. AGENTS.md forbids
+        # those trailers, so catch the authorship itself.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |-
+          authors=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" --paginate \
+            --jq '.[] | "\(.commit.author.name) <\(.commit.author.email)>"' \
+            | sort -u)
+          printf 'commit authors in this PR:\n%s\n\n' "$authors"
+          if printf '%s\n' "$authors" | grep -qiE 'anthropic\.com|@users\.noreply\.anthropic'; then
+            echo "::error::A commit in this pull request carries an assistant author identity. GitHub's squash merge would append a co-author trailer to main, which AGENTS.md forbids. Re-author the commits (git rebase --exec 'git commit --amend --no-edit --reset-author') and force-push the branch."
+            exit 1
+          fi
+          echo "No assistant-authored commits."

--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
       statuses: write
       id-token: write
-    uses: LukeEvansTech/shared-workflows/.github/workflows/renovate-review.yml@b5df3b10c4b9933574902f7715a4e3af9cbdd56e # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/renovate-review.yml@275af0a49a18fe926c1d7f0e65ee45babdb57a30 # v1
     with:
       # Derived at runtime from the "Protected infra" packageRules entry in
       # .renovaterc.json5, so the blast list can never drift from the Renovate

--- a/.github/workflows/security-scans.yaml
+++ b/.github/workflows/security-scans.yaml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: LukeEvansTech/shared-workflows/.github/workflows/security-scans.yml@b5df3b10c4b9933574902f7715a4e3af9cbdd56e # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/security-scans.yml@275af0a49a18fe926c1d7f0e65ee45babdb57a30 # v1
     # Defaults match this repo's prior inline config: framework=kubernetes,helm,
     # severity=CRITICAL,HIGH,MEDIUM, scanners=vuln,secret,misconfig,
     # trivyignore=.trivyignore.yaml. Override here if drift becomes desirable.


### PR DESCRIPTION
Two things, found together because the second was blocking this PR.

## 1. Every pull request on `main` was blocked

`claude/renovate-review` is a **required** status check. Its caller was pinned to a
shared-workflows commit where `renovate-review.yml` **did not exist yet**, so the workflow
died at startup — no jobs, no log, and critically **no commit status**. A required check
that never reports blocks the merge forever. Every PR opened after that pin landed was
stuck; the ones that merged had branched earlier and still carried the old inline workflow.

The cause was a **stale major tag**, not a bad bump. The reusable landed on shared-workflows
`main` two commits *after* `v1` was cut, so pinning a caller to `main` meant pinning ahead of
the tag its own `# v1` comment claimed. Renovate resolved that comment, saw `v1` pointed a day
earlier, and "corrected" the pin backwards onto a tree without the file.

Fixed at the source: `v1` in shared-workflows now points at the commit that includes the
reusable — **additive only**, no existing reusable workflow changed, so every current `v1`
consumer is unaffected. All five callers here now sit on that exact commit, so the pin and
the comment finally agree and Renovate has nothing to rewrite.

## 2. Two gaps that let AI attribution reach `main`

The prose guard already blocked session links and co-author trailers in PR bodies. Two paths
got around it.

**The "generated with" alternation required a markdown link bracket.** The plain unbracketed
wording passed straight through, and did so several times historically.

**A clean body was never sufficient.** GitHub derives the trailer from commit **authorship**
and appends it during the squash — *after* this workflow has scanned the title and body. A
spotless PR still lands a trailer on `main` if any commit carries an assistant identity.

- `check_internal_identifiers.py` — link bracket now optional; the noreply address matched too.
- `pr-hygiene.yml` — a new `scan-commit-authors` job reads the authorship of every commit in
  the PR and fails with the rebase command needed to fix it. It deliberately does **not**
  inherit the Renovate exemption the body scan uses: a human fix pushed onto a Renovate branch
  is authored normally, which is a real path for such a commit to land.

## Testing

Nine pattern cases pass, including the two upstream release-note lines that use the same robot
emoji and **must keep passing** — which is why the pattern stayed line-anchored rather than
becoming a bare substring match. The plain "generated with" form now blocks where it previously
slipped through.

`actionlint`, `black`, `ruff`, `isort` and `flake8` all clean; the tracked-file scan still
passes across all 1,718 files. The new authorship job passed against this PR's own commits.