### PR TITLE
feat(rook-ceph): upgrade Ceph to v20.2.4

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -11,17 +11,17 @@ spec:
     kind: OCIRepository
     name: rook-ceph-cluster
   values:
-    # Hold Ceph on v20.2.2 for the chart move to v1.20.6; the data-plane upgrade to
-    # v20.2.4 lands separately so an operator bump and a rolling mon/mgr/OSD/MDS
-    # restart are never the same change. Without this the chart default silently
-    # carries the cluster forward (v1.20.4 defaults to v20.2.2, v1.20.6 to v20.2.4).
+    # No cephImage pin: the CHART governs the Ceph version, and it moves with the
+    # chart (v1.20.4 shipped v20.2.2, v1.20.6 ships v20.2.4). The pin that held
+    # v20.2.2 through the v1.20.6 chart move has done its job and is removed here,
+    # which is what performs the v20.2.2 -> v20.2.4 data-plane upgrade.
     #
-    # Set cephImage, NOT cephClusterSpec.cephVersion: the chart derives both the
-    # version and the toolbox image from cephImage, and specifying both renders a
-    # duplicate key. The chart's own values.yaml says the same.
-    cephImage:
-      repository: quay.io/ceph/ceph
-      tag: v20.2.2
+    # An explicit pin is deliberately NOT kept: no Renovate manager in this
+    # repository tracks an inline cephImage tag, so it would be hand-maintained and
+    # would silently go stale. Instead, rook-ceph sits in the "Protected infra"
+    # packageRules entry, so every chart bump gets a human review -- and that
+    # reviewer must check whether the chart's default Ceph version has moved,
+    # because a chart bump alone will roll every mon, mgr, OSD and MDS.
     monitoring:
       enabled: true
       createPrometheusRules: true


### PR DESCRIPTION
Phase two of the split that began when the chart moved to v1.20.6. That change pinned `cephImage` so
an operator bump could not drag the data plane with it; **removing the pin here is what performs the
v20.2.2 → v20.2.4 upgrade**, on its own, with nothing else changing.

> [!WARNING]
> This is a rolling restart of **every mon, mgr, OSD and MDS**, behind `ceph-block` (the default
> StorageClass) and `ceph-filesystem` (RWX). Merge it in a window where you can watch it, and expect
> `HEALTH_WARN` with degraded PGs while daemons cycle.

## Why the pin is removed rather than advanced to v20.2.4

An explicit pin would be **hand-maintained**. No Renovate manager in this repository tracks an inline
`cephImage` tag — the `customManagers` are all purpose-built regexes for talosctl, Minecraft,
homebridge and Grafana dashboards, none of which match it. A pin nobody updates is exactly the
failure that took every pull request down earlier today, when a `# v1` comment pointed at a tag that
had stopped moving.

So the chart owns the version. The protection against a silent data-plane move is procedural
instead: `rook-ceph` sits in the **Protected infra** `packageRules` entry and never auto-merges, so a
human sees every chart bump. The values comment now tells that reviewer explicitly to check whether
the chart's default Ceph version moved, since a chart bump alone will roll the whole data plane.

## Pre-flight

- Cluster is `HEALTH_OK`, 3 mons in quorum, 6/6 OSDs, 169 pgs `active+clean`
- All three nodes freshly on Talos v1.13.9, so the OS layer is settled
- The `rook` mgr module is already disabled — relevant, because it crash-loops the mgr every ~15s on
  v20.2.3/v20.2.4 ([rook#18124](https://github.com/rook/rook/issues/18124)). Landing that first was
  deliberate; this upgrade would be actively unpleasant with it still enabled.

## Expected afterwards, handled separately

`AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` clears itself after 2–3 hours.
`AUTH_INSECURE_CLIENT_KEY_TYPE` persists and needs either daemon cephx key rotation or a
`healthCheck.muteHealthWarning` entry. Deciding which once the actual post-upgrade health state is
visible, rather than pre-emptively muting warnings that rotation should properly fix.

**Not** rotating the CSI keys: they need kernel 7.0+ and the fleet is on 6.18 even after v1.13.9.
Both storage paths here are kernel clients.