### PR TITLE
ci(renovate-review): re-pin to shared-workflows dadd5af

### DIFF
--- a/.github/workflows/renovate-review.yaml
+++ b/.github/workflows/renovate-review.yaml
@@ -32,7 +32,7 @@ jobs:
       pull-requests: write
       statuses: write
       id-token: write
-    uses: LukeEvansTech/shared-workflows/.github/workflows/renovate-review.yml@dadd5af322f177cba99a056f34c5454d62908d75 # v1
+    uses: LukeEvansTech/shared-workflows/.github/workflows/renovate-review.yml@4a27af481a70705a65b82c72ef62fc58c5af6ed0 # v1
     with:
       # Derived at runtime from the "Protected infra" packageRules entry in
       # .renovaterc.json5, so the blast list can never drift from the Renovate


### PR DESCRIPTION
Picks up [shared-workflows#42](https://github.com/LukeEvansTech/shared-workflows/pull/42).

Every usage-limit annotation since the rollout has read:

```text
Claude usage limit hit (429) - re-run once the window resets: Error
```

`.error.message` on the 429 body is literally `"Error"`. The reset time lives in the rate-limit response headers, which the reusable now reads — so the message becomes `resets 15:40 UTC` / `retry in 60m` instead.

Confirmed live on talos-cluster #4497 earlier today. Fail-closed behaviour is unchanged.