### PR TITLE
fix(homepage): https tile links and nine missing tile icons

### DIFF
--- a/kubernetes/apps/default/netronome/ks.yaml
+++ b/kubernetes/apps/default/netronome/ks.yaml
@@ -23,7 +23,7 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Netronome
       HOMEPAGE_GROUP: Tools
-      HOMEPAGE_ICON: speedtest-tracker.svg
+      HOMEPAGE_ICON: netronome.png
       HOMEPAGE_DESCRIPTION: Speed test tracker
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/pairdrop/ks.yaml
+++ b/kubernetes/apps/default/pairdrop/ks.yaml
@@ -18,7 +18,7 @@ spec:
       APP: *app
       HOMEPAGE_NAME: PairDrop
       HOMEPAGE_GROUP: Tools
-      HOMEPAGE_ICON: pairdrop.svg
+      HOMEPAGE_ICON: pairdrop.png
       HOMEPAGE_DESCRIPTION: Local file sharing
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/tandoor/ks.yaml
+++ b/kubernetes/apps/default/tandoor/ks.yaml
@@ -23,7 +23,7 @@ spec:
       VOLSYNC_CAPACITY: 5Gi
       HOMEPAGE_NAME: Tandoor
       HOMEPAGE_GROUP: Productivity
-      HOMEPAGE_ICON: tandoor.svg
+      HOMEPAGE_ICON: tandoor-recipes.svg
       HOMEPAGE_DESCRIPTION: Recipe manager
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/default/wallos/ks.yaml
+++ b/kubernetes/apps/default/wallos/ks.yaml
@@ -23,7 +23,7 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Wallos
       HOMEPAGE_GROUP: Tools
-      HOMEPAGE_ICON: wallos.svg
+      HOMEPAGE_ICON: wallos.png
       HOMEPAGE_DESCRIPTION: Subscription tracker
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/downloads/autobrr/ks.yaml
+++ b/kubernetes/apps/downloads/autobrr/ks.yaml
@@ -23,7 +23,7 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Autobrr
       HOMEPAGE_GROUP: Downloads
-      HOMEPAGE_ICON: autobrr
+      HOMEPAGE_ICON: autobrr.svg
       HOMEPAGE_DESCRIPTION: Torrent automation
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/home/zwave/ks.yaml
+++ b/kubernetes/apps/home/zwave/ks.yaml
@@ -23,7 +23,7 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Z-Wave
       HOMEPAGE_GROUP: Home
-      HOMEPAGE_ICON: z-wave.svg
+      HOMEPAGE_ICON: z-wave-js-ui.svg
       HOMEPAGE_DESCRIPTION: Z-Wave controller
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/media/autopulse/ks.yaml
+++ b/kubernetes/apps/media/autopulse/ks.yaml
@@ -20,7 +20,7 @@ spec:
       VOLSYNC_CAPACITY: 1Gi
       HOMEPAGE_NAME: Autopulse
       HOMEPAGE_GROUP: Media
-      HOMEPAGE_ICON: autopulse.svg
+      HOMEPAGE_ICON: mdi-autorenew
       HOMEPAGE_DESCRIPTION: Media automation
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/media/tdarr/ks.yaml
+++ b/kubernetes/apps/media/tdarr/ks.yaml
@@ -25,7 +25,7 @@ spec:
       VOLSYNC_CAPACITY: 10Gi
       HOMEPAGE_NAME: Tdarr
       HOMEPAGE_GROUP: Media
-      HOMEPAGE_ICON: tdarr.svg
+      HOMEPAGE_ICON: tdarr.png
       HOMEPAGE_DESCRIPTION: Media transcoding
   prune: true
   retryInterval: 2m

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -63,13 +63,10 @@ spec:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *hostname
       lbipam.cilium.io/ips: 10.32.8.88
+  # https is listed first on purpose: homepage derives a discovered tile's URL
+  # scheme from listeners[0] when the HTTPRoute's parentRef has no sectionName
+  # (none of ours do), so http-first rendered every tile as http://.
   listeners:
-    - name: http
-      protocol: HTTP
-      port: 80
-      allowedRoutes:
-        namespaces:
-          from: Same
     - name: https
       protocol: HTTPS
       port: 443
@@ -80,6 +77,12 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-production-tls"
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/gateway_v1.json
 apiVersion: gateway.networking.k8s.io/v1
@@ -101,13 +104,10 @@ spec:
     annotations:
       external-dns.alpha.kubernetes.io/hostname: *internalHost
       lbipam.cilium.io/ips: 10.32.8.87
+  # https is listed first on purpose: homepage derives a discovered tile's URL
+  # scheme from listeners[0] when the HTTPRoute's parentRef has no sectionName
+  # (none of ours do), so http-first rendered every tile as http://.
   listeners:
-    - name: http
-      protocol: HTTP
-      port: 80
-      allowedRoutes:
-        namespaces:
-          from: Same
     - name: https
       protocol: HTTPS
       port: 443
@@ -118,6 +118,12 @@ spec:
         certificateRefs:
           - kind: Secret
             name: "${SECRET_DOMAIN/./-}-production-tls"
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Same
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.envoyproxy.io/backendtrafficpolicy_v1alpha1.json
 apiVersion: gateway.envoyproxy.io/v1alpha1

--- a/kubernetes/apps/security/anubis/ks.yaml
+++ b/kubernetes/apps/security/anubis/ks.yaml
@@ -18,7 +18,7 @@ spec:
       APP: *app
       HOMEPAGE_NAME: Anubis
       HOMEPAGE_GROUP: Security
-      HOMEPAGE_ICON: anubis.svg
+      HOMEPAGE_ICON: anubis.png
       HOMEPAGE_DESCRIPTION: Bot protection
   prune: true
   retryInterval: 2m


### PR DESCRIPTION
Follow-up to #4539.

- **Tiles linked to `http://`.** Homepage derives a discovered tile's URL scheme from the parent Gateway's `listeners[0]` when the HTTPRoute's parentRef has no `sectionName` (none of ours do). With the http listener listed first, all 75 tiles rendered `http://…`. Both gateways now list `https` first; Gateway API attaches no meaning to listener order, so this is behaviour-neutral for routing.
- **Nine tiles had icons the dashboard-icons CDN does not serve** (404, verified per icon): switched to the png variant where only that exists (anubis, pairdrop, tdarr, wallos, netronome), the CDN's actual names for Tandoor (`tandoor-recipes`) and Z-Wave (`z-wave-js-ui`), `autobrr.svg` (was extension-less), and an mdi icon for Autopulse, which has no icon at all.

Validated with `flate test` (network namespace) and the CI super-linter image scoped to the changed files.