### PR TITLE
feat(rook-ceph): rotate daemon cephx keys and mute what cannot be rotated

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -69,6 +69,36 @@ spec:
         urlPrefix: /
         ssl: false
         prometheusEndpoint: http://prometheus-operated.observability.svc.cluster.local:9090
+      # Ceph v20.2.4 asserts on cephx key ciphers (CVE-2025-30156). Rotating the DAEMON
+      # keys is what clears both HEALTH_ERR items, AUTH_INSECURE_SERVICE_KEY_TYPE and
+      # AUTH_INSECURE_SERVICE_TICKETS. keyGeneration: 2 per upstream's guide.
+      #
+      # keyGeneration is APPEND-ONLY — the CRD enforces "keyGeneration cannot be removed
+      # once set", so deleting this field makes the API server reject every later
+      # CephCluster update and the HelmRelease stops reconciling. Raise the number to
+      # rotate again; never remove it.
+      #
+      # csi keys stay on the chart default (aes): AES256K needs a 7.0+ kernel, the fleet
+      # is on 6.18 even after Talos v1.13.9, and both storage paths here are kernel
+      # clients (krbd, and the built-in CephFS kernel client per KB-025).
+      security:
+        cephx:
+          daemon:
+            keyRotationPolicy: KeyGeneration
+            keyGeneration: 2
+      # These three cannot be cleared here, so they are muted rather than left to mask
+      # later health changes: CLIENT_KEY_TYPE needs those CSI keys rotated, and
+      # KEYS_ALLOWED/KEYS_CREATABLE need allowedCiphers restricted to aes256k, which
+      # would lock the same clients out. AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE is
+      # deliberately not muted — it clears itself once the daemons re-key.
+      healthCheck:
+        muteHealthWarning:
+          AUTH_INSECURE_CLIENT_KEY_TYPE:
+            policy: mute
+          AUTH_INSECURE_KEYS_ALLOWED:
+            policy: mute
+          AUTH_INSECURE_KEYS_CREATABLE:
+            policy: mute
       mgr:
         modules:
           - name: diskprediction_local


### PR DESCRIPTION
The cluster has been `HEALTH_ERR` since the v20.2.4 upgrade. Ceph v20.2.4 asserts on cephx key
ciphers (CVE-2025-30156) and reports six findings — but only **two are errors**, and both come from
daemon keys:

| Finding | Level | Resolution |
| --- | --- | --- |
| `AUTH_INSECURE_SERVICE_KEY_TYPE` — 10 mds/osd entities | **ERR** | daemon key rotation (this PR) |
| `AUTH_INSECURE_SERVICE_TICKETS` — monitors issuing insecure tickets | **ERR** | daemon key rotation (this PR) |
| `AUTH_INSECURE_CLIENT_KEY_TYPE` — 8 clients incl. CSI | WRN | muted — see below |
| `AUTH_INSECURE_KEYS_ALLOWED` | WRN | muted — see below |
| `AUTH_INSECURE_KEYS_CREATABLE` | WRN | muted — see below |
| `AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` | WRN | **not** muted, self-clears |

Upstream's quick-resolution guide confirms daemon rotation clears exactly the two errors and
explicitly does *not* clear the others.

## Why three are muted rather than fixed

All three routes lead to the same wall. `CLIENT_KEY_TYPE` needs the CSI and rbd-mirror client keys
rotated; `KEYS_ALLOWED` and `KEYS_CREATABLE` need `allowedCiphers` restricted to `aes256k`, which
would lock those same clients out. Both require **AES256K CSI keys, which need a 7.0+ kernel** — the
fleet runs 6.18 even after today's Talos v1.13.9 upgrade, and both storage paths here are kernel
clients (krbd, and the built-in CephFS kernel client per KB-025).

So these are not deferred work; they are not actionable on this cluster until Talos ships a 7.0+
kernel. Muting them with the reason recorded inline is better than leaving the cluster permanently
red, which would mask the next real health change.

`AUTH_INSECURE_ROTATING_SERVICE_KEY_TYPE` is deliberately **left unmuted** — it clears on its own
within a few hours once the daemons re-key, and muting a transient would hide the evidence that the
rotation actually worked.

## The append-only trap

`keyGeneration` cannot be removed once set. The CRD enforces it:

```text
rule:    !has(oldSelf.keyGeneration) || has(self.keyGeneration)
message: keyGeneration cannot be removed once set
```

Delete or comment out that field later and the API server rejects **every** subsequent CephCluster
update, stalling the HelmRelease. To rotate again, raise the number. Never remove it. That is why
the warning lives in the values file itself rather than only in this description.

## Pre-flight

Ceph is fully upgraded and the data plane is healthy — 13/13 daemons on v20.2.4, 169 pgs
`active+clean`, 6/6 OSDs, 3 mons in quorum, volumes healthy. Everything outstanding is auth policy.