### PR TITLE
feat(minecraft)!: upgrade server to 26.2 on the Java 25 image

### DIFF
--- a/kubernetes/apps/games/minecraft/app/helmrelease.yaml
+++ b/kubernetes/apps/games/minecraft/app/helmrelease.yaml
@@ -18,13 +18,13 @@ spec:
           app:
             image:
               repository: itzg/minecraft-server
-              tag: java21@sha256:3527decf11fbdeb77acd1b035ad65dd1fc83a288c2891a68b31e98b7330a610f
+              tag: java25@sha256:9d2707c109da523f5f71c2ad7e38e4fdf7e500f8301ea45bc22708036cf593bb
             env:
               TZ: "${TIMEZONE}"
               # Server type and version
               TYPE: "PAPER"
               # renovate: datasource=custom.minecraft-release
-              VERSION: "1.21.11"
+              VERSION: "26.2"
               # Server settings
               EULA: "TRUE"
               SERVER_NAME: "Minecraft Server"


### PR DESCRIPTION
Replaces the Renovate update blocked by closed #3533 (`minecraft-release 1.21.11 → 26.2`).

## Why now
- Paper **26.2** has STABLE builds since 2026-08-24 (`fill.papermc.io/v3/projects/paper/versions/26.2/builds` → channels `["ALPHA","BETA","STABLE"]`, latest STABLE build 117). That was the blocker recorded in #3534.
- Mojang's version manifest lists 26.2 (and 26.1.2) with `javaVersion.majorVersion = 25`; 1.21.11 was 21. The current `java21` image cannot start a 26.x server, so this PR moves the image to `itzg/minecraft-server:java25` (index digest verified against the registry) together with `VERSION: "26.2"`.

## Notes
- World upgrade is one-way. VolSync snapshots from 2026-08-25 exist on both targets (NFS 08:05Z, R2 00:42Z) for rollback.
- No plugins are configured, so no plugin-compat risk.
- `flate build hr minecraft -n games` renders the new image and env cleanly.
- After merge, Renovate's dashboard entry "blocked by closed PR" for minecraft-release clears on its own (the pin is current).