### PR TITLE
fix(hermes): drop the /login gatus probe override

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -132,15 +132,6 @@ spec:
             port: *dashboard_port
     route:
       app:
-        annotations:
-          # Probe /login, not /: upstream's auto-SSO on an unauthenticated /
-          # calls start_login() on the password-only basic provider and 500s
-          # (NousResearch/hermes-agent#55130 et al., open). /login renders the
-          # working form for everyone, so it's also the browser entry URL
-          # until upstream fixes the redirect.
-          gatus.home-operations.com/endpoint: |-
-            url: https://{{ .Release.Name }}.${SECRET_DOMAIN}/login
-            conditions: ["[STATUS] == 200"]
         hostnames:
           - "{{ .Release.Name }}.${SECRET_DOMAIN}"
         parentRefs:


### PR DESCRIPTION
## Why

#3497 parked a gatus probe override on `/login` because upstream's auto-SSO redirected unauthenticated `GET /` into `/auth/login?provider=basic`, which called `start_login()` on the password-only provider and 500'd.

Upstream closed all six tracked issues (NousResearch/hermes-agent#55130, #56067, #57868, #58020, #58166, #60660); the `supports_password` guard in `_auto_sso_response()` and the `/auth/login` route is present in `v2026.8.16.2`, deployed here since #4364.

## Verified live

- `GET /` → 302 → `/login?next=%2F` → 200 (was 302 → `/auth/login` → 500)
- `GET /auth/login?provider=basic` → 302 → `/login` (was 500)
- 0 `NotImplementedError` in pod logs over 24h
- gatus follows redirects, so the default `[STATUS] == 200` check against the route root passes (same shape as paperless, which already passes on a 302→login)

## Change

Delete the 9-line annotation block; the route falls back to the gatus-sidecar default check. Closes #3497.
