### PR TITLE
feat(autopulse): wire Sonarr/Radarr triggers to a Jellyfin target

### DIFF
--- a/docs/docs/apps/autopulse.md
+++ b/docs/docs/apps/autopulse.md
@@ -1,21 +1,34 @@
 # Autopulse
 
 Media-automation app in the `media` namespace (bjw-s app-template HelmRelease).
-Watches sources and notifies media targets to rescan. Runs minimal: pod Ready,
-web UI on the internal route, no triggers/targets wired yet.
+Receives import/upgrade webhooks from Sonarr and Radarr and tells Jellyfin to
+rescan just the changed paths.
 
 ## Purpose
 
-- Bring autopulse online on image `v2.0.0` in a deliberately minimal config:
-  - Pod becomes `Ready`; web UI reachable at `autopulse.${SECRET_DOMAIN}`,
-      served via `envoy-internal` (internal-only).
-  - SQLite database persisted on a VolSync-backed PVC (NFS + remote backups).
-  - Triggers/targets intentionally omitted. Integrations are added later.
-- Not in scope (for the minimal bring-up): wiring source/target integrations,
-  or exposing the app externally.
+- Sonarr and Radarr trigger autopulse on import/upgrade; autopulse's one target
+  is Jellyfin (`http://jellyfin.media.svc.cluster.local:8096`), scanned per
+  path rather than whole-library.
+- Web UI reachable at `autopulse.${SECRET_DOMAIN}` via `envoy-internal`
+  (internal-only); SQLite database persisted on a VolSync-backed PVC.
+- Not in scope: a Plex target, or exposing the app externally.
 
 ## Design decisions
 
+- **Jellyfin is the only target — Plex is deliberately absent.** Sonarr and
+  Radarr both already carry a native "Plex Media Server" Connect notification
+  (`updateLibrary: true`, on import and upgrade), so a Plex target here would
+  double-scan. Jellyfin has no such native notifier in either app and, with the
+  library mounted over NFS, receives no filesystem events — that is the gap
+  autopulse closes.
+- **No `rewrite:` blocks.** The Sonarr/Radarr root folders are `/media/tv` and
+  `/media/movies`, and autopulse, Sonarr, Radarr and Jellyfin all mount the same
+  export at `/media`, so the path a trigger sends is already the path Jellyfin
+  expects. `opts.check_path: true` makes autopulse stat the file before
+  notifying, which is why the HelmRelease mounts the media export read-only.
+- **Trigger auth is the app's basic auth.** autopulse has no per-trigger token;
+  Sonarr/Radarr POST to `/triggers/sonarr` / `/triggers/radarr` with the same
+  `auth.username` / `auth.password` as the UI.
 - **SQLite, not Postgres.** v2.0.0 changed the default `database_url` from
   PostgreSQL to a SQLite file (`sqlite://data/autopulse.db`, resolving to
   `/app/data/autopulse.db`). The minimal config embraces this: no database
@@ -78,10 +91,14 @@ web UI on the internal route, no triggers/targets wired yet.
   defaults. Create the `autopulse` 1Password login item (username `admin` + a
   generated 32-char password) via `op item create` in the operator's signed-in
   shell, never the UI, never committed. The field labels `username`/`password`
-  must match the `{{ .username }}` / `{{ .password }}` template vars.
-- **Empty `triggers`/`targets` may be rejected.** The minimal config omits both
-  maps (serde should default them to empty). If startup logs complain about
-  missing keys, add explicit `triggers: {}` / `targets: {}` to the inline config.
+  must match the `{{ .username }}` / `{{ .password }}` template vars. The
+  Jellyfin API key (Dashboard → API Keys, one issued for `autopulse`) lives on
+  the same item as a concealed `JELLYFIN_TOKEN` field.
+- **The Sonarr/Radarr side is not in git.** Each app needs a Connect → Webhook
+  (Settings → Connect) pointing at
+  `http://autopulse.media.svc.cluster.local:2875/triggers/<sonarr|radarr>`,
+  method `POST`, basic auth with the autopulse credentials, on Import and
+  Upgrade (Rename/Delete too if wanted). Re-add them after any *arr restore.
 - **First-deploy restore finds no snapshot.** This is standard VolSync
   bootstrap: the `ReplicationDestination` provisions an empty PVC and the app
   initializes a fresh DB. No manual action.

