### PR TITLE
fix(seedbox): stop SeedboxContainerDown paging on one-shot containers

### DIFF
--- a/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
+++ b/kubernetes/apps/observability/seedbox/app/prometheusrule.yaml
@@ -247,21 +247,42 @@ spec:
     - name: seedbox-docker.rules
       rules:
         # The declarative restore inits (apps/*/compose.yaml, service
-        # restore-<app>) are one-shots: they run, exit 0 and STAY exited. That
-        # is their steady state, so they are excluded from SeedboxContainerDown
-        # above — without the exclusion every one of them pages forever, which
-        # is exactly what happened when they first landed (13 across the fleet).
+        # restore-<app>) and the config inits (service init-<thing>) are
+        # one-shots: they run, exit 0 and STAY exited. That is their steady
+        # state, so they are excluded from SeedboxContainerDown below — without
+        # the exclusion every one of them pages forever, which is exactly what
+        # happened when they first landed (13 across the fleet).
+        #
+        # The exclusion is the container label `alerts.oneshot=true`, set on
+        # every seedbox-apps service that carries `restart: "no"`. It replaced a
+        # name regex (`name!~".*-restore-.*-[0-9]+"`) on 2026-08-23, which had
+        # silently missed `filebrowser-init-filebrowser-config-1` — an init-,
+        # not a restore- — so that container paged as "not running" while
+        # sitting in its correct steady state of exited (0).
+        #
+        # A name regex is the wrong mechanism here. "This container is supposed
+        # to exit" is DECLARED INTENT, and it cannot be derived from what
+        # docker_state_exporter publishes: it exposes only restartcount,
+        # startedat, finishedat, health_status, oomkilled and status — no exit
+        # code, and no restart policy, so the one real discriminator
+        # (RestartPolicy=no) is invisible to Prometheus. Nor does
+        # com.docker.compose.oneoff help; that marks `docker compose run`
+        # containers and reads False for every service on the box.
+        #
+        # A new one-shot added WITHOUT the label pages — the safe failure
+        # direction. A widened regex would instead silently swallow any real
+        # service whose name ever contained `-init-`.
         #
         # A restore init that FAILS is still caught, just not here. It exits
         # non-zero, so compose never starts the app it gates, and the app is
         # left in `created` rather than `exited` — which is why `created` was
-        # added to the status list above. Nothing sits in `created` for
+        # added to the status list below. Nothing sits in `created` for
         # 10m in normal operation; a deploy moves through it in seconds.
         - alert: SeedboxContainerDown
           annotations:
             summary: "Seedbox container {{ $labels.name }} is not running (state: {{ $labels.status }})."
           expr: |-
-            container_state_status{job="seedbox-docker", status=~"exited|dead|created", container_label_cd_doco_metadata_manager="doco-cd", name!~".*-restore-.*-[0-9]+"} == 1
+            container_state_status{job="seedbox-docker", status=~"exited|dead|created", container_label_cd_doco_metadata_manager="doco-cd", container_label_alerts_oneshot!="true"} == 1
           for: 10m
           labels:
             severity: critical

--- a/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
+++ b/kubernetes/apps/observability/seedbox/app/scrapeconfig.yaml
@@ -169,8 +169,20 @@ spec:
       targetLabel: instance
       replacement: seedbox
   metricRelabelings:
-    # Drop the noisy per-container label set but KEEP cd_doco_metadata_manager,
-    # so "container down" can be scoped to the GitOps-managed fleet and a
-    # hand-run throwaway never pages. Same shape as the truenas and appliance jobs.
+    # Drop the noisy per-container label set but KEEP two container labels:
+    #   - cd_doco_metadata_manager, so "container down" can be scoped to the
+    #     GitOps-managed fleet and a hand-run throwaway never pages.
+    #   - alerts_oneshot, which marks a container that is SUPPOSED to sit in
+    #     exited (0) forever (the restore/config inits in seedbox-apps, every
+    #     service with `restart: "no"`). SeedboxContainerDown excludes on it.
+    # Otherwise the shape matches the truenas and appliance jobs.
+    #
+    # ⚠️ This labelkeep is an ALLOW-LIST: a label the exporter publishes but
+    # that is not named here simply does not exist in Prometheus. Adding a new
+    # container label to seedbox-apps is therefore only half the job — verify
+    # with `count(container_state_status{container_label_<x>="..."})` against
+    # the real Prometheus before writing a rule that depends on it. Forgetting
+    # this on 2026-08-23 made a corrected SeedboxContainerDown match 8
+    # containers instead of 0, i.e. worse than the bug it fixed.
     - action: labelkeep
-      regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager
+      regex: __name__|job|instance|name|status|health_status|container_label_cd_doco_metadata_manager|container_label_alerts_oneshot


### PR DESCRIPTION
Companion to LukeEvansTech/seedbox-apps#139 (merged and deployed — all 8 containers now carry the label).

## The bug

`SeedboxContainerDown` excluded one-shots **by name**:

```promql
name!~".*-restore-.*-[0-9]+"
```

That covers the seven backrest restore inits and misses the eighth: `init-filebrowser-config` is an `init-`, not a `restore-`. Confirmed against live Prometheus — the old expression matches exactly one container:

```text
container_state_status{...,name!~".*-restore-.*-[0-9]+"} == 1
  → filebrowser-init-filebrowser-config-1   status=exited
```

It has been paging as *"container is not running"* while sitting in its correct steady state of `exited (0)`.

## Why the exclusion moves to a label

A name regex is the wrong mechanism. **"This container is supposed to exit" is declared intent**, and it cannot be derived from what `docker_state_exporter` publishes — six families only: `restartcount`, `startedat`, `finishedat`, `health_status`, `oomkilled`, `status`. **No exit code, no restart policy**, so the one genuine discriminator (`RestartPolicy=no`, true of all 8 and nothing else) is invisible to Prometheus. `com.docker.compose.oneoff` isn't a substitute either — it marks `docker compose run` containers and reads `False` for every service on the box.

Widening to `.*-(restore|init)-.*-[0-9]+` would also silently swallow any *real* service whose name ever contained `-init-` — failure in the dangerous direction. A one-shot added without the label pages instead, which is the safe direction.

## The second half — easy to miss

The scrape config's `labelkeep` is an **allow-list**. `container_label_alerts_oneshot` existed on the exporter (60 series, verified on the box) and *still did not exist in Prometheus*, so the label-based rule matched **8 containers instead of 0** — worse than the bug it fixes.

Measured both ways before and after:

| Expression | Matches |
| --- | --- |
| old (name regex) | **1** — `filebrowser-init-filebrowser-config-1` |
| new label rule, `labelkeep` unchanged | **8** — label invisible, so nothing is excluded |
| `count(container_state_status{container_label_alerts_oneshot="true"})` | **0** — the proof |

So this PR widens the `labelkeep` regex too, and leaves a warning in the comment for the next person adding a container label.

## Verification after merge

Flux reconcile, then re-run:

```promql
container_state_status{job="seedbox-docker", status=~"exited|dead|created",
  container_label_cd_doco_metadata_manager="doco-cd",
  container_label_alerts_oneshot!="true"} == 1
```

Expected: **0**. I'll confirm on the live instance once it reconciles.