### PR TITLE
fix(homepage): point the Sortarr tile at the logo upstream still serves

### DIFF
--- a/kubernetes/apps/media/sortarr/ks.yaml
+++ b/kubernetes/apps/media/sortarr/ks.yaml
@@ -18,7 +18,7 @@ spec:
       APP: *app
       HOMEPAGE_NAME: Sortarr
       HOMEPAGE_GROUP: Media
-      HOMEPAGE_ICON: https://raw.githubusercontent.com/Jaredharper1/Sortarr/main/static/sortarr.svg
+      HOMEPAGE_ICON: https://raw.githubusercontent.com/Jaredharper1/Sortarr/main/static/logo.svg
       HOMEPAGE_DESCRIPTION: Media storage analytics
   prune: true
   retryInterval: 2m


### PR DESCRIPTION
Follow-up to #4541. Upstream renamed `static/sortarr.svg` to `static/logo.svg` (the old URL 404s), so the tile rendered a broken image; dashboard-icons has no Sortarr icon either. Verified the new URL serves `image/svg+xml`.