### PR TITLE
feat(pocket-id,shlink): enable MaxMind GeoLite2 geolocation

### DIFF
--- a/kubernetes/apps/default/shlink/app/externalsecret.yaml
+++ b/kubernetes/apps/default/shlink/app/externalsecret.yaml
@@ -15,6 +15,9 @@ spec:
       engineVersion: v2
       data:
         INITIAL_API_KEY: "{{ .SHLINK_API_KEY }}"
+        GEOLITE_LICENSE_KEY: "{{ .MAXMIND_LICENSE_KEY }}"
   dataFrom:
+    - extract:
+        key: maxmind
     - extract:
         key: shlink

--- a/kubernetes/apps/default/shlink/app/helmrelease.yaml
+++ b/kubernetes/apps/default/shlink/app/helmrelease.yaml
@@ -25,6 +25,14 @@ spec:
               IS_HTTPS_ENABLED: "true"
               TASK_WORKER_NUM: 4
               WEB_WORKER_NUM: 1
+              # Keep skipping the boot-time download even though a license key
+              # is now set: the image entrypoint runs under `set -e`, so a
+              # MaxMind outage at start would crash-loop the pod. Shlink's
+              # visit-time updater fetches the database in the background
+              # instead and refreshes it every 30 days. It lands on the data
+              # PVC (data/GeoLite2-City.mmdb) because Shlink has no path
+              # override; a single ~60 MiB file is an accepted exception to
+              # keeping caches off backed-up volumes.
               SKIP_INITIAL_GEOLITE_DOWNLOAD: "true"
               DISABLE_TRACKING_FROM: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
             envFrom:

--- a/kubernetes/apps/security/pocket-id/app/externalsecret.yaml
+++ b/kubernetes/apps/security/pocket-id/app/externalsecret.yaml
@@ -14,8 +14,7 @@ spec:
       engineVersion: v2
       data:
         ENCRYPTION_KEY: "{{ .POCKET_ID_ENCRYPTION_KEY }}"
-        # TODO: Maxmind
-        # MAXMIND_LICENSE_KEY: "{{ .MAXMIND_LICENSE_KEY }}"
+        MAXMIND_LICENSE_KEY: "{{ .MAXMIND_LICENSE_KEY }}"
         # TODO: Configure Active Directory/LDAP settings
         # LDAP_BIND_DN: "{{ .LDAP_BIND_DN }}"
         # LDAP_BIND_PASSWORD: "{{ .LDAP_BIND_PASSWORD }}"
@@ -38,8 +37,7 @@ spec:
     #     key: active-directory
     - extract:
         key: cloudnative-pg
-    # TODO: Uncomment when MaxMind is configured
-    # - extract:
-    #     key: maxmind
+    - extract:
+        key: maxmind
     - extract:
         key: pocket-id

--- a/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
+++ b/kubernetes/apps/security/pocket-id/app/helmrelease.yaml
@@ -83,8 +83,12 @@ spec:
               SESSION_DURATION: "43800"
               TRUST_PROXY: "true"
               UPLOAD_PATH: /app/data/uploads
-              # TODO: Enable when MaxMind is configured
-              # GEOLITE_DB_PATH: /app/data/GeoLite2-City.mmdb
+              # GeoLite2-City is a cache of a public artifact, not state:
+              # pocket-id downloads it on start when missing and refreshes it
+              # every 14 days (temp file + rename in the same directory). Keep
+              # it on the geolite emptyDir below rather than the default
+              # data/GeoLite2-City.mmdb, which sits on the VolSync-backed PVC.
+              GEOLITE_DB_PATH: /app/geolite/GeoLite2-City.mmdb
             envFrom: *envFrom
             probes:
               liveness: &probes
@@ -148,3 +152,11 @@ spec:
             app:
               - path: /tmp
                 subPath: tmp
+      geolite:
+        # ~60 MiB mmdb plus its in-flight replacement during a refresh.
+        type: emptyDir
+        sizeLimit: 256Mi
+        advancedMounts:
+          pocket-id:
+            app:
+              - path: /app/geolite


### PR DESCRIPTION
## Summary

Both apps had GeoLite wiring stubbed out pending a MaxMind account. The license key now lives in the `maxmind` 1Password item (Talos vault, API Credential) and flows in through each app's ExternalSecret.

- **pocket-id** — `MAXMIND_LICENSE_KEY` from the secret; `GEOLITE_DB_PATH` moved to a capped `emptyDir` (256Mi). Pocket ID downloads GeoLite2-City on start when missing and refreshes it every 14 days (temp file + rename in the same dir), so it is a rebuildable cache and stays off the VolSync-backed PVC — same rule as tracearr's poster cache (#4561).
- **shlink** — `GEOLITE_LICENSE_KEY` from the secret. `SKIP_INITIAL_GEOLITE_DOWNLOAD` stays on: the image entrypoint runs under `set -e`, so a MaxMind outage at boot would crash-loop the pod. Shlink's visit-time updater fetches the database in the background and refreshes it every 30 days. Shlink has no path override, so its ~60 MiB copy stays on the data PVC (accepted exception).

## Verification

- `just kube flate-build-hr` for both apps renders the new env, `/app/geolite` mount and `emptyDir sizeLimit: 256Mi`.
- Scoped super-linter run (`slim-v8`, the `just lint` flags) exits 0 against the four files.
- Post-merge: pocket-id log shows `GeoLite2 City database successfully refreshed` and `/app/geolite/GeoLite2-City.mmdb` exists; shlink `bin/cli visit:download-db` succeeds.