--- a/kubernetes/apps/media/autopulse/app/externalsecret.yaml
+++ b/kubernetes/apps/media/autopulse/app/externalsecret.yaml
@@ -13,10 +13,12 @@ spec:
     name: autopulse-secret
     template:
       engineVersion: v2
-      # TODO(autopulse-integrations): minimal config (no triggers/targets). Expand the block
-      # below with triggers:/targets: (e.g. sonarr/radarr -> plex/jellyfin); add any required
-      # tokens as fields on the autopulse 1Password item, referenced here as {{ .field }}.
-      # https://github.com/LukeEvansTech/talos-cluster/issues/2868
+      # Sonarr/Radarr POST to /triggers/<name> with the basic-auth creds below; the
+      # only target is Jellyfin — both *arr apps already push library updates to
+      # Plex through their native "Plex Media Server" Connect notification, and
+      # Jellyfin gets no inotify events from the NFS-backed library. No rewrite:
+      # the *arr root folders (/media/tv, /media/movies), this pod and Jellyfin
+      # all see the same export at /media. check_path needs that mount.
       data:
         config.yaml: |
           app:
@@ -24,6 +26,18 @@ spec:
           auth:
             username: "{{ .username }}"
             password: "{{ .password }}"
+          opts:
+            check_path: true
+          triggers:
+            sonarr:
+              type: sonarr
+            radarr:
+              type: radarr
+          targets:
+            jellyfin:
+              type: jellyfin
+              url: http://jellyfin.media.svc.cluster.local:8096
+              token: "{{ .JELLYFIN_TOKEN }}"
   dataFrom:
     - extract:
         key: autopulse

--- a/kubernetes/apps/media/autopulse/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autopulse/app/helmrelease.yaml
@@ -69,10 +69,13 @@ spec:
           - path: /app/config.yaml
             subPath: config.yaml
             readOnly: true
-      # TODO(autopulse-integrations): when wiring triggers/targets, re-add a read-only media
-      # volume here using the resolvable internal NFS host the other media apps use (the prior
-      # draft host did not resolve and blocked startup; removed in #2867).
-      # https://github.com/LukeEvansTech/talos-cluster/issues/2868
+      media:
+        type: nfs
+        server: ${SECRET_STORAGE_SERVER:-localhost}
+        path: /mnt/pool/media
+        globalMounts:
+          - path: /media
+            readOnly: true
       tmp:
         type: emptyDir
         globalMounts:


### PR DESCRIPTION
## Why

autopulse has run with no triggers/targets since #2866. Checked the *arr apps' Connect settings via their APIs: **Sonarr and Radarr both already have a native "Plex Media Server" notification** (`updateLibrary: true`, on import + upgrade), so a Plex target here would double-scan. Jellyfin has no such notifier in either app and, over NFS, gets no filesystem events — that is the one gap worth closing.

## Change

- `config.yaml`: `triggers: sonarr, radarr` → `targets: jellyfin` (`{{ .JELLYFIN_TOKEN }}`, a new concealed field on the existing `autopulse` 1Password item, so `dataFrom` is unchanged). `opts.check_path: true`.
- Read-only `media` NFS mount at `/media`, identical to the sibling media apps. No `rewrite:` — the *arr root folders are `/media/tv` and `/media/movies` and every party sees the same export at `/media`.
- Docs page updated: design rationale, plus the *arr-side Connect → Webhook that lives outside git.

## After merge

Add the Connect → Webhook in Sonarr and Radarr (`POST http://autopulse.media.svc.cluster.local:2875/triggers/<sonarr|radarr>`, basic auth). Closes #2868.
